### PR TITLE
feat(response): C6 governed-response saga domain model (#680)

### DIFF
--- a/internal/domain/responsesaga/saga.go
+++ b/internal/domain/responsesaga/saga.go
@@ -1,0 +1,176 @@
+package responsesaga
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// VerificationOutcome is the result of checking a response's post-condition via telemetry. Note the
+// explicit "unknown, insufficient coverage" — the honest answer when the telemetry needed to confirm the
+// effect was not observed; it is NOT treated as success.
+type VerificationOutcome string
+
+const (
+	VerificationSucceeded VerificationOutcome = "succeeded"
+	VerificationFailed    VerificationOutcome = "failed"
+	VerificationUnknown   VerificationOutcome = "unknown_insufficient_coverage"
+	VerificationTimedOut  VerificationOutcome = "timed_out"
+	VerificationPending   VerificationOutcome = "" // not yet verified
+)
+
+// Valid reports whether v is a known (or the pending zero) outcome.
+func (v VerificationOutcome) Valid() bool {
+	switch v {
+	case VerificationSucceeded, VerificationFailed, VerificationUnknown, VerificationTimedOut, VerificationPending:
+		return true
+	default:
+		return false
+	}
+}
+
+// ReversibilityClass states how reversible a response is — a reversal COMMAND is not the same as restored
+// STATE, so this is declared up front and a rollback still carries its own verified post-condition.
+type ReversibilityClass string
+
+const (
+	ReversibilityGuaranteed   ReversibilityClass = "guaranteed"
+	ReversibilityCompensating ReversibilityClass = "compensating"
+	ReversibilityBestEffort   ReversibilityClass = "best_effort"
+	ReversibilityIrreversible ReversibilityClass = "irreversible"
+)
+
+// Valid reports whether r is a known reversibility class.
+func (r ReversibilityClass) Valid() bool {
+	switch r {
+	case ReversibilityGuaranteed, ReversibilityCompensating, ReversibilityBestEffort, ReversibilityIrreversible:
+		return true
+	default:
+		return false
+	}
+}
+
+// ResponseAttempt is one at-least-once execution attempt, journaled by the agent BEFORE the side effect so
+// a re-delivery is idempotent: the IdempotencyKey dedups a repeated issue of the same attempt, and the
+// TargetFingerprint pins exactly what was acted on. It records the command and (once verified) the
+// verification outcome.
+type ResponseAttempt struct {
+	ActionID            shared.ID
+	Attempt             int
+	IdempotencyKey      string
+	Target              TargetFingerprint
+	State               SagaState
+	CommandOutcome      string
+	VerificationOutcome VerificationOutcome
+	At                  time.Time
+}
+
+// Validate enforces a well-formed attempt.
+func (a ResponseAttempt) Validate() error {
+	if a.ActionID.IsZero() {
+		return fmt.Errorf("%w: response attempt has no action id", shared.ErrValidation)
+	}
+	if a.Attempt < 1 {
+		return fmt.Errorf("%w: response attempt number must be >= 1", shared.ErrValidation)
+	}
+	if a.IdempotencyKey == "" {
+		return fmt.Errorf("%w: response attempt has no idempotency key", shared.ErrValidation)
+	}
+	if !a.State.Valid() {
+		return fmt.Errorf("%w: response attempt has unknown state %q", shared.ErrValidation, a.State)
+	}
+	if !a.VerificationOutcome.Valid() {
+		return fmt.Errorf("%w: response attempt has unknown verification outcome %q", shared.ErrValidation, a.VerificationOutcome)
+	}
+	return a.Target.Validate()
+}
+
+// Saga is the governed-response state machine for one action: its target, declared reversibility, current
+// state, and the journal of execution attempts. Its safety-critical fields are UNEXPORTED so the only way
+// to advance state is Transition — a caller cannot assign state = StateVerifiedSucceeded directly and
+// fabricate a "contained" verdict that skipped the telemetry Verifying gate, nor swap the validated Target
+// for an unvalidated one. Construct with NewSaga; read via the getters.
+type Saga struct {
+	actionID      shared.ID
+	target        TargetFingerprint
+	reversibility ReversibilityClass
+	state         SagaState
+	attempts      []ResponseAttempt
+	seen          map[string]ResponseAttempt
+}
+
+// NewSaga starts a saga in StateProposed for a validated target + reversibility class.
+func NewSaga(actionID shared.ID, target TargetFingerprint, reversibility ReversibilityClass) (*Saga, error) {
+	if actionID.IsZero() {
+		return nil, fmt.Errorf("%w: response saga has no action id", shared.ErrValidation)
+	}
+	if err := target.Validate(); err != nil {
+		return nil, err
+	}
+	if !reversibility.Valid() {
+		return nil, fmt.Errorf("%w: unknown reversibility class %q", shared.ErrValidation, reversibility)
+	}
+	return &Saga{actionID: actionID, target: target, reversibility: reversibility, state: StateProposed, seen: map[string]ResponseAttempt{}}, nil
+}
+
+// ActionID is the action this saga governs.
+func (s *Saga) ActionID() shared.ID { return s.actionID }
+
+// Target is the stable fingerprint of what the response acts on.
+func (s *Saga) Target() TargetFingerprint { return s.target }
+
+// Reversibility is the declared reversibility class of the response.
+func (s *Saga) Reversibility() ReversibilityClass { return s.reversibility }
+
+// State is the current saga state.
+func (s *Saga) State() SagaState { return s.state }
+
+// Transition advances the saga to a new state, rejecting an illegal transition (in particular
+// CommandApplied -> VerifiedSucceeded, which must pass through Verifying).
+func (s *Saga) Transition(to SagaState) error {
+	if err := requireTransition(s.state, to); err != nil {
+		return err
+	}
+	s.state = to
+	return nil
+}
+
+// RecordAttempt journals an execution attempt, idempotently by IdempotencyKey: re-recording an identical
+// attempt under a seen key is a no-op (so an at-least-once re-issue does not double-journal). The attempt
+// must be valid and belong to this saga's action. A seen key re-used for a DIFFERENT attempt is rejected —
+// silently masking it would hide a caller bug that could double-apply a distinct destructive action.
+func (s *Saga) RecordAttempt(a ResponseAttempt) error {
+	if err := a.Validate(); err != nil {
+		return err
+	}
+	if a.ActionID != s.actionID {
+		return fmt.Errorf("%w: attempt belongs to %s, not %s", shared.ErrValidation, a.ActionID, s.actionID)
+	}
+	if s.seen == nil { // defend against a struct-literal-constructed saga bypassing NewSaga
+		s.seen = map[string]ResponseAttempt{}
+	}
+	if prev, dup := s.seen[a.IdempotencyKey]; dup {
+		if prev != a {
+			return fmt.Errorf("%w: idempotency key %q re-used for a different attempt", shared.ErrValidation, a.IdempotencyKey)
+		}
+		return nil
+	}
+	s.seen[a.IdempotencyKey] = a
+	s.attempts = append(s.attempts, a)
+	return nil
+}
+
+// Attempts returns a copy of the journaled attempts in record order.
+func (s *Saga) Attempts() []ResponseAttempt {
+	out := make([]ResponseAttempt, len(s.attempts))
+	copy(out, s.attempts)
+	return out
+}
+
+// Contained reports whether the response reached a telemetry-verified success — StateVerifiedSucceeded, or
+// StateCompleted (verified then finalized without a rollback). It is NEVER true for StateCommandApplied on
+// its own: a command being issued is not proof the post-condition held.
+func (s *Saga) Contained() bool {
+	return s.state == StateVerifiedSucceeded || s.state == StateCompleted
+}

--- a/internal/domain/responsesaga/saga_test.go
+++ b/internal/domain/responsesaga/saga_test.go
@@ -1,0 +1,193 @@
+package responsesaga
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const actionID = shared.ID("act-1")
+
+var base = time.Unix(1_800_000_000, 0).UTC()
+
+func procTarget() TargetFingerprint {
+	return TargetFingerprint{Kind: FingerprintProcess, ProcessEntityID: "pe_abc"}
+}
+
+func mustSaga(t *testing.T) *Saga {
+	t.Helper()
+	s, err := NewSaga(actionID, procTarget(), ReversibilityGuaranteed)
+	if err != nil {
+		t.Fatalf("new saga: %v", err)
+	}
+	return s
+}
+
+func advance(t *testing.T, s *Saga, states ...SagaState) {
+	t.Helper()
+	for _, st := range states {
+		if err := s.Transition(st); err != nil {
+			t.Fatalf("transition to %s: %v", st, err)
+		}
+	}
+}
+
+func TestSagaHappyPathToVerifiedContainment(t *testing.T) {
+	s := mustSaga(t)
+	advance(t, s, StateAwaitingApproval, StateApproved, StateIssued, StateClaimed, StateExecuting, StateCommandApplied, StateVerifying, StateVerifiedSucceeded)
+	if !s.Contained() {
+		t.Fatal("verified-succeeded must report contained")
+	}
+	if s.State().Terminal() {
+		t.Fatal("verified-succeeded is not itself terminal (it can still finalize or roll back)")
+	}
+	// Finalizing a verified success reaches a real terminal state while staying contained.
+	advance(t, s, StateCompleted)
+	if !s.State().Terminal() {
+		t.Fatal("completed must be terminal")
+	}
+	if !s.Contained() {
+		t.Fatal("a completed (verified, not reverted) response must still report contained")
+	}
+	if s.Transition(StateRollbackRequested) == nil {
+		t.Fatal("no transition out of a terminal completed state")
+	}
+}
+
+// TestCommandAppliedIsNotVerifiedSucceeded is the crown invariant: a saga cannot jump from a successful
+// command to verified success — it must pass through the telemetry Verifying step.
+func TestCommandAppliedIsNotVerifiedSucceeded(t *testing.T) {
+	s := mustSaga(t)
+	advance(t, s, StateAwaitingApproval, StateApproved, StateIssued, StateClaimed, StateExecuting, StateCommandApplied)
+	if err := s.Transition(StateVerifiedSucceeded); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("command_applied -> verified_succeeded must be illegal, got %v", err)
+	}
+	if s.Contained() {
+		t.Fatal("a command applied but not verified must not report contained")
+	}
+	// The only legal next step is verifying.
+	if !CanTransition(StateCommandApplied, StateVerifying) {
+		t.Fatal("command_applied must be able to enter verifying")
+	}
+}
+
+func TestSagaVerificationOutcomesToRollback(t *testing.T) {
+	for _, outcome := range []SagaState{StateVerificationFailed, StateVerificationUnknown, StateTimedOut} {
+		s := mustSaga(t)
+		advance(t, s, StateAwaitingApproval, StateApproved, StateIssued, StateClaimed, StateExecuting, StateCommandApplied, StateVerifying, outcome, StateRollbackRequested, StateRollingBack, StateRolledBack)
+		if !s.State().Terminal() {
+			t.Fatalf("rolled_back must be terminal (via %s)", outcome)
+		}
+		if s.Contained() {
+			t.Fatalf("a non-succeeded verification (%s) must not report contained", outcome)
+		}
+	}
+}
+
+func TestSagaRejectsIllegalTransitions(t *testing.T) {
+	s := mustSaga(t)
+	// proposed -> issued (skipping approval) is illegal.
+	if err := s.Transition(StateIssued); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("proposed -> issued must be illegal, got %v", err)
+	}
+	// unknown target state.
+	if err := s.Transition("bogus"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("unknown state must be rejected, got %v", err)
+	}
+	// terminal has no exits.
+	advance(t, s, StateRejected)
+	if !s.State().Terminal() {
+		t.Fatal("rejected must be terminal")
+	}
+	if s.Transition(StateApproved) == nil {
+		t.Fatal("no transition out of a terminal state")
+	}
+}
+
+func TestTargetFingerprintValidate(t *testing.T) {
+	ok := []TargetFingerprint{
+		{Kind: FingerprintProcess, ProcessEntityID: "pe_x"},
+		{Kind: FingerprintFile, FilePath: "/etc/x", FileDevice: 1, FileInode: 2},
+		{Kind: FingerprintFile, FilePath: "/etc/x", FileHash: "abc"},
+		{Kind: FingerprintHost, HostID: "host-1", NetpolGeneration: 3},
+	}
+	for _, f := range ok {
+		if err := f.Validate(); err != nil {
+			t.Fatalf("valid target rejected: %+v: %v", f, err)
+		}
+	}
+	bad := []TargetFingerprint{
+		{Kind: FingerprintProcess},                                 // no stable entity id (bare PID not allowed)
+		{Kind: FingerprintFile, FilePath: "/etc/x"},                // path alone is rebindable
+		{Kind: FingerprintFile, FilePath: "/etc/x", FileDevice: 1}, // device-only is not a stable identity
+		{Kind: FingerprintFile, FilePath: "/etc/x", FileInode: 2},  // inode-only is ambiguous across filesystems
+		{Kind: FingerprintFile, FileDevice: 1, FileInode: 2},       // no path
+		{Kind: FingerprintHost},                                    // no host id
+		{Kind: FingerprintHost, HostID: "host-1"},                  // no netpol generation (staleness undetectable)
+		{Kind: "bogus", ProcessEntityID: "pe_x"},
+	}
+	for _, f := range bad {
+		if err := f.Validate(); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("invalid target accepted: %+v", f)
+		}
+	}
+}
+
+func TestRecordAttemptIdempotentAndValidated(t *testing.T) {
+	s := mustSaga(t)
+	a := ResponseAttempt{ActionID: actionID, Attempt: 1, IdempotencyKey: "k1", Target: procTarget(), State: StateExecuting, CommandOutcome: "applied", At: base}
+	if err := s.RecordAttempt(a); err != nil {
+		t.Fatal(err)
+	}
+	// Same idempotency key -> no-op (at-least-once re-issue).
+	if err := s.RecordAttempt(a); err != nil {
+		t.Fatal(err)
+	}
+	if len(s.Attempts()) != 1 {
+		t.Fatalf("duplicate idempotency key must not double-journal, got %d", len(s.Attempts()))
+	}
+	// Same key re-used for a DIFFERENT attempt is rejected (masking it could double-apply a distinct action).
+	divergent := a
+	divergent.CommandOutcome = "different"
+	if err := s.RecordAttempt(divergent); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("re-used idempotency key with a different attempt must be rejected, got %v", err)
+	}
+	if len(s.Attempts()) != 1 {
+		t.Fatalf("a rejected divergent attempt must not be journaled, got %d", len(s.Attempts()))
+	}
+	// Foreign action rejected.
+	if err := s.RecordAttempt(ResponseAttempt{ActionID: "other", Attempt: 1, IdempotencyKey: "k2", Target: procTarget(), State: StateExecuting}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("foreign action attempt must be rejected, got %v", err)
+	}
+	// Invalid attempt (no key) rejected.
+	if err := s.RecordAttempt(ResponseAttempt{ActionID: actionID, Attempt: 1, Target: procTarget(), State: StateExecuting}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("attempt without idempotency key must be rejected, got %v", err)
+	}
+}
+
+func TestNewSagaValidation(t *testing.T) {
+	s := mustSaga(t)
+	if s.ActionID() != actionID || s.Target() != procTarget() || s.Reversibility() != ReversibilityGuaranteed || s.State() != StateProposed {
+		t.Fatalf("new saga getters wrong: %s %+v %s %s", s.ActionID(), s.Target(), s.Reversibility(), s.State())
+	}
+	if _, err := NewSaga("", procTarget(), ReversibilityGuaranteed); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("missing action id must be rejected")
+	}
+	if _, err := NewSaga(actionID, TargetFingerprint{Kind: FingerprintProcess}, ReversibilityGuaranteed); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("invalid target must be rejected")
+	}
+	if _, err := NewSaga(actionID, procTarget(), "bogus"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("invalid reversibility must be rejected")
+	}
+}
+
+func TestOutcomeAndReversibilityValidity(t *testing.T) {
+	if !VerificationSucceeded.Valid() || !VerificationUnknown.Valid() || !VerificationPending.Valid() || VerificationOutcome("x").Valid() {
+		t.Fatal("verification outcome validity wrong")
+	}
+	if !ReversibilityGuaranteed.Valid() || !ReversibilityIrreversible.Valid() || ReversibilityClass("x").Valid() {
+		t.Fatal("reversibility validity wrong")
+	}
+}

