### PR TITLE
feat(edr): complete retro-hunt coverage and incident triage HTTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Coverage-honest incident investigation and analyst triage.** Runtime detections can pivot to a
+  deterministic surrounding endpoint State Timeline with explicit sampled, gapped, lost, expired, and
+  capped-window coverage signals. Tenant-scoped incident APIs now expose projections and immutable event
+  history, while review-gated owner, comment, state, and disposition mutations append attributable events
+  under optimistic concurrency without coupling disposition to risk.
+
 - **Independent signed agent detection delivery.** Confirmed detections now drain from an isolated P1
   WAL lane into crash-recoverable batches, using an agent-owned Ed25519 key registered with
   proof-of-possession. Pending sequence/membership survives restart and lost responses, local records

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -44,6 +44,8 @@ tags:
   description: Risk-based remediation deadlines, immutable assessments, policy versions, and human-owned lifecycle governance
 - name: fleet
   description: Enrolled-agent transport and operator fleet administration
+- name: incidents
+  description: Tenant-scoped runtime incidents, immutable event history, and human triage
 
 paths:
   /healthz:
@@ -1912,6 +1914,152 @@ paths:
         '403': {$ref: '#/components/responses/Forbidden'}
         '404': {$ref: '#/components/responses/NotFound'}
 
+  /api/v1/incidents:
+    get:
+      tags: [incidents]
+      operationId: listIncidents
+      summary: List tenant-scoped runtime incidents
+      parameters:
+      - name: asset_id
+        in: query
+        schema: {type: string, minLength: 1}
+        description: Optional exact asset filter
+      - name: limit
+        in: query
+        schema: {type: integer, minimum: 1, maximum: 100, default: 100}
+      responses:
+        '200':
+          description: Stable incident-id-ordered result
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/IncidentList'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '500': {$ref: '#/components/responses/InternalServerError'}
+
+  /api/v1/incidents/{id}:
+    parameters:
+    - $ref: '#/components/parameters/IncidentId'
+    get:
+      tags: [incidents]
+      operationId: getIncident
+      summary: Get the current event-sourced incident projection
+      responses:
+        '200':
+          description: Current incident projection
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/Incident'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '500': {$ref: '#/components/responses/InternalServerError'}
+
+  /api/v1/incidents/{id}/events:
+    parameters:
+    - $ref: '#/components/parameters/IncidentId'
+    get:
+      tags: [incidents]
+      operationId: getIncidentEventHistory
+      summary: Get the immutable attributable incident event log
+      responses:
+        '200':
+          description: Events in ascending revision order
+          content:
+            application/json:
+              schema: {$ref: '#/components/schemas/IncidentEventList'}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '500': {$ref: '#/components/responses/InternalServerError'}
+
+  /api/v1/incidents/{id}/owner:
+    parameters:
+    - $ref: '#/components/parameters/IncidentId'
+    put:
+      tags: [incidents]
+      operationId: changeIncidentOwner
+      summary: Assign an incident owner through an append-only event
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/IncidentOwnerMutation'}
+      responses:
+        '200': {description: Updated incident projection, content: {application/json: {schema: {$ref: '#/components/schemas/Incident'}}}}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {description: Expected revision is stale, content: {application/json: {schema: {$ref: '#/components/schemas/Error'}}}}
+        '500': {$ref: '#/components/responses/InternalServerError'}
+
+  /api/v1/incidents/{id}/comments:
+    parameters:
+    - $ref: '#/components/parameters/IncidentId'
+    post:
+      tags: [incidents]
+      operationId: addIncidentComment
+      summary: Append an attributable analyst comment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/IncidentCommentMutation'}
+      responses:
+        '200': {description: Updated incident projection, content: {application/json: {schema: {$ref: '#/components/schemas/Incident'}}}}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {description: Expected revision is stale, content: {application/json: {schema: {$ref: '#/components/schemas/Error'}}}}
+        '500': {$ref: '#/components/responses/InternalServerError'}
+
+  /api/v1/incidents/{id}/state:
+    parameters:
+    - $ref: '#/components/parameters/IncidentId'
+    post:
+      tags: [incidents]
+      operationId: changeIncidentState
+      summary: Advance the incident through the legal workflow graph
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/IncidentStateMutation'}
+      responses:
+        '200': {description: Updated incident projection, content: {application/json: {schema: {$ref: '#/components/schemas/Incident'}}}}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {description: Expected revision is stale, content: {application/json: {schema: {$ref: '#/components/schemas/Error'}}}}
+        '500': {$ref: '#/components/responses/InternalServerError'}
+
+  /api/v1/incidents/{id}/disposition:
+    parameters:
+    - $ref: '#/components/parameters/IncidentId'
+    post:
+      tags: [incidents]
+      operationId: setIncidentDisposition
+      summary: Set the analyst verdict without changing workflow state or risk
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/IncidentDispositionMutation'}
+      responses:
+        '200': {description: Updated incident projection, content: {application/json: {schema: {$ref: '#/components/schemas/Incident'}}}}
+        '400': {$ref: '#/components/responses/BadRequest'}
+        '401': {$ref: '#/components/responses/Unauthorized'}
+        '403': {$ref: '#/components/responses/Forbidden'}
+        '404': {$ref: '#/components/responses/NotFound'}
+        '409': {description: Expected revision is stale, content: {application/json: {schema: {$ref: '#/components/schemas/Error'}}}}
+        '500': {$ref: '#/components/responses/InternalServerError'}
+
 components:
   securitySchemes:
     bearerAuth:
@@ -1946,6 +2094,11 @@ components:
       schema: {type: string, minLength: 1}
     AITriageReviewId:
       name: rid
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
+    IncidentId:
+      name: id
       in: path
       required: true
       schema: {type: string, minLength: 1}
@@ -2145,6 +2298,166 @@ components:
           additionalProperties:
             type: string
             enum: [ok, failed]
