### PR TITLE
feat(baseline): D4 concept-drift + seasonality (#737)

### DIFF
--- a/internal/domain/baseline/drift.go
+++ b/internal/domain/baseline/drift.go
@@ -1,0 +1,127 @@
+package baseline
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// HoursPerWeek is the seasonality period: behavior is bucketed by hour-of-week so a legitimately periodic
+// load (a nightly batch job, a Monday-morning spike) is compared against the same hour on other weeks
+// rather than being scored as anomalous.
+const HoursPerWeek = 168
+
+// nanosPerHour is 1 hour in Unix nanoseconds.
+const nanosPerHour int64 = 3600 * 1_000_000_000
+
+// SeasonBucket returns the hour-of-week (0..167) for an observation timestamp given as Unix NANOSECONDS.
+// It is PURE ARITHMETIC over the passed timestamp — it never reads the wall clock — so it is deterministic
+// and reproducible for evidence. The week is anchored to Monday 00:00 UTC (the Unix epoch, 1970-01-01, is
+// a Thursday = hour 72 of a Monday-started week). The result is normalized into [0,167] for any int64; the
+// arithmetic is exact for positive (post-1970) timestamps, which is all real telemetry. Callers must bucket
+// on the sensor-observed occurred-at, never a client-influenced field.
+func SeasonBucket(unixNanos int64) int {
+	hours := unixNanos / nanosPerHour
+	hw := (hours + 72) % HoursPerWeek
+	if hw < 0 {
+		hw += HoursPerWeek
+	}
+	return int(hw)
+}
+
+// SeasonalGroup composes a base group id with its hour-of-week bucket, so a caller can key a baseline per
+// (group, season) and keep periodic load from contaminating the off-peak baseline. A caller that does not
+// want seasonality simply uses the plain group id. Deterministic (SeasonBucket is pure).
+func SeasonalGroup(group string, unixNanos int64) string {
+	return fmt.Sprintf("%s|hw=%d", group, SeasonBucket(unixNanos))
+}
+
+// DefaultDriftScore is the anomaly-score floor (≈ >2σ, band 2) at or above which a scoring window counts
+// as divergent for drift purposes.
+const DefaultDriftScore riskassessment.Score = 65
+
+// DefaultDriftThreshold is how many CONSECUTIVE divergent windows must be seen before drift is declared —
+// the hysteresis that keeps a single transient blip from flapping an active baseline into re-baselining.
+const DefaultDriftThreshold = 3
+
+// DriftTracker decides when an active baseline has genuinely drifted (concept drift), as opposed to seeing
+// a one-off anomalous window. It counts CONSECUTIVE divergent windows and declares drift only once a
+// sustained run reaches the threshold; any non-divergent window resets the run (hysteresis). It is a
+// deterministic, clock-free STATEFUL accumulator mutated through its pointer receivers (do not copy it
+// mid-run, or you fork its state). The usecase feeds it each window's anomaly score and, when it reports
+// drift, drives the baseline active -> drifted transition (then a clean re-baseline).
+type DriftTracker struct {
+	driftScore riskassessment.Score
+	threshold  int
+	run        int
+	drifted    bool
+}
+
+// NewDriftTracker builds a tracker. A zero/omitted driftScore or threshold falls back to the defaults; an
+// out-of-range driftScore is rejected.
+func NewDriftTracker(driftScore riskassessment.Score, threshold int) (*DriftTracker, error) {
+	if driftScore == 0 {
+		driftScore = DefaultDriftScore
+	}
+	if threshold == 0 {
+		threshold = DefaultDriftThreshold
+	}
+	if !driftScore.Valid() {
+		return nil, fmt.Errorf("%w: drift score %d out of range", shared.ErrValidation, driftScore)
+	}
+	if threshold < 1 {
+		return nil, fmt.Errorf("%w: drift threshold must be >= 1", shared.ErrValidation)
+	}
+	return &DriftTracker{driftScore: driftScore, threshold: threshold}, nil
+}
+
+// NewDriftTrackerFrom rehydrates a tracker to a persisted (run, drifted) state, so drift progress survives
+// a process restart / worker-lease handoff instead of restarting from zero. It validates the same bounds
+// as NewDriftTracker plus the latch invariant: run is in [0, threshold], and a run at the threshold is
+// consistent only with drifted=true.
+func NewDriftTrackerFrom(driftScore riskassessment.Score, threshold, run int, drifted bool) (*DriftTracker, error) {
+	d, err := NewDriftTracker(driftScore, threshold)
+	if err != nil {
+		return nil, err
+	}
+	if run < 0 || run > d.threshold {
+		return nil, fmt.Errorf("%w: drift run %d out of range [0,%d]", shared.ErrValidation, run, d.threshold)
+	}
+	if run >= d.threshold && !drifted {
+		return nil, fmt.Errorf("%w: a run at the threshold must be drifted", shared.ErrValidation)
+	}
+	d.run = run
+	d.drifted = drifted
+	return d, nil
+}
+
+// Observe folds one window's anomaly score and reports whether the baseline has drifted. A window at or
+// above the drift score extends the divergent run; anything below resets it (hysteresis). Once drift is
+// declared it latches until Reset (a re-baseline).
+func (d *DriftTracker) Observe(anomaly riskassessment.Score) bool {
+	if d.drifted {
+		return true
+	}
+	if anomaly >= d.driftScore {
+		d.run++
+	} else {
+		d.run = 0
+	}
+	if d.run >= d.threshold {
+		d.drifted = true
+	}
+	return d.drifted
+}
+
+// Drifted reports the latched drift state.
+func (d *DriftTracker) Drifted() bool { return d.drifted }
+
+// Run reports the current consecutive-divergent-window count (for observability/persistence).
+func (d *DriftTracker) Run() int { return d.run }
+
+// Reset clears the tracker for a fresh baseline (call alongside a reset_pending -> learning re-baseline).
+func (d *DriftTracker) Reset() {
+	d.run = 0
+	d.drifted = false
+}

--- a/internal/domain/baseline/drift_test.go
+++ b/internal/domain/baseline/drift_test.go
@@ -1,0 +1,134 @@
+package baseline
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestSeasonBucketDeterministicAndPeriodic(t *testing.T) {
+	// Unix epoch (Thu 1970-01-01 00:00 UTC) is hour 72 of a Monday-started week.
+	if got := SeasonBucket(0); got != 72 {
+		t.Fatalf("epoch bucket = %d, want 72", got)
+	}
+	// +1 hour advances the bucket by one.
+	if got := SeasonBucket(nanosPerHour); got != 73 {
+		t.Fatalf("epoch+1h bucket = %d, want 73", got)
+	}
+	// Exactly one week later is the SAME bucket (periodicity — the point of seasonality).
+	weekNanos := int64(HoursPerWeek) * nanosPerHour
+	if SeasonBucket(0) != SeasonBucket(weekNanos) || SeasonBucket(5*nanosPerHour) != SeasonBucket(5*nanosPerHour+weekNanos) {
+		t.Fatal("same hour-of-week one week apart must map to the same bucket")
+	}
+	// Always in range, and deterministic for a fixed input.
+	for _, ns := range []int64{0, nanosPerHour, 123 * nanosPerHour, 9999 * nanosPerHour} {
+		b := SeasonBucket(ns)
+		if b < 0 || b >= HoursPerWeek {
+			t.Fatalf("bucket %d out of range for %d", b, ns)
+		}
+		if b != SeasonBucket(ns) {
+			t.Fatal("SeasonBucket must be deterministic")
+		}
+	}
+	if g := SeasonalGroup("web-tier", 0); g != "web-tier|hw=72" {
+		t.Fatalf("seasonal group = %q, want web-tier|hw=72", g)
+	}
+}
+
+func TestDriftTrackerHysteresis(t *testing.T) {
+	// Sustained divergence declares drift at the threshold.
+	d, err := NewDriftTracker(65, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Observe(90) || d.Observe(90) {
+		t.Fatal("must not drift before the threshold of consecutive divergent windows")
+	}
+	if !d.Observe(90) {
+		t.Fatal("third consecutive divergent window must declare drift")
+	}
+	if !d.Drifted() {
+		t.Fatal("drift must latch")
+	}
+	// Latches even if a subsequent window is normal.
+	if !d.Observe(5) {
+		t.Fatal("drift must stay latched until Reset")
+	}
+	d.Reset()
+	if d.Drifted() || d.Run() != 0 {
+		t.Fatal("Reset must clear drift + run")
+	}
+}
+
+func TestDriftTrackerTransientBlipDoesNotDrift(t *testing.T) {
+	d, _ := NewDriftTracker(65, 3)
+	// A blip (one divergent window) then a normal window resets the run — never reaches threshold.
+	for i := 0; i < 10; i++ {
+		if d.Observe(90) { // divergent
+			t.Fatalf("unexpected drift at iter %d", i)
+		}
+		if d.Observe(10) { // normal -> resets run
+			t.Fatalf("unexpected drift at iter %d after reset", i)
+		}
+	}
+	if d.Drifted() {
+		t.Fatal("alternating blip/normal must never declare drift (hysteresis)")
+	}
+}
+
+func TestDriftTrackerDefaultsAndValidation(t *testing.T) {
+	// Zero args fall back to defaults.
+	d, err := NewDriftTracker(0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < DefaultDriftThreshold-1; i++ {
+		if d.Observe(DefaultDriftScore) {
+			t.Fatal("must not drift before default threshold")
+		}
+	}
+	if !d.Observe(DefaultDriftScore) {
+		t.Fatal("must drift at the default threshold")
+	}
+	// Invalid inputs rejected.
+	if _, err := NewDriftTracker(riskassessment.Score(200), 3); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("out-of-range drift score must be rejected, got %v", err)
+	}
+	if _, err := NewDriftTracker(65, -1); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("negative threshold must be rejected, got %v", err)
+	}
+}
+
+func TestDriftTrackerRehydration(t *testing.T) {
+	// Rehydrate mid-run: a persisted run of 2/3 continues to drift on the next divergent window.
+	d, err := NewDriftTrackerFrom(65, 3, 2, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.Run() != 2 || d.Drifted() {
+		t.Fatalf("rehydrated state wrong: run=%d drifted=%v", d.Run(), d.Drifted())
+	}
+	if !d.Observe(90) {
+		t.Fatal("a rehydrated run of 2/3 must drift on the next divergent window")
+	}
+	// Rehydrate an already-drifted tracker.
+	d2, err := NewDriftTrackerFrom(65, 3, 3, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !d2.Drifted() {
+		t.Fatal("rehydrated drifted tracker must report drifted")
+	}
+	// Invariant violations rejected.
+	if _, err := NewDriftTrackerFrom(65, 3, 4, true); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("run above threshold must be rejected, got %v", err)
+	}
+	if _, err := NewDriftTrackerFrom(65, 3, 3, false); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("run at threshold with drifted=false must be rejected, got %v", err)
+	}
+	if _, err := NewDriftTrackerFrom(65, 3, -1, false); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("negative run must be rejected, got %v", err)
+	}
+}


