### PR TITLE
feat(baseline): D5 persistence + coverage-honest RiskContext.Behavior factor (#738)

### DIFF
--- a/internal/domain/baseline/baseline.go
+++ b/internal/domain/baseline/baseline.go
@@ -68,6 +68,59 @@ func NewBaseline(key Key) (*Baseline, error) {
 	return &Baseline{key: key, state: StateLearning}, nil
 }
 
+// NewBaselineFrom rehydrates a baseline from a persisted key + state + per-feature summaries, so a store
+// can reload one without re-folding raw observations. summaries must be exactly NumFeatures entries in
+// feature order. It validates integrity fail-closed: a consistent shared observation count within
+// [0, MaxObservations], non-negative bounded sums, and non-negative variance (obs*sumSq >= sum^2) — a
+// crafted/corrupt row that violates these is rejected rather than loaded into the scorer.
+func NewBaselineFrom(key Key, state State, summaries []FeatureSummary) (*Baseline, error) {
+	if err := key.Validate(); err != nil {
+		return nil, err
+	}
+	if !state.Valid() {
+		return nil, fmt.Errorf("%w: unknown baseline state %q", shared.ErrValidation, state)
+	}
+	if len(summaries) != numFeatures {
+		return nil, fmt.Errorf("%w: baseline needs %d feature summaries, got %d", shared.ErrValidation, numFeatures, len(summaries))
+	}
+	b := &Baseline{key: key, state: state}
+	obs := summaries[0].Count
+	if obs < 0 || obs > MaxObservations {
+		return nil, fmt.Errorf("%w: baseline observation count %d out of range [0,%d]", shared.ErrValidation, obs, MaxObservations)
+	}
+	b.obs = obs
+	for f := 0; f < numFeatures; f++ {
+		s := summaries[f]
+		if s.Feature != Feature(f) {
+			return nil, fmt.Errorf("%w: summary %d is for feature %q, expected %q", shared.ErrValidation, f, s.Feature.Name(), Feature(f).Name())
+		}
+		if s.Count != obs {
+			return nil, fmt.Errorf("%w: feature %s count %d disagrees with observation count %d", shared.ErrValidation, Feature(f).Name(), s.Count, obs)
+		}
+		if s.Sum < 0 || s.SumSq < 0 || s.Min < 0 || s.Max < 0 {
+			return nil, fmt.Errorf("%w: feature %s has a negative accumulator", shared.ErrValidation, Feature(f).Name())
+		}
+		if s.Max > MaxFeatureValue || s.Min > s.Max {
+			return nil, fmt.Errorf("%w: feature %s has an out-of-range or inverted min/max", shared.ErrValidation, Feature(f).Name())
+		}
+		if s.Sum > obs*MaxFeatureValue || s.SumSq > obs*MaxFeatureValue*MaxFeatureValue {
+			return nil, fmt.Errorf("%w: feature %s accumulator exceeds the bound for %d observations", shared.ErrValidation, Feature(f).Name(), obs)
+		}
+		// Non-negative variance: obs*sumSq >= sum^2. Checked in math/big because both products can exceed
+		// int64 near the accumulator cap (obs*sumSq up to ~1e24) — the same overflow discipline as the
+		// scorer's featureBand, so the integrity gate cannot be defeated by wraparound.
+		lhs := new(big.Int).Mul(big.NewInt(obs), big.NewInt(s.SumSq))
+		if lhs.Cmp(new(big.Int).Mul(big.NewInt(s.Sum), big.NewInt(s.Sum))) < 0 {
+			return nil, fmt.Errorf("%w: feature %s has negative variance (obs*sumSq < sum^2)", shared.ErrValidation, Feature(f).Name())
+		}
+		b.sum[f] = s.Sum
+		b.sumSq[f] = s.SumSq
+		b.min[f] = s.Min
+		b.max[f] = s.Max
+	}
+	return b, nil
+}
+
 // Key returns the baseline's identity.
 func (b *Baseline) Key() Key { return b.key }
 

--- a/internal/domain/baseline/baseline_test.go
+++ b/internal/domain/baseline/baseline_test.go
@@ -225,6 +225,41 @@ func TestObservationAndKeyValidation(t *testing.T) {
 	}
 }
 
