### PR TITLE
feat(incident): C5 analyst triage workflow (#679)

### DIFF
--- a/internal/usecase/fleet/incidenttriage/service.go
+++ b/internal/usecase/fleet/incidenttriage/service.go
@@ -1,0 +1,131 @@
+// Package incidenttriage is the Phase C analyst triage loop (#594, C5 #679): the human-driven mutations
+// on an incident — take ownership, comment, change workflow status, and set a disposition — each recorded
+// as an attributable incident.IncidentEvent on the append-only log (C7) and mirrored to the tamper-evident
+// audit log. State, Disposition, and risk stay independent: a disposition never mutates the risk score.
+// RBAC is enforced at the HTTP edge; this usecase requires an attributable actor and audits every
+// mutation.
+package incidenttriage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// IncidentAppender is the consumer-side view of the incident store this usecase needs: read the current
+// projection (for its revision) and append events under optimistic concurrency with projectability
+// validation. incidentuc.Service satisfies it; defined here so triage does not import a sibling usecase.
+type IncidentAppender interface {
+	Get(ctx context.Context, id shared.ID) (incident.Incident, error)
+	Append(ctx context.Context, id shared.ID, expectedRevision int, events []incident.IncidentEvent) (incident.Incident, error)
+}
+
+// Service performs analyst triage mutations on incidents.
+type Service struct {
+	incidents IncidentAppender
+	audit     ports.AuditLogger
+	now       func() time.Time
+}
+
+// NewService constructs the triage service. now supplies event timestamps (injected for determinism).
+func NewService(incidents IncidentAppender, audit ports.AuditLogger, now func() time.Time) (*Service, error) {
+	if incidents == nil {
+		return nil, fmt.Errorf("%w: triage service requires an incident store", shared.ErrValidation)
+	}
+	if audit == nil {
+		return nil, fmt.Errorf("%w: triage service requires an audit logger", shared.ErrValidation)
+	}
+	if now == nil {
+		return nil, fmt.Errorf("%w: triage service requires a clock", shared.ErrValidation)
+	}
+	return &Service{incidents: incidents, audit: audit, now: now}, nil
+}
+
+// AssignOwner sets the incident's owner. actor is the authenticated principal responsible (it MUST be the
+// server-side principal, never a request-body field) and follows ctx to keep it away from the other string
+// params.
+func (s *Service) AssignOwner(ctx context.Context, actor string, id shared.ID, owner string) (incident.Incident, error) {
+	if owner == "" {
+		return incident.Incident{}, fmt.Errorf("%w: owner is required", shared.ErrValidation)
+	}
+	return s.apply(ctx, actor, id, "incident.owner_changed",
+		func(at time.Time) incident.IncidentEvent {
+			return incident.IncidentEvent{IncidentID: id, Kind: incident.EventOwnerChanged, At: at, Actor: actor, Owner: owner}
+		}, map[string]string{"owner": owner})
+}
+
+// Comment records an analyst note.
+func (s *Service) Comment(ctx context.Context, actor string, id shared.ID, text string) (incident.Incident, error) {
+	if text == "" {
+		return incident.Incident{}, fmt.Errorf("%w: comment text is required", shared.ErrValidation)
+	}
+	return s.apply(ctx, actor, id, "incident.commented",
+		func(at time.Time) incident.IncidentEvent {
+			return incident.IncidentEvent{IncidentID: id, Kind: incident.EventAnalystCommented, At: at, Actor: actor, Comment: text}
+		}, nil)
+}
+
+// ChangeStatus moves the incident to a new workflow state (the append rejects an illegal transition).
+func (s *Service) ChangeStatus(ctx context.Context, actor string, id shared.ID, to incident.State) (incident.Incident, error) {
+	if !to.Valid() {
+		return incident.Incident{}, fmt.Errorf("%w: unknown target state %q", shared.ErrValidation, to)
+	}
+	return s.apply(ctx, actor, id, "incident.status_changed",
+		func(at time.Time) incident.IncidentEvent {
+			return incident.IncidentEvent{IncidentID: id, Kind: incident.EventStatusChanged, At: at, Actor: actor, To: to}
+		}, map[string]string{"to": string(to)})
+}
+
+// SetDisposition records the analyst's verdict (independent of state and risk).
+func (s *Service) SetDisposition(ctx context.Context, actor string, id shared.ID, disposition incident.Disposition) (incident.Incident, error) {
+	if !disposition.Valid() {
+		return incident.Incident{}, fmt.Errorf("%w: unknown disposition %q", shared.ErrValidation, disposition)
+	}
+	return s.apply(ctx, actor, id, "incident.disposition_set",
+		func(at time.Time) incident.IncidentEvent {
+			return incident.IncidentEvent{IncidentID: id, Kind: incident.EventDispositionSet, At: at, Actor: actor, Disposition: disposition}
+		}, map[string]string{"disposition": string(disposition)})
+}
+
+// apply is the shared mutation path: require an actor, load the current revision, append the built event
+// under optimistic concurrency, then audit. The append validates projectability (e.g. a legal transition)
+// and fails closed before anything is recorded.
+//
+// Ordering rationale (attribution, golden rule 6): the PRIMARY attributable record IS the incident event
+// itself — it carries the Actor and lives on the append-only, tamper-evident incident log (C7). The
+// ports.AuditLogger is a SECONDARY, cross-cutting trail. Auditing AFTER a successful append means a failed
+// append never leaves a false audit record for a mutation that did not happen.
+//
+// Caller contract on an audit-failure error: the mutation IS already committed (the incident event is
+// durable and carries the attribution) — the error signals only that the secondary audit trail has a gap.
+// The caller MUST NOT blindly retry (the stores are not transactional and the append is not idempotent, so
+// a retry would append a DUPLICATE event); treat it as committed-but-unaudited and reconcile/alert.
+func (s *Service) apply(ctx context.Context, actor string, id shared.ID, action string, build func(time.Time) incident.IncidentEvent, meta map[string]string) (incident.Incident, error) {
+	if id.IsZero() {
+		return incident.Incident{}, fmt.Errorf("%w: incident id is required", shared.ErrValidation)
+	}
+	if actor == "" {
+		return incident.Incident{}, fmt.Errorf("%w: triage mutation requires an actor", shared.ErrValidation)
+	}
+	cur, err := s.incidents.Get(ctx, id)
+	if err != nil {
+		return incident.Incident{}, err
+	}
+	at := s.now().UTC()
+	updated, err := s.incidents.Append(ctx, id, cur.Revision, []incident.IncidentEvent{build(at)})
+	if err != nil {
+		return incident.Incident{}, err
+	}
+	entry := ports.AuditEntry{Actor: actor, Action: action, Target: id.String(), At: at, Metadata: map[string]string{}}
+	for k, v := range meta {
+		entry.Metadata[k] = v
+	}
+	if err := s.audit.Record(ctx, entry); err != nil {
+		return incident.Incident{}, fmt.Errorf("audit %s: %w", action, err)
+	}
+	return updated, nil
+}

--- a/internal/usecase/fleet/incidenttriage/service_test.go
+++ b/internal/usecase/fleet/incidenttriage/service_test.go
@@ -1,0 +1,168 @@
+package incidenttriage
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/incidentuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	tenant = shared.ID("tenant-t")
+	asset  = shared.ID("asset-t")
+	incID  = shared.ID("inc-t")
+)
+
+var base = time.Unix(1_800_000_000, 0).UTC()
+
+// captureAudit records entries; if fail is set, Record errors.
+type captureAudit struct {
+	mu      sync.Mutex
+	entries []ports.AuditEntry
+	fail    bool
+}
+
+func (c *captureAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	if c.fail {
+		return errors.New("audit down")
+	}
+	c.mu.Lock()
+	c.entries = append(c.entries, e)
+	c.mu.Unlock()
+	return nil
+}
+
+func setup(t *testing.T) (*Service, *captureAudit, context.Context, *incidentuc.Service) {
+	t.Helper()
+	store := memory.NewIncidentEventStore()
+	inc, err := incidentuc.NewService(store)
+	if err != nil {
+		t.Fatal(err)
+	}
+	audit := &captureAudit{}
+	var n int
+	clock := func() time.Time { n++; return base.Add(time.Duration(n) * time.Minute) }
+	svc, err := NewService(inc, audit, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := shared.WithTenant(context.Background(), tenant)
+	// Seed a fresh incident (StateNew).
+	created := incident.IncidentEvent{IncidentID: incID, Kind: incident.EventCreated, At: base, Actor: "correlator", AssetID: asset, Severity: shared.SeverityHigh, DetectionID: "d1"}
+	if _, err := inc.Append(ctx, incID, 0, []incident.IncidentEvent{created}); err != nil {
+		t.Fatal(err)
+	}
+	return svc, audit, ctx, inc
+}
+
+func TestTriageFullLoopAuditsEveryMutation(t *testing.T) {
+	svc, audit, ctx, _ := setup(t)
+	if _, err := svc.AssignOwner(ctx, "alice", incID, "alice"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Comment(ctx, "alice", incID, "investigating this"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.ChangeStatus(ctx, "alice", incID, incident.StateInvestigating); err != nil {
+		t.Fatal(err)
+	}
+	inc, err := svc.SetDisposition(ctx, "alice", incID, incident.DispositionTruePositive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inc.OwnerID != "alice" || inc.State != incident.StateInvestigating || inc.Disposition != incident.DispositionTruePositive || len(inc.Comments) != 1 {
+		t.Fatalf("triage projection wrong: %+v", inc)
+	}
+	if len(audit.entries) != 4 {
+		t.Fatalf("every mutation must be audited, got %d", len(audit.entries))
+	}
+	wantActions := map[string]bool{"incident.owner_changed": false, "incident.commented": false, "incident.status_changed": false, "incident.disposition_set": false}
+	for _, e := range audit.entries {
+		if _, ok := wantActions[e.Action]; !ok {
+			t.Fatalf("unexpected audit action %q", e.Action)
+		}
+		wantActions[e.Action] = true
+		if e.Target != incID.String() || e.Actor != "alice" {
+			t.Fatalf("audit entry not attributed: %+v", e)
+		}
+	}
+	for a, seen := range wantActions {
+		if !seen {
+			t.Fatalf("missing audit for %s", a)
+		}
+	}
+}
+
+func TestTriageDispositionDoesNotChangeRisk(t *testing.T) {
+	svc, _, ctx, inc := setup(t)
+	// Attach a risk assessment first (via the incident store directly).
+	risk := &riskassessment.RiskAssessment{AssessmentID: "ra-1", ScorerVersion: "v1", PolicyVersion: "p1", Risk: 88, Confidence: 61, Coverage: 43}
+	cur, _ := inc.Get(ctx, incID)
+	if _, err := inc.Append(ctx, incID, cur.Revision, []incident.IncidentEvent{{IncidentID: incID, Kind: incident.EventRiskReassessed, At: base.Add(30 * time.Second), Actor: "scorer", Risk: risk}}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := svc.SetDisposition(ctx, "alice", incID, incident.DispositionFalsePositive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Risk == nil || got.Risk.Risk != 88 {
+		t.Fatalf("disposition must not change risk: %+v", got.Risk)
+	}
+}
+
+func TestTriageIllegalTransitionRejectedNotAudited(t *testing.T) {
+	svc, audit, ctx, _ := setup(t)
+	// new -> resolved is illegal; the append's project-validation rejects it.
+	if _, err := svc.ChangeStatus(ctx, "alice", incID, incident.StateResolved); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("illegal transition must be rejected, got %v", err)
+	}
+	if len(audit.entries) != 0 {
+		t.Fatal("a rejected mutation must NOT be audited")
+	}
+}
+
+func TestTriageAuditFailurePropagates(t *testing.T) {
+	svc, audit, ctx, inc := setup(t)
+	audit.fail = true
+	if _, err := svc.Comment(ctx, "alice", incID, "note"); err == nil {
+		t.Fatal("an audit failure must propagate")
+	}
+	// The event WAS appended (audit is after append); the projection reflects it, but the mutation is
+	// reported failed so the caller knows the audit gap.
+	got, _ := inc.Get(ctx, incID)
+	if len(got.Comments) != 1 {
+		t.Fatalf("append happens before audit; comment present, got %d", len(got.Comments))
+	}
+}
+
+func TestTriageFailsClosed(t *testing.T) {
+	svc, _, ctx, _ := setup(t)
+	bad := []func() error{
+		func() error { _, e := svc.AssignOwner(ctx, "alice", incID, ""); return e },
+		func() error { _, e := svc.Comment(ctx, "alice", incID, ""); return e },
+		func() error { _, e := svc.ChangeStatus(ctx, "alice", incID, "bogus"); return e },
+		func() error { _, e := svc.SetDisposition(ctx, "alice", incID, "bogus"); return e },
+		func() error { _, e := svc.Comment(ctx, "", incID, "x"); return e },   // no actor
+		func() error { _, e := svc.Comment(ctx, "alice", "", "x"); return e }, // no incident id
+	}
+	for i, f := range bad {
+		if err := f(); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("case %d must fail closed, got %v", i, err)
+		}
+	}
+	// Unknown incident -> ErrNotFound from Get.
+	if _, err := svc.Comment(ctx, "alice", "missing", "x"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("unknown incident must be ErrNotFound, got %v", err)
+	}
+	if _, err := NewService(nil, &captureAudit{}, time.Now); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("nil store must be rejected")
+	}
+}


### PR DESCRIPTION
Phase C5 (#679): analyst triage usecase (`internal/usecase/fleet/incidenttriage`) — AssignOwner/Comment/ChangeStatus/SetDisposition, each an attributable incident.IncidentEvent on the append-only log (C7, optimistic-concurrency) + a secondary audit-log record. State/Disposition/risk stay independent; illegal transitions rejected fail-closed (no event, no audit). Consumer-side IncidentAppender interface avoids a usecase→usecase import. Dual-reviewed: go-arch MERGEABLE + security SHIP; non-blocking items folded in (actor after ctx, clock .UTC(), documented committed-but-unaudited no-blind-retry contract). RBAC + actor-from-principal is enforced by the C5 HTTP layer (later). Pure usecase; race-green, 95.0%. CI off — validated locally.