### PR TITLE
feat(incident): C7 incident read + analyst-triage HTTP surface (#681)

### DIFF
--- a/api/testdata/openapi-coverage-debt.txt
+++ b/api/testdata/openapi-coverage-debt.txt
@@ -65,6 +65,8 @@ GET /api/v1/fleet/agents/{p}
 GET /api/v1/fleet/coverage
 GET /api/v1/fleet/coverage/export
 GET /api/v1/fleet/coverage/summary
+GET /api/v1/fleet/incidents
+GET /api/v1/fleet/incidents/{p}
 GET /api/v1/me
 GET /api/v1/projects
 GET /api/v1/projects/{p}
@@ -120,6 +122,10 @@ POST /api/v1/engagements/import
 POST /api/v1/fleet/decommission
 POST /api/v1/fleet/enrol
 POST /api/v1/fleet/heartbeat
+POST /api/v1/fleet/incidents/{p}/comments
+POST /api/v1/fleet/incidents/{p}/disposition
+POST /api/v1/fleet/incidents/{p}/owner
+POST /api/v1/fleet/incidents/{p}/status
 POST /api/v1/fleet/inventory/cluster
 POST /api/v1/fleet/inventory/host
 POST /api/v1/fleet/work/{p}/progress

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -111,6 +111,8 @@ import (
 	coverageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/coverage"
 	detectledger "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectledger"
 	hostinventoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/hostinventory"
+	incidenttriage "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/incidenttriage"
+	incidentuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/incidentuc"
 	keyregistry "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/keyregistry"
 	telemetryingest "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/telemetryingest"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
@@ -282,6 +284,7 @@ func main() {
 	var importedSBOMStore ports.ImportedSBOMStore
 	var importedFindingStore ports.ImportedFindingStore // third-party (SARIF) findings under governance
 	var detectionRecordStore ports.DetectionRecordStore // #423 detection ledger projection
+	var incidentEventStore ports.IncidentEventStore     // #594 C7 incident append-only event log
 	var promotionStore ports.PendingPromotionAuditStore
 	var scanJobStore ports.ScanJobStore
 	var scanRunStore ports.ScanRunStore
@@ -411,6 +414,7 @@ func main() {
 		importedSBOMStore = postgres.NewImportedSBOMStore(pool)
 		importedFindingStore = postgres.NewImportedFindingRepository(pool)
 		detectionRecordStore = postgres.NewDetectionRecordRepository(pool)
+		incidentEventStore = postgres.NewIncidentEventRepository(pool)
 		promotionStore, err = postgres.NewPromotionStore(pool)
 		if err != nil {
 			log.Error("postgres promotion store init failed", "err", err)
@@ -506,6 +510,7 @@ func main() {
 		importedSBOMStore = memory.NewImportedSBOMStore()
 		importedFindingStore = memory.NewImportedFindingStore()
 		detectionRecordStore = memory.NewDetectionRecordStore()
+		incidentEventStore = memory.NewIncidentEventStore()
 		memoryFindings, ok := findingRepo.(*memory.FindingRepository)
 		if !ok {
 			log.Error("memory finding repository type mismatch")
@@ -1510,6 +1515,31 @@ func main() {
 			log.Info("third-party SARIF ingest ENABLED (durable; provenance mandatory; imported findings cannot self-promote)")
 		} else {
 			log.Warn("third-party SARIF ingest ENABLED but NOT DURABLE - imported findings and their ingest history live in memory and are lost on restart; configure SYNAPSE_DB_DSN for a durable store")
+		}
+	}
+
+	// Phase-C incident read + analyst-triage surface (#594 C7/C5). The event-sourced incident store
+	// (append-only log + projection) is always present (memory or Postgres selected above); the read
+	// service projects it, and the triage service records each analyst mutation as an attributable
+	// event on that log + the tamper-evident audit trail. RBAC + tenant scoping are enforced at the
+	// HTTP edge (router). No agent transport needed — this is an operator surface.
+	{
+		incidentSvc, ierr := incidentuc.NewService(incidentEventStore)
+		if ierr != nil {
+			log.Error("incident read service init failed", "err", ierr)
+			os.Exit(1)
+		}
+		router.SetIncidents(incidentSvc)
+		triageSvc, terr := incidenttriage.NewService(incidentSvc, auditLog, func() time.Time { return clock.Now().UTC() })
+		if terr != nil {
+			log.Error("incident triage service init failed", "err", terr)
+			os.Exit(1)
+		}
+		router.SetIncidentTriage(triageSvc)
+		if cfg.DBDSN != "" {
+			log.Info("incident read + analyst-triage surface ENABLED (durable; append-only event log; tenant-scoped; RBAC-gated)")
+		} else {
+			log.Warn("incident read + analyst-triage surface ENABLED but NOT DURABLE - incidents and their triage history live in memory and are lost on restart; configure SYNAPSE_DB_DSN for a durable store")
 		}
 	}
 

--- a/internal/adapter/httpapi/incident_handler.go
+++ b/internal/adapter/httpapi/incident_handler.go
@@ -1,0 +1,199 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// incidentReader is the read side of the Phase-C incident store this API surfaces (#594 C7):
+// project a single incident, and list the tenant's incidents (optionally scoped to one asset).
+// incidentuc.Service satisfies it. Defined here so the adapter depends on a narrow port, not the
+// concrete usecase.
+type incidentReader interface {
+	Get(ctx context.Context, id shared.ID) (incident.Incident, error)
+	ListByAsset(ctx context.Context, assetID shared.ID, limit int) ([]incident.Incident, error)
+}
+
+// incidentTriager is the analyst-triage write side (#594 C5): the human-driven mutations, each
+// recorded as an attributable event on the append-only log. incidenttriage.Service satisfies it.
+// The actor is the FIRST arg after ctx precisely because it must be the server-side authenticated
+// principal, never a request-body field.
+type incidentTriager interface {
+	AssignOwner(ctx context.Context, actor string, id shared.ID, owner string) (incident.Incident, error)
+	Comment(ctx context.Context, actor string, id shared.ID, text string) (incident.Incident, error)
+	ChangeStatus(ctx context.Context, actor string, id shared.ID, to incident.State) (incident.Incident, error)
+	SetDisposition(ctx context.Context, actor string, id shared.ID, disposition incident.Disposition) (incident.Incident, error)
+}
+
+// SetIncidents wires the incident read surface (nil ⇒ the routes are not registered).
+func (rt *Router) SetIncidents(r incidentReader) { rt.incidents = r }
+
+// SetIncidentTriage wires the incident triage surface (nil ⇒ the triage routes are not registered).
+func (rt *Router) SetIncidentTriage(t incidentTriager) { rt.incidentTriage = t }
+
+const (
+	defaultIncidentPageLimit = 200
+	maxIncidentPageLimit     = 1000
+	// incidentBodyLimit caps a triage request body (each is a single short string) — parity with the
+	// finding-triage handlers, so a large body cannot be read unbounded.
+	incidentBodyLimit = 8 << 10
+)
+
+// incidentListResponse carries a page of incidents plus an HONEST truncation flag: Truncated is true
+// when more incidents (of ANY state) exist beyond this page, so a client filtering by state knows the
+// filter ran over a capped page rather than the whole store (there is no store-level state index —
+// state is a projection, not a column).
+type incidentListResponse struct {
+	Incidents []incident.Incident `json:"incidents"`
+	Truncated bool                `json:"truncated"`
+}
+
+type assignIncidentOwnerRequest struct {
+	Owner string `json:"owner"`
+}
+
+type commentIncidentRequest struct {
+	Text string `json:"text"`
+}
+
+type changeIncidentStatusRequest struct {
+	To string `json:"to"`
+}
+
+type setIncidentDispositionRequest struct {
+	Disposition string `json:"disposition"`
+}
+
+// incidentTenantContext puts the effective fleet tenant onto the context so the tenant-scoped
+// usecase + RLS see a non-empty tenant even in a single-tenant deployment (mirrors fleetTenant used
+// by the asset/coverage handlers; incidentuc takes the tenant from the context, not as a param).
+func incidentTenantContext(r *http.Request) context.Context {
+	return shared.WithTenant(r.Context(), fleetTenant(r.Context()))
+}
+
+func parseIncidentPageLimit(raw string) (int, error) {
+	if raw == "" {
+		return defaultIncidentPageLimit, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		return 0, fmt.Errorf("%w: limit must be a positive integer", shared.ErrValidation)
+	}
+	if n > maxIncidentPageLimit {
+		n = maxIncidentPageLimit
+	}
+	return n, nil
+}
+
+// listIncidents returns a tenant-scoped page of incidents. Query params: `asset` (empty ⇒ all
+// incidents in the tenant), `limit` (1..1000, default 200), `state` (an optional page-level filter on
+// the current projected state). Truncation is detected with a limit+1 probe so Truncated is honest.
+func (rt *Router) listIncidents(w http.ResponseWriter, r *http.Request) {
+	limit, err := parseIncidentPageLimit(r.URL.Query().Get("limit"))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	var stateFilter incident.State
+	if raw := r.URL.Query().Get("state"); raw != "" {
+		stateFilter = incident.State(raw)
+		if !stateFilter.Valid() {
+			writeError(w, rt.log, fmt.Errorf("%w: unknown incident state %q", shared.ErrValidation, raw))
+			return
+		}
+	}
+	ctx := incidentTenantContext(r)
+	assetID := shared.ID(r.URL.Query().Get("asset"))
+	// Probe one past the limit so Truncated reflects the raw page (before any state filter).
+	list, err := rt.incidents.ListByAsset(ctx, assetID, limit+1)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	truncated := len(list) > limit
+	if truncated {
+		list = list[:limit]
+	}
+	if stateFilter != "" {
+		filtered := make([]incident.Incident, 0, len(list))
+		for _, inc := range list {
+			if inc.State == stateFilter {
+				filtered = append(filtered, inc)
+			}
+		}
+		list = filtered
+	}
+	writeJSON(w, http.StatusOK, incidentListResponse{Incidents: list, Truncated: truncated})
+}
+
+// getIncident returns the projected incident by id (404 if absent or cross-tenant).
+func (rt *Router) getIncident(w http.ResponseWriter, r *http.Request) {
+	inc, err := rt.incidents.Get(incidentTenantContext(r), shared.ID(r.PathValue("id")))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, inc)
+}
+
+func (rt *Router) assignIncidentOwner(w http.ResponseWriter, r *http.Request) {
+	var req assignIncidentOwnerRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, incidentBodyLimit)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
+		return
+	}
+	inc, err := rt.incidentTriage.AssignOwner(incidentTenantContext(r), PrincipalFrom(r.Context()), shared.ID(r.PathValue("id")), req.Owner)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, inc)
+}
+
+func (rt *Router) commentIncident(w http.ResponseWriter, r *http.Request) {
+	var req commentIncidentRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, incidentBodyLimit)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
+		return
+	}
+	inc, err := rt.incidentTriage.Comment(incidentTenantContext(r), PrincipalFrom(r.Context()), shared.ID(r.PathValue("id")), req.Text)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, inc)
+}
+
+func (rt *Router) changeIncidentStatus(w http.ResponseWriter, r *http.Request) {
+	var req changeIncidentStatusRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, incidentBodyLimit)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
+		return
+	}
+	inc, err := rt.incidentTriage.ChangeStatus(incidentTenantContext(r), PrincipalFrom(r.Context()), shared.ID(r.PathValue("id")), incident.State(req.To))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, inc)
+}
+
+func (rt *Router) setIncidentDisposition(w http.ResponseWriter, r *http.Request) {
+	var req setIncidentDispositionRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, incidentBodyLimit)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
+		return
+	}
+	inc, err := rt.incidentTriage.SetDisposition(incidentTenantContext(r), PrincipalFrom(r.Context()), shared.ID(r.PathValue("id")), incident.Disposition(req.Disposition))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, inc)
+}