--- a/internal/domain/responsesaga/state.go
+++ b/internal/domain/responsesaga/state.go
@@ -1,0 +1,103 @@
+// Package responsesaga is the pure-domain state machine for a GOVERNED response action's full lifecycle
+// (Phase C, C6 #680) — the distributed saga from proposal through approval, agent execution, and a
+// TELEMETRY-VERIFIED post-condition to an optional rollback. Its defining discipline: CommandApplied is
+// NOT VerifiedSucceeded — a successful `kill` syscall is not proof of containment — so a response can only
+// reach StateVerifiedSucceeded by passing through StateVerifying (a telemetry check), never directly from
+// StateCommandApplied. Targets are identified by a stable TargetFingerprint (never a bare PID), and each
+// at-least-once execution attempt is journaled with an idempotency key so a re-issue cannot double-apply.
+//
+// This package owns the saga model + transition rules; the agent-side execution, the live
+// telemetry-verification, and the wiring onto the incident (C1 ResponseRequested/ResponseVerified events)
+// are composed on top of it.
+package responsesaga
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// SagaState is a stage in the governed-response lifecycle.
+type SagaState string
+
+const (
+	StateProposed            SagaState = "proposed"
+	StateAwaitingApproval    SagaState = "awaiting_approval"
+	StateApproved            SagaState = "approved"
+	StateRejected            SagaState = "rejected"
+	StateIssued              SagaState = "issued"
+	StateClaimed             SagaState = "claimed"
+	StateExecuting           SagaState = "executing"
+	StateCommandApplied      SagaState = "command_applied"
+	StateCommandFailed       SagaState = "command_failed"
+	StateVerifying           SagaState = "verifying"
+	StateVerifiedSucceeded   SagaState = "verified_succeeded"
+	StateVerificationFailed  SagaState = "verification_failed"
+	StateVerificationUnknown SagaState = "verification_unknown"
+	StateTimedOut            SagaState = "timed_out"
+	StateRollbackRequested   SagaState = "rollback_requested"
+	StateRollingBack         SagaState = "rolling_back"
+	StateRolledBack          SagaState = "rolled_back"
+	StateRollbackFailed      SagaState = "rollback_failed"
+	// StateCompleted is the terminal state of a telemetry-verified response that was accepted and NOT
+	// reverted, so a contained response reaches a real end state — a worker keying "done" off Terminal()
+	// would otherwise loop forever on a StateVerifiedSucceeded whose only other exit is a rollback.
+	StateCompleted SagaState = "completed"
+)
+
+// transitions is the legal state graph. Crucially, StateVerifiedSucceeded is reachable ONLY from
+// StateVerifying — never from StateCommandApplied — encoding "command applied != post-condition verified".
+// Every post-command verification outcome (failed/unknown/timed-out) can request a conservative rollback.
+var transitions = map[SagaState][]SagaState{
+	StateProposed:            {StateAwaitingApproval, StateRejected},
+	StateAwaitingApproval:    {StateApproved, StateRejected},
+	StateApproved:            {StateIssued},
+	StateRejected:            {},
+	StateIssued:              {StateClaimed},
+	StateClaimed:             {StateExecuting},
+	StateExecuting:           {StateCommandApplied, StateCommandFailed},
+	StateCommandApplied:      {StateVerifying},
+	StateCommandFailed:       {StateRollbackRequested},
+	StateVerifying:           {StateVerifiedSucceeded, StateVerificationFailed, StateVerificationUnknown, StateTimedOut},
+	StateVerifiedSucceeded:   {StateCompleted, StateRollbackRequested},
+	StateVerificationFailed:  {StateRollbackRequested},
+	StateVerificationUnknown: {StateRollbackRequested},
+	StateTimedOut:            {StateRollbackRequested},
+	StateRollbackRequested:   {StateRollingBack},
+	StateRollingBack:         {StateRolledBack, StateRollbackFailed},
+	StateCompleted:           {},
+	StateRolledBack:          {},
+	StateRollbackFailed:      {},
+}
+
+// Valid reports whether s is a known state.
+func (s SagaState) Valid() bool {
+	_, ok := transitions[s]
+	return ok
+}
+
+// Terminal reports whether s has no outgoing transitions.
+func (s SagaState) Terminal() bool {
+	next, ok := transitions[s]
+	return ok && len(next) == 0
+}
+
+// CanTransition reports whether from -> to is a legal saga transition.
+func CanTransition(from, to SagaState) bool {
+	for _, n := range transitions[from] {
+		if n == to {
+			return true
+		}
+	}
+	return false
+}
+
+func requireTransition(from, to SagaState) error {
+	if !to.Valid() {
+		return fmt.Errorf("%w: unknown response saga state %q", shared.ErrValidation, to)
+	}
+	if !CanTransition(from, to) {
+		return fmt.Errorf("%w: illegal response saga transition %s -> %s", shared.ErrValidation, from, to)
+	}
+	return nil
+}

