### PR TITLE
Feat/627 a6 query authz audit

### DIFF
--- a/internal/adapter/httpapi/detection_handler.go
+++ b/internal/adapter/httpapi/detection_handler.go
@@ -26,21 +26,39 @@ func (rt *Router) SetDetectionReader(r detectionReader) {
 
 // listDetections returns the engagement's chained detections, or — with ?view=incidents — the incident
 // rollup over them (the individual detections remain the ledger underneath). PermView + withEngTenant;
-// a cross-tenant engagement is already a 404 before this runs.
+// a cross-tenant engagement is already a 404 before this runs. A6 adds a second, field-level authz layer
+// to the evidence-bearing records view and requires a query-audit entry before either read executes.
 func (rt *Router) listDetections(w http.ResponseWriter, r *http.Request) {
 	engID := shared.ID(r.PathValue("id"))
-	if rt.detections == nil {
-		// Not wired: an empty, honest answer (not a 500), consistent with the read being optional.
-		writeJSON(w, http.StatusOK, map[string]any{"detections": []detection.Record{}})
-		return
-	}
 	if r.URL.Query().Get("view") == "incidents" {
+		if err := rt.auditDetectionQuery(r.Context(), engID, "incidents", detectionFieldScopeSummary); err != nil {
+			writeError(w, rt.log, err)
+			return
+		}
+		if rt.detections == nil {
+			writeJSON(w, http.StatusOK, map[string]any{"incidents": []detection.Incident{}, "field_scope": detectionFieldScopeSummary})
+			return
+		}
 		inc, err := rt.detections.Incidents(r.Context(), engID)
 		if err != nil {
 			writeError(w, rt.log, err)
 			return
 		}
-		writeJSON(w, http.StatusOK, map[string]any{"incidents": inc})
+		writeJSON(w, http.StatusOK, map[string]any{"incidents": inc, "field_scope": detectionFieldScopeSummary})
+		return
+	}
+
+	scope, err := detectionFieldScopeFor(r.Context())
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	if err := rt.auditDetectionQuery(r.Context(), engID, "records", scope); err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	if rt.detections == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"detections": []detection.Record{}, "field_scope": scope})
 		return
 	}
 	recs, err := rt.detections.ListDetections(r.Context(), engID)
@@ -48,5 +66,5 @@ func (rt *Router) listDetections(w http.ResponseWriter, r *http.Request) {
 		writeError(w, rt.log, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, map[string]any{"detections": recs})
+	writeJSON(w, http.StatusOK, map[string]any{"detections": projectDetectionRecords(recs, scope), "field_scope": scope})
 }