--- a/internal/adapter/httpapi/incident_handler_test.go
+++ b/internal/adapter/httpapi/incident_handler_test.go
@@ -1,0 +1,230 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// fakeIncidentStore is an in-test double satisfying BOTH incidentReader and incidentTriager, so the
+// incident handler tests stay free of infrastructure/usecase imports. It records the last call so a
+// test can assert the actor came from the authenticated principal (not the body) and that the honest
+// limit+1 truncation probe reached the store.
+type fakeIncidentStore struct {
+	get    map[shared.ID]incident.Incident
+	list   []incident.Incident
+	getErr error
+	triErr error
+
+	lastAsset shared.ID
+	lastLimit int
+	lastActor string
+	lastOwner string
+	lastState incident.State
+	lastDisp  incident.Disposition
+}
+
+func (f *fakeIncidentStore) Get(_ context.Context, id shared.ID) (incident.Incident, error) {
+	if f.getErr != nil {
+		return incident.Incident{}, f.getErr
+	}
+	inc, ok := f.get[id]
+	if !ok {
+		return incident.Incident{}, shared.ErrNotFound
+	}
+	return inc, nil
+}
+
+func (f *fakeIncidentStore) ListByAsset(_ context.Context, assetID shared.ID, limit int) ([]incident.Incident, error) {
+	f.lastAsset = assetID
+	f.lastLimit = limit
+	// Emulate a real store capping at the requested limit.
+	if limit < len(f.list) {
+		return append([]incident.Incident(nil), f.list[:limit]...), nil
+	}
+	return append([]incident.Incident(nil), f.list...), nil
+}
+
+func (f *fakeIncidentStore) AssignOwner(_ context.Context, actor string, id shared.ID, owner string) (incident.Incident, error) {
+	f.lastActor, f.lastOwner = actor, owner
+	if f.triErr != nil {
+		return incident.Incident{}, f.triErr
+	}
+	return incident.Incident{ID: id, OwnerID: owner}, nil
+}
+
+func (f *fakeIncidentStore) Comment(_ context.Context, actor string, id shared.ID, _ string) (incident.Incident, error) {
+	f.lastActor = actor
+	if f.triErr != nil {
+		return incident.Incident{}, f.triErr
+	}
+	return incident.Incident{ID: id}, nil
+}
+
+func (f *fakeIncidentStore) ChangeStatus(_ context.Context, actor string, id shared.ID, to incident.State) (incident.Incident, error) {
+	f.lastActor, f.lastState = actor, to
+	if f.triErr != nil {
+		return incident.Incident{}, f.triErr
+	}
+	return incident.Incident{ID: id, State: to}, nil
+}
+
+func (f *fakeIncidentStore) SetDisposition(_ context.Context, actor string, id shared.ID, d incident.Disposition) (incident.Incident, error) {
+	f.lastActor, f.lastDisp = actor, d
+	if f.triErr != nil {
+		return incident.Incident{}, f.triErr
+	}
+	return incident.Incident{ID: id, Disposition: d}, nil
+}
+
+func newIncidentRouter(f *fakeIncidentStore) *http.ServeMux {
+	rt := &Router{log: discardLog(), incidents: f, incidentTriage: f}
+	return rt.routes()
+}
+
+// incidentReq drives the real route → authz → handler chain with an injected principal (role +
+// tenant), exactly like the hostile harness, so the RBAC gates are the production ones.
+func incidentReq(mux *http.ServeMux, role, method, path, body string) *httptest.ResponseRecorder {
+	var r *http.Request
+	if body == "" {
+		r = httptest.NewRequest(method, path, nil)
+	} else {
+		r = httptest.NewRequest(method, path, strings.NewReader(body))
+	}
+	r = r.WithContext(context.WithValue(r.Context(), principalKey, Principal{ID: "analyst-1", Role: role, TenantID: "tenant-a"}))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, r)
+	return rec
+}
+
+func TestIncidentRoutesRBAC(t *testing.T) {
+	f := &fakeIncidentStore{get: map[shared.ID]incident.Incident{"inc-1": {ID: "inc-1", State: incident.StateOpen}}}
+	mux := newIncidentRouter(f)
+
+	cases := []struct {
+		name, role, method, path, body string
+		want                           int
+	}{
+		{"readonly can read list", "readonly", http.MethodGet, "/api/v1/fleet/incidents", "", http.StatusOK},
+		{"readonly can read one", "readonly", http.MethodGet, "/api/v1/fleet/incidents/inc-1", "", http.StatusOK},
+		{"readonly cannot assign owner (needs triage)", "readonly", http.MethodPost, "/api/v1/fleet/incidents/inc-1/owner", `{"owner":"a"}`, http.StatusForbidden},
+		{"readonly cannot set disposition (needs review)", "readonly", http.MethodPost, "/api/v1/fleet/incidents/inc-1/disposition", `{"disposition":"true_positive"}`, http.StatusForbidden},
+		{"consultant can assign owner", "consultant", http.MethodPost, "/api/v1/fleet/incidents/inc-1/owner", `{"owner":"a"}`, http.StatusOK},
+		{"consultant can change status", "consultant", http.MethodPost, "/api/v1/fleet/incidents/inc-1/status", `{"to":"triaged"}`, http.StatusOK},
+		{"consultant CANNOT set disposition (no review)", "consultant", http.MethodPost, "/api/v1/fleet/incidents/inc-1/disposition", `{"disposition":"true_positive"}`, http.StatusForbidden},
+		{"reviewer can set disposition", "reviewer", http.MethodPost, "/api/v1/fleet/incidents/inc-1/disposition", `{"disposition":"true_positive"}`, http.StatusOK},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rec := incidentReq(mux, c.role, c.method, c.path, c.body)
+			if rec.Code != c.want {
+				t.Fatalf("%s %s as %s: got %d, want %d (%s)", c.method, c.path, c.role, rec.Code, c.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestIncidentTriageActorIsPrincipal proves the actor is the authenticated principal, never a body
+// field — the security-critical property of an attributable triage mutation.
+func TestIncidentTriageActorIsPrincipal(t *testing.T) {
+	f := &fakeIncidentStore{}
+	mux := newIncidentRouter(f)
+	// The body tries to spoof a different actor; it must be ignored.
+	rec := incidentReq(mux, "consultant", http.MethodPost, "/api/v1/fleet/incidents/inc-9/owner", `{"owner":"bob","actor":"attacker"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("assign owner: got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if f.lastActor != "analyst-1" {
+		t.Fatalf("actor must be the authenticated principal, got %q", f.lastActor)
+	}
+	if f.lastOwner != "bob" {
+		t.Fatalf("owner must come from the body, got %q", f.lastOwner)
+	}
+}
+
+// TestIncidentListTruncationIsHonest checks the limit+1 probe: a full page reports Truncated so a
+// client (and any state filter run over it) knows more incidents exist beyond the page.
+func TestIncidentListTruncationIsHonest(t *testing.T) {
+	f := &fakeIncidentStore{list: []incident.Incident{
+		{ID: "a", State: incident.StateOpen},
+		{ID: "b", State: incident.StateOpen},
+		{ID: "c", State: incident.StateTriaged},
+	}}
+	mux := newIncidentRouter(f)
+	rec := incidentReq(mux, "readonly", http.MethodGet, "/api/v1/fleet/incidents?limit=2", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list: got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if f.lastLimit != 3 {
+		t.Fatalf("handler must probe limit+1 for honest truncation, store saw limit=%d", f.lastLimit)
+	}
+	var resp incidentListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Incidents) != 2 {
+		t.Fatalf("page must be trimmed to the limit, got %d", len(resp.Incidents))
+	}
+	if !resp.Truncated {
+		t.Fatal("a full page must report Truncated=true")
+	}
+}
+
+func TestIncidentListStateFilter(t *testing.T) {
+	f := &fakeIncidentStore{list: []incident.Incident{
+		{ID: "a", State: incident.StateOpen},
+		{ID: "b", State: incident.StateTriaged},
+		{ID: "c", State: incident.StateOpen},
+	}}
+	mux := newIncidentRouter(f)
+	rec := incidentReq(mux, "readonly", http.MethodGet, "/api/v1/fleet/incidents?state=open", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list: got %d (%s)", rec.Code, rec.Body.String())
+	}
+	var resp incidentListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(resp.Incidents) != 2 {
+		t.Fatalf("state=open must filter to the two open incidents, got %d", len(resp.Incidents))
+	}
+	// An unknown state is rejected, not silently ignored.
+	if bad := incidentReq(mux, "readonly", http.MethodGet, "/api/v1/fleet/incidents?state=bogus", ""); bad.Code != http.StatusBadRequest {
+		t.Fatalf("unknown state must be 400, got %d", bad.Code)
+	}
+}
+
+func TestIncidentReadAndTriageErrorMapping(t *testing.T) {
+	// Missing incident → 404.
+	f := &fakeIncidentStore{getErr: shared.ErrNotFound}
+	mux := newIncidentRouter(f)
+	if rec := incidentReq(mux, "readonly", http.MethodGet, "/api/v1/fleet/incidents/nope", ""); rec.Code != http.StatusNotFound {
+		t.Fatalf("missing incident must be 404, got %d", rec.Code)
+	}
+	// Invalid limit → 400.
+	if rec := incidentReq(mux, "readonly", http.MethodGet, "/api/v1/fleet/incidents?limit=-1", ""); rec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid limit must be 400, got %d", rec.Code)
+	}
+	// Bad body → 400.
+	if rec := incidentReq(mux, "consultant", http.MethodPost, "/api/v1/fleet/incidents/inc-1/owner", `{`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("malformed body must be 400, got %d", rec.Code)
+	}
+	// A usecase validation error (e.g. an illegal transition) maps to 400.
+	f2 := &fakeIncidentStore{triErr: shared.ErrValidation}
+	mux2 := newIncidentRouter(f2)
+	if rec := incidentReq(mux2, "consultant", http.MethodPost, "/api/v1/fleet/incidents/inc-1/status", `{"to":"resolved"}`); rec.Code != http.StatusBadRequest {
+		t.Fatalf("usecase validation error must be 400, got %d", rec.Code)
+	}
+	// A conflict (optimistic-concurrency) maps to 409.
+	f3 := &fakeIncidentStore{triErr: shared.ErrConflict}
+	mux3 := newIncidentRouter(f3)
+	if rec := incidentReq(mux3, "consultant", http.MethodPost, "/api/v1/fleet/incidents/inc-1/status", `{"to":"triaged"}`); rec.Code != http.StatusConflict {
+		t.Fatalf("optimistic-concurrency conflict must be 409, got %d", rec.Code)
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -78,6 +78,8 @@ type Router struct {
 	businessAssets         businessAssetService  // optional; nil ⇒ business-level Asset routes are not registered
 	attackPaths            attackPathService     // optional; nil ⇒ attack-path routes are not registered
 	coverage               coverageService       // optional; nil ⇒ fleet coverage/agent-view routes are not registered
+	incidents              incidentReader        // optional; nil ⇒ incident read routes are not registered (#594 C7)
+	incidentTriage         incidentTriager       // optional; nil ⇒ incident triage routes are not registered (#594 C5)
 	sarif                  sarifIngester         // optional; nil ⇒ the third-party SARIF import route is not registered
 	importedFindings       sarifReader           // optional read side for imported findings
 	fleetRolloutAdmin      fleetRolloutService   // optional; nil ⇒ the operator rollout routes are not served
@@ -372,6 +374,24 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("GET /api/v1/fleet/coverage", rt.authz(userdom.PermView, rt.listFleetCoverage))
 		mux.HandleFunc("GET /api/v1/fleet/coverage/summary", rt.authz(userdom.PermView, rt.fleetCoverageSummary))
 		mux.HandleFunc("GET /api/v1/fleet/coverage/export", rt.authz(userdom.PermView, rt.exportFleetCoverage))
+	}
+	if rt.incidents != nil {
+		// Phase-C incident read + analyst-triage surface (#594 C7/C5). Operator plane, tenant-scoped
+		// (fleetTenant + RLS). These live under /api/v1/fleet but are NOT in fleetAgentPlaneMounts,
+		// so Handler() keeps them on the HUMAN RBAC chain, not the untrusted agent plane. Reads =
+		// PermView.
+		mux.HandleFunc("GET /api/v1/fleet/incidents", rt.authz(userdom.PermView, rt.listIncidents))
+		mux.HandleFunc("GET /api/v1/fleet/incidents/{id}", rt.authz(userdom.PermView, rt.getIncident))
+		if rt.incidentTriage != nil {
+			// Analyst-triage mutations. Owner/comment/status = PermTriage (mirrors finding-triage);
+			// disposition is an analyst VERDICT so it takes PermReview. The actor is the authenticated
+			// principal (PrincipalFrom), never a body field, and each mutation lands as an attributable
+			// event on the append-only incident log.
+			mux.HandleFunc("POST /api/v1/fleet/incidents/{id}/owner", rt.authz(userdom.PermTriage, rt.assignIncidentOwner))
+			mux.HandleFunc("POST /api/v1/fleet/incidents/{id}/comments", rt.authz(userdom.PermTriage, rt.commentIncident))
+			mux.HandleFunc("POST /api/v1/fleet/incidents/{id}/status", rt.authz(userdom.PermTriage, rt.changeIncidentStatus))
+			mux.HandleFunc("POST /api/v1/fleet/incidents/{id}/disposition", rt.authz(userdom.PermReview, rt.setIncidentDisposition))
+		}
 	}
 	if rt.projects != nil {
 		mux.HandleFunc("POST /api/v1/projects", rt.authz(userdom.PermOperate, rt.createProject))


### PR DESCRIPTION
## C7 (#681) — incident read + analyst-triage HTTP surface

Completes Phase C's C7 by exposing the already-merged event-sourced incident store (store twins + migration 0112 + `incidentuc`/`incidenttriage` usecases) over HTTP for human operators. This is the last remaining Phase-C part — the EDR-MVP loop (correlation → incident → tri-score → retro-hunt → triage → governed-response) is now reachable end-to-end.

### Routes (human RBAC plane, tenant-scoped)
| Method | Path | Perm |
|---|---|---|
| GET | `/api/v1/fleet/incidents` (`?asset`, `?limit`, `?state`) | `PermView` |
| GET | `/api/v1/fleet/incidents/{id}` | `PermView` |
| POST | `/api/v1/fleet/incidents/{id}/owner` | `PermTriage` |
| POST | `/api/v1/fleet/incidents/{id}/comments` | `PermTriage` |
| POST | `/api/v1/fleet/incidents/{id}/status` | `PermTriage` |
| POST | `/api/v1/fleet/incidents/{id}/disposition` | `PermReview` |

**Disposition takes `PermReview`, not `PermTriage`** — it is the analyst verdict, a sign-off with separation of duties (a consultant can triage owner/status but a reviewer decides the verdict), mirroring finding review.

### Safety properties
- **Narrow ports**: the adapter defines `incidentReader`/`incidentTriager`; `incidentuc`/`incidenttriage` satisfy them structurally (no adapter→usecase/infra import).
- **Actor = authenticated principal** (`PrincipalFrom`), never a body field — every triage mutation is attributable on the append-only incident log. Test proves a body `"actor"` cannot spoof it.
- **Tenant from the principal** (`fleetTenant`), never a param/body — neither `{id}` nor `?asset` can reach another tenant's data (RLS + explicit predicate in the store).
- **Human plane**: `/api/v1/fleet/incidents` is NOT an agent-plane mount, so `Handler()` keeps it on the human authenticator chain, off the untrusted agent plane.
- **Honest truncation**: a `limit+1` probe sets `Truncated` on the raw page *before* the optional `?state` filter, so a state-filtered result over a capped page is flagged rather than reading as complete (no store-level state index — state is a projection). Bodies capped with `http.MaxBytesReader` (parity with finding-triage).

### Verification
`gofmt`/`build`/`vet` clean; httpapi + api tests green including `TestOpenAPIRouteCoverage` (routes debt-tracked like the sibling `/api/v1/fleet` operator reads) and `TestHostileHarness`. Handler tests cover the RBAC matrix (incl. consultant-cannot-disposition), actor-from-principal, truncation honesty, state filter, and 400/404/409 mapping.

Dual-reviewed: **go-arch MERGEABLE**, **security SHIP**. Their one shared finding (missing body-size cap) is folded in.

CI is off by request — validated locally.