### PR DESCRIPTION
## D4 — concept-drift + seasonality (#737)

Extends the merged Phase-D `internal/domain/baseline/` package with the drift/seasonality layer (non-AI). Pure domain.

- **`SeasonBucket` / `SeasonalGroup`** — bucket behavior by hour-of-week (0..167) via **pure arithmetic** over the observation's own Unix-nanos timestamp (no wall-clock read), Monday-anchored and deterministic. Periodic load (a nightly batch, a Monday spike) is compared against the same hour on other weeks instead of reading as anomalous. Seasonality is **opt-in keying only** — each `(group, season)` keeps its own honest baseline + eligibility gate; it partitions baselines, never discounts Risk. Callers bucket on the **sensor occurred-at**, never a client-influenced field.
- **`DriftTracker`** — declares concept drift only after **N consecutive** divergent windows (anomaly ≥ `driftScore`), resetting the run on any normal window (**hysteresis**) so a transient blip can't flap an active baseline into re-baselining; drift **latches** until `Reset`. Clock-free stateful accumulator; `run` can't overflow (latches at threshold). `NewDriftTrackerFrom` rehydrates persisted `(run, drifted)` so drift progress survives a worker-lease handoff.

### Review + verification
Dual-reviewed — **go-arch MERGEABLE, security SHIP**. Security confirmed seasonality is keying-only (can't dodge scoring or lower Risk) and the forced-drift→re-baseline chain is defended in depth by the merged anti-poisoning gate + clean-reset; the residual (feed `Fold` an honestly-flagged `LearnWindow` during the attack window) lives in the **D5 usecase wiring** and is tracked for that PR. Folded in the review notes (negative-timestamp/value-type wording, rehydration constructor + test). `gofmt`/`build`/`vet` clean, `go test -race` green at **92%**.

CI is off by request — validated locally.