--- a/internal/domain/responsesaga/target.go
+++ b/internal/domain/responsesaga/target.go
@@ -1,0 +1,66 @@
+package responsesaga
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// FingerprintKind is the sort of target a response acts on.
+type FingerprintKind string
+
+const (
+	FingerprintProcess FingerprintKind = "process"
+	FingerprintFile    FingerprintKind = "file"
+	FingerprintHost    FingerprintKind = "host"
+)
+
+// TargetFingerprint stably identifies what a response acts on, so a re-issued action cannot hit the wrong
+// thing after a PID/path is recycled. It is NEVER a bare PID: a process target is the A1 ProcessEntityID
+// (hash of asset+boot+pid+start-time); a file target is device+inode (+optional content hash), not just a
+// rebindable path; a host target is the host id plus the network-policy generation the action assumes, so
+// a stale management-channel change is detectable.
+type TargetFingerprint struct {
+	Kind FingerprintKind
+	// process
+	ProcessEntityID shared.ID
+	// file
+	FilePath   string
+	FileDevice uint64
+	FileInode  uint64
+	FileHash   string
+	// host
+	HostID           shared.ID
+	NetpolGeneration int64
+}
+
+// Validate enforces a stable, non-PID identity appropriate to the kind.
+func (f TargetFingerprint) Validate() error {
+	switch f.Kind {
+	case FingerprintProcess:
+		if f.ProcessEntityID.IsZero() {
+			return fmt.Errorf("%w: process target requires a stable ProcessEntityID (never a bare PID)", shared.ErrValidation)
+		}
+	case FingerprintFile:
+		if f.FilePath == "" {
+			return fmt.Errorf("%w: file target requires a path", shared.ErrValidation)
+		}
+		// A stable file identity is the device+inode PAIR (a device alone names a whole filesystem, an
+		// inode alone is ambiguous across filesystems) or a content hash — never a partial of either.
+		if (f.FileDevice == 0 || f.FileInode == 0) && f.FileHash == "" {
+			return fmt.Errorf("%w: file target requires the device+inode pair or a content hash (a path alone is rebindable)", shared.ErrValidation)
+		}
+	case FingerprintHost:
+		if f.HostID.IsZero() {
+			return fmt.Errorf("%w: host target requires a host id", shared.ErrValidation)
+		}
+		// The netpol generation the action assumes is what makes a stale management-channel change
+		// detectable, so it must be a real (>=1) generation, not the unset zero.
+		if f.NetpolGeneration < 1 {
+			return fmt.Errorf("%w: host target requires the assumed network-policy generation (>=1)", shared.ErrValidation)
+		}
+	default:
+		return fmt.Errorf("%w: unknown target fingerprint kind %q", shared.ErrValidation, f.Kind)
+	}
+	return nil
+}