--- a/internal/adapter/httpapi/detection_privacy.go
+++ b/internal/adapter/httpapi/detection_privacy.go
@@ -1,0 +1,119 @@
+package httpapi
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// detectionFieldScope is the A6 on-plane field authorization decision for detection/hunt-style reads.
+// Coarse route admission remains at Router.authz(PermView); this second, subtract-only decision controls
+// whether direct-value evidence fields may leave the HTTP boundary. It deliberately reuses the existing
+// role capabilities instead of inventing a parallel permission lattice that could drift from authz.
+type detectionFieldScope string
+
+const (
+	detectionFieldScopeRestricted detectionFieldScope = "restricted"
+	detectionFieldScopeFull       detectionFieldScope = "full"
+	detectionFieldScopeSummary    detectionFieldScope = "summary"
+)
+
+// detectionFieldScopeFor derives field visibility from the same Role.Can capability table used by the
+// single authz chokepoint. A pure read-only principal may see detection metadata but not direct-value
+// evidence. Roles that already hold an investigative/mutating/review capability may see the source-side
+// redacted evidence. Unknown/machine roles fail closed even if this helper is ever called outside authz.
+func detectionFieldScopeFor(ctx context.Context) (detectionFieldScope, error) {
+	p, ok := principalObj(ctx)
+	if !ok {
+		return "", fmt.Errorf("%w: detection field authorization requires an authenticated principal", shared.ErrForbidden)
+	}
+	role := userdom.Role(p.Role)
+	if !role.Can(userdom.PermView) {
+		return "", fmt.Errorf("%w: detection field authorization requires view permission", shared.ErrForbidden)
+	}
+	if role.Can(userdom.PermOperate) || role.Can(userdom.PermReview) || role.Can(userdom.PermAdminister) {
+		return detectionFieldScopeFull, nil
+	}
+	return detectionFieldScopeRestricted, nil
+}
+
+// projectDetectionRecords returns a deep copy of the query result. Restricted scope strips fields whose
+// direct values can carry user/host-sensitive material while preserving structural metadata needed to
+// understand that evidence exists. The source-side A6 scrub remains the first privacy layer; this is a
+// second, subtract-only authorization layer and can never restore a value already redacted at source.
+func projectDetectionRecords(records []detection.Record, scope detectionFieldScope) []detection.Record {
+	out := make([]detection.Record, len(records))
+	for i, record := range records {
+		out[i] = record
+		evidence := make([]detection.Event, len(record.Detection.Evidence))
+		for j, event := range record.Detection.Evidence {
+			evidence[j] = projectDetectionEvent(event, scope)
+		}
+		out[i].Detection.Evidence = evidence
+	}
+	return out
+}
+
+func projectDetectionEvent(event detection.Event, scope detectionFieldScope) detection.Event {
+	out := event
+	if event.Process != nil {
+		process := *event.Process
+		process.Args = append([]string(nil), event.Process.Args...)
+		if scope == detectionFieldScopeRestricted {
+			process.Path = ""
+			process.Args = nil
+		}
+		out.Process = &process
+	}
+	if event.Network != nil {
+		network := *event.Network
+		if scope == detectionFieldScopeRestricted {
+			network.RemoteAddr = ""
+		}
+		out.Network = &network
+	}
+	if event.File != nil {
+		file := *event.File
+		if scope == detectionFieldScopeRestricted {
+			file.Path = ""
+		}
+		out.File = &file
+	}
+	if event.Privilege != nil {
+		privilege := *event.Privilege
+		out.Privilege = &privilege
+	}
+	return out
+}
+
+// auditDetectionQuery records the governed read BEFORE any query executes. Query audit is mandatory for
+// this A6 surface: an unavailable audit sink fails closed, so raw evidence can never be returned from an
+// unaudited read. Router.vulnerabilityAudit is the existing writable append-only audit port wired by the
+// composition root; despite the historical field name it points at the shared audit log used system-wide.
+func (rt *Router) auditDetectionQuery(ctx context.Context, engagementID shared.ID, view string, scope detectionFieldScope) error {
+	p, ok := principalObj(ctx)
+	if !ok {
+		return fmt.Errorf("%w: detection query audit requires an authenticated principal", shared.ErrForbidden)
+	}
+	if rt.vulnerabilityAudit == nil {
+		return fmt.Errorf("%w: detection query audit sink is not configured", shared.ErrSaturated)
+	}
+	if err := rt.vulnerabilityAudit.Record(ctx, ports.AuditEntry{
+		Actor:  p.ID,
+		Action: "detection.query",
+		Target: engagementID.String(),
+		At:     time.Now().UTC(),
+		Metadata: map[string]string{
+			"view":        view,
+			"field_scope": string(scope),
+		},
+	}); err != nil {
+		return fmt.Errorf("%w: record detection query audit: %v", shared.ErrSaturated, err)
+	}
+	return nil
+}

--- a/internal/adapter/httpapi/detection_privacy.go
+++ b/internal/adapter/httpapi/detection_privacy.go
@@ -67,6 +67,7 @@ func projectDetectionEvent(event detection.Event, scope detectionFieldScope) det
 		if scope == detectionFieldScopeRestricted {
 			process.Path = ""
 			process.Args = nil
+			process.Comm = ""
 		}
 		out.Process = &process
 	}
@@ -74,6 +75,7 @@ func projectDetectionEvent(event detection.Event, scope detectionFieldScope) det
 		network := *event.Network
 		if scope == detectionFieldScopeRestricted {
 			network.RemoteAddr = ""
+			network.Comm = ""
 		}
 		out.Network = &network
 	}
@@ -81,11 +83,15 @@ func projectDetectionEvent(event detection.Event, scope detectionFieldScope) det
 		file := *event.File
 		if scope == detectionFieldScopeRestricted {
 			file.Path = ""
+			file.Comm = ""
 		}
 		out.File = &file
 	}
 	if event.Privilege != nil {
 		privilege := *event.Privilege
+		if scope == detectionFieldScopeRestricted {
+			privilege.Comm = ""
+		}
 		out.Privilege = &privilege
 	}
 	return out