+
+    IncidentState:
+      type: string
+      enum: [new, open, triaged, investigating, contained, remediated, resolved, closed, reopened]
+
+    IncidentDisposition:
+      type: string
+      enum: [unknown, true_positive, benign_positive, false_positive, duplicate, test]
+
+    IncidentRiskAssessment:
+      type: object
+      additionalProperties: false
+      required: [assessment_id, incident_revision, scorer_version, policy_version, input_snapshot_hash, risk, confidence, coverage, coverage_vector, context, factor_contributions, reason_codes, created_at]
+      properties:
+        assessment_id: {type: string}
+        incident_revision: {type: integer, minimum: 0}
+        scorer_version: {type: string}
+        policy_version: {type: string}
+        input_snapshot_hash: {type: string}
+        risk: {type: integer, minimum: 0, maximum: 100}
+        confidence: {type: integer, minimum: 0, maximum: 100}
+        coverage: {type: integer, minimum: 0, maximum: 100}
+        coverage_vector:
+          type: object
+          additionalProperties: false
+          required: [process, network, file, privilege, reasons]
+          properties:
+            process: {type: integer, minimum: 0, maximum: 100}
+            network: {type: integer, minimum: 0, maximum: 100}
+            file: {type: integer, minimum: 0, maximum: 100}
+            privilege: {type: integer, minimum: 0, maximum: 100}
+            reasons: {type: array, items: {type: string}}
+        context:
+          type: object
+          additionalProperties: false
+          required: [threat, exposure, behavior]
+          properties:
+            threat: {type: integer, minimum: 0, maximum: 100}
+            exposure: {type: integer, minimum: 0, maximum: 100}
+            behavior: {type: integer, minimum: 0, maximum: 100}
+        factor_contributions:
+          type: array
+          items:
+            type: object
+            additionalProperties: false
+            required: [factor, points, reason]
+            properties:
+              factor: {type: string}
+              points: {type: integer, minimum: 0, maximum: 100}
+              reason: {type: string}
+        reason_codes: {type: array, items: {type: string}}
+        created_at: {type: string, format: date-time}
+
+    IncidentComment:
+      type: object
+      additionalProperties: false
+      required: [at, actor, text]
+      properties:
+        at: {type: string, format: date-time}
+        actor: {type: string, minLength: 1, maxLength: 256}
+        text: {type: string, minLength: 1, maxLength: 8192}
+
+    IncidentResponseRef:
+      type: object
+      additionalProperties: false
+      required: [action_id, verified]
+      properties:
+        action_id: {type: string}
+        verified: {type: boolean}
+
+    Incident:
+      type: object
+      additionalProperties: false
+      required: [id, asset_id, title, severity, state, disposition, owner_id, detection_ids, comments, responses, revision, created_at, updated_at]
+      properties:
+        id: {type: string, minLength: 1}
+        asset_id: {type: string, minLength: 1}
+        title: {type: string}
+        severity: {type: string, enum: ['', unknown, info, low, medium, high, critical]}
+        state: {$ref: '#/components/schemas/IncidentState'}
+        disposition: {$ref: '#/components/schemas/IncidentDisposition'}
+        owner_id: {type: string, maxLength: 256}
+        detection_ids: {type: array, items: {type: string}}
+        risk: {$ref: '#/components/schemas/IncidentRiskAssessment'}
+        merged_into: {type: string}
+        comments: {type: array, items: {$ref: '#/components/schemas/IncidentComment'}}
+        responses: {type: array, items: {$ref: '#/components/schemas/IncidentResponseRef'}}
+        revision: {type: integer, minimum: 1}
+        created_at: {type: string, format: date-time}
+        updated_at: {type: string, format: date-time}
+
+    IncidentList:
+      type: object
+      additionalProperties: false
+      required: [incidents]
+      properties:
+        incidents: {type: array, items: {$ref: '#/components/schemas/Incident'}}
+
+    IncidentEvent:
+      type: object
+      additionalProperties: false
+      required: [revision, kind, at, actor]
+      properties:
+        revision: {type: integer, minimum: 1}
+        kind:
+          type: string
+          enum: [created, detection_attached, detection_detached, status_changed, owner_changed, disposition_set, risk_reassessed, analyst_commented, merged, response_requested, response_verified]
+        at: {type: string, format: date-time}
+        actor: {type: string, minLength: 1, maxLength: 256}
+        asset_id: {type: string}
+        title: {type: string}
+        severity: {type: string, enum: [unknown, info, low, medium, high, critical]}
+        detection_id: {type: string}
+        to: {$ref: '#/components/schemas/IncidentState'}
+        owner: {type: string, maxLength: 256}
+        disposition: {$ref: '#/components/schemas/IncidentDisposition'}
+        risk: {$ref: '#/components/schemas/IncidentRiskAssessment'}
+        comment: {type: string, maxLength: 8192}
+        merged_into: {type: string}
+        response_action_id: {type: string}
+        verified: {type: boolean}
+
+    IncidentEventList:
+      type: object
+      additionalProperties: false
+      required: [events]
+      properties:
+        events: {type: array, items: {$ref: '#/components/schemas/IncidentEvent'}}
+
+    IncidentOwnerMutation:
+      type: object
+      additionalProperties: false
+      required: [owner, expected_revision]
+      properties:
+        owner: {type: string, minLength: 1, maxLength: 256}
+        expected_revision: {type: integer, minimum: 1}
+
+    IncidentCommentMutation:
+      type: object
+      additionalProperties: false
+      required: [comment, expected_revision]
+      properties:
+        comment: {type: string, minLength: 1, maxLength: 8192}
+        expected_revision: {type: integer, minimum: 1}
+
+    IncidentStateMutation:
+      type: object
+      additionalProperties: false
+      required: [state, expected_revision]
+      properties:
+        state: {$ref: '#/components/schemas/IncidentState'}
+        expected_revision: {type: integer, minimum: 1}
+
+    IncidentDispositionMutation:
+      type: object
+      additionalProperties: false
+      required: [disposition, expected_revision]
+      properties:
+        disposition: {$ref: '#/components/schemas/IncidentDisposition'}
+        expected_revision: {type: integer, minimum: 1}
 
     SLATier:
       type: string

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -111,6 +111,8 @@ import (
 	coverageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/coverage"
 	detectledger "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectledger"
 	hostinventoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/hostinventory"
+	incidenttriage "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/incidenttriage"
+	incidentuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/incidentuc"
 	keyregistry "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/keyregistry"
 	telemetryingest "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/telemetryingest"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
@@ -264,6 +266,7 @@ func main() {
 	var fleetAgentStore ports.FleetAgentStore
 	var agentSigningKeyStore ports.AgentSigningKeyStore       // A0.2 signing-key registry (A3 resolve+verify)
 	var telemetryTransportStore ports.TelemetryTransportStore // A3 telemetry transport sequencing state
+	var incidentEventStore ports.IncidentEventStore           // C7 append-only incident event log
 	var fleetRolloutStore ports.FleetRolloutStore             // operator update-rollout plans (#412 req 9)
 	var leaderStore ports.LeaderStore                         // postgres only; nil in memory mode (single process)
 	var findingRepo ports.FindingRepository
@@ -435,6 +438,7 @@ func main() {
 		fleetAgentStore = postgres.NewFleetAgentRepository(pool)
 		agentSigningKeyStore = postgres.NewAgentSigningKeyRepository(pool)
 		telemetryTransportStore = postgres.NewTelemetryTransportRepository(pool)
+		incidentEventStore = postgres.NewIncidentEventRepository(pool)
 		fleetRolloutStore = postgres.NewFleetRolloutRepository(pool)
 		leaderStore = postgres.NewLeaderStore(pool)
 		// SECURITY (#431 req 6, #432, #409): the fleet_* tables are RLS-protected, but RLS is a
@@ -486,6 +490,7 @@ func main() {
 		fleetAgentStore = memory.NewFleetAgentStore()
 		agentSigningKeyStore = memory.NewAgentSigningKeyStore()
 		telemetryTransportStore = memory.NewTelemetryTransportStore()
+		incidentEventStore = memory.NewIncidentEventStore()
 		fleetRolloutStore = memory.NewFleetRolloutStore()
 		findingRepo = memory.NewFindingRepository()
 		judgmentStore = memory.NewJudgmentStore()
@@ -961,6 +966,17 @@ func main() {
 		os.Exit(1)
 	}
 	router := httpapi.NewRouter(log, auth, engService, scaService, aupService, findingsService, exportService, reportService, evidenceService, reconService, logBroker, transferService, auditService, vexService, usersService, credentialsService)
+	incidentService, err := incidentuc.NewService(incidentEventStore)
+	if err != nil {
+		log.Error("incident service init failed", "err", err)
+		os.Exit(1)
+	}
+	incidentTriageService, err := incidenttriage.NewService(incidentService, auditLog, clock.Now)
+	if err != nil {
+		log.Error("incident triage service init failed", "err", err)
+		os.Exit(1)
+	}
+	router.SetIncidents(incidentService, incidentTriageService)
 	if cfg.OIDCEnabled {
 		provider, oidcErr := oidcadapter.New(context.Background(), oidcadapter.Config{
 			Issuer: cfg.OIDCIssuer, ClientID: cfg.OIDCClientID, ClientSecret: cfg.OIDCClientSecret,

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -359,10 +359,12 @@ func TestHostileHarness(t *testing.T) {
 	rt.SetThreatModel(&fakeThreatModel{})     // register the threat-model ingest/read routes so the harness guards their gates
 	rt.SetWriteupDrafts(&fakeWriteupDrafts{}) // register the writeup-draft sign-off routes so the harness guards their SoD gates
 	rt.SetAITriageReviews(&aiReviewFake{})    // register AI-triage queue read/claim/decision routes
-	rt.SetRules(&fakeRules{})                 // register rule catalog routes so the harness guards their gates
-	rt.SetFleetCoverage(harnessCoverage{})    // register #413 fleet-coverage routes so the harness guards their view/tenant gates
-	rt.SetAttackPaths(attackSvc)              // real #419 service proves cross-tenant derived data isolation
-	rt.SetSARIFIngest(harnessSARIF{})         // register the #415 import route so the harness guards its operate/tenant gates
+	incidentFake := &incidentHTTPFake{}
+	rt.SetIncidents(incidentFake, incidentFake) // register incident read/triage routes (#679)
+	rt.SetRules(&fakeRules{})                   // register rule catalog routes so the harness guards their gates
+	rt.SetFleetCoverage(harnessCoverage{})      // register #413 fleet-coverage routes so the harness guards their view/tenant gates
+	rt.SetAttackPaths(attackSvc)                // real #419 service proves cross-tenant derived data isolation
+	rt.SetSARIFIngest(harnessSARIF{})           // register the #415 import route so the harness guards its operate/tenant gates
 	rt.SetImportedFindings(harnessImportedFindings{})
 	rt.SetDetectionReader(harnessDetections{})  // register the #423 detection-ledger read route
 	rt.SetPurpleCoverageReader(harnessPurple{}) // register the #426 purple-coverage read route
@@ -515,6 +517,12 @@ func TestHostileHarness(t *testing.T) {
 		{"readonly may list AI-triage reviews (view)", "readonly", "tenantA", true, http.MethodGet, "/api/v1/ai-triage/reviews", http.StatusOK},
 		{"machine may not claim AI-triage review (review/SoD)", "agent", "tenantA", true, http.MethodPost, "/api/v1/ai-triage/reviews/r1/claim", http.StatusForbidden},
 		{"consultant may not decide AI-triage review (review)", "consultant", "tenantA", true, http.MethodPost, "/api/v1/ai-triage/reviews/r1/decision", http.StatusForbidden},
+		// Incident mutations are human review actions. The HTTP surface intentionally exposes only
+		// owner/comment/state/disposition, never a generic event append that could mint response events.
+		{"readonly may list incidents (view)", "readonly", "tenantA", true, http.MethodGet, "/api/v1/incidents", http.StatusOK},
+		{"machine may not list incidents (view/SoD)", "agent", "tenantA", true, http.MethodGet, "/api/v1/incidents", http.StatusForbidden},
+		{"consultant may not set incident disposition (review)", "consultant", "tenantA", true, http.MethodPost, "/api/v1/incidents/inc-1/disposition", http.StatusForbidden},
+		{"machine may not set incident disposition (review/SoD)", "mcp", "tenantA", true, http.MethodPost, "/api/v1/incidents/inc-1/disposition", http.StatusForbidden},
 		// Rule Catalog (PermView): no tenant context required, but machine roles denied.
 		{"machine may not list rules (view/SoD)", "agent", "tenantA", true, http.MethodGet, "/api/v1/rules", http.StatusForbidden},
 		{"machine may not get rule (view/SoD)", "agent", "tenantA", true, http.MethodGet, "/api/v1/rules/go:sql-injection", http.StatusForbidden},

--- a/internal/adapter/httpapi/incident_handler.go
+++ b/internal/adapter/httpapi/incident_handler.go
@@ -1,0 +1,358 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const incidentMutationBodyCap = 16 << 10
+
+type incidentCommentResponse struct {
+	At    time.Time `json:"at"`
+	Actor string    `json:"actor"`
+	Text  string    `json:"text"`
+}
+
+type incidentResponseRefResponse struct {
+	ActionID string `json:"action_id"`
+	Verified bool   `json:"verified"`
+}
+
+type incidentCoverageVectorResponse struct {
+	Process   riskassessment.Score `json:"process"`
+	Network   riskassessment.Score `json:"network"`
+	File      riskassessment.Score `json:"file"`
+	Privilege riskassessment.Score `json:"privilege"`
+	Reasons   []string             `json:"reasons"`
+}
+
+type incidentRiskContextResponse struct {
+	Threat   riskassessment.Score `json:"threat"`
+	Exposure riskassessment.Score `json:"exposure"`
+	Behavior riskassessment.Score `json:"behavior"`
+}
+
+type incidentFactorContributionResponse struct {
+	Factor string               `json:"factor"`
+	Points riskassessment.Score `json:"points"`
+	Reason string               `json:"reason"`
+}
+
+type incidentRiskResponse struct {
+	AssessmentID        string                               `json:"assessment_id"`
+	IncidentRevision    int                                  `json:"incident_revision"`
+	ScorerVersion       string                               `json:"scorer_version"`
+	PolicyVersion       string                               `json:"policy_version"`
+	InputSnapshotHash   string                               `json:"input_snapshot_hash"`
+	Risk                riskassessment.Score                 `json:"risk"`
+	Confidence          riskassessment.Score                 `json:"confidence"`
+	Coverage            riskassessment.Score                 `json:"coverage"`
+	CoverageVector      incidentCoverageVectorResponse       `json:"coverage_vector"`
+	Context             incidentRiskContextResponse          `json:"context"`
+	FactorContributions []incidentFactorContributionResponse `json:"factor_contributions"`
+	ReasonCodes         []string                             `json:"reason_codes"`
+	CreatedAt           time.Time                            `json:"created_at"`
+}
+
+type incidentResponse struct {
+	ID           string                        `json:"id"`
+	AssetID      string                        `json:"asset_id"`
+	Title        string                        `json:"title"`
+	Severity     shared.Severity               `json:"severity"`
+	State        incident.State                `json:"state"`
+	Disposition  incident.Disposition          `json:"disposition"`
+	OwnerID      string                        `json:"owner_id"`
+	DetectionIDs []shared.ID                   `json:"detection_ids"`
+	Risk         *incidentRiskResponse         `json:"risk,omitempty"`
+	MergedInto   string                        `json:"merged_into,omitempty"`
+	Comments     []incidentCommentResponse     `json:"comments"`
+	Responses    []incidentResponseRefResponse `json:"responses"`
+	Revision     int                           `json:"revision"`
+	CreatedAt    time.Time                     `json:"created_at"`
+	UpdatedAt    time.Time                     `json:"updated_at"`
+}
+
+type incidentEventResponse struct {
+	Revision         int                   `json:"revision"`
+	Kind             incident.EventKind    `json:"kind"`
+	At               time.Time             `json:"at"`
+	Actor            string                `json:"actor"`
+	AssetID          string                `json:"asset_id,omitempty"`
+	Title            string                `json:"title,omitempty"`
+	Severity         shared.Severity       `json:"severity,omitempty"`
+	DetectionID      string                `json:"detection_id,omitempty"`
+	To               incident.State        `json:"to,omitempty"`
+	Owner            string                `json:"owner,omitempty"`
+	Disposition      incident.Disposition  `json:"disposition,omitempty"`
+	Risk             *incidentRiskResponse `json:"risk,omitempty"`
+	Comment          string                `json:"comment,omitempty"`
+	MergedInto       string                `json:"merged_into,omitempty"`
+	ResponseActionID string                `json:"response_action_id,omitempty"`
+	Verified         *bool                 `json:"verified,omitempty"`
+}
+
+func (rt *Router) listIncidents(w http.ResponseWriter, r *http.Request) {
+	assetID, limit, err := incidentListParams(r)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	items, err := rt.incidents.ListByAsset(r.Context(), assetID, limit)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	out := make([]incidentResponse, len(items))
+	for i, item := range items {
+		out[i] = incidentDTO(item)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"incidents": out})
+}
+
+func (rt *Router) getIncident(w http.ResponseWriter, r *http.Request) {
+	id, err := incidentPathID(r)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	item, err := rt.incidents.Get(r.Context(), id)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, incidentDTO(item))
+}
+
+func (rt *Router) incidentHistory(w http.ResponseWriter, r *http.Request) {
+	id, err := incidentPathID(r)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	events, err := rt.incidents.History(r.Context(), id)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	out := make([]incidentEventResponse, len(events))
+	for i, event := range events {
+		out[i] = incidentEventDTO(event, i+1)
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"events": out})
+}
+
+func (rt *Router) changeIncidentOwner(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Owner            string `json:"owner"`
+		ExpectedRevision int    `json:"expected_revision"`
+	}
+	if !decodeIncidentMutation(w, r, &body) {
+		return
+	}
+	id, err := incidentPathID(r)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	if err := rt.requireIncidentRevision(r.Context(), id, body.ExpectedRevision); err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	updated, err := rt.incidentTriage.AssignOwner(r.Context(), PrincipalFrom(r.Context()), id, strings.TrimSpace(body.Owner))
+	writeIncidentMutation(w, rt, updated, err)
+}
+
+func (rt *Router) addIncidentComment(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Comment          string `json:"comment"`
+		ExpectedRevision int    `json:"expected_revision"`
+	}
+	if !decodeIncidentMutation(w, r, &body) {
+		return
+	}
+	id, err := incidentPathID(r)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	if err := rt.requireIncidentRevision(r.Context(), id, body.ExpectedRevision); err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	updated, err := rt.incidentTriage.Comment(r.Context(), PrincipalFrom(r.Context()), id, strings.TrimSpace(body.Comment))
+	writeIncidentMutation(w, rt, updated, err)
+}
+
+func (rt *Router) changeIncidentState(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		State            incident.State `json:"state"`
+		ExpectedRevision int            `json:"expected_revision"`
+	}
+	if !decodeIncidentMutation(w, r, &body) {
+		return
+	}
+	id, err := incidentPathID(r)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	if err := rt.requireIncidentRevision(r.Context(), id, body.ExpectedRevision); err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	updated, err := rt.incidentTriage.ChangeStatus(r.Context(), PrincipalFrom(r.Context()), id, body.State)
+	writeIncidentMutation(w, rt, updated, err)
+}
+
+func (rt *Router) setIncidentDisposition(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Disposition      incident.Disposition `json:"disposition"`
+		ExpectedRevision int                  `json:"expected_revision"`
+	}
+	if !decodeIncidentMutation(w, r, &body) {
+		return
+	}
+	id, err := incidentPathID(r)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	if err := rt.requireIncidentRevision(r.Context(), id, body.ExpectedRevision); err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	updated, err := rt.incidentTriage.SetDisposition(r.Context(), PrincipalFrom(r.Context()), id, body.Disposition)
+	writeIncidentMutation(w, rt, updated, err)
+}
+
+func decodeIncidentMutation(w http.ResponseWriter, r *http.Request, target any) bool {
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, incidentMutationBodyCap))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
+		return false
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
+		return false
+	}
+	return true
+}
+
+func writeIncidentMutation(w http.ResponseWriter, rt *Router, updated incident.Incident, err error) {
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, incidentDTO(updated))
+}
+
+func (rt *Router) requireIncidentRevision(ctx context.Context, id shared.ID, expected int) error {
+	if expected < 1 {
+		return fmt.Errorf("%w: expected revision must be at least 1", shared.ErrValidation)
+	}
+	current, err := rt.incidents.Get(ctx, id)
+	if err != nil {
+		return err
+	}
+	if current.Revision != expected {
+		return fmt.Errorf("%w: incident %s at revision %d, expected %d", shared.ErrConflict, id, current.Revision, expected)
+	}
+	return nil
+}
+
+func incidentPathID(r *http.Request) (shared.ID, error) {
+	id := shared.ID(strings.TrimSpace(r.PathValue("id")))
+	if id.IsZero() {
+		return "", fmt.Errorf("%w: incident id is required", shared.ErrValidation)
+	}
+	return id, nil
+}
+
+func incidentListParams(r *http.Request) (shared.ID, int, error) {
+	for key := range r.URL.Query() {
+		if key != "asset_id" && key != "limit" {
+			return "", 0, fmt.Errorf("%w: unsupported query parameter: %s", shared.ErrValidation, key)
+		}
+	}
+	assetID := shared.ID(strings.TrimSpace(r.URL.Query().Get("asset_id")))
+	limit := 100
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil || parsed < 1 || parsed > 100 {
+			return "", 0, fmt.Errorf("%w: limit must be between 1 and 100", shared.ErrValidation)
+		}
+		limit = parsed
+	}
+	return assetID, limit, nil
+}
+
+func incidentDTO(item incident.Incident) incidentResponse {
+	out := incidentResponse{
+		ID: item.ID.String(), AssetID: item.AssetID.String(), Title: item.Title, Severity: item.Severity,
+		State: item.State, Disposition: item.Disposition, OwnerID: item.OwnerID,
+		DetectionIDs: append([]shared.ID{}, item.DetectionIDs...), MergedInto: item.MergedInto.String(),
+		Revision: item.Revision, CreatedAt: item.CreatedAt, UpdatedAt: item.UpdatedAt,
+		Comments:  make([]incidentCommentResponse, len(item.Comments)),
+		Responses: make([]incidentResponseRefResponse, len(item.Responses)),
+	}
+	for i, comment := range item.Comments {
+		out.Comments[i] = incidentCommentResponse{At: comment.At, Actor: comment.Actor, Text: comment.Text}
+	}
+	for i, response := range item.Responses {
+		out.Responses[i] = incidentResponseRefResponse{ActionID: response.ActionID.String(), Verified: response.Verified}
+	}
+	if item.Risk != nil {
+		out.Risk = incidentRiskDTO(*item.Risk)
+	}
+	return out
+}
+
+func incidentEventDTO(event incident.IncidentEvent, revision int) incidentEventResponse {
+	out := incidentEventResponse{
+		Revision: revision, Kind: event.Kind, At: event.At, Actor: event.Actor,
+		AssetID: event.AssetID.String(), Title: event.Title, Severity: event.Severity,
+		DetectionID: event.DetectionID.String(), To: event.To, Owner: event.Owner,
+		Disposition: event.Disposition, Comment: event.Comment, MergedInto: event.MergedInto.String(),
+		ResponseActionID: event.ResponseActionID.String(),
+	}
+	if event.Risk != nil {
+		out.Risk = incidentRiskDTO(*event.Risk)
+	}
+	if event.Kind == incident.EventResponseVerified {
+		verified := event.Verified
+		out.Verified = &verified
+	}
+	return out
+}
+
+func incidentRiskDTO(risk riskassessment.RiskAssessment) *incidentRiskResponse {
+	out := &incidentRiskResponse{
+		AssessmentID: risk.AssessmentID.String(), IncidentRevision: risk.IncidentRevision,
+		ScorerVersion: risk.ScorerVersion, PolicyVersion: risk.PolicyVersion,
+		InputSnapshotHash: risk.InputSnapshotHash, Risk: risk.Risk, Confidence: risk.Confidence,
+		Coverage: risk.Coverage,
+		CoverageVector: incidentCoverageVectorResponse{
+			Process: risk.CoverageVector.Process, Network: risk.CoverageVector.Network,
+			File: risk.CoverageVector.File, Privilege: risk.CoverageVector.Privilege,
+			Reasons: append([]string{}, risk.CoverageVector.Reasons...),
+		},
+		Context:             incidentRiskContextResponse{Threat: risk.Context.Threat, Exposure: risk.Context.Exposure, Behavior: risk.Context.Behavior},
+		FactorContributions: make([]incidentFactorContributionResponse, len(risk.FactorContributions)),
+		ReasonCodes:         append([]string{}, risk.ReasonCodes...), CreatedAt: risk.CreatedAt,
+	}
+	for i, factor := range risk.FactorContributions {
+		out.FactorContributions[i] = incidentFactorContributionResponse{Factor: factor.Factor, Points: factor.Points, Reason: factor.Reason}
+	}
+	return out
+}