### PR DESCRIPTION
## C6 (#680) — governed-response saga domain model

Pure-domain state machine (`internal/domain/responsesaga`) for a governed active-response action's full lifecycle: `proposed → awaiting_approval → approved → issued → claimed → executing → command_applied → verifying → verified_succeeded | verification_failed | verification_unknown | timed_out → (completed | rollback…)`.

### Crown safety invariant
**CommandApplied ≠ VerifiedSucceeded.** A successful `kill`/quarantine/isolate command is not proof of containment, so `verified_succeeded` is reachable **only** through the telemetry `verifying` step. The saga's safety-critical fields (`state`, `target`, `actionID`, `reversibility`) are **unexported** — `Transition` is the sole path to advance state, so a caller cannot assign `state = verified_succeeded` directly and fabricate a "contained" verdict that skipped verification. `Contained()` is true only at `verified_succeeded`/`completed`.

### What it models
- **TargetFingerprint** — never a bare PID: process = A1 `ProcessEntityID`; file = device+inode **pair** (or content hash), not a rebindable path; host = host id + assumed netpol generation (staleness-detectable).
- **VerificationOutcome** — explicit `unknown_insufficient_coverage`, not treated as success.
- **ReversibilityClass** — declared up front (guaranteed/compensating/best_effort/irreversible).
- **ResponseAttempt journal** — idempotent by `IdempotencyKey` (at-least-once re-issue does not double-apply); a key re-used for a **different** attempt is rejected, not silently masked.
- Terminal `completed` so a contained saga reaches a real end state (a worker keying "done" off `Terminal()` cannot loop).

### Discipline
Pure domain — imports only `domain/shared` + stdlib. Fail-closed `Validate()` on every type, no panic, no clock/I/O. Agent-side execution, live telemetry verification, and incident wiring are composed on top in the deferred Linux-agent tail.

### Verification
`gofmt`/`build`/`vet` clean; `go test -race -cover` green at **93.3%**. Dual-reviewed (go-arch + security); all findings folded in — unexported fields (HIGH), device+inode pair (MEDIUM), struct-literal nil-map guard (MEDIUM), host netpol generation (LOW), divergent-key idempotency (LOW), `completed` terminal.

CI is off by request — validated locally.