+func TestNewBaselineFromNearCapAndVarianceCheck(t *testing.T) {
+	// A near-cap but VALID row: every observation = MaxFeatureValue (variance 0). obs*sumSq and sum^2 both
+	// reach ~1e24 and overflow int64 — the big.Int integrity check must NOT wrongly reject it.
+	valid := make([]FeatureSummary, NumFeatures)
+	for f := 0; f < NumFeatures; f++ {
+		valid[f] = FeatureSummary{
+			Feature: Feature(f),
+			Count:   MaxObservations,
+			Sum:     MaxObservations * MaxFeatureValue,
+			SumSq:   MaxObservations * MaxFeatureValue * MaxFeatureValue,
+			Min:     MaxFeatureValue,
+			Max:     MaxFeatureValue,
+		}
+	}
+	if _, err := NewBaselineFrom(key(), StateActive, valid); err != nil {
+		t.Fatalf("a valid near-cap baseline must rehydrate (no int64 overflow in the variance check): %v", err)
+	}
+	// A genuinely negative-variance row (obs*sumSq < sum^2) must be rejected.
+	bad := make([]FeatureSummary, NumFeatures)
+	for f := 0; f < NumFeatures; f++ {
+		bad[f] = FeatureSummary{Feature: Feature(f), Count: 10, Sum: 100, SumSq: 500, Min: 0, Max: 10}
+	}
+	if _, err := NewBaselineFrom(key(), StateActive, bad); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("a negative-variance row must be rejected, got %v", err)
+	}
+	// An inverted min/max must be rejected.
+	inv := make([]FeatureSummary, NumFeatures)
+	for f := 0; f < NumFeatures; f++ {
+		inv[f] = FeatureSummary{Feature: Feature(f), Count: 1, Sum: 2, SumSq: 4, Min: 5, Max: 2}
+	}
+	if _, err := NewBaselineFrom(key(), StateActive, inv); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("inverted min/max must be rejected, got %v", err)
+	}
+}
+
 func TestLearnEligibilityFailClosed(t *testing.T) {
 	if ok, why := okWin().Eligible(); !ok {
 		t.Fatalf("clean window must be eligible, got %q", why)

--- a/internal/domain/baseline/feature.go
+++ b/internal/domain/baseline/feature.go
@@ -26,6 +26,10 @@ const (
 	numFeatures = iota
 )
 
+// NumFeatures is the number of behavioral features in an Observation vector — the exact length a caller
+// (e.g. a persistence layer rehydrating via NewBaselineFrom) must provide.
+const NumFeatures = numFeatures
+
 // featureNames gives each feature a stable name for reasons/validation messages, indexed by Feature.
 var featureNames = [numFeatures]string{
 	"process_spawn_rate",

--- a/internal/infrastructure/persistence/memory/baseline_store.go
+++ b/internal/infrastructure/persistence/memory/baseline_store.go
@@ -1,0 +1,108 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/baseline"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// BaselineStore is the in-memory twin of the behavioral-baseline projection (Phase D / D5). It is
+// tenant-bucketed and upholds the same upsert-by-(tenant,group) contract as the Postgres tier. Reached
+// only through ports.BaselineStore.
+type BaselineStore struct {
+	mu   sync.Mutex
+	recs map[shared.ID]map[string]ports.BaselineRecord // tenant -> group -> record
+}
+
+var _ ports.BaselineStore = (*BaselineStore)(nil)
+
+// NewBaselineStore creates an empty in-memory baseline store.
+func NewBaselineStore() *BaselineStore {
+	return &BaselineStore{recs: make(map[shared.ID]map[string]ports.BaselineRecord)}
+}
+
+func requireBaselineTenant(ctx context.Context) (shared.ID, error) {
+	if t, ok := shared.TenantFrom(ctx); ok && t != "" {
+		return t, nil
+	}
+	return "", fmt.Errorf("%w: baseline store operation requires a tenant in context", shared.ErrValidation)
+}
+
+// validateRecord enforces the record is well-formed and its key's tenant matches the context tenant (no
+// cross-tenant write via a mismatched key).
+func validateBaselineRecord(tenant shared.ID, rec ports.BaselineRecord) error {
+	if err := rec.Key.Validate(); err != nil {
+		return err
+	}
+	if rec.Key.Tenant != tenant {
+		return fmt.Errorf("%w: baseline key tenant %q does not match context tenant %q", shared.ErrValidation, rec.Key.Tenant, tenant)
+	}
+	if !rec.State.Valid() {
+		return fmt.Errorf("%w: unknown baseline state %q", shared.ErrValidation, rec.State)
+	}
+	// Rehydrate to validate the summaries/accumulator integrity uniformly with the Postgres tier.
+	if _, err := baseline.NewBaselineFrom(rec.Key, rec.State, rec.Summaries); err != nil {
+		return err
+	}
+	if rec.DriftRun < 0 {
+		return fmt.Errorf("%w: drift run must be non-negative", shared.ErrValidation)
+	}
+	return nil
+}
+
+// Save upserts a baseline record for its key.
+func (s *BaselineStore) Save(ctx context.Context, rec ports.BaselineRecord) error {
+	tenant, err := requireBaselineTenant(ctx)
+	if err != nil {
+		return err
+	}
+	if err := validateBaselineRecord(tenant, rec); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	byGroup := s.recs[tenant]
+	if byGroup == nil {
+		byGroup = make(map[string]ports.BaselineRecord)
+		s.recs[tenant] = byGroup
+	}
+	byGroup[rec.Key.Group] = cloneBaselineRecord(rec)
+	return nil
+}
+
+// Load returns the record for a key, or shared.ErrNotFound.
+func (s *BaselineStore) Load(ctx context.Context, key baseline.Key) (ports.BaselineRecord, error) {
+	tenant, err := requireBaselineTenant(ctx)
+	if err != nil {
+		return ports.BaselineRecord{}, err
+	}
+	if err := key.Validate(); err != nil {
+		return ports.BaselineRecord{}, err
+	}
+	if key.Tenant != tenant {
+		return ports.BaselineRecord{}, fmt.Errorf("%w: baseline key tenant %q does not match context tenant %q", shared.ErrValidation, key.Tenant, tenant)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	rec, ok := s.recs[tenant][key.Group]
+	if !ok {
+		return ports.BaselineRecord{}, fmt.Errorf("%w: baseline %s/%s", shared.ErrNotFound, key.Tenant, key.Group)
+	}
+	// Re-validate on read (defense-in-depth + parity with the Postgres tier): a stored record must always
+	// rehydrate to a valid baseline.
+	if _, err := baseline.NewBaselineFrom(rec.Key, rec.State, rec.Summaries); err != nil {
+		return ports.BaselineRecord{}, err
+	}
+	return cloneBaselineRecord(rec), nil
+}
+
+// cloneBaselineRecord deep-copies the summaries slice so a stored record never aliases the caller's.
+func cloneBaselineRecord(rec ports.BaselineRecord) ports.BaselineRecord {
+	cp := rec
+	cp.Summaries = append([]baseline.FeatureSummary(nil), rec.Summaries...)
+	return cp
+}

--- a/internal/infrastructure/persistence/memory/baseline_store_test.go
+++ b/internal/infrastructure/persistence/memory/baseline_store_test.go
@@ -1,0 +1,82 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/baseline"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func sums(count int64) []baseline.FeatureSummary {
+	out := make([]baseline.FeatureSummary, baseline.NumFeatures)
+	for f := 0; f < baseline.NumFeatures; f++ {
+		out[f] = baseline.FeatureSummary{Feature: baseline.Feature(f), Count: count, Sum: 2 * count, SumSq: 4 * count, Min: 2, Max: 2}
+	}
+	return out
+}
+
+func rec(tenant shared.ID, group string) ports.BaselineRecord {
+	return ports.BaselineRecord{
+		Key:       baseline.Key{Tenant: tenant, Group: group},
+		State:     baseline.StateActive,
+		Summaries: sums(10),
+		DriftRun:  1,
+		Drifted:   false,
+		UpdatedAt: time.Unix(1_700_000_000, 0).UTC(),
+	}
+}
+
+func TestBaselineStoreRoundTripAndTenantIsolation(t *testing.T) {
+	s := NewBaselineStore()
+	ctxA := shared.WithTenant(context.Background(), "ta")
+	ctxB := shared.WithTenant(context.Background(), "tb")
+
+	if err := s.Save(ctxA, rec("ta", "web")); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := s.Load(ctxA, baseline.Key{Tenant: "ta", Group: "web"})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.State != baseline.StateActive || got.Summaries[0].Count != 10 || got.DriftRun != 1 {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+	// Idempotent re-save (upsert) with a new state.
+	up := rec("ta", "web")
+	up.State = baseline.StateStale
+	if err := s.Save(ctxA, up); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := s.Load(ctxA, baseline.Key{Tenant: "ta", Group: "web"}); got.State != baseline.StateStale {
+		t.Fatalf("upsert did not update state, got %s", got.State)
+	}
+	// Tenant B cannot see tenant A's baseline.
+	if _, err := s.Load(ctxB, baseline.Key{Tenant: "tb", Group: "web"}); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("tenant B must not see A's baseline, got %v", err)
+	}
+	// A key whose tenant disagrees with the context tenant is rejected (no cross-tenant write/read).
+	if err := s.Save(ctxA, rec("tb", "web")); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("cross-tenant key on save must be rejected, got %v", err)
+	}
+	if _, err := s.Load(ctxA, baseline.Key{Tenant: "tb", Group: "web"}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("cross-tenant key on load must be rejected, got %v", err)
+	}
+	// No tenant in context is rejected.
+	if err := s.Save(context.Background(), rec("ta", "web")); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing tenant must be rejected, got %v", err)
+	}
+}
+
+func TestBaselineStoreRejectsCorruptSummaries(t *testing.T) {
+	s := NewBaselineStore()
+	ctx := shared.WithTenant(context.Background(), "ta")
+	bad := rec("ta", "web")
+	bad.Summaries = bad.Summaries[:2] // wrong length
+	if err := s.Save(ctx, bad); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("wrong-length summaries must be rejected, got %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/baseline_repo.go
+++ b/internal/infrastructure/persistence/postgres/baseline_repo.go
@@ -1,0 +1,130 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/baseline"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// BaselineRepository is the Postgres tier for the behavioral-baseline projection (Phase D / D5). A
+// baseline is a MUTABLE projection keyed by (tenant, group), upserted in place; integrity is enforced by
+// the domain (baseline.NewBaselineFrom validates the accumulators on load) and the usecase. Every method
+// runs under the authenticated ctx tenant via WithContextTenant (RLS) with an explicit tenant_id predicate
+// as defense-in-depth. Reached only through ports.BaselineStore.
+type BaselineRepository struct {
+	pool *pgxpool.Pool
+}
+
+var _ ports.BaselineStore = (*BaselineRepository)(nil)
+
+// NewBaselineRepository constructs the baseline store over a pgx pool.
+func NewBaselineRepository(pool *pgxpool.Pool) *BaselineRepository {
+	return &BaselineRepository{pool: pool}
+}
+
+func requireBaselineRepoTenant(ctx context.Context) (shared.ID, error) {
+	if t, ok := shared.TenantFrom(ctx); ok && t != "" {
+		return t, nil
+	}
+	return "", fmt.Errorf("%w: baseline store operation requires a tenant in context", shared.ErrValidation)
+}
+
+// Save upserts a baseline record for its (tenant, group) key.
+func (r *BaselineRepository) Save(ctx context.Context, rec ports.BaselineRecord) error {
+	tenant, err := requireBaselineRepoTenant(ctx)
+	if err != nil {
+		return err
+	}
+	if err := rec.Key.Validate(); err != nil {
+		return err
+	}
+	if rec.Key.Tenant != tenant {
+		return fmt.Errorf("%w: baseline key tenant %q does not match context tenant %q", shared.ErrValidation, rec.Key.Tenant, tenant)
+	}
+	if !rec.State.Valid() {
+		return fmt.Errorf("%w: unknown baseline state %q", shared.ErrValidation, rec.State)
+	}
+	// Rehydrate to validate accumulator integrity before persisting (same gate as the memory twin + load).
+	if _, err := baseline.NewBaselineFrom(rec.Key, rec.State, rec.Summaries); err != nil {
+		return err
+	}
+	if rec.DriftRun < 0 {
+		return fmt.Errorf("%w: drift run must be non-negative", shared.ErrValidation)
+	}
+	summaries, err := json.Marshal(rec.Summaries)
+	if err != nil {
+		return fmt.Errorf("marshal baseline summaries: %w", err)
+	}
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO baselines
+			(tenant_id, group_id, state, summaries, drift_run, drifted, updated_at)
+			VALUES ($1, $2, $3, $4, $5, $6, $7)
+			ON CONFLICT (tenant_id, group_id) DO UPDATE SET
+				state = EXCLUDED.state,
+				summaries = EXCLUDED.summaries,
+				drift_run = EXCLUDED.drift_run,
+				drifted = EXCLUDED.drifted,
+				updated_at = EXCLUDED.updated_at`,
+			tenant.String(), rec.Key.Group, string(rec.State), summaries, rec.DriftRun, rec.Drifted, rec.UpdatedAt.UTC())
+		if err != nil {
+			return fmt.Errorf("upsert baseline: %w", err)
+		}
+		return nil
+	})
+}
+
+// Load returns the record for a key, or shared.ErrNotFound.
+func (r *BaselineRepository) Load(ctx context.Context, key baseline.Key) (ports.BaselineRecord, error) {
+	tenant, err := requireBaselineRepoTenant(ctx)
+	if err != nil {
+		return ports.BaselineRecord{}, err
+	}
+	if err := key.Validate(); err != nil {
+		return ports.BaselineRecord{}, err
+	}
+	if key.Tenant != tenant {
+		return ports.BaselineRecord{}, fmt.Errorf("%w: baseline key tenant %q does not match context tenant %q", shared.ErrValidation, key.Tenant, tenant)
+	}
+	var rec ports.BaselineRecord
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		var state string
+		var summaries []byte
+		var driftRun int
+		var drifted bool
+		row := tx.QueryRow(ctx, `SELECT state, summaries, drift_run, drifted, updated_at
+			FROM baselines WHERE tenant_id=$1 AND group_id=$2`, tenant.String(), key.Group)
+		if err := row.Scan(&state, &summaries, &driftRun, &drifted, &rec.UpdatedAt); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("%w: baseline %s/%s", shared.ErrNotFound, key.Tenant, key.Group)
+			}
+			return fmt.Errorf("load baseline: %w", err)
+		}
+		var sums []baseline.FeatureSummary
+		if err := json.Unmarshal(summaries, &sums); err != nil {
+			return fmt.Errorf("unmarshal baseline summaries: %w", err)
+		}
+		// Re-validate the stored row on read (defense-in-depth): a tampered/corrupt DB row must fail closed
+		// here rather than reach the scorer, mirroring the Save-side gate.
+		if _, err := baseline.NewBaselineFrom(key, baseline.State(state), sums); err != nil {
+			return err
+		}
+		rec.Key = key
+		rec.State = baseline.State(state)
+		rec.Summaries = sums
+		rec.DriftRun = driftRun
+		rec.Drifted = drifted
+		return nil
+	})
+	if err != nil {
+		return ports.BaselineRecord{}, err
+	}
+	return rec, nil
+}

--- a/internal/infrastructure/persistence/postgres/baseline_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/baseline_repo_test.go
@@ -1,0 +1,97 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/baseline"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func baselineSums(count int64) []baseline.FeatureSummary {
+	out := make([]baseline.FeatureSummary, baseline.NumFeatures)
+	for f := 0; f < baseline.NumFeatures; f++ {
+		out[f] = baseline.FeatureSummary{Feature: baseline.Feature(f), Count: count, Sum: 2 * count, SumSq: 4 * count, Min: 2, Max: 2}
+	}
+	return out
+}
+
+func TestBaselineRepository(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	id := randHex(t)
+	tenant := shared.ID("bl-" + id)
+	other := shared.ID("bl-other-" + id)
+	for _, tn := range []shared.ID{tenant, other} {
+		if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES($1,$1)`, tn.String()); err != nil {
+			t.Fatalf("seed tenant: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		for _, tn := range []shared.ID{tenant, other} {
+			_, _ = pool.Exec(bg, `DELETE FROM baselines WHERE tenant_id=$1`, tn.String())
+			_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id=$1`, tn.String())
+		}
+	})
+
+	repo := NewBaselineRepository(pool)
+	tctx := shared.WithTenant(ctx, tenant)
+	octx := shared.WithTenant(ctx, other)
+	key := baseline.Key{Tenant: tenant, Group: "web-tier"}
+
+	// Not found before save.
+	if _, err := repo.Load(tctx, key); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got %v", err)
+	}
+	// Save + load round-trip.
+	rec := ports.BaselineRecord{Key: key, State: baseline.StateActive, Summaries: baselineSums(12), DriftRun: 2, Drifted: false, UpdatedAt: time.Unix(1_800_000_000, 0).UTC()}
+	if err := repo.Save(tctx, rec); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := repo.Load(tctx, key)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if got.State != baseline.StateActive || got.DriftRun != 2 || len(got.Summaries) != baseline.NumFeatures || got.Summaries[0].Count != 12 {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+	// The reloaded summaries rehydrate a valid domain baseline.
+	if _, err := baseline.NewBaselineFrom(got.Key, got.State, got.Summaries); err != nil {
+		t.Fatalf("reloaded record must rehydrate: %v", err)
+	}
+	// Upsert updates in place.
+	rec.State = baseline.StateDrifted
+	rec.Drifted = true
+	rec.DriftRun = 3
+	if err := repo.Save(tctx, rec); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := repo.Load(tctx, key); got.State != baseline.StateDrifted || !got.Drifted || got.DriftRun != 3 {
+		t.Fatalf("upsert did not update, got state=%s drifted=%v run=%d", got.State, got.Drifted, got.DriftRun)
+	}
+	// Tenant isolation: other tenant cannot see it.
+	if _, err := repo.Load(octx, baseline.Key{Tenant: other, Group: "web-tier"}); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant load must be ErrNotFound, got %v", err)
+	}
+	// Cross-tenant key rejected before touching the DB.
+	if err := repo.Save(tctx, ports.BaselineRecord{Key: baseline.Key{Tenant: other, Group: "x"}, State: baseline.StateLearning, Summaries: baselineSums(0), UpdatedAt: time.Unix(1, 0).UTC()}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("cross-tenant key must be rejected, got %v", err)
+	}
+}

--- a/internal/usecase/fleet/baselineuc/service.go
+++ b/internal/usecase/fleet/baselineuc/service.go
@@ -1,0 +1,263 @@
+// Package baselineuc is the Phase D behavioral-baseline usecase (#594, D5 #738): it drives the pure-domain
+// baseline lifecycle over a persistent store and produces the coverage-honest RiskContext.Behavior factor.
+// It is the ONLY place a Behavior anomaly becomes a risk factor, and it stays a FACTOR: it never sets Risk
+// or a disposition and never touches the Confidence axis. Learning is anti-poisoning-gated (it folds an
+// observation only through the domain eligibility gate), and it is coverage-honest — a not-yet-trustworthy
+// baseline abstains (Scoreable=false), which the caller routes to lower Coverage, never to fabricate Risk.
+package baselineuc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/baseline"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Policy is the deterministic configuration of the baseline lifecycle. DriftScore/DriftThreshold are the
+// drift-tracker config (service policy, not per-baseline state); MinObservations is the cold-start floor
+// before a learning baseline may become active.
+type Policy struct {
+	MinObservations int64
+	DriftScore      riskassessment.Score
+	DriftThreshold  int
+}
+
+// DefaultPolicy is the shipped baseline policy.
+func DefaultPolicy() Policy {
+	return Policy{MinObservations: 30, DriftScore: baseline.DefaultDriftScore, DriftThreshold: baseline.DefaultDriftThreshold}
+}
+
+// Assessment is the outcome of observing one window: the Behavior factor for the risk scorer, whether it is
+// trustworthy (Scoreable), the baseline's current state, and human reasons. Behavior is 0 whenever
+// Scoreable is false — the caller places Behavior into RiskContext.Behavior ONLY when Scoreable, and
+// otherwise reflects the gap in Coverage (never in Risk).
+type Assessment struct {
+	Behavior  riskassessment.Score
+	Scoreable bool
+	State     baseline.State
+	Reasons   []string
+}
+
+// Service drives baselines over a store, auditing every lifecycle transition.
+type Service struct {
+	store  ports.BaselineStore
+	audit  ports.AuditLogger
+	now    func() time.Time
+	policy Policy
+}
+
+// NewService constructs the baseline usecase. now supplies the persisted timestamp (injected for
+// determinism). An invalid policy is rejected.
+func NewService(store ports.BaselineStore, audit ports.AuditLogger, now func() time.Time, policy Policy) (*Service, error) {
+	if store == nil {
+		return nil, fmt.Errorf("%w: baseline service requires a store", shared.ErrValidation)
+	}
+	if audit == nil {
+		return nil, fmt.Errorf("%w: baseline service requires an audit logger", shared.ErrValidation)
+	}
+	if now == nil {
+		return nil, fmt.Errorf("%w: baseline service requires a clock", shared.ErrValidation)
+	}
+	if policy.MinObservations < 1 {
+		return nil, fmt.Errorf("%w: policy MinObservations must be >= 1", shared.ErrValidation)
+	}
+	// Validate the drift config via the domain constructor (defaults zero fields, rejects out-of-range).
+	if _, err := baseline.NewDriftTracker(policy.DriftScore, policy.DriftThreshold); err != nil {
+		return nil, err
+	}
+	// Normalize the drift config to its EFFECTIVE (defaulted) values so the usecase's fold-gate uses the
+	// same drift score the tracker does — otherwise a policy with DriftScore==0 would gate folding on
+	// `anomaly >= 0` (always true) while the tracker used the default, silently disagreeing.
+	if policy.DriftScore == 0 {
+		policy.DriftScore = baseline.DefaultDriftScore
+	}
+	if policy.DriftThreshold == 0 {
+		policy.DriftThreshold = baseline.DefaultDriftThreshold
+	}
+	return &Service{store: store, audit: audit, now: now, policy: policy}, nil
+}
+
+// Observe scores one window's observation against the entity/peer-group baseline and, if the window is
+// eligible, folds it in to keep learning — advancing the lifecycle (cold-start -> active; sustained drift
+// -> drifted). The returned Assessment carries the coverage-honest Behavior factor. The observation is
+// SCORED against the CURRENT baseline BEFORE it is folded, so a window never scores against a baseline that
+// already contains it.
+func (s *Service) Observe(ctx context.Context, actor string, key baseline.Key, obs baseline.Observation, window baseline.LearnWindow) (Assessment, error) {
+	if actor == "" {
+		return Assessment{}, fmt.Errorf("%w: baseline observation requires an actor", shared.ErrValidation)
+	}
+	if err := key.Validate(); err != nil {
+		return Assessment{}, err
+	}
+	if err := obs.Validate(); err != nil {
+		return Assessment{}, err
+	}
+
+	b, dt, err := s.load(ctx, key)
+	if err != nil {
+		return Assessment{}, err
+	}
+
+	// 1) Score this observation against the current baseline (abstains unless active).
+	anomaly, scoreable := b.Anomaly(obs)
+	a := Assessment{State: b.State(), Behavior: 0}
+	if scoreable {
+		a.Behavior, a.Scoreable = anomaly, true
+	} else {
+		a.Reasons = append(a.Reasons, fmt.Sprintf("baseline not active (state=%s) — abstaining", b.State()))
+	}
+
+	// The single lifecycle transition (if any) this call makes; audited AFTER the durable save below.
+	var pendingAudit string
+
+	// 2) Drift: feed the anomaly to the tracker; on sustained drift, leave active for drifted.
+	if scoreable && dt.Observe(anomaly) && b.State() == baseline.StateActive {
+		if err := b.Transition(baseline.StateDrifted); err != nil {
+			return Assessment{}, err
+		}
+		pendingAudit = "baseline.drifted"
+		a.State = b.State()
+		a.Reasons = append(a.Reasons, "sustained drift detected — re-baseline required")
+	}
+
+	// 3) Learn: fold through the eligibility gate, only while learning-capable and below the cap. An
+	// observation that itself scores anomalous is NOT folded — absorbing it would let the baseline chase an
+	// attacker's behavior (poisoning) or wash out genuine drift before the tracker can catch it; a real
+	// change instead accumulates drift and re-baselines cleanly.
+	if eligible, why := window.Eligible(); !eligible {
+		a.Reasons = append(a.Reasons, "not learned: "+why)
+	} else if scoreable && anomaly >= s.policy.DriftScore {
+		a.Reasons = append(a.Reasons, "not learned: window is anomalous (possible drift or attack)")
+	} else if !foldable(b.State()) {
+		a.Reasons = append(a.Reasons, fmt.Sprintf("not learned: baseline is %s", b.State()))
+	} else if b.ObservationCount() >= baseline.MaxObservations {
+		a.Reasons = append(a.Reasons, "not learned: observation cap reached — re-baseline required")
+	} else {
+		if err := b.Fold(obs, window); err != nil {
+			return Assessment{}, err
+		}
+		// 4) Cold-start complete: activate.
+		if b.State() == baseline.StateLearning && b.ReadyToActivate(s.policy.MinObservations) {
+			if err := b.Transition(baseline.StateActive); err != nil {
+				return Assessment{}, err
+			}
+			pendingAudit = "baseline.activated"
+			a.State = b.State()
+		}
+	}
+
+	// Persist FIRST; the saved record carries the new state (the primary attributable change). Audit is a
+	// secondary cross-cutting trail, so a lifecycle transition is audited only AFTER it is durable — a
+	// failed save never leaves a false audit entry. On an audit-failure error the transition IS committed;
+	// the caller must NOT blindly retry (Observe folds, so a retry double-counts) — treat it as
+	// committed-but-unaudited and reconcile.
+	if err := s.save(ctx, b, dt); err != nil {
+		return Assessment{}, err
+	}
+	if pendingAudit != "" {
+		if err := s.recordTransition(ctx, actor, key, pendingAudit); err != nil {
+			return Assessment{}, err
+		}
+	}
+	return a, nil
+}
+
+// Rebaseline drives a drifted/poisoned baseline through a clean re-baseline (reset_pending -> learning),
+// zeroing its accumulators so it re-learns from fresh eligible windows. Audited.
+func (s *Service) Rebaseline(ctx context.Context, actor string, key baseline.Key) error {
+	if actor == "" {
+		return fmt.Errorf("%w: re-baseline requires an actor", shared.ErrValidation)
+	}
+	b, dt, err := s.load(ctx, key)
+	if err != nil {
+		return err
+	}
+	switch b.State() {
+	case baseline.StateDrifted, baseline.StatePoisoned:
+		// eligible for re-baseline
+	default:
+		return fmt.Errorf("%w: baseline in state %s is not eligible for re-baseline", shared.ErrValidation, b.State())
+	}
+	if err := b.Transition(baseline.StateResetPending); err != nil {
+		return err
+	}
+	if err := b.Transition(baseline.StateLearning); err != nil { // clears accumulators (domain reset)
+		return err
+	}
+	dt.Reset()
+	// Persist the clean re-baseline first, then audit (committed-but-unaudited on an audit error; do not
+	// blindly retry).
+	if err := s.save(ctx, b, dt); err != nil {
+		return err
+	}
+	return s.recordTransition(ctx, actor, key, "baseline.rebaselined")
+}
+
+// load reads the persisted baseline + drift tracker, or fresh ones if none exists yet.
+func (s *Service) load(ctx context.Context, key baseline.Key) (*baseline.Baseline, *baseline.DriftTracker, error) {
+	rec, err := s.store.Load(ctx, key)
+	if errors.Is(err, shared.ErrNotFound) {
+		b, nerr := baseline.NewBaseline(key)
+		if nerr != nil {
+			return nil, nil, nerr
+		}
+		dt, derr := baseline.NewDriftTracker(s.policy.DriftScore, s.policy.DriftThreshold)
+		if derr != nil {
+			return nil, nil, derr
+		}
+		return b, dt, nil
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	b, err := baseline.NewBaselineFrom(rec.Key, rec.State, rec.Summaries)
+	if err != nil {
+		return nil, nil, err
+	}
+	dt, err := baseline.NewDriftTrackerFrom(s.policy.DriftScore, s.policy.DriftThreshold, rec.DriftRun, rec.Drifted)
+	if err != nil {
+		return nil, nil, err
+	}
+	return b, dt, nil
+}
+
+// save persists the baseline + drift-tracker progress.
+func (s *Service) save(ctx context.Context, b *baseline.Baseline, dt *baseline.DriftTracker) error {
+	sum := b.Summary()
+	return s.store.Save(ctx, ports.BaselineRecord{
+		Key:       b.Key(),
+		State:     b.State(),
+		Summaries: append([]baseline.FeatureSummary(nil), sum[:]...),
+		DriftRun:  dt.Run(),
+		Drifted:   dt.Drifted(),
+		UpdatedAt: s.now().UTC(),
+	})
+}
+
+func (s *Service) recordTransition(ctx context.Context, actor string, key baseline.Key, action string) error {
+	if err := s.audit.Record(ctx, ports.AuditEntry{
+		Actor:    actor,
+		Action:   action,
+		Target:   key.Tenant.String() + "/" + key.Group,
+		At:       s.now().UTC(),
+		Metadata: map[string]string{"group": key.Group},
+	}); err != nil {
+		return fmt.Errorf("audit %s: %w", action, err)
+	}
+	return nil
+}
+
+// foldable reports whether the baseline may still learn in this state.
+func foldable(st baseline.State) bool {
+	switch st {
+	case baseline.StateLearning, baseline.StateActive, baseline.StateStale:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/usecase/fleet/baselineuc/service_test.go
+++ b/internal/usecase/fleet/baselineuc/service_test.go
@@ -1,0 +1,215 @@
+package baselineuc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/baseline"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeAudit struct{ actions []string }
+
+func (f *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	f.actions = append(f.actions, e.Action)
+	return nil
+}
+
+const tenant = shared.ID("t1")
+
+func obs(spawn, fanout, newexec, priv, files int64) baseline.Observation {
+	return baseline.Observation{Values: [baseline.NumFeatures]int64{spawn, fanout, newexec, priv, files}}
+}
+
+func okWin() baseline.LearnWindow { return baseline.LearnWindow{Coverage: 90, MinCoverage: 60} }
+
+func newSvc(t *testing.T) (*Service, *fakeAudit, context.Context) {
+	t.Helper()
+	audit := &fakeAudit{}
+	svc, err := NewService(memory.NewBaselineStore(), audit, func() time.Time { return time.Unix(1_700_000_000, 0).UTC() },
+		Policy{MinObservations: 3, DriftScore: 65, DriftThreshold: 3})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	return svc, audit, shared.WithTenant(context.Background(), tenant)
+}
+
+func key() baseline.Key { return baseline.Key{Tenant: tenant, Group: "web-tier"} }
+
+func TestColdStartActivatesThenScores(t *testing.T) {
+	svc, audit, ctx := newSvc(t)
+	steady := obs(2, 5, 1, 0, 3)
+	// First 3 eligible observations are cold-start: abstain, then activate on the 3rd fold.
+	for i := 0; i < 3; i++ {
+		a, err := svc.Observe(ctx, "analyst", key(), steady, okWin())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if a.Scoreable {
+			t.Fatalf("observation %d during cold-start must abstain", i)
+		}
+	}
+	// Now active — a steady observation scores low; a wild one scores high.
+	low, err := svc.Observe(ctx, "analyst", key(), steady, okWin())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !low.Scoreable || low.State != baseline.StateActive {
+		t.Fatalf("baseline must be active + scoreable, got scoreable=%v state=%s", low.Scoreable, low.State)
+	}
+	high, err := svc.Observe(ctx, "analyst", key(), obs(50, 80, 20, 9, 40), okWin())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !high.Scoreable || high.Behavior < 65 {
+		t.Fatalf("a wild deviation must yield a high Behavior factor, got %d (scoreable=%v)", high.Behavior, high.Scoreable)
+	}
+	if low.Behavior > high.Behavior {
+		t.Fatalf("steady (%d) must not exceed wild (%d)", low.Behavior, high.Behavior)
+	}
+	// Activation was audited.
+	var activated bool
+	for _, act := range audit.actions {
+		if act == "baseline.activated" {
+			activated = true
+		}
+	}
+	if !activated {
+		t.Fatal("activation must be audited")
+	}
+}
+
+func TestSustainedDriftTransitionsAndThenAbstains(t *testing.T) {
+	svc, audit, ctx := newSvc(t)
+	steady := obs(2, 5, 1, 0, 3)
+	for i := 0; i < 3; i++ {
+		if _, err := svc.Observe(ctx, "analyst", key(), steady, okWin()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Three consecutive wild windows => sustained drift.
+	wild := obs(50, 80, 20, 9, 40)
+	var last Assessment
+	for i := 0; i < 3; i++ {
+		a, err := svc.Observe(ctx, "analyst", key(), wild, okWin())
+		if err != nil {
+			t.Fatal(err)
+		}
+		last = a
+	}
+	if last.State != baseline.StateDrifted {
+		t.Fatalf("sustained drift must transition to drifted, got %s", last.State)
+	}
+	// Once drifted the baseline abstains (coverage-honesty), not fabricating a score.
+	after, err := svc.Observe(ctx, "analyst", key(), steady, okWin())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.Scoreable {
+		t.Fatal("a drifted baseline must abstain")
+	}
+	var drifted bool
+	for _, act := range audit.actions {
+		if act == "baseline.drifted" {
+			drifted = true
+		}
+	}
+	if !drifted {
+		t.Fatal("drift must be audited")
+	}
+}
+
+func TestAntiPoisoningWindowIsNotLearned(t *testing.T) {
+	svc, _, ctx := newSvc(t)
+	steady := obs(2, 5, 1, 0, 3)
+	// An incident-active window must not be folded — it scores (abstains, still learning) but does not learn.
+	for i := 0; i < 5; i++ {
+		if _, err := svc.Observe(ctx, "analyst", key(), steady, baseline.LearnWindow{IncidentActive: true, Coverage: 90, MinCoverage: 60}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rec, err := memoryLoad(t, svc, ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.State != baseline.StateLearning {
+		t.Fatalf("baseline must still be learning (nothing was learned from tainted windows), got %s", rec.State)
+	}
+	if rec.Summaries[0].Count != 0 {
+		t.Fatalf("no observations should have been folded from tainted windows, got %d", rec.Summaries[0].Count)
+	}
+}
+
+func TestRebaselineClearsAndRelearns(t *testing.T) {
+	svc, _, ctx := newSvc(t)
+	steady := obs(2, 5, 1, 0, 3)
+	for i := 0; i < 3; i++ {
+		if _, err := svc.Observe(ctx, "analyst", key(), steady, okWin()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Force drift.
+	wild := obs(50, 80, 20, 9, 40)
+	for i := 0; i < 3; i++ {
+		if _, err := svc.Observe(ctx, "analyst", key(), wild, okWin()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := svc.Rebaseline(ctx, "analyst", key()); err != nil {
+		t.Fatalf("rebaseline: %v", err)
+	}
+	rec, err := memoryLoad(t, svc, ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.State != baseline.StateLearning || rec.Summaries[0].Count != 0 || rec.Drifted {
+		t.Fatalf("rebaseline must reset to a clean learning baseline, got state=%s count=%d drifted=%v", rec.State, rec.Summaries[0].Count, rec.Drifted)
+	}
+	// Rebaselining a healthy (learning/active) baseline is rejected.
+	if err := svc.Rebaseline(ctx, "analyst", key()); err == nil {
+		t.Fatal("re-baselining a non-drifted baseline must be rejected")
+	}
+}
+
+func TestObserveValidation(t *testing.T) {
+	svc, _, ctx := newSvc(t)
+	if _, err := svc.Observe(ctx, "", key(), obs(1, 1, 1, 1, 1), okWin()); err == nil {
+		t.Fatal("missing actor must be rejected")
+	}
+	if _, err := svc.Observe(ctx, "a", baseline.Key{Group: "g"}, obs(1, 1, 1, 1, 1), okWin()); err == nil {
+		t.Fatal("invalid key must be rejected")
+	}
+}
+
+func TestNewServiceValidation(t *testing.T) {
+	audit := &fakeAudit{}
+	now := func() time.Time { return time.Unix(1, 0).UTC() }
+	store := memory.NewBaselineStore()
+	if _, err := NewService(nil, audit, now, DefaultPolicy()); err == nil {
+		t.Fatal("nil store must be rejected")
+	}
+	if _, err := NewService(store, nil, now, DefaultPolicy()); err == nil {
+		t.Fatal("nil audit must be rejected")
+	}
+	if _, err := NewService(store, audit, nil, DefaultPolicy()); err == nil {
+		t.Fatal("nil clock must be rejected")
+	}
+	if _, err := NewService(store, audit, now, Policy{MinObservations: 0, DriftScore: 65, DriftThreshold: 3}); err == nil {
+		t.Fatal("zero MinObservations must be rejected")
+	}
+	if _, err := NewService(store, audit, now, Policy{MinObservations: 5, DriftScore: 200, DriftThreshold: 3}); err == nil {
+		t.Fatal("out-of-range drift score must be rejected")
+	}
+	if _, err := NewService(store, audit, now, DefaultPolicy()); err != nil {
+		t.Fatalf("default policy must be valid: %v", err)
+	}
+}
+
+// memoryLoad reads the persisted record straight from the store for assertions.
+func memoryLoad(t *testing.T, svc *Service, ctx context.Context) (ports.BaselineRecord, error) {
+	t.Helper()
+	return svc.store.Load(ctx, key())
+}

--- a/internal/usecase/ports/baseline_store.go
+++ b/internal/usecase/ports/baseline_store.go
@@ -1,0 +1,31 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/baseline"
+)
+
+// BaselineRecord is the persisted form of one behavioral baseline (Phase D, D5 #738): its key, lifecycle
+// state, per-feature accumulators (exactly baseline.NumFeatures entries, in feature order), and the
+// drift-tracker's per-baseline progress. It is a MUTABLE projection — unlike the append-only evidence and
+// incident logs, a re-observation upserts it in place — but the usecase audits every state transition.
+// The drift-tracker CONFIG (score/threshold) is service policy, not stored here; only its run/latch state
+// travels with the baseline so drift progress survives a restart.
+type BaselineRecord struct {
+	Key       baseline.Key
+	State     baseline.State
+	Summaries []baseline.FeatureSummary
+	DriftRun  int
+	Drifted   bool
+	UpdatedAt time.Time
+}
+
+// BaselineStore persists behavioral baselines, tenant-scoped from the context. A baseline is a mutable
+// projection keyed by (tenant, group): Save upserts the record for its key; Load returns the current
+// record or shared.ErrNotFound. Save is idempotent — re-saving an equal record leaves the same state.
+type BaselineStore interface {
+	Save(ctx context.Context, rec BaselineRecord) error
+	Load(ctx context.Context, key baseline.Key) (BaselineRecord, error)
+}

--- a/migrations/0114_baselines.sql
+++ b/migrations/0114_baselines.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- Phase D / D5 (#738): the behavioral-baseline projection. Unlike the append-only evidence/incident
+-- ledgers, a baseline is a MUTABLE projection — a re-observation upserts it in place — so this table has
+-- no append-only trigger; integrity comes from the domain (baseline.NewBaselineFrom validates the
+-- accumulators on every load) and the usecase (which audits every lifecycle transition). One row per
+-- (tenant, group); the group is a peer-group or entity id, optionally seasonally keyed by the usecase.
+CREATE TABLE baselines (
+    tenant_id  TEXT NOT NULL REFERENCES tenants(id),
+    group_id   TEXT NOT NULL,
+    state      TEXT NOT NULL,
+    -- summaries is the []baseline.FeatureSummary vector (per-feature count/sum/sumSq/min/max) as JSON; it
+    -- is the authoritative accumulator content the domain rehydrates. Deterministic integer values only.
+    summaries  JSONB NOT NULL,
+    -- drift-tracker per-baseline progress (config score/threshold is service policy, not stored here).
+    drift_run  INT NOT NULL DEFAULT 0 CHECK (drift_run >= 0),
+    drifted    BOOLEAN NOT NULL DEFAULT FALSE,
+    updated_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, group_id)
+);
+CALL synapse_enable_tenant_rls('baselines');
+
+-- +goose Down
+DROP TABLE baselines;


### PR DESCRIPTION
## D5 — baseline persistence + coverage-honest RiskContext.Behavior factor (#738)

Completes **Phase D (behavioral EDR, non-AI, #639)**: turns the pure-domain baseline (D1–D4) into a live per-entity/peer-group **Behavior factor** that feeds the C3 risk scorer — the `BehaviorWeight` the scorer has reserved since C3. It is a **factor, never a verdict**.

### What's in it
- **Domain**: `NewBaselineFrom` rehydration constructor (fail-closed integrity: feature order, count consistency, bounded non-negative sums, `min≤max`, and non-negative variance `obs·sumSq ≥ sum²` checked in **`math/big`** so it can't be defeated by int64 overflow near the cap) + exported `NumFeatures`.
- **`ports.BaselineStore`** + `BaselineRecord`; **memory + postgres twins** — upsert-by-`(tenant,group)` mutable projection, tenant-scoped, cross-tenant key rejected, **re-validated on Load** (defense-in-depth). **Migration 0114** — `baselines` table, RLS, FK to `tenants`, no append-only trigger (a baseline is a mutable projection).
- **`baselineuc.Service`** — `Observe` scores the window against the **current** baseline *before* folding it, feeds drift, and folds only **eligible + non-anomalous** windows (an ineligible *or* itself-anomalous window is never learned → an attacker can neither poison via a tainted window nor walk the baseline toward their behavior). Advances the lifecycle (cold-start→active; sustained drift→drifted) and returns the coverage-honest `Assessment{Behavior, Scoreable, State, Reasons}`: **Behavior is emitted only when active**, else it abstains (`Scoreable=false`) — lowering Coverage, never fabricating Risk. Never sets Risk/disposition; never touches the Confidence axis. `Rebaseline` does the clean `drifted/poisoned → reset_pending → learning` reset. Every transition is audited **after** the durable save.

### Review + verification
Dual-reviewed — **go-arch MERGEABLE, security SHIP**. Every finding folded in: the MEDIUM int64-overflow in the variance gate → `math/big` + a near-cap regression test; validate-on-Load in both twins; drift-policy default normalization (the fold-gate now uses the same effective drift score as the tracker); audit-after-persist ordering; `min≤max` bound. Security confirmed anti-poisoning holds end-to-end, tenant isolation/no-IDOR across the new store, and coverage-honesty preserved. `gofmt`/`build`/`vet` clean, `-race` green, **PG integration green on a fresh DB** (0114 applies + RLS + tenant isolation + upsert + rehydration).

Closes the buildable core of #738. 🎉 With D1–D5 merged, **Phase D is complete** — the tri-factor Risk score now has a Behavior producer.

CI is off by request — validated locally.