--- a/internal/adapter/httpapi/incident_handler_test.go
+++ b/internal/adapter/httpapi/incident_handler_test.go
@@ -1,0 +1,189 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type incidentHTTPFake struct {
+	lastAction      string
+	lastID          shared.ID
+	lastActor       string
+	lastValue       string
+	lastAsset       shared.ID
+	lastLimit       int
+	mutationInvoked bool
+}
+
+func (f *incidentHTTPFake) item() incident.Incident {
+	return incident.Incident{
+		ID: "inc-1", AssetID: "asset-1", Title: "Suspicious process", Severity: shared.SeverityHigh,
+		State: incident.StateNew, Disposition: incident.DispositionUnknown, Revision: 2,
+		CreatedAt: time.Unix(100, 0).UTC(), UpdatedAt: time.Unix(101, 0).UTC(),
+	}
+}
+
+func (f *incidentHTTPFake) Get(_ context.Context, id shared.ID) (incident.Incident, error) {
+	f.lastID = id
+	return f.item(), nil
+}
+
+func (f *incidentHTTPFake) ListByAsset(_ context.Context, asset shared.ID, limit int) ([]incident.Incident, error) {
+	f.lastAsset, f.lastLimit = asset, limit
+	return []incident.Incident{f.item()}, nil
+}
+
+func (f *incidentHTTPFake) History(_ context.Context, id shared.ID) ([]incident.IncidentEvent, error) {
+	f.lastID = id
+	return []incident.IncidentEvent{{IncidentID: id, Kind: incident.EventCreated, At: time.Unix(100, 0).UTC(), Actor: "correlator", AssetID: "asset-1"}}, nil
+}
+
+func (f *incidentHTTPFake) mutated(action string, id shared.ID, actor, value string) (incident.Incident, error) {
+	f.lastAction, f.lastID, f.lastActor, f.lastValue = action, id, actor, value
+	f.mutationInvoked = true
+	item := f.item()
+	item.Revision++
+	return item, nil
+}
+
+func (f *incidentHTTPFake) AssignOwner(_ context.Context, actor string, id shared.ID, owner string) (incident.Incident, error) {
+	return f.mutated("owner", id, actor, owner)
+}
+
+func (f *incidentHTTPFake) Comment(_ context.Context, actor string, id shared.ID, comment string) (incident.Incident, error) {
+	return f.mutated("comment", id, actor, comment)
+}
+
+func (f *incidentHTTPFake) ChangeStatus(_ context.Context, actor string, id shared.ID, state incident.State) (incident.Incident, error) {
+	return f.mutated("state", id, actor, string(state))
+}
+
+func (f *incidentHTTPFake) SetDisposition(_ context.Context, actor string, id shared.ID, disposition incident.Disposition) (incident.Incident, error) {
+	return f.mutated("disposition", id, actor, string(disposition))
+}
+
+func TestIncidentReadHandlers(t *testing.T) {
+	fake := &incidentHTTPFake{}
+	rt := &Router{log: discardLog(), incidents: fake}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/incidents?asset_id=asset-1&limit=25", nil)
+	rec := httptest.NewRecorder()
+	rt.listIncidents(rec, req)
+	if rec.Code != http.StatusOK || fake.lastAsset != "asset-1" || fake.lastLimit != 25 {
+		t.Fatalf("list: status=%d asset=%s limit=%d body=%s", rec.Code, fake.lastAsset, fake.lastLimit, rec.Body.String())
+	}
+	var listed struct {
+		Incidents []incidentResponse `json:"incidents"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &listed); err != nil || len(listed.Incidents) != 1 || listed.Incidents[0].ID != "inc-1" {
+		t.Fatalf("list response: %+v err=%v", listed, err)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/incidents/inc-1/events", nil)
+	req.SetPathValue("id", "inc-1")
+	rec = httptest.NewRecorder()
+	rt.incidentHistory(rec, req)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), `"revision":1`) || !strings.Contains(rec.Body.String(), `"kind":"created"`) {
+		t.Fatalf("history: status=%d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestIncidentMutationHandlersMapAuthenticatedActor(t *testing.T) {
+	cases := []struct {
+		name, method, path, body, action, value string
+		handler                                 func(*Router, http.ResponseWriter, *http.Request)
+	}{
+		{"owner", http.MethodPut, "/api/v1/incidents/inc-1/owner", `{"owner":"bob","expected_revision":2}`, "owner", "bob", (*Router).changeIncidentOwner},
+		{"comment", http.MethodPost, "/api/v1/incidents/inc-1/comments", `{"comment":"investigating","expected_revision":2}`, "comment", "investigating", (*Router).addIncidentComment},
+		{"state", http.MethodPost, "/api/v1/incidents/inc-1/state", `{"state":"investigating","expected_revision":2}`, "state", "investigating", (*Router).changeIncidentState},
+		{"disposition", http.MethodPost, "/api/v1/incidents/inc-1/disposition", `{"disposition":"true_positive","expected_revision":2}`, "disposition", "true_positive", (*Router).setIncidentDisposition},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &incidentHTTPFake{}
+			rt := &Router{log: discardLog(), incidents: fake, incidentTriage: fake}
+			req := httptest.NewRequest(tc.method, tc.path, strings.NewReader(tc.body))
+			req.SetPathValue("id", "inc-1")
+			req = withPrincipal(req, "analyst-1", "reviewer")
+			rec := httptest.NewRecorder()
+			tc.handler(rt, rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status=%d body=%s", rec.Code, rec.Body.String())
+			}
+			if fake.lastAction != tc.action || fake.lastID != "inc-1" || fake.lastActor != "analyst-1" || fake.lastValue != tc.value {
+				t.Fatalf("mapped mutation: %+v", fake)
+			}
+		})
+	}
+}
+
+func TestIncidentMutationRejectsUnknownBodyField(t *testing.T) {
+	fake := &incidentHTTPFake{}
+	rt := &Router{log: discardLog(), incidents: fake, incidentTriage: fake}
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/incidents/inc-1/owner", strings.NewReader(`{"owner":"bob","expected_revision":2,"event_kind":"response_verified"}`))
+	req.SetPathValue("id", "inc-1")
+	rec := httptest.NewRecorder()
+	rt.changeIncidentOwner(rec, req)
+	if rec.Code != http.StatusBadRequest || fake.mutationInvoked {
+		t.Fatalf("smuggled event field: status=%d invoked=%v body=%s", rec.Code, fake.mutationInvoked, rec.Body.String())
+	}
+}
+
+func TestIncidentRoutesEnforceReviewPermission(t *testing.T) {
+	fake := &incidentHTTPFake{}
+	rt := &Router{log: discardLog()}
+	rt.SetIncidents(fake, fake)
+	mux := rt.routes()
+
+	send := func(role, method, path, body string) int {
+		req := httptest.NewRequest(method, path, strings.NewReader(body))
+		req = withPrincipal(req, role+"-user", role)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		return rec.Code
+	}
+	if code := send("readonly", http.MethodGet, "/api/v1/incidents", ""); code != http.StatusOK {
+		t.Fatalf("readonly list status=%d, want 200", code)
+	}
+	for _, role := range []string{"readonly", "consultant", "agent", "mcp"} {
+		fake.mutationInvoked = false
+		if code := send(role, http.MethodPost, "/api/v1/incidents/inc-1/disposition", `{"disposition":"true_positive","expected_revision":2}`); code != http.StatusForbidden {
+			t.Fatalf("role %s mutation status=%d, want 403", role, code)
+		}
+		if fake.mutationInvoked {
+			t.Fatalf("role %s reached incident mutation", role)
+		}
+	}
+	if code := send("reviewer", http.MethodPost, "/api/v1/incidents/inc-1/disposition", `{"disposition":"true_positive","expected_revision":2}`); code != http.StatusOK {
+		t.Fatalf("reviewer mutation status=%d, want 200", code)
+	}
+}
+
+func TestIncidentMutationRejectsStaleRevision(t *testing.T) {
+	fake := &incidentHTTPFake{}
+	rt := &Router{log: discardLog(), incidents: fake, incidentTriage: fake}
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/incidents/inc-1/owner", strings.NewReader(`{"owner":"bob","expected_revision":1}`))
+	req.SetPathValue("id", "inc-1")
+	rec := httptest.NewRecorder()
+	rt.changeIncidentOwner(rec, req)
+	if rec.Code != http.StatusConflict || fake.mutationInvoked {
+		t.Fatalf("stale mutation: status=%d invoked=%v body=%s", rec.Code, fake.mutationInvoked, rec.Body.String())
+	}
+}
+
+func TestIncidentListRejectsUnboundedOrUnknownQueries(t *testing.T) {
+	for _, target := range []string{"/api/v1/incidents?limit=101", "/api/v1/incidents?limit=nope", "/api/v1/incidents?tenant=other"} {
+		req := httptest.NewRequest(http.MethodGet, target, nil)
+		if _, _, err := incidentListParams(req); err == nil {
+			t.Fatalf("query %s must fail", target)
+		}
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -10,6 +10,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/qualitygate"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -72,6 +73,8 @@ type Router struct {
 	threatModels           threatModelService    // optional; nil ⇒ threat-model routes are not registered
 	drafts                 writeupDraftService   // optional; nil ⇒ writeup-draft sign-off routes are not registered
 	aiTriageReviews        aiTriageReviewService // optional; nil ⇒ AI-triage review queue routes are not registered
+	incidents              incidentReadService   // optional; nil ⇒ incident read routes are not registered
+	incidentTriage         incidentTriageService // optional; nil ⇒ incident mutation routes are not registered
 	projects               projectService        // optional; nil ⇒ project routes are not registered
 	assets                 assetService          // optional; nil ⇒ fleet asset routes are not registered
 	cspm                   *cspm.Service         // optional; nil ⇒ CSPM routes are not registered
@@ -139,6 +142,22 @@ type aiTriageReviewService interface {
 	Decide(ctx context.Context, tenantID, id shared.ID, actor string, decision aitriagereview.Decision, rationale string, expectedVersion int) (aitriagereview.Review, error)
 }
 
+// incidentReadService exposes projections and immutable history without generic append access.
+type incidentReadService interface {
+	Get(context.Context, shared.ID) (incident.Incident, error)
+	ListByAsset(context.Context, shared.ID, int) ([]incident.Incident, error)
+	History(context.Context, shared.ID) ([]incident.IncidentEvent, error)
+}
+
+// incidentTriageService is deliberately narrow: HTTP callers can only perform the four human C5
+// mutations. The generic incident event appender remains inaccessible at the transport edge.
+type incidentTriageService interface {
+	AssignOwner(context.Context, string, shared.ID, string) (incident.Incident, error)
+	Comment(context.Context, string, shared.ID, string) (incident.Incident, error)
+	ChangeStatus(context.Context, string, shared.ID, incident.State) (incident.Incident, error)
+	SetDisposition(context.Context, string, shared.ID, incident.Disposition) (incident.Incident, error)
+}
+
 // SetJudgments wires the AI judgment lifecycle endpoints. nil ⇒ routes are not registered.
 func (rt *Router) SetJudgments(s judgmentService) { rt.judgments = s }
 
@@ -181,6 +200,12 @@ func (rt *Router) SetWriteupDrafts(s writeupDraftService) { rt.drafts = s }
 
 // SetAITriageReviews wires the tenant-scoped human review queue.
 func (rt *Router) SetAITriageReviews(s aiTriageReviewService) { rt.aiTriageReviews = s }
+
+// SetIncidents wires the tenant-scoped incident reads and audited human-triage workflow.
+func (rt *Router) SetIncidents(read incidentReadService, triage incidentTriageService) {
+	rt.incidents = read
+	rt.incidentTriage = triage
+}
 
 // qualityGateService is the HTTP slice for tenant-scoped gate management.
 type qualityGateService interface {
@@ -314,6 +339,17 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("GET /api/v1/ai-triage/reviews", rt.authz(userdom.PermView, rt.listAITriageReviews))
 		mux.HandleFunc("POST /api/v1/ai-triage/reviews/{rid}/claim", rt.authz(userdom.PermReview, rt.claimAITriageReview))
 		mux.HandleFunc("POST /api/v1/ai-triage/reviews/{rid}/decision", rt.authz(userdom.PermReview, rt.decideAITriageReview))
+	}
+	if rt.incidents != nil {
+		mux.HandleFunc("GET /api/v1/incidents", rt.authz(userdom.PermView, rt.listIncidents))
+		mux.HandleFunc("GET /api/v1/incidents/{id}", rt.authz(userdom.PermView, rt.getIncident))
+		mux.HandleFunc("GET /api/v1/incidents/{id}/events", rt.authz(userdom.PermView, rt.incidentHistory))
+	}
+	if rt.incidents != nil && rt.incidentTriage != nil {
+		mux.HandleFunc("PUT /api/v1/incidents/{id}/owner", rt.authz(userdom.PermReview, rt.changeIncidentOwner))
+		mux.HandleFunc("POST /api/v1/incidents/{id}/comments", rt.authz(userdom.PermReview, rt.addIncidentComment))
+		mux.HandleFunc("POST /api/v1/incidents/{id}/state", rt.authz(userdom.PermReview, rt.changeIncidentState))
+		mux.HandleFunc("POST /api/v1/incidents/{id}/disposition", rt.authz(userdom.PermReview, rt.setIncidentDisposition))
 	}
 	if rt.sla != nil {
 		mux.HandleFunc("GET /api/v1/sla/policies", rt.authz(userdom.PermView, rt.listSLAPolicies))

--- a/internal/usecase/fleet/incidenttriage/service.go
+++ b/internal/usecase/fleet/incidenttriage/service.go
@@ -9,11 +9,19 @@ package incidenttriage
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	maxActorRunes   = 256
+	maxOwnerRunes   = 256
+	maxCommentRunes = 8 * 1024
 )
 
 // IncidentAppender is the consumer-side view of the incident store this usecase needs: read the current
@@ -49,23 +57,31 @@ func NewService(incidents IncidentAppender, audit ports.AuditLogger, now func() 
 // server-side principal, never a request-body field) and follows ctx to keep it away from the other string
 // params.
 func (s *Service) AssignOwner(ctx context.Context, actor string, id shared.ID, owner string) (incident.Incident, error) {
+	owner = strings.TrimSpace(owner)
 	if owner == "" {
 		return incident.Incident{}, fmt.Errorf("%w: owner is required", shared.ErrValidation)
 	}
+	if utf8.RuneCountInString(owner) > maxOwnerRunes {
+		return incident.Incident{}, fmt.Errorf("%w: owner exceeds %d characters", shared.ErrValidation, maxOwnerRunes)
+	}
 	return s.apply(ctx, actor, id, "incident.owner_changed",
-		func(at time.Time) incident.IncidentEvent {
-			return incident.IncidentEvent{IncidentID: id, Kind: incident.EventOwnerChanged, At: at, Actor: actor, Owner: owner}
+		func(at time.Time, authenticatedActor string) incident.IncidentEvent {
+			return incident.IncidentEvent{IncidentID: id, Kind: incident.EventOwnerChanged, At: at, Actor: authenticatedActor, Owner: owner}
 		}, map[string]string{"owner": owner})
 }
 
 // Comment records an analyst note.
 func (s *Service) Comment(ctx context.Context, actor string, id shared.ID, text string) (incident.Incident, error) {
+	text = strings.TrimSpace(text)
 	if text == "" {
 		return incident.Incident{}, fmt.Errorf("%w: comment text is required", shared.ErrValidation)
 	}
+	if utf8.RuneCountInString(text) > maxCommentRunes {
+		return incident.Incident{}, fmt.Errorf("%w: comment exceeds %d characters", shared.ErrValidation, maxCommentRunes)
+	}
 	return s.apply(ctx, actor, id, "incident.commented",
-		func(at time.Time) incident.IncidentEvent {
-			return incident.IncidentEvent{IncidentID: id, Kind: incident.EventAnalystCommented, At: at, Actor: actor, Comment: text}
+		func(at time.Time, authenticatedActor string) incident.IncidentEvent {
+			return incident.IncidentEvent{IncidentID: id, Kind: incident.EventAnalystCommented, At: at, Actor: authenticatedActor, Comment: text}
 		}, nil)
 }
 
@@ -75,8 +91,8 @@ func (s *Service) ChangeStatus(ctx context.Context, actor string, id shared.ID, 
 		return incident.Incident{}, fmt.Errorf("%w: unknown target state %q", shared.ErrValidation, to)
 	}
 	return s.apply(ctx, actor, id, "incident.status_changed",
-		func(at time.Time) incident.IncidentEvent {
-			return incident.IncidentEvent{IncidentID: id, Kind: incident.EventStatusChanged, At: at, Actor: actor, To: to}
+		func(at time.Time, authenticatedActor string) incident.IncidentEvent {
+			return incident.IncidentEvent{IncidentID: id, Kind: incident.EventStatusChanged, At: at, Actor: authenticatedActor, To: to}
 		}, map[string]string{"to": string(to)})
 }
 
@@ -86,8 +102,8 @@ func (s *Service) SetDisposition(ctx context.Context, actor string, id shared.ID
 		return incident.Incident{}, fmt.Errorf("%w: unknown disposition %q", shared.ErrValidation, disposition)
 	}
 	return s.apply(ctx, actor, id, "incident.disposition_set",
-		func(at time.Time) incident.IncidentEvent {
-			return incident.IncidentEvent{IncidentID: id, Kind: incident.EventDispositionSet, At: at, Actor: actor, Disposition: disposition}
+		func(at time.Time, authenticatedActor string) incident.IncidentEvent {
+			return incident.IncidentEvent{IncidentID: id, Kind: incident.EventDispositionSet, At: at, Actor: authenticatedActor, Disposition: disposition}
 		}, map[string]string{"disposition": string(disposition)})
 }
 
@@ -104,19 +120,23 @@ func (s *Service) SetDisposition(ctx context.Context, actor string, id shared.ID
 // durable and carries the attribution) — the error signals only that the secondary audit trail has a gap.
 // The caller MUST NOT blindly retry (the stores are not transactional and the append is not idempotent, so
 // a retry would append a DUPLICATE event); treat it as committed-but-unaudited and reconcile/alert.
-func (s *Service) apply(ctx context.Context, actor string, id shared.ID, action string, build func(time.Time) incident.IncidentEvent, meta map[string]string) (incident.Incident, error) {
+func (s *Service) apply(ctx context.Context, actor string, id shared.ID, action string, build func(time.Time, string) incident.IncidentEvent, meta map[string]string) (incident.Incident, error) {
+	actor = strings.TrimSpace(actor)
 	if id.IsZero() {
 		return incident.Incident{}, fmt.Errorf("%w: incident id is required", shared.ErrValidation)
 	}
 	if actor == "" {
 		return incident.Incident{}, fmt.Errorf("%w: triage mutation requires an actor", shared.ErrValidation)
 	}
+	if utf8.RuneCountInString(actor) > maxActorRunes {
+		return incident.Incident{}, fmt.Errorf("%w: triage mutation actor exceeds %d characters", shared.ErrValidation, maxActorRunes)
+	}
 	cur, err := s.incidents.Get(ctx, id)
 	if err != nil {
 		return incident.Incident{}, err
 	}
 	at := s.now().UTC()
-	updated, err := s.incidents.Append(ctx, id, cur.Revision, []incident.IncidentEvent{build(at)})
+	updated, err := s.incidents.Append(ctx, id, cur.Revision, []incident.IncidentEvent{build(at, actor)})
 	if err != nil {
 		return incident.Incident{}, err
 	}

--- a/internal/usecase/fleet/incidenttriage/service_test.go
+++ b/internal/usecase/fleet/incidenttriage/service_test.go
@@ -3,6 +3,7 @@ package incidenttriage
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -147,10 +148,20 @@ func TestTriageFailsClosed(t *testing.T) {
 	svc, _, ctx, _ := setup(t)
 	bad := []func() error{
 		func() error { _, e := svc.AssignOwner(ctx, "alice", incID, ""); return e },
+		func() error { _, e := svc.AssignOwner(ctx, "alice", incID, "   "); return e },
+		func() error {
+			_, e := svc.AssignOwner(ctx, "alice", incID, strings.Repeat("x", maxOwnerRunes+1))
+			return e
+		},
 		func() error { _, e := svc.Comment(ctx, "alice", incID, ""); return e },
+		func() error {
+			_, e := svc.Comment(ctx, "alice", incID, strings.Repeat("x", maxCommentRunes+1))
+			return e
+		},
 		func() error { _, e := svc.ChangeStatus(ctx, "alice", incID, "bogus"); return e },
 		func() error { _, e := svc.SetDisposition(ctx, "alice", incID, "bogus"); return e },
-		func() error { _, e := svc.Comment(ctx, "", incID, "x"); return e },   // no actor
+		func() error { _, e := svc.Comment(ctx, "", incID, "x"); return e }, // no actor
+		func() error { _, e := svc.Comment(ctx, strings.Repeat("x", maxActorRunes+1), incID, "x"); return e },
 		func() error { _, e := svc.Comment(ctx, "alice", "", "x"); return e }, // no incident id
 	}
 	for i, f := range bad {
@@ -164,5 +175,27 @@ func TestTriageFailsClosed(t *testing.T) {
 	}
 	if _, err := NewService(nil, &captureAudit{}, time.Now); !errors.Is(err, shared.ErrValidation) {
 		t.Fatal("nil store must be rejected")
+	}
+}
+
+func TestTriageCanonicalizesAttributionAndText(t *testing.T) {
+	svc, audit, ctx, inc := setup(t)
+	if _, err := svc.AssignOwner(ctx, "  alice  ", incID, "  bob  "); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Comment(ctx, "  alice  ", incID, "  note  "); err != nil {
+		t.Fatal(err)
+	}
+	got, err := inc.Get(ctx, incID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.OwnerID != "bob" || len(got.Comments) != 1 || got.Comments[0].Actor != "alice" || got.Comments[0].Text != "note" {
+		t.Fatalf("canonicalized incident = %+v", got)
+	}
+	for _, entry := range audit.entries {
+		if entry.Actor != "alice" {
+			t.Fatalf("audit actor = %q, want alice", entry.Actor)
+		}
 	}
 }

--- a/internal/usecase/fleet/incidentuc/service.go
+++ b/internal/usecase/fleet/incidentuc/service.go
@@ -88,6 +88,23 @@ func (s *Service) ListByAsset(ctx context.Context, assetID shared.ID, limit int)
 	return out, nil
 }
 
+// History returns the immutable incident event log in revision order. The event log is the audit trail:
+// every analyst mutation carries its authenticated actor and server-side timestamp and is never updated
+// or deleted.
+func (s *Service) History(ctx context.Context, id shared.ID) ([]incident.IncidentEvent, error) {
+	if id.IsZero() {
+		return nil, fmt.Errorf("%w: incident id is required", shared.ErrValidation)
+	}
+	events, err := s.store.LoadEvents(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if len(events) == 0 {
+		return nil, fmt.Errorf("%w: incident %s", shared.ErrNotFound, id)
+	}
+	return events, nil
+}
+
 // RecordCorrelation persists correlator output (a flat event stream, grouped by incident) as NEW
 // incidents. It is IDEMPOTENT for batch correlation: an incident id that already exists is skipped (the
 // correlator mints deterministic ids, so re-running over the same window records nothing new). Attaching

--- a/internal/usecase/fleet/incidentuc/service_test.go
+++ b/internal/usecase/fleet/incidentuc/service_test.go
@@ -131,3 +131,10 @@ func TestListByAsset(t *testing.T) {
 		t.Fatalf("other asset must list nothing, got %d", len(other))
 	}
 }
+
+func TestHistoryNotFound(t *testing.T) {
+	svc, ctx := newSvc(t)
+	if _, err := svc.History(ctx, "missing"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("missing history must be ErrNotFound, got %v", err)
+	}
+}

--- a/internal/usecase/fleet/retrohunt/service.go
+++ b/internal/usecase/fleet/retrohunt/service.go
@@ -27,21 +27,57 @@ type Request struct {
 	Limit    int
 }
 
-// Result is the surrounding-timeline window. Entries are event-time ordered. Truncated reports that the
-// store's limit capped the window, so the caller knows the view may be partial (coverage honesty); a
-// deeper gap/sample overlay from the telemetry coverage store is a documented follow-up.
+// Result is the surrounding-timeline window. Entries are event-time ordered. Coverage combines timeline
+// truncation with raw-telemetry sampling, sequence-gap, and loss metadata for the exact window.
 type Result struct {
 	AssetID   shared.ID
 	From      time.Time
 	To        time.Time
 	Entries   []endpoint.TimelineEntry
 	Truncated bool
+	Coverage  Coverage
+}
+
+// CoverageReason is a stable, machine-readable explanation for an incomplete window.
+type CoverageReason string
+
+const (
+	CoverageSampled              CoverageReason = "telemetry_sampled"
+	CoverageSequenceGap          CoverageReason = "telemetry_sequence_gap"
+	CoverageLoss                 CoverageReason = "telemetry_loss"
+	CoverageTelemetryUnavailable CoverageReason = "telemetry_unavailable"
+	CoverageTimelineTruncated    CoverageReason = "timeline_limit"
+	CoverageTelemetryIncomplete  CoverageReason = "telemetry_incomplete"
+)
+
+// Coverage proves whether the returned timeline can be treated as complete for the requested window.
+// Complete is false whenever raw telemetry was sampled, lost, sequence-gapped, unavailable, or the
+// projected timeline was capped.
+type Coverage struct {
+	Complete          bool
+	Sampled           bool
+	MaxSampleRate     int
+	TimelineTruncated bool
+	TelemetryObserved bool
+	SequenceGaps      []ports.TelemetrySequenceGap
+	Losses            []ports.TelemetryLoss
+	Reasons           []CoverageReason
+}
+
+// TelemetryHuntReader is the read-only telemetry surface used to establish coverage honesty.
+type TelemetryHuntReader interface {
+	Query(context.Context, ports.HuntQuery) (ports.HuntResult, error)
 }
 
 // Service answers retro-hunt queries over the endpoint State Timeline.
 type Service struct {
-	timeline ports.EndpointTimelineStore
+	timeline  ports.EndpointTimelineStore
+	telemetry TelemetryHuntReader
 }
+
+// SetTelemetryReader enables sampling/gap/loss coverage checks over the exact hunt window. Until a
+// reader is configured, hunts remain usable but explicitly report telemetry_unavailable and incomplete.
+func (s *Service) SetTelemetryReader(telemetry TelemetryHuntReader) { s.telemetry = telemetry }
 
 // NewService constructs the retro-hunt service over an endpoint-timeline store.
 func NewService(timeline ports.EndpointTimelineStore) (*Service, error) {
@@ -77,6 +113,9 @@ func (s *Service) Hunt(ctx context.Context, req Request) (Result, error) {
 	if effLimit <= 0 {
 		effLimit = defaultHuntLimit
 	}
+	if effLimit > maxHuntLimit {
+		return Result{}, fmt.Errorf("%w: retro-hunt limit exceeds %d", shared.ErrValidation, maxHuntLimit)
+	}
 	entries, err := s.timeline.QueryTimeline(ctx, ports.EndpointTimelineQuery{
 		AssetID: req.AssetID, From: from, To: to, EntityID: req.EntityID, Limit: effLimit + 1,
 	})
@@ -88,9 +127,72 @@ func (s *Service) Hunt(ctx context.Context, req Request) (Result, error) {
 		entries = entries[:effLimit]
 		truncated = true
 	}
-	return Result{AssetID: req.AssetID, From: from, To: to, Entries: entries, Truncated: truncated}, nil
+	coverage, err := s.coverage(ctx, req.AssetID, from, to, truncated)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		AssetID: req.AssetID, From: from, To: to, Entries: entries,
+		Truncated: truncated, Coverage: coverage,
+	}, nil
+}
+
+func (s *Service) coverage(ctx context.Context, assetID shared.ID, from, to time.Time, timelineTruncated bool) (Coverage, error) {
+	if s.telemetry == nil {
+		coverage := Coverage{MaxSampleRate: 1, TimelineTruncated: timelineTruncated}
+		coverage.Reasons = append(coverage.Reasons, CoverageTelemetryUnavailable)
+		if timelineTruncated {
+			coverage.Reasons = append(coverage.Reasons, CoverageTimelineTruncated)
+		}
+		return coverage, nil
+	}
+	hunt, err := s.telemetry.Query(ctx, ports.HuntQuery{
+		Kind: ports.HuntContext, AssetID: assetID, Since: from, Until: to, Limit: 1,
+	})
+	if err != nil {
+		return Coverage{}, fmt.Errorf("retro-hunt coverage query: %w", err)
+	}
+	return coverageFor(hunt, timelineTruncated), nil
+}
+
+func coverageFor(hunt ports.HuntResult, timelineTruncated bool) Coverage {
+	maxSampleRate := hunt.MaxSampleRate
+	if maxSampleRate < 1 {
+		maxSampleRate = 1
+	}
+	sampled := hunt.Sampled || maxSampleRate > 1
+	coverage := Coverage{
+		Sampled: sampled, MaxSampleRate: maxSampleRate, TimelineTruncated: timelineTruncated,
+		TelemetryObserved: hunt.RowsScanned > 0,
+		SequenceGaps:      append([]ports.TelemetrySequenceGap{}, hunt.SequenceGaps...),
+		Losses:            append([]ports.TelemetryLoss{}, hunt.Losses...),
+	}
+	if sampled {
+		coverage.Reasons = append(coverage.Reasons, CoverageSampled)
+	}
+	if len(coverage.SequenceGaps) > 0 {
+		coverage.Reasons = append(coverage.Reasons, CoverageSequenceGap)
+	}
+	if len(coverage.Losses) > 0 {
+		coverage.Reasons = append(coverage.Reasons, CoverageLoss)
+	}
+	if !coverage.TelemetryObserved {
+		coverage.Reasons = append(coverage.Reasons, CoverageTelemetryUnavailable)
+	}
+	if timelineTruncated {
+		coverage.Reasons = append(coverage.Reasons, CoverageTimelineTruncated)
+	}
+	knownIncomplete := sampled || len(coverage.SequenceGaps) > 0 || len(coverage.Losses) > 0 || !coverage.TelemetryObserved
+	if !hunt.Complete && !knownIncomplete {
+		coverage.Reasons = append(coverage.Reasons, CoverageTelemetryIncomplete)
+	}
+	coverage.Complete = hunt.Complete && len(coverage.Reasons) == 0
+	return coverage
 }
 
 // defaultHuntLimit bounds a retro-hunt window when the caller specifies no (or a non-positive) limit; it
 // is below the timeline store's own cap so a full page is always reportable as Truncated.
 const defaultHuntLimit = 1000
+
+// maxHuntLimit leaves room for the look-ahead row under timeline stores' 10k hard cap.
+const maxHuntLimit = 9999

--- a/internal/usecase/fleet/retrohunt/service_test.go
+++ b/internal/usecase/fleet/retrohunt/service_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 const (
@@ -18,6 +19,17 @@ const (
 )
 
 var base = time.Unix(1_800_000_000, 0).UTC()
+
+type coverageReader struct {
+	result ports.HuntResult
+	err    error
+	query  ports.HuntQuery
+}
+
+func (r *coverageReader) Query(_ context.Context, query ports.HuntQuery) (ports.HuntResult, error) {
+	r.query = query
+	return r.result, r.err
+}
 
 func newSvc(t *testing.T) (*Service, context.Context, *memory.EndpointTimelineStore) {
 	t.Helper()
@@ -90,15 +102,19 @@ func TestHuntTruncation(t *testing.T) {
 	if len(res.Entries) != 2 || !res.Truncated {
 		t.Fatalf("expected truncated 2-entry result, got %d truncated=%v", len(res.Entries), res.Truncated)
 	}
+	if !hasCoverageReason(res.Coverage, CoverageTimelineTruncated) {
+		t.Fatalf("timeline cap missing from coverage: %+v", res.Coverage)
+	}
 }
 
 func TestHuntFailsClosed(t *testing.T) {
 	svc, ctx, _ := newSvc(t)
 	bad := []Request{
-		{Around: base, Before: time.Minute},                            // no asset
-		{AssetID: asset, Before: time.Minute},                          // no trigger time
-		{AssetID: asset, Around: base, Before: -1, After: time.Minute}, // negative look-back
-		{AssetID: asset, Around: base},                                 // zero-width window
+		{Around: base, Before: time.Minute},                                          // no asset
+		{AssetID: asset, Before: time.Minute},                                        // no trigger time
+		{AssetID: asset, Around: base, Before: -1, After: time.Minute},               // negative look-back
+		{AssetID: asset, Around: base},                                               // zero-width window
+		{AssetID: asset, Around: base, Before: time.Minute, Limit: maxHuntLimit + 1}, // unsafe limit
 	}
 	for i, req := range bad {
 		if _, err := svc.Hunt(ctx, req); !errors.Is(err, shared.ErrValidation) {
@@ -108,6 +124,80 @@ func TestHuntFailsClosed(t *testing.T) {
 	if _, err := NewService(nil); !errors.Is(err, shared.ErrValidation) {
 		t.Fatal("nil store must be rejected")
 	}
+}
+
+func TestHuntCoverageIsHonestAboutSamplingGapsAndLoss(t *testing.T) {
+	svc, ctx, store := newSvc(t)
+	seed(t, ctx, store)
+	reader := &coverageReader{result: ports.HuntResult{
+		RowsScanned: 3, Sampled: true, MaxSampleRate: 10, Complete: false,
+		SequenceGaps: []ports.TelemetrySequenceGap{{Missing: 2}},
+		Losses:       []ports.TelemetryLoss{{Reason: "agent batch truncated"}},
+	}}
+	svc.SetTelemetryReader(reader)
+
+	res, err := svc.Hunt(ctx, Request{AssetID: asset, Around: base, Before: time.Minute, After: time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Coverage.Complete || !res.Coverage.Sampled || res.Coverage.MaxSampleRate != 10 {
+		t.Fatalf("coverage = %+v", res.Coverage)
+	}
+	for _, reason := range []CoverageReason{CoverageSampled, CoverageSequenceGap, CoverageLoss} {
+		if !hasCoverageReason(res.Coverage, reason) {
+			t.Fatalf("coverage missing %q: %+v", reason, res.Coverage)
+		}
+	}
+	if reader.query.Kind != ports.HuntContext || reader.query.AssetID != asset ||
+		!reader.query.Since.Equal(base.Add(-time.Minute)) || !reader.query.Until.Equal(base.Add(time.Minute)) {
+		t.Fatalf("coverage query does not match timeline window: %+v", reader.query)
+	}
+}
+
+func TestHuntCoverageCanProveCompleteWindow(t *testing.T) {
+	svc, ctx, store := newSvc(t)
+	seed(t, ctx, store)
+	svc.SetTelemetryReader(&coverageReader{result: ports.HuntResult{
+		RowsScanned: 3, MaxSampleRate: 1, Complete: true,
+	}})
+
+	res, err := svc.Hunt(ctx, Request{AssetID: asset, Around: base, Before: time.Minute, After: time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.Coverage.Complete || len(res.Coverage.Reasons) != 0 {
+		t.Fatalf("complete coverage = %+v", res.Coverage)
+	}
+}
+
+func TestHuntWithoutTelemetryDoesNotClaimCompleteness(t *testing.T) {
+	svc, ctx, store := newSvc(t)
+	seed(t, ctx, store)
+	res, err := svc.Hunt(ctx, Request{AssetID: asset, Around: base, Before: time.Minute, After: time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Coverage.Complete || !hasCoverageReason(res.Coverage, CoverageTelemetryUnavailable) {
+		t.Fatalf("missing telemetry must be explicit: %+v", res.Coverage)
+	}
+}
+
+func TestHuntCoverageQueryErrorPropagates(t *testing.T) {
+	svc, ctx, store := newSvc(t)
+	seed(t, ctx, store)
+	svc.SetTelemetryReader(&coverageReader{err: errors.New("telemetry unavailable")})
+	if _, err := svc.Hunt(ctx, Request{AssetID: asset, Around: base, Before: time.Minute, After: time.Minute}); err == nil {
+		t.Fatal("coverage query error must fail closed")
+	}
+}
+
+func hasCoverageReason(coverage Coverage, want CoverageReason) bool {
+	for _, reason := range coverage.Reasons {
+		if reason == want {
+			return true
+		}
+	}
+	return false
 }
 
 func TestHuntDefaultLimitReportsTruncation(t *testing.T) {


### PR DESCRIPTION
## Summary

- complete the coverage-honesty portion of #678 by overlaying telemetry sampling, sequence-gap, persisted-loss, unavailable-data, and timeline-cap signals on the exact State Timeline window
- expose tenant-scoped incident projections and immutable event history, then wire the four #679 analyst mutations through the audited incident-triage usecase
- gate reads with PermView and mutations with PermReview; source actor identity from the authenticated principal and reject generic-event field smuggling
- require optimistic expected revisions at the HTTP edge so stale or retried mutations fail with a conflict, while disposition remains independent of risk
- wire both PostgreSQL and in-memory incident event stores into synapse-api and document the API in OpenAPI

## Verification

- targeted Go packages and OpenAPI route coverage pass
- make build vet typecheck passes
- web production build passes
- go test ./... passes except the two existing Windows-only ACL assertions in synapse-fptriage-release and egressbroker

Follow-up to #678
Follow-up to #679