### PR TITLE
feat(baseline): Phase D behavioral-baseline domain core (D1+D2+D3, #639)

### DIFF
--- a/internal/domain/baseline/baseline.go
+++ b/internal/domain/baseline/baseline.go
@@ -1,0 +1,233 @@
+package baseline
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// MaxObservations caps how many observations a single baseline accumulates before it must be re-baselined.
+// It bounds the int64 sum/sumSq accumulators (MaxObservations * MaxFeatureValue^2 stays under MaxInt64) and
+// models the reality that a baseline is a bounded rolling window, not an infinite accumulator. Fold refuses
+// past this ceiling so the usecase rolls/decays rather than silently overflowing.
+const MaxObservations int64 = 1_000_000
+
+// Key identifies what a baseline is learned for: a tenant plus a group, where the group is either
+// a peer-group id (peer-group baselining) or a single entity id. Peer-group baselining is first-class so a
+// brand-new workload inherits its group's normal rather than cold-starting from nothing.
+type Key struct {
+	Tenant shared.ID
+	Group  string
+}
+
+// Validate enforces a well-formed key.
+func (k Key) Validate() error {
+	if k.Tenant.IsZero() {
+		return fmt.Errorf("%w: baseline key requires a tenant", shared.ErrValidation)
+	}
+	if k.Group == "" {
+		return fmt.Errorf("%w: baseline key requires a group (peer-group or entity id)", shared.ErrValidation)
+	}
+	return nil
+}
+
+// FeatureSummary is the deterministic per-feature accumulation of a baseline: enough to compute mean and
+// population variance exactly in integer arithmetic (no floats, so it hashes/compares reproducibly). Count
+// is shared across features (one observation contributes one value per feature) but carried per-summary
+// for a self-describing persisted row.
+type FeatureSummary struct {
+	Feature Feature
+	Count   int64
+	Sum     int64
+	SumSq   int64
+	Min     int64
+	Max     int64
+}
+
+// Baseline is the per-key behavioral baseline aggregate: its lifecycle state plus a deterministic,
+// REORDER-INVARIANT fold of eligible observations (count/sum/sumSq/min/max are all order-independent, so
+// re-folding the same observations in any order yields a byte-identical summary — the property Phase-C
+// evidence needs). Construct with NewBaseline; advance state only via Transition.
+type Baseline struct {
+	key   Key
+	state State
+	obs   int64
+	sum   [numFeatures]int64
+	sumSq [numFeatures]int64
+	min   [numFeatures]int64
+	max   [numFeatures]int64
+}
+
+// NewBaseline starts a baseline in StateLearning for a validated key.
+func NewBaseline(key Key) (*Baseline, error) {
+	if err := key.Validate(); err != nil {
+		return nil, err
+	}
+	return &Baseline{key: key, state: StateLearning}, nil
+}
+
+// Key returns the baseline's identity.
+func (b *Baseline) Key() Key { return b.key }
+
+// State returns the current lifecycle state.
+func (b *Baseline) State() State { return b.state }
+
+// ObservationCount returns how many observations have been folded.
+func (b *Baseline) ObservationCount() int64 { return b.obs }
+
+// Scoreable reports whether the baseline may currently yield an anomaly score (state == active).
+func (b *Baseline) Scoreable() bool { return b.state.Scoreable() }
+
+// ReadyToActivate reports whether enough observations have accrued to leave cold-start. The caller drives
+// the learning -> active transition; the baseline only reports readiness (it never self-advances).
+func (b *Baseline) ReadyToActivate(minObservations int64) bool {
+	return minObservations > 0 && b.obs >= minObservations
+}
+
+// Transition advances the lifecycle state, rejecting an illegal transition. Entering StateLearning (only
+// reachable from reset_pending) ZEROES the accumulators: a re-baseline must start clean so it can never
+// keep folding onto the prior, possibly-poisoned, sums.
+func (b *Baseline) Transition(to State) error {
+	if err := requireTransition(b.state, to); err != nil {
+		return err
+	}
+	b.state = to
+	if to == StateLearning {
+		b.reset()
+	}
+	return nil
+}
+
+// reset zeroes the accumulators for a clean (re-)baseline. State is not touched here.
+func (b *Baseline) reset() {
+	b.obs = 0
+	b.sum = [numFeatures]int64{}
+	b.sumSq = [numFeatures]int64{}
+	b.min = [numFeatures]int64{}
+	b.max = [numFeatures]int64{}
+}
+
+// Fold accumulates one observation captured under window w. It FOLDS THROUGH THE ELIGIBILITY GATE: an
+// ineligible window (incident/emulation/active-response/degraded/low-coverage — see LearnWindow.Eligible)
+// is rejected before any mutation, so tainted data cannot be folded even by a caller that forgot to check
+// (the anti-poisoning gate is enforced here, not by convention). Folding is further allowed ONLY in a
+// learning-capable state (learning/active/stale) — a drifted/poisoned/reset_pending/disabled baseline must
+// NOT keep learning — and is refused past MaxObservations so the accumulators cannot overflow.
+func (b *Baseline) Fold(o Observation, w LearnWindow) error {
+	if err := o.Validate(); err != nil {
+		return err
+	}
+	if ok, why := w.Eligible(); !ok {
+		return fmt.Errorf("%w: window not eligible for learning: %s", shared.ErrValidation, why)
+	}
+	switch b.state {
+	case StateLearning, StateActive, StateStale:
+		// learning-capable
+	default:
+		return fmt.Errorf("%w: cannot fold into a %s baseline", shared.ErrValidation, b.state)
+	}
+	if b.obs >= MaxObservations {
+		return fmt.Errorf("%w: baseline observation cap (%d) reached; re-baseline required", shared.ErrValidation, MaxObservations)
+	}
+	first := b.obs == 0
+	b.obs++
+	for f := 0; f < numFeatures; f++ {
+		v := o.Values[f]
+		b.sum[f] += v
+		b.sumSq[f] += v * v
+		if first || v < b.min[f] {
+			b.min[f] = v
+		}
+		if first || v > b.max[f] {
+			b.max[f] = v
+		}
+	}
+	return nil
+}
+
+// Summary returns the per-feature accumulation in fixed feature order (deterministic).
+func (b *Baseline) Summary() [numFeatures]FeatureSummary {
+	var out [numFeatures]FeatureSummary
+	for f := 0; f < numFeatures; f++ {
+		out[f] = FeatureSummary{Feature: Feature(f), Count: b.obs, Sum: b.sum[f], SumSq: b.sumSq[f], Min: b.min[f], Max: b.max[f]}
+	}
+	return out
+}
+
+// Anomaly scores how far observation o deviates from the learned baseline as a 0..100 Score, and reports
+// whether the baseline was scoreable at all. It abstains (0, false) unless the baseline is active with at
+// least one observation — a non-active baseline must NOT fabricate a score (coverage-honesty).
+//
+// The score is the WORST per-feature deviation band, measured in standard deviations using EXACT integer
+// arithmetic (no mean truncation, no sqrt, no division): with mean = sum/obs and population variance var,
+// the test (v-mean)^2 <= k*var is equivalent to (obs*v - sum)^2 <= k*(obs*sumSq - sum^2), and obs^2*var =
+// obs*sumSq - sum^2. A variance floor of 1 unit^2 (adding obs^2) keeps a zero-variance feature from
+// screaming at a ±1 wobble. The comparison is done in math/big so it CANNOT overflow — a wild deviation
+// can never wrap into a low band and read as "normal" (a detector-evasion this safety path must prevent).
+func (b *Baseline) Anomaly(o Observation) (riskassessment.Score, bool) {
+	if !b.state.Scoreable() || b.obs <= 0 {
+		return 0, false
+	}
+	if err := o.Validate(); err != nil {
+		return 0, false
+	}
+	worst := 0
+	for f := 0; f < numFeatures; f++ {
+		band := b.featureBand(f, o.Values[f])
+		if band > worst {
+			worst = band
+		}
+	}
+	return bandScore(worst), true
+}
+
+// featureBand returns 0 (<=1σ), 1 (<=2σ), 2 (<=3σ), or 3 (>3σ) for feature f at value v. It uses
+// arbitrary-precision integers so the exact-variance comparison is overflow-free and deterministic:
+// there is no int64 product that could wrap and collapse a large deviation to band 0.
+func (b *Baseline) featureBand(f int, v int64) int {
+	obs := big.NewInt(b.obs)
+	sum := big.NewInt(b.sum[f])
+	// num = obs*sumSq - sum^2 = obs^2 * variance, always >= 0.
+	num := new(big.Int).Mul(obs, big.NewInt(b.sumSq[f]))
+	num.Sub(num, new(big.Int).Mul(sum, sum))
+	// Variance floor of 1 unit^2: num >= obs^2.
+	if obs2 := new(big.Int).Mul(obs, obs); num.Cmp(obs2) < 0 {
+		num = obs2
+	}
+	// d = obs*(v - mean); lhs = d^2 = obs^2 * (v-mean)^2.
+	d := new(big.Int).Sub(new(big.Int).Mul(obs, big.NewInt(v)), sum)
+	lhs := new(big.Int).Mul(d, d)
+	switch {
+	case lhs.Cmp(num) <= 0:
+		return 0
+	case lhs.Cmp(new(big.Int).Mul(big.NewInt(4), num)) <= 0:
+		return 1
+	case lhs.Cmp(new(big.Int).Mul(big.NewInt(9), num)) <= 0:
+		return 2
+	default:
+		return 3
+	}
+}
+
+// bandScore maps a deviation band to a 0..100 anomaly score, monotonic in the band.
+func bandScore(band int) riskassessment.Score {
+	switch band {
+	case 0:
+		return 10
+	case 1:
+		return 35
+	case 2:
+		return 65
+	default:
+		return 90
+	}
+}
+
+// Clone returns a deep copy (the arrays are values, so a struct copy is a full copy) — a safe seam for a
+// persistence layer to hand out without aliasing internal state.
+func (b *Baseline) Clone() *Baseline {
+	cp := *b
+	return &cp
+}

--- a/internal/domain/baseline/baseline_test.go
+++ b/internal/domain/baseline/baseline_test.go
@@ -1,0 +1,248 @@
+package baseline
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func key() Key { return Key{Tenant: "t1", Group: "web-tier"} }
+
+func obs(spawn, fanout, newexec, priv, files int64) Observation {
+	return Observation{Values: [numFeatures]int64{spawn, fanout, newexec, priv, files}}
+}
+
+// okWin is a clean, well-covered learning window (eligible).
+func okWin() LearnWindow { return LearnWindow{Coverage: 90, MinCoverage: 60} }
+
+func mustBaseline(t *testing.T) *Baseline {
+	t.Helper()
+	b, err := NewBaseline(key())
+	if err != nil {
+		t.Fatalf("new baseline: %v", err)
+	}
+	return b
+}
+
+// learnSteady folds n copies of a steady observation (through the eligibility gate) and activates.
+func learnSteady(t *testing.T, b *Baseline, n int, o Observation) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		if err := b.Fold(o, okWin()); err != nil {
+			t.Fatalf("fold: %v", err)
+		}
+	}
+	if err := b.Transition(StateActive); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+}
+
+func TestStateMachine(t *testing.T) {
+	for _, s := range []State{StateLearning, StateStale, StateDrifted, StatePoisoned, StateResetPending, StateDisabled} {
+		if s.Scoreable() {
+			t.Fatalf("%s must not be scoreable", s)
+		}
+	}
+	if !StateActive.Scoreable() {
+		t.Fatal("active must be scoreable")
+	}
+	b := mustBaseline(t)
+	for _, to := range []State{StateActive, StateDrifted, StateResetPending, StateLearning, StateActive} {
+		if err := b.Transition(to); err != nil {
+			t.Fatalf("transition to %s: %v", to, err)
+		}
+	}
+	if err := b.Transition(StateDisabled); err != nil {
+		t.Fatalf("active->disabled: %v", err)
+	}
+	if !b.State().Terminal() {
+		t.Fatal("disabled must be terminal")
+	}
+	if b.Transition(StateLearning) == nil {
+		t.Fatal("no transition out of disabled")
+	}
+	b2 := mustBaseline(t)
+	if err := b2.Transition(StateDrifted); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("learning->drifted must be illegal, got %v", err)
+	}
+	if err := b2.Transition("bogus"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("unknown state must be rejected, got %v", err)
+	}
+}
+
+func TestFoldIsReorderInvariant(t *testing.T) {
+	obsSeq := []Observation{obs(2, 5, 1, 0, 3), obs(3, 4, 0, 1, 2), obs(1, 6, 2, 0, 4), obs(4, 5, 1, 0, 3)}
+	fwd := mustBaseline(t)
+	for _, o := range obsSeq {
+		if err := fwd.Fold(o, okWin()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rev := mustBaseline(t)
+	for i := len(obsSeq) - 1; i >= 0; i-- {
+		if err := rev.Fold(obsSeq[i], okWin()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if fwd.Summary() != rev.Summary() {
+		t.Fatalf("fold not reorder-invariant:\n fwd=%+v\n rev=%+v", fwd.Summary(), rev.Summary())
+	}
+	if fwd.ObservationCount() != 4 {
+		t.Fatalf("obs count = %d, want 4", fwd.ObservationCount())
+	}
+}
+
+func TestColdStartAbstains(t *testing.T) {
+	b := mustBaseline(t)
+	for i := 0; i < 5; i++ {
+		if err := b.Fold(obs(2, 5, 1, 0, 3), okWin()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, ok := b.Anomaly(obs(99, 99, 9, 9, 99)); ok {
+		t.Fatal("a learning baseline must abstain from scoring")
+	}
+	if b.ReadyToActivate(10) {
+		t.Fatal("5 obs must not be ready to activate at min 10")
+	}
+	if !b.ReadyToActivate(5) {
+		t.Fatal("5 obs must be ready to activate at min 5")
+	}
+}
+
+func TestAnomalyMonotonicAndScoreableGate(t *testing.T) {
+	b := mustBaseline(t)
+	seq := []Observation{obs(2, 5, 1, 0, 3), obs(2, 5, 1, 0, 3), obs(3, 4, 1, 0, 3), obs(1, 6, 1, 0, 3), obs(2, 5, 1, 0, 3), obs(2, 5, 1, 0, 3)}
+	for _, o := range seq {
+		if err := b.Fold(o, okWin()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := b.Transition(StateActive); err != nil {
+		t.Fatal(err)
+	}
+	near, ok := b.Anomaly(obs(2, 5, 1, 0, 3))
+	if !ok {
+		t.Fatal("active baseline must be scoreable")
+	}
+	mild, _ := b.Anomaly(obs(4, 7, 1, 0, 3))
+	wild, _ := b.Anomaly(obs(50, 80, 20, 9, 40))
+	if !(near <= mild && mild <= wild) {
+		t.Fatalf("anomaly must be monotonic in deviation: near=%d mild=%d wild=%d", near, mild, wild)
+	}
+	if !near.Valid() || !wild.Valid() {
+		t.Fatal("scores must be in range")
+	}
+	if wild < 65 {
+		t.Fatalf("a wild deviation must score high, got %d", wild)
+	}
+}
+
+// TestAnomalyLargeValueDoesNotWrapToNormal is the overflow-evasion regression: a maximally large valid
+// feature value against a small-valued baseline must score in the TOP band, never wrap to band 0 "normal".
+func TestAnomalyLargeValueDoesNotWrapToNormal(t *testing.T) {
+	b := mustBaseline(t)
+	learnSteady(t, b, 20, obs(2, 5, 1, 0, 3))
+	// A single feature slammed to the max — with wrapping int64 math this could have collapsed to band 0.
+	huge := obs(MaxFeatureValue, 5, 1, 0, 3)
+	score, ok := b.Anomaly(huge)
+	if !ok {
+		t.Fatal("active baseline must score")
+	}
+	if score < 65 {
+		t.Fatalf("a max-value deviation must score in a high band, got %d (overflow wrap?)", score)
+	}
+}
+
+func TestFoldThroughEligibilityGateRejectsTaintedWindow(t *testing.T) {
+	b := mustBaseline(t)
+	// An incident-active window must be refused before any mutation.
+	if err := b.Fold(obs(2, 5, 1, 0, 3), LearnWindow{IncidentActive: true, Coverage: 90, MinCoverage: 60}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("fold through incident window must be rejected, got %v", err)
+	}
+	if b.ObservationCount() != 0 {
+		t.Fatalf("a rejected fold must not mutate; obs=%d", b.ObservationCount())
+	}
+	// The true zero-value window (no coverage floor established) is also refused.
+	if err := b.Fold(obs(2, 5, 1, 0, 3), LearnWindow{}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("fold through zero-value window must be rejected, got %v", err)
+	}
+	if b.ObservationCount() != 0 {
+		t.Fatalf("zero-value window must not mutate; obs=%d", b.ObservationCount())
+	}
+}
+
+func TestReBaselineClearsAccumulators(t *testing.T) {
+	b := mustBaseline(t)
+	learnSteady(t, b, 8, obs(9, 9, 9, 9, 9)) // learn a (hypothetically poisoned) high baseline
+	// Drift → request reset → re-baseline.
+	if err := b.Transition(StateDrifted); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Transition(StateResetPending); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Transition(StateLearning); err != nil {
+		t.Fatal(err)
+	}
+	if b.ObservationCount() != 0 {
+		t.Fatalf("re-baseline must clear observations, got %d", b.ObservationCount())
+	}
+	var zero [numFeatures]FeatureSummary
+	for f := 0; f < numFeatures; f++ {
+		zero[f] = FeatureSummary{Feature: Feature(f)}
+	}
+	if b.Summary() != zero {
+		t.Fatalf("re-baseline must zero the accumulators, got %+v", b.Summary())
+	}
+}
+
+func TestFoldRejectedInNonLearningState(t *testing.T) {
+	b := mustBaseline(t)
+	learnSteady(t, b, 3, obs(2, 5, 1, 0, 3))
+	if err := b.Transition(StateDrifted); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Fold(obs(2, 5, 1, 0, 3), okWin()); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("folding into a drifted baseline must be rejected, got %v", err)
+	}
+}
+
+func TestObservationAndKeyValidation(t *testing.T) {
+	if _, err := NewBaseline(Key{Group: "g"}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("missing tenant must be rejected")
+	}
+	if _, err := NewBaseline(Key{Tenant: "t"}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("missing group must be rejected")
+	}
+	b := mustBaseline(t)
+	if err := b.Fold(Observation{Values: [numFeatures]int64{1, -1, 0, 0, 0}}, okWin()); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("negative feature value must be rejected, got %v", err)
+	}
+	if err := b.Fold(obs(MaxFeatureValue+1, 0, 0, 0, 0), okWin()); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("feature value above MaxFeatureValue must be rejected, got %v", err)
+	}
+}
+
+func TestLearnEligibilityFailClosed(t *testing.T) {
+	if ok, why := okWin().Eligible(); !ok {
+		t.Fatalf("clean window must be eligible, got %q", why)
+	}
+	for name, w := range map[string]LearnWindow{
+		"incident":        {IncidentActive: true, Coverage: 90, MinCoverage: 60},
+		"emulation":       {Emulation: true, Coverage: 90, MinCoverage: 60},
+		"active-response": {ActiveResponse: true, Coverage: 90, MinCoverage: 60},
+		"degraded":        {SensorDegraded: true, Coverage: 90, MinCoverage: 60},
+		"low-coverage":    {Coverage: 40, MinCoverage: 60},
+		"zero-value":      {},
+		"no-floor":        {Coverage: 90},
+		"no-coverage":     {MinCoverage: 60},
+	} {
+		if ok, why := w.Eligible(); ok {
+			t.Fatalf("%s window must be ineligible", name)
+		} else if why == "" {
+			t.Fatalf("%s window must carry a reason", name)
+		}
+	}
+}

--- a/internal/domain/baseline/eligibility.go
+++ b/internal/domain/baseline/eligibility.go
@@ -1,0 +1,51 @@
+package baseline
+
+import "github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+
+// LearnWindow describes the conditions under which an observation window was captured, so the baseline can
+// refuse to learn from data that would poison it or that was not honestly observed. It is the
+// anti-poisoning + coverage-honesty gate: a baseline must NEVER train on an incident-active,
+// adversary-emulation, active-response, sensor-degraded, or low-coverage window.
+type LearnWindow struct {
+	// IncidentActive: an incident was open for this entity/group during the window — abnormal by definition.
+	IncidentActive bool
+	// Emulation: an adversary-emulation / purple-team exercise was running — synthetic malice.
+	Emulation bool
+	// ActiveResponse: a response action (kill/quarantine/isolate) was in flight — perturbed behavior.
+	ActiveResponse bool
+	// SensorDegraded: the sensor was degraded/unhealthy — the window is not a faithful sample.
+	SensorDegraded bool
+	// Coverage is the honest observed coverage floor for the window (0..100).
+	Coverage riskassessment.Score
+	// MinCoverage is the floor the window must meet to be trusted for learning (0..100).
+	MinCoverage riskassessment.Score
+}
+
+// Eligible reports whether the window may be learned from, and if not, a human reason. It is FAIL-CLOSED:
+// any disqualifying flag, or coverage below the required floor, excludes the window. Because a zero-value
+// LearnWindow has Coverage 0, an unspecified/ambiguous window is ineligible by default — you must
+// affirmatively establish clean, sufficiently-covered conditions to learn.
+func (w LearnWindow) Eligible() (bool, string) {
+	switch {
+	case w.IncidentActive:
+		return false, "incident active during window"
+	case w.Emulation:
+		return false, "adversary-emulation window"
+	case w.ActiveResponse:
+		return false, "active-response window"
+	case w.SensorDegraded:
+		return false, "sensor degraded during window"
+	case !w.Coverage.Valid() || !w.MinCoverage.Valid():
+		return false, "coverage out of range"
+	case w.MinCoverage <= 0:
+		// A zeroed/absent floor must NOT read as "trusted" — the zero value is ineligible, so a caller
+		// that forgets to establish a floor cannot silently learn (fail-closed, golden rule 2).
+		return false, "no coverage floor established"
+	case w.Coverage <= 0:
+		return false, "no observed coverage"
+	case w.Coverage < w.MinCoverage:
+		return false, "coverage below learning floor"
+	default:
+		return true, ""
+	}
+}

--- a/internal/domain/baseline/feature.go
+++ b/internal/domain/baseline/feature.go
@@ -1,0 +1,72 @@
+package baseline
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Feature is one behavioral dimension observed per entity/peer-group over a window. The set is FIXED and
+// ORDERED (an array index, not a map key) so a baseline summary and anomaly score are deterministic — no
+// map iteration in any output. New features append at the end; existing indices never change.
+type Feature int
+
+const (
+	// FeatureProcessSpawnRate: process spawns observed in the window.
+	FeatureProcessSpawnRate Feature = iota
+	// FeatureNetworkFanout: distinct network peers contacted in the window.
+	FeatureNetworkFanout
+	// FeatureNewExecPaths: distinct exec paths not seen before in the window.
+	FeatureNewExecPaths
+	// FeaturePrivilegeEvents: setuid/setresuid/capset events in the window.
+	FeaturePrivilegeEvents
+	// FeatureFileWriteBreadth: distinct files written in the window.
+	FeatureFileWriteBreadth
+	// numFeatures is the array size — keep last.
+	numFeatures = iota
+)
+
+// featureNames gives each feature a stable name for reasons/validation messages, indexed by Feature.
+var featureNames = [numFeatures]string{
+	"process_spawn_rate",
+	"network_fanout",
+	"new_exec_paths",
+	"privilege_events",
+	"file_write_breadth",
+}
+
+// Name returns the stable name of the feature (empty for an out-of-range value).
+func (f Feature) Name() string {
+	if f < 0 || int(f) >= numFeatures {
+		return ""
+	}
+	return featureNames[f]
+}
+
+// MaxFeatureValue is the enforced upper bound on any per-window feature count. It is a real invariant, not
+// a comment: together with MaxObservations it keeps every product in the anomaly math (and the int64
+// sum/sumSq accumulators) far below overflow, and a per-window count above a million is itself pathological
+// (clamp/reject rather than trust it). MaxObservations * MaxFeatureValue^2 stays well under MaxInt64.
+const MaxFeatureValue int64 = 1_000_000
+
+// Observation is one window's behavioral counts for an entity/peer-group — a fixed-size, ordered vector
+// of bounded non-negative integer feature values. Integer (not float) keeps the fold deterministic.
+type Observation struct {
+	Values [numFeatures]int64
+}
+
+// Validate enforces non-negative, bounded feature values (counts cannot be negative, and are capped at
+// MaxFeatureValue so the deterministic anomaly math cannot overflow — an unbounded count is rejected, never
+// silently wrapped).
+func (o Observation) Validate() error {
+	for f := 0; f < numFeatures; f++ {
+		v := o.Values[f]
+		if v < 0 {
+			return fmt.Errorf("%w: observation feature %s is negative (%d)", shared.ErrValidation, Feature(f).Name(), v)
+		}
+		if v > MaxFeatureValue {
+			return fmt.Errorf("%w: observation feature %s value %d exceeds max %d", shared.ErrValidation, Feature(f).Name(), v, MaxFeatureValue)
+		}
+	}
+	return nil
+}

--- a/internal/domain/baseline/state.go
+++ b/internal/domain/baseline/state.go
@@ -1,0 +1,84 @@
+// Package baseline is the pure-domain behavioral-baseline model for Phase D of the EDR data plane
+// (#594, D1-D4). It learns normal per-entity/peer-group behavior and scores how far a fresh observation
+// deviates — an anomaly that becomes a RiskContext.Behavior FACTOR, never a verdict. Its disciplines
+// mirror the rest of the data plane: deterministic + reorder-invariant folds (so a baseline summary is
+// reproducible for evidence), fail-closed validation, and coverage-honesty — a baseline yields an anomaly
+// score ONLY while it is trustworthy (state == active); otherwise it abstains, which lowers Coverage,
+// never Risk. The eBPF collection and the live scoring loop are composed on top (deferred agent tail).
+package baseline
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// State is where a baseline sits in its trust lifecycle. A baseline is trustworthy for anomaly
+// scoring ONLY in StateActive; every other state means "do not score from me" (coverage-honesty).
+type State string
+
+const (
+	// StateLearning: accumulating observations, not yet enough to score (cold-start).
+	StateLearning State = "learning"
+	// StateActive: enough clean observations; the ONLY state that yields an anomaly score.
+	StateActive State = "active"
+	// StateStale: no recent observations; not scoreable until fresh data revives it.
+	StateStale State = "stale"
+	// StateDrifted: sustained divergence detected; must re-baseline before scoring again.
+	StateDrifted State = "drifted"
+	// StatePoisoned: learned from (or suspected of) tainted data; must re-baseline.
+	StatePoisoned State = "poisoned"
+	// StateResetPending: marked for a clean re-baseline; transitions back to learning.
+	StateResetPending State = "reset_pending"
+	// StateDisabled: operator-disabled; terminal (re-enabling means a fresh baseline).
+	StateDisabled State = "disabled"
+)
+
+// transitions is the legal lifecycle graph. Learning gathers until active; active keeps learning online
+// but can go stale/drifted/poisoned; drift and poison both force a reset_pending -> learning re-baseline.
+// disabled is terminal. Crucially StateActive is the sole Scoreable() state.
+var transitions = map[State][]State{
+	StateLearning:     {StateActive, StatePoisoned, StateDisabled},
+	StateActive:       {StateStale, StateDrifted, StatePoisoned, StateDisabled},
+	StateStale:        {StateActive, StateDrifted, StatePoisoned, StateDisabled},
+	StateDrifted:      {StateResetPending, StateDisabled},
+	StatePoisoned:     {StateResetPending, StateDisabled},
+	StateResetPending: {StateLearning, StateDisabled},
+	StateDisabled:     {},
+}
+
+// Valid reports whether s is a known state.
+func (s State) Valid() bool {
+	_, ok := transitions[s]
+	return ok
+}
+
+// Terminal reports whether s has no outgoing transitions (only StateDisabled).
+func (s State) Terminal() bool {
+	next, ok := transitions[s]
+	return ok && len(next) == 0
+}
+
+// Scoreable reports whether a baseline in this state may yield an anomaly score. Only StateActive is
+// trustworthy; any other state abstains (which lowers Coverage, never Risk).
+func (s State) Scoreable() bool { return s == StateActive }
+
+// CanTransition reports whether from -> to is a legal baseline transition.
+func CanTransition(from, to State) bool {
+	for _, n := range transitions[from] {
+		if n == to {
+			return true
+		}
+	}
+	return false
+}
+
+func requireTransition(from, to State) error {
+	if !to.Valid() {
+		return fmt.Errorf("%w: unknown baseline state %q", shared.ErrValidation, to)
+	}
+	if !CanTransition(from, to) {
+		return fmt.Errorf("%w: illegal baseline transition %s -> %s", shared.ErrValidation, from, to)
+	}
+	return nil
+}


### PR DESCRIPTION
## Phase D behavioral-baseline domain core (D1+D2+D3 of #639)

The pure-domain foundation for **Phase D — Behavioral EDR (non-AI)** (#639): a per-entity/peer-group baseline that learns "normal" and scores how far a fresh observation deviates. The anomaly is a **`RiskContext.Behavior` factor, never a verdict** — the C3 scorer already reserves `BehaviorWeight`, waiting for this producer.

Closes the buildable core of **#734 (D1)**, **#735 (D2)**, **#736 (D3)**. Drift/seasonality (D4 #737) and the usecase + persistence + Risk wiring (D5 #738) follow in later PRs.

### What's in `internal/domain/baseline/`
- **D1 `state.go`** — trust lifecycle `learning → active → stale/drifted/poisoned → reset_pending → learning`; `disabled` terminal. **`StateActive` is the sole `Scoreable()` state** — every other state abstains, which lowers Coverage, never Risk.
- **D2 `feature.go` + `baseline.go`** — fixed ordered feature vector + a **deterministic, reorder-invariant fold** (count/sum/sumSq/min/max ⇒ byte-identical `Summary()` regardless of order, the Phase-C evidence property). `Anomaly()` = worst per-feature deviation band via the exact test `(obs·v − sum)² ≤ k·(obs·sumSq − sum²)` computed in **`math/big`** (overflow-free). Cold-start abstains until `MinObservations`.
- **D3 `eligibility.go`** — **fail-closed** anti-poisoning gate: never learns from an incident / adversary-emulation / active-response / sensor-degraded / low-coverage window, and the **zero-value window is ineligible** (no floor ⇒ not trusted).

### Enforcement, not convention
- `Fold(o, w)` folds **through** the eligibility gate — an ineligible window is rejected before any mutation (tainted data cannot be folded even if a caller forgets to check).
- Folding refused in tainted/non-learning states and past `MaxObservations`; feature values bounded by `MaxFeatureValue`, so the int64 accumulators cannot overflow.
- A re-baseline (`reset_pending → learning`) **zeroes the accumulators** — it can never keep folding onto prior poisoned sums.

### Discipline
Pure domain — imports only `domain/shared` + `domain/riskassessment` (verified no cycle). Fail-closed `Validate()` on every type, no clock/I/O, no panic. eBPF collection, the live scoring loop, drift/seasonality (D4), and persistence + the coverage-honest `RiskContext.Behavior` wiring (D5) are the deferred tail.

### Review + verification
Dual-reviewed. Initial pass found real blockers — **all folded in before merge**: fail-closed eligibility on the zero value (was fail-open), `math/big` overflow-proof scoring + value/observation bounds (a wild deviation could have wrapped to "normal"), fold-through-gate enforcement, and clean re-baseline. **Both re-reviews clean (go-arch mergeable, security SHIP)**, each fix backed by a regression test. `gofmt`/`build`/`vet` clean, `go test -race` green at **91%**.

CI is off by request — validated locally.