--- a/internal/adapter/httpapi/detection_privacy_test.go
+++ b/internal/adapter/httpapi/detection_privacy_test.go
@@ -1,0 +1,246 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type detectionQueryReaderStub struct {
+	records       []detection.Record
+	incidents     []detection.Incident
+	listCalls     int
+	incidentCalls int
+	order         *[]string
+}
+
+func (s *detectionQueryReaderStub) ListDetections(context.Context, shared.ID) ([]detection.Record, error) {
+	s.listCalls++
+	if s.order != nil {
+		*s.order = append(*s.order, "read")
+	}
+	return s.records, nil
+}
+
+func (s *detectionQueryReaderStub) Incidents(context.Context, shared.ID) ([]detection.Incident, error) {
+	s.incidentCalls++
+	if s.order != nil {
+		*s.order = append(*s.order, "read")
+	}
+	return s.incidents, nil
+}
+
+type detectionQueryAuditStub struct {
+	entries []ports.AuditEntry
+	err     error
+	order   *[]string
+}
+
+func (s *detectionQueryAuditStub) Record(_ context.Context, entry ports.AuditEntry) error {
+	if s.order != nil {
+		*s.order = append(*s.order, "audit")
+	}
+	if s.err != nil {
+		return s.err
+	}
+	s.entries = append(s.entries, entry)
+	return nil
+}
+
+func sensitiveDetectionRecord(secret string) detection.Record {
+	at := time.Unix(1_725_000_000, 0).UTC()
+	return detection.Record{
+		ID:           "det-1",
+		TenantID:     "tenant-1",
+		EngagementID: "eng-1",
+		AssetID:      "asset-1",
+		AgentID:      "agent-1",
+		Detection: detection.Detection{
+			RuleID:        "rule-1",
+			RuleVersion:   1,
+			Class:         detection.ClassProcess,
+			Severity:      shared.SeverityHigh,
+			HostID:        "host-1",
+			AgentID:       "agent-1",
+			ObservedCount: 3,
+			Observed:      at,
+			Evidence: []detection.Event{
+				{Class: detection.ClassProcess, At: at, Host: "host-1", Process: &detection.ProcessEvent{
+					PID: 101, PPID: 1, Comm: "worker", Path: "/srv/" + secret, Args: []string{"--credential", secret}, UID: 1000,
+				}},
+				{Class: detection.ClassNetwork, At: at, Host: "host-1", Network: &detection.NetworkEvent{
+					Proto: "tcp", RemoteAddr: "203.0.113.7", RemotePort: 443, Direction: "outbound", PID: 101, Comm: "worker",
+				}},
+				{Class: detection.ClassFile, At: at, Host: "host-1", File: &detection.FileEvent{
+					Path: "/tmp/" + secret, Op: "open", PID: 101, Comm: "worker",
+				}},
+			},
+		},
+		EvidenceID: "evidence-1",
+		BatchSeq:   9,
+		RecordedAt: at,
+	}
+}
+
+func runDetectionQuery(t *testing.T, rt *Router, role, rawURL string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, rawURL, nil).WithContext(ctxAs(role))
+	req.SetPathValue("id", "eng-1")
+	rec := httptest.NewRecorder()
+	rt.authz(userdom.PermView, rt.listDetections)(rec, req)
+	return rec
+}
+
+func TestListDetectionsReadonlyStripsSensitiveFieldsAndAuditsFirst(t *testing.T) {
+	secret := "fixture-" + "private-value"
+	source := sensitiveDetectionRecord(secret)
+	order := []string{}
+	reader := &detectionQueryReaderStub{records: []detection.Record{source}, order: &order}
+	audit := &detectionQueryAuditStub{order: &order}
+	rt := &Router{log: discardLog(), detections: reader, vulnerabilityAudit: audit}
+
+	rec := runDetectionQuery(t, rt, "readonly", "/api/v1/engagements/eng-1/detections")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("readonly query: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(order) != 2 || order[0] != "audit" || order[1] != "read" {
+		t.Fatalf("query must audit before data read, got order %v", order)
+	}
+	var response struct {
+		Detections []detection.Record `json:"detections"`
+		FieldScope string             `json:"field_scope"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.FieldScope != string(detectionFieldScopeRestricted) || len(response.Detections) != 1 {
+		t.Fatalf("unexpected restricted response: scope=%q records=%d", response.FieldScope, len(response.Detections))
+	}
+	evidence := response.Detections[0].Detection.Evidence
+	if evidence[0].Process.Path != "" || evidence[0].Process.Args != nil {
+		t.Errorf("readonly process evidence leaked direct values: %+v", evidence[0].Process)
+	}
+	if evidence[1].Network.RemoteAddr != "" {
+		t.Errorf("readonly network evidence leaked remote address %q", evidence[1].Network.RemoteAddr)
+	}
+	if evidence[2].File.Path != "" {
+		t.Errorf("readonly file evidence leaked path %q", evidence[2].File.Path)
+	}
+	if evidence[0].Process.PID != 101 || evidence[0].Process.Comm != "worker" || evidence[1].Network.RemotePort != 443 {
+		t.Errorf("restricted projection removed structural evidence unexpectedly: %+v", evidence)
+	}
+
+	// Projection is subtract-only and must never mutate the ledger-owned object returned by the reader.
+	if got := reader.records[0].Detection.Evidence[0].Process.Path; got != "/srv/"+secret {
+		t.Fatalf("projection mutated stored process path: %q", got)
+	}
+	if got := reader.records[0].Detection.Evidence[0].Process.Args[1]; got != secret {
+		t.Fatalf("projection mutated stored argv: %q", got)
+	}
+
+	if len(audit.entries) != 1 {
+		t.Fatalf("want one query audit entry, got %d", len(audit.entries))
+	}
+	entry := audit.entries[0]
+	if entry.Actor != "p1" || entry.Action != "detection.query" || entry.Target != "eng-1" || entry.Metadata["view"] != "records" || entry.Metadata["field_scope"] != "restricted" {
+		t.Fatalf("unexpected query audit entry: %+v", entry)
+	}
+	encodedAudit, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("marshal audit entry: %v", err)
+	}
+	if strings.Contains(string(encodedAudit), secret) || strings.Contains(string(encodedAudit), "203.0.113.7") {
+		t.Fatalf("query audit must contain metadata only, not sensitive evidence: %s", encodedAudit)
+	}
+}
+
+func TestListDetectionsInvestigativeRolesRetainSourceRedactedEvidence(t *testing.T) {
+	secret := "fixture-" + "visible-after-source-scrub"
+	for _, role := range []string{"consultant", "reviewer", "admin"} {
+		t.Run(role, func(t *testing.T) {
+			reader := &detectionQueryReaderStub{records: []detection.Record{sensitiveDetectionRecord(secret)}}
+			audit := &detectionQueryAuditStub{}
+			rt := &Router{log: discardLog(), detections: reader, vulnerabilityAudit: audit}
+
+			rec := runDetectionQuery(t, rt, role, "/api/v1/engagements/eng-1/detections")
+			if rec.Code != http.StatusOK {
+				t.Fatalf("query: want 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+			var response struct {
+				Detections []detection.Record `json:"detections"`
+				FieldScope string             `json:"field_scope"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+				t.Fatalf("decode response: %v", err)
+			}
+			if response.FieldScope != string(detectionFieldScopeFull) {
+				t.Fatalf("want full field scope, got %q", response.FieldScope)
+			}
+			process := response.Detections[0].Detection.Evidence[0].Process
+			if process.Path != "/srv/"+secret || len(process.Args) != 2 || process.Args[1] != secret {
+				t.Fatalf("full scope unexpectedly removed already-source-scrubbed evidence: %+v", process)
+			}
+			if len(audit.entries) != 1 || audit.entries[0].Metadata["field_scope"] != "full" {
+				t.Fatalf("full-scope query not audited correctly: %+v", audit.entries)
+			}
+		})
+	}
+}
+
+func TestListDetectionsAuditFailureFailsClosedBeforeRead(t *testing.T) {
+	order := []string{}
+	reader := &detectionQueryReaderStub{records: []detection.Record{sensitiveDetectionRecord("fixture-value")}, order: &order}
+	audit := &detectionQueryAuditStub{err: errors.New("audit unavailable"), order: &order}
+	rt := &Router{log: discardLog(), detections: reader, vulnerabilityAudit: audit}
+
+	rec := runDetectionQuery(t, rt, "consultant", "/api/v1/engagements/eng-1/detections")
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("audit failure: want 503, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if reader.listCalls != 0 {
+		t.Fatalf("audit failure must stop before reader, list calls=%d", reader.listCalls)
+	}
+	if len(order) != 1 || order[0] != "audit" {
+		t.Fatalf("audit failure touched data path: order=%v", order)
+	}
+	if rec.Header().Get("Retry-After") == "" {
+		t.Fatal("saturated audit failure should carry Retry-After")
+	}
+}
+
+func TestDetectionIncidentViewIsSummaryScopedAndAudited(t *testing.T) {
+	reader := &detectionQueryReaderStub{incidents: []detection.Incident{{Key: "rule\x00asset", RuleID: "rule", AssetID: "asset-1", Count: 1}}}
+	audit := &detectionQueryAuditStub{}
+	rt := &Router{log: discardLog(), detections: reader, vulnerabilityAudit: audit}
+
+	rec := runDetectionQuery(t, rt, "readonly", "/api/v1/engagements/eng-1/detections?view=incidents")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("incident query: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if reader.incidentCalls != 1 || reader.listCalls != 0 {
+		t.Fatalf("unexpected reader calls: incidents=%d records=%d", reader.incidentCalls, reader.listCalls)
+	}
+	var response struct {
+		Incidents  []detection.Incident `json:"incidents"`
+		FieldScope string               `json:"field_scope"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if response.FieldScope != string(detectionFieldScopeSummary) || len(response.Incidents) != 1 {
+		t.Fatalf("unexpected incident response: scope=%q incidents=%d", response.FieldScope, len(response.Incidents))
+	}
+	if len(audit.entries) != 1 || audit.entries[0].Metadata["view"] != "incidents" || audit.entries[0].Metadata["field_scope"] != "summary" {
+		t.Fatalf("incident query audit mismatch: %+v", audit.entries)
+	}
+}

--- a/internal/adapter/httpapi/detection_privacy_test.go
+++ b/internal/adapter/httpapi/detection_privacy_test.go
@@ -145,6 +145,11 @@ func TestListDetectionsReadonlyStripsSensitiveFieldsAndAuditsFirst(t *testing.T)
 	if evidence[0].Process.PID != 101 || evidence[1].Network.RemotePort != 443 || evidence[2].File.Op != "open" || evidence[3].Privilege.Cap != "CAP_SYS_ADMIN" {
 		t.Errorf("restricted projection removed structural evidence unexpectedly: %+v", evidence)
 	}
+	for _, forbidden := range []string{secret, "203.0.113.7", "worker"} {
+		if strings.Contains(rec.Body.String(), forbidden) {
+			t.Fatalf("readonly response leaked direct evidence value %q: %s", forbidden, rec.Body.String())
+		}
+	}
 
 	// Projection is subtract-only and must never mutate the ledger-owned object returned by the reader.
 	if got := reader.records[0].Detection.Evidence[0].Process.Path; got != "/srv/"+secret {
@@ -155,6 +160,15 @@ func TestListDetectionsReadonlyStripsSensitiveFieldsAndAuditsFirst(t *testing.T)
 	}
 	if got := reader.records[0].Detection.Evidence[0].Process.Comm; got != "worker" {
 		t.Fatalf("projection mutated stored command name: %q", got)
+	}
+	if got := reader.records[0].Detection.Evidence[1].Network.RemoteAddr; got != "203.0.113.7" {
+		t.Fatalf("projection mutated stored remote address: %q", got)
+	}
+	if got := reader.records[0].Detection.Evidence[2].File.Path; got != "/tmp/"+secret {
+		t.Fatalf("projection mutated stored file path: %q", got)
+	}
+	if got := reader.records[0].Detection.Evidence[3].Privilege.Comm; got != "worker" {
+		t.Fatalf("projection mutated stored privilege command: %q", got)
 	}
 
 	if len(audit.entries) != 1 {
@@ -175,7 +189,7 @@ func TestListDetectionsReadonlyStripsSensitiveFieldsAndAuditsFirst(t *testing.T)
 
 func TestListDetectionsInvestigativeRolesRetainSourceRedactedEvidence(t *testing.T) {
 	secret := "fixture-" + "visible-after-source-scrub"
-	for _, role := range []string{"consultant", "reviewer", "admin"} {
+	for _, role := range []string{"consultant", "member", "reviewer", "admin"} {
 		t.Run(role, func(t *testing.T) {
 			reader := &detectionQueryReaderStub{records: []detection.Record{sensitiveDetectionRecord(secret)}}
 			audit := &detectionQueryAuditStub{}
@@ -206,6 +220,34 @@ func TestListDetectionsInvestigativeRolesRetainSourceRedactedEvidence(t *testing
 	}
 }
 
+func TestDetectionProjectionFullScopeIsDeepCopy(t *testing.T) {
+	secret := "fixture-deep-copy"
+	source := sensitiveDetectionRecord(secret)
+	projected := projectDetectionRecords([]detection.Record{source}, detectionFieldScopeFull)
+	if len(projected) != 1 || len(projected[0].Detection.Evidence) != 4 {
+		t.Fatalf("unexpected projection shape: %+v", projected)
+	}
+
+	projected[0].Detection.Evidence[0].Process.Path = "/mutated"
+	projected[0].Detection.Evidence[0].Process.Args[1] = "mutated"
+	projected[0].Detection.Evidence[1].Network.RemoteAddr = "198.51.100.99"
+	projected[0].Detection.Evidence[2].File.Path = "/mutated"
+	projected[0].Detection.Evidence[3].Privilege.Comm = "mutated"
+
+	if source.Detection.Evidence[0].Process.Path != "/srv/"+secret || source.Detection.Evidence[0].Process.Args[1] != secret {
+		t.Fatalf("full projection aliases process evidence: %+v", source.Detection.Evidence[0].Process)
+	}
+	if source.Detection.Evidence[1].Network.RemoteAddr != "203.0.113.7" {
+		t.Fatalf("full projection aliases network evidence: %+v", source.Detection.Evidence[1].Network)
+	}
+	if source.Detection.Evidence[2].File.Path != "/tmp/"+secret {
+		t.Fatalf("full projection aliases file evidence: %+v", source.Detection.Evidence[2].File)
+	}
+	if source.Detection.Evidence[3].Privilege.Comm != "worker" {
+		t.Fatalf("full projection aliases privilege evidence: %+v", source.Detection.Evidence[3].Privilege)
+	}
+}
+
 func TestListDetectionsAuditFailureFailsClosedBeforeRead(t *testing.T) {
 	order := []string{}
 	reader := &detectionQueryReaderStub{records: []detection.Record{sensitiveDetectionRecord("fixture-value")}, order: &order}
@@ -224,6 +266,66 @@ func TestListDetectionsAuditFailureFailsClosedBeforeRead(t *testing.T) {
 	}
 	if rec.Header().Get("Retry-After") == "" {
 		t.Fatal("saturated audit failure should carry Retry-After")
+	}
+}
+
+func TestDetectionQueryMissingAuditSinkFailsClosedForEveryView(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		url  string
+	}{
+		{name: "records", url: "/api/v1/engagements/eng-1/detections"},
+		{name: "incidents", url: "/api/v1/engagements/eng-1/detections?view=incidents"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			reader := &detectionQueryReaderStub{
+				records:   []detection.Record{sensitiveDetectionRecord("fixture-value")},
+				incidents: []detection.Incident{{Key: "rule\x00asset", RuleID: "rule", AssetID: "asset-1", Count: 1}},
+			}
+			rt := &Router{log: discardLog(), detections: reader}
+
+			rec := runDetectionQuery(t, rt, "consultant", tc.url)
+			if rec.Code != http.StatusServiceUnavailable {
+				t.Fatalf("missing audit sink: want 503, got %d: %s", rec.Code, rec.Body.String())
+			}
+			if reader.listCalls != 0 || reader.incidentCalls != 0 {
+				t.Fatalf("missing audit sink must stop before every data read: records=%d incidents=%d", reader.listCalls, reader.incidentCalls)
+			}
+			if rec.Header().Get("Retry-After") == "" {
+				t.Fatal("missing audit sink should carry Retry-After")
+			}
+		})
+	}
+}
+
+func TestDetectionQueryDeniedRolesNeverReachAuditOrReader(t *testing.T) {
+	for _, role := range []string{"mcp", "agent", "unknown"} {
+		t.Run(role, func(t *testing.T) {
+			reader := &detectionQueryReaderStub{records: []detection.Record{sensitiveDetectionRecord("fixture-value")}}
+			audit := &detectionQueryAuditStub{}
+			rt := &Router{log: discardLog(), detections: reader, vulnerabilityAudit: audit}
+
+			rec := runDetectionQuery(t, rt, role, "/api/v1/engagements/eng-1/detections")
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("role %q: want 403, got %d: %s", role, rec.Code, rec.Body.String())
+			}
+			if reader.listCalls != 0 || reader.incidentCalls != 0 || len(audit.entries) != 0 {
+				t.Fatalf("denied role reached governed query path: records=%d incidents=%d audits=%d", reader.listCalls, reader.incidentCalls, len(audit.entries))
+			}
+		})
+	}
+}
+
+func TestDetectionQueryWithoutReaderIsStillAudited(t *testing.T) {
+	audit := &detectionQueryAuditStub{}
+	rt := &Router{log: discardLog(), vulnerabilityAudit: audit}
+
+	rec := runDetectionQuery(t, rt, "readonly", "/api/v1/engagements/eng-1/detections")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("empty governed query: want 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if len(audit.entries) != 1 || audit.entries[0].Metadata["view"] != "records" || audit.entries[0].Metadata["field_scope"] != "restricted" {
+		t.Fatalf("empty query must still be audited: %+v", audit.entries)
 	}
 }
 

--- a/internal/adapter/httpapi/detection_privacy_test.go
+++ b/internal/adapter/httpapi/detection_privacy_test.go
@@ -72,7 +72,7 @@ func sensitiveDetectionRecord(secret string) detection.Record {
 			Severity:      shared.SeverityHigh,
 			HostID:        "host-1",
 			AgentID:       "agent-1",
-			ObservedCount: 3,
+			ObservedCount: 4,
 			Observed:      at,
 			Evidence: []detection.Event{
 				{Class: detection.ClassProcess, At: at, Host: "host-1", Process: &detection.ProcessEvent{
@@ -83,6 +83,9 @@ func sensitiveDetectionRecord(secret string) detection.Record {
 				}},
 				{Class: detection.ClassFile, At: at, Host: "host-1", File: &detection.FileEvent{
 					Path: "/tmp/" + secret, Op: "open", PID: 101, Comm: "worker",
+				}},
+				{Class: detection.ClassPrivilege, At: at, Host: "host-1", Privilege: &detection.PrivilegeEvent{
+					PID: 101, Comm: "worker", FromUID: 1000, ToUID: 0, Cap: "CAP_SYS_ADMIN", Kind: "setuid",
 				}},
 			},
 		},
@@ -127,16 +130,19 @@ func TestListDetectionsReadonlyStripsSensitiveFieldsAndAuditsFirst(t *testing.T)
 		t.Fatalf("unexpected restricted response: scope=%q records=%d", response.FieldScope, len(response.Detections))
 	}
 	evidence := response.Detections[0].Detection.Evidence
-	if evidence[0].Process.Path != "" || evidence[0].Process.Args != nil {
+	if evidence[0].Process.Path != "" || evidence[0].Process.Args != nil || evidence[0].Process.Comm != "" {
 		t.Errorf("readonly process evidence leaked direct values: %+v", evidence[0].Process)
 	}
-	if evidence[1].Network.RemoteAddr != "" {
-		t.Errorf("readonly network evidence leaked remote address %q", evidence[1].Network.RemoteAddr)
+	if evidence[1].Network.RemoteAddr != "" || evidence[1].Network.Comm != "" {
+		t.Errorf("readonly network evidence leaked direct values: %+v", evidence[1].Network)
 	}
-	if evidence[2].File.Path != "" {
-		t.Errorf("readonly file evidence leaked path %q", evidence[2].File.Path)
+	if evidence[2].File.Path != "" || evidence[2].File.Comm != "" {
+		t.Errorf("readonly file evidence leaked direct values: %+v", evidence[2].File)
 	}
-	if evidence[0].Process.PID != 101 || evidence[0].Process.Comm != "worker" || evidence[1].Network.RemotePort != 443 {
+	if evidence[3].Privilege.Comm != "" {
+		t.Errorf("readonly privilege evidence leaked command name: %+v", evidence[3].Privilege)
+	}
+	if evidence[0].Process.PID != 101 || evidence[1].Network.RemotePort != 443 || evidence[2].File.Op != "open" || evidence[3].Privilege.Cap != "CAP_SYS_ADMIN" {
 		t.Errorf("restricted projection removed structural evidence unexpectedly: %+v", evidence)
 	}
 
@@ -146,6 +152,9 @@ func TestListDetectionsReadonlyStripsSensitiveFieldsAndAuditsFirst(t *testing.T)
 	}
 	if got := reader.records[0].Detection.Evidence[0].Process.Args[1]; got != secret {
 		t.Fatalf("projection mutated stored argv: %q", got)
+	}
+	if got := reader.records[0].Detection.Evidence[0].Process.Comm; got != "worker" {
+		t.Fatalf("projection mutated stored command name: %q", got)
 	}
 
 	if len(audit.entries) != 1 {
@@ -159,7 +168,7 @@ func TestListDetectionsReadonlyStripsSensitiveFieldsAndAuditsFirst(t *testing.T)
 	if err != nil {
 		t.Fatalf("marshal audit entry: %v", err)
 	}
-	if strings.Contains(string(encodedAudit), secret) || strings.Contains(string(encodedAudit), "203.0.113.7") {
+	if strings.Contains(string(encodedAudit), secret) || strings.Contains(string(encodedAudit), "203.0.113.7") || strings.Contains(string(encodedAudit), "worker") {
 		t.Fatalf("query audit must contain metadata only, not sensitive evidence: %s", encodedAudit)
 	}
 }
@@ -187,7 +196,7 @@ func TestListDetectionsInvestigativeRolesRetainSourceRedactedEvidence(t *testing
 				t.Fatalf("want full field scope, got %q", response.FieldScope)
 			}
 			process := response.Detections[0].Detection.Evidence[0].Process
-			if process.Path != "/srv/"+secret || len(process.Args) != 2 || process.Args[1] != secret {
+			if process.Path != "/srv/"+secret || len(process.Args) != 2 || process.Args[1] != secret || process.Comm != "worker" {
 				t.Fatalf("full scope unexpectedly removed already-source-scrubbed evidence: %+v", process)
 			}
 			if len(audit.entries) != 1 || audit.entries[0].Metadata["field_scope"] != "full" {

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -603,7 +603,7 @@ func TestHostileHarness(t *testing.T) {
 	// appear in tenantB's coverage or agent list (the #413 no-cross-tenant-aggregate requirement).
 	for _, path := range []string{"/api/v1/fleet/coverage", "/api/v1/fleet/agents", "/api/v1/fleet/coverage/export"} {
 		if code, body := send("readonly", "tenantA", http.MethodGet, path, true); code != http.StatusOK || !strings.Contains(body, "asset-A") && !strings.Contains(body, "ag1") {
-			// sanity: tenantA genuinely sees its own data at %s (code=%d body=%s)
+			// sanity: tenantA genuinely sees its own data, so the emptiness below is meaningful.
 			t.Fatalf("tenantA must see its own fleet data at %s (code=%d body=%s)", path, code, body)
 		}
 		if code, body := send("readonly", "tenantB", http.MethodGet, path, true); code != http.StatusOK {

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -364,6 +364,7 @@ func TestHostileHarness(t *testing.T) {
 	rt.SetAttackPaths(attackSvc)              // real #419 service proves cross-tenant derived data isolation
 	rt.SetSARIFIngest(harnessSARIF{})         // register the #415 import route so the harness guards its operate/tenant gates
 	rt.SetImportedFindings(harnessImportedFindings{})
+	rt.SetVulnerabilityAudit(audit)
 	rt.SetDetectionReader(harnessDetections{})  // register the #423 detection-ledger read route
 	rt.SetPurpleCoverageReader(harnessPurple{}) // register the #426 purple-coverage read route
 	rt.SetFleetRolloutAdmin(harnessRollout{})
@@ -597,7 +598,6 @@ func TestHostileHarness(t *testing.T) {
 	if code, body := send("readonly", "tenantB", http.MethodGet, "/api/v1/attack-paths", true); code != http.StatusOK || strings.Contains(body, "tenant-A-secret-marker") {
 		t.Errorf("tenantB attack paths leaked tenantA data (code=%d body=%s)", code, body)
 	}
-
 	// Cross-tenant fleet reads must return NOTHING, not merely a 200. tenantA's asset id must never
 	// appear in tenantB's coverage or agent list (the #413 no-cross-tenant-aggregate requirement).
 	for _, path := range []string{"/api/v1/fleet/coverage", "/api/v1/fleet/agents", "/api/v1/fleet/coverage/export"} {

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -598,11 +598,12 @@ func TestHostileHarness(t *testing.T) {
 	if code, body := send("readonly", "tenantB", http.MethodGet, "/api/v1/attack-paths", true); code != http.StatusOK || strings.Contains(body, "tenant-A-secret-marker") {
 		t.Errorf("tenantB attack paths leaked tenantA data (code=%d body=%s)", code, body)
 	}
+
 	// Cross-tenant fleet reads must return NOTHING, not merely a 200. tenantA's asset id must never
 	// appear in tenantB's coverage or agent list (the #413 no-cross-tenant-aggregate requirement).
 	for _, path := range []string{"/api/v1/fleet/coverage", "/api/v1/fleet/agents", "/api/v1/fleet/coverage/export"} {
 		if code, body := send("readonly", "tenantA", http.MethodGet, path, true); code != http.StatusOK || !strings.Contains(body, "asset-A") && !strings.Contains(body, "ag1") {
-			// sanity: tenantA genuinely sees its own data, so the emptiness below is meaningful.
+			// sanity: tenantA genuinely sees its own data at %s (code=%d body=%s)
 			t.Fatalf("tenantA must see its own fleet data at %s (code=%d body=%s)", path, code, body)
 		}
 		if code, body := send("readonly", "tenantB", http.MethodGet, path, true); code != http.StatusOK {


### PR DESCRIPTION
## Summary

Completes the reachable A6 field-RBAC/query-audit tail on the existing detection/evidence query surface.

- derives detection field scope from the existing role permission table
- strips direct-value process path/argv/command, remote address/command, file path/command, and privilege command fields for `readonly`
- preserves source-redacted evidence for investigative/review/admin roles
- deep-copies projected records so query-time minimization cannot mutate ledger-owned evidence
- audits `detection.query` before data access and fails closed if the audit write cannot be recorded
- exposes `field_scope` on record and incident-summary responses
- covers RBAC, audit ordering/failure, data minimization, deep-copy behavior, and incident summary reads

This intentionally reuses the source-side privacy work merged in #658 and does not duplicate it or expand into X6 fleet-wide governance in #635.

## CI qualification

Validated at `32de25bc10fc163e5bd15e2a6a5a27ad6eba5177` in fork PR run #620.

Frontend passes. Backend Linux and Windows build/vet pass; the changed `internal/adapter/httpapi` package is confirmed passing on Windows. Repository-wide Backend/Lint jobs remain red in off-scope areas; the exact base SHA `43adde627425293405a9393760dfe31ab383e5eb` is independently red in the same classes of jobs in run #613 before this branch. No current lint finding touches an A6 changed file.

Refs #627