### PR TITLE
feat(exposure): X5 continuous-exposure fusion domain core (#634)

### DIFF
--- a/internal/domain/exposure/exposure.go
+++ b/internal/domain/exposure/exposure.go
@@ -1,0 +1,125 @@
+// Package exposure is the pure-domain continuous-exposure fusion for cross-cutting workstream X5 (#634):
+// it fuses per-component vulnerability exposures for one asset into a single riskassessment.RiskContext
+// Exposure factor (0..100). Its defining precision is RUNNING-vs-INSTALLED — the same CVE carried by a
+// process actually observed running ranks strictly above one merely present in inventory. It REUSES the
+// already-evaluated deterministic risk output (vulnerabilityrisk: KEV-then-EPSS×CVSS Priority); it never
+// recomputes KEV/EPSS/CVSS. Like Phase D's Behavior factor, exposure is a FACTOR, never a verdict, and the
+// producing usecase abstains (lowers Coverage, not Risk) when inventory/runtime data is incomplete.
+package exposure
+
+import (
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Presence is whether a vulnerable component was merely INSTALLED (present in inventory/SBOM) or observed
+// RUNNING (a process/container carrying it was seen executing) — the running-vs-installed distinction X5
+// adds. A running vulnerable component is a materially higher exposure than an installed-only one.
+type Presence string
+
+const (
+	// PresenceInstalled: present in inventory/SBOM, not observed running.
+	PresenceInstalled Presence = "installed"
+	// PresenceRunning: a running process/container carrying the component was observed via telemetry.
+	PresenceRunning Presence = "running"
+)
+
+// Valid reports whether p is a known presence.
+func (p Presence) Valid() bool { return p == PresenceInstalled || p == PresenceRunning }
+
+// ComponentExposure is one vulnerable (component × advisory) occurrence's contribution to an asset's
+// exposure, expressed with the ALREADY-evaluated risk Priority (1 highest .. 5 background, from
+// vulnerabilityrisk) plus KEV and its running/installed presence. X5 reuses this evaluation, never redoing
+// the KEV/EPSS/CVSS math.
+type ComponentExposure struct {
+	ComponentID shared.ID
+	AdvisoryID  shared.ID
+	// Severity is carried as EVIDENCE (for the producing usecase's reasons/display) and validated, but it
+	// is NOT a fusion input — Priority already encodes the KEV-then-EPSS×CVSS ordering that drives scoring.
+	Severity shared.Severity
+	Priority int
+	KEV      bool
+	Presence Presence
+}
+
+// Validate enforces a well-formed exposure element.
+func (c ComponentExposure) Validate() error {
+	if c.ComponentID.IsZero() {
+		return fmt.Errorf("%w: component exposure requires a component id", shared.ErrValidation)
+	}
+	if c.AdvisoryID.IsZero() {
+		return fmt.Errorf("%w: component exposure requires an advisory id", shared.ErrValidation)
+	}
+	if c.Priority < 1 || c.Priority > 5 {
+		return fmt.Errorf("%w: component exposure priority %d out of range [1,5]", shared.ErrValidation, c.Priority)
+	}
+	if !c.Severity.Valid() {
+		return fmt.Errorf("%w: component exposure has unknown severity %q", shared.ErrValidation, c.Severity)
+	}
+	if !c.Presence.Valid() {
+		return fmt.Errorf("%w: component exposure has unknown presence %q", shared.ErrValidation, c.Presence)
+	}
+	return nil
+}
+
+const (
+	// kevFloor: a Known-Exploited vulnerability is at least this exposed regardless of its numeric priority
+	// (CISA KEV ranks above all non-KEV — the "KEV, then EPSS×CVSS" ordering).
+	kevFloor riskassessment.Score = 90
+	// installedNumer/installedDenom damp an installed-but-not-observed-running exposure to half its running
+	// weight, so the SAME CVE ranks strictly below its running counterpart (the running-vs-installed win).
+	installedNumer riskassessment.Score = 1
+	installedDenom riskassessment.Score = 2
+)
+
+// priorityBase maps a vulnerabilityrisk Priority (1 highest .. 5 background) to a 0..100 base exposure.
+func priorityBase(priority int) riskassessment.Score {
+	switch priority {
+	case 1:
+		return 100
+	case 2:
+		return 80
+	case 3:
+		return 55
+	case 4:
+		return 30
+	case 5:
+		return 10
+	default:
+		return 0
+	}
+}
+
+// componentScore is the weighted 0..100 exposure of one vulnerable component: its priority base, floored
+// up for KEV, then halved when only installed (not observed running).
+func componentScore(c ComponentExposure) riskassessment.Score {
+	base := priorityBase(c.Priority)
+	if c.KEV && base < kevFloor {
+		base = kevFloor
+	}
+	if c.Presence == PresenceInstalled {
+		base = base * installedNumer / installedDenom
+	}
+	return base
+}
+
+// Fuse aggregates one asset's per-component exposures into a single RiskContext.Exposure Score. It is the
+// WORST component's weighted exposure (a max): many low exposures never eclipse one severe one, and a
+// running vulnerable component always outranks the same CVE merely installed. It is deterministic and
+// ORDER-INDEPENDENT (max), integer-only, and reproducible. An empty set fuses to 0 (no known exposure —
+// the producing usecase distinguishes "scanned clean" from "no data" via its abstain/Scoreable signal,
+// mirroring the Behavior factor). Every element is validated; an invalid one fails closed.
+func Fuse(exposures []ComponentExposure) (riskassessment.Score, error) {
+	var worst riskassessment.Score
+	for _, c := range exposures {
+		if err := c.Validate(); err != nil {
+			return 0, err
+		}
+		if s := componentScore(c); s > worst {
+			worst = s
+		}
+	}
+	return worst, nil
+}

--- a/internal/domain/exposure/exposure_test.go
+++ b/internal/domain/exposure/exposure_test.go
@@ -1,0 +1,166 @@
+package exposure
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func ce(id string, priority int, kev bool, presence Presence) ComponentExposure {
+	return ComponentExposure{
+		ComponentID: shared.ID("comp-" + id),
+		AdvisoryID:  shared.ID("adv-" + id),
+		Severity:    shared.SeverityHigh,
+		Priority:    priority,
+		KEV:         kev,
+		Presence:    presence,
+	}
+}
+
+func TestFuseEmptyIsZero(t *testing.T) {
+	s, err := Fuse(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != 0 {
+		t.Fatalf("empty exposure must fuse to 0, got %d", s)
+	}
+}
+
+// TestRunningOutranksInstalled is the running-vs-installed precision: the SAME CVE ranks strictly higher
+// when observed running than when merely installed.
+func TestRunningOutranksInstalled(t *testing.T) {
+	running, err := Fuse([]ComponentExposure{ce("a", 1, false, PresenceRunning)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	installed, err := Fuse([]ComponentExposure{ce("a", 1, false, PresenceInstalled)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !(running > installed) {
+		t.Fatalf("a running vuln (%d) must outrank the same installed vuln (%d)", running, installed)
+	}
+	if running != 100 || installed != 50 {
+		t.Fatalf("priority-1 running=100 installed=50 expected, got running=%d installed=%d", running, installed)
+	}
+}
+
+func TestFuseIsMaxAndOrderIndependent(t *testing.T) {
+	set := []ComponentExposure{
+		ce("low", 5, false, PresenceRunning),     // 10
+		ce("mid", 3, false, PresenceInstalled),   // 55/2 = 27
+		ce("crit", 1, false, PresenceInstalled),  // 100/2 = 50
+		ce("running", 2, false, PresenceRunning), // 80
+	}
+	fwd, err := Fuse(set)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Reverse order -> identical (max is order-independent).
+	rev := make([]ComponentExposure, len(set))
+	for i := range set {
+		rev[len(set)-1-i] = set[i]
+	}
+	rev2, err := Fuse(rev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fwd != rev2 {
+		t.Fatalf("Fuse must be order-independent: %d vs %d", fwd, rev2)
+	}
+	// Worst is the running priority-2 (80), not the installed priority-1 (50): running-vs-installed matters.
+	if fwd != 80 {
+		t.Fatalf("expected worst=80 (running P2 beats installed P1), got %d", fwd)
+	}
+	// Many lows never eclipse one severe one.
+	manyLows := []ComponentExposure{ce("l1", 5, false, PresenceRunning), ce("l2", 5, false, PresenceRunning), ce("l3", 4, false, PresenceRunning)}
+	low, _ := Fuse(manyLows)
+	if low >= fwd {
+		t.Fatalf("many low exposures (%d) must not eclipse a severe one (%d)", low, fwd)
+	}
+}
+
+func TestKEVFloor(t *testing.T) {
+	// A KEV vuln with a mediocre numeric priority is still floored to a high exposure when running.
+	s, err := Fuse([]ComponentExposure{ce("kev", 4, true, PresenceRunning)}) // base 30 -> KEV floor 90
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s != 90 {
+		t.Fatalf("KEV running must floor to 90, got %d", s)
+	}
+	// KEV but only installed: floored to 90 then halved to 45 (still ranks below a running KEV).
+	inst, _ := Fuse([]ComponentExposure{ce("kev", 4, true, PresenceInstalled)})
+	if inst != 45 {
+		t.Fatalf("KEV installed = 45 expected, got %d", inst)
+	}
+	if !(s > inst) {
+		t.Fatalf("running KEV (%d) must outrank installed KEV (%d)", s, inst)
+	}
+}
+
+// TestRunningStrictlyOutranksInstalledAtEveryPriority locks the running-vs-installed invariant across the
+// whole priority range (not just P1), for both KEV and non-KEV.
+func TestRunningStrictlyOutranksInstalledAtEveryPriority(t *testing.T) {
+	for p := 1; p <= 5; p++ {
+		for _, kev := range []bool{false, true} {
+			run, err := Fuse([]ComponentExposure{ce("x", p, kev, PresenceRunning)})
+			if err != nil {
+				t.Fatal(err)
+			}
+			inst, err := Fuse([]ComponentExposure{ce("x", p, kev, PresenceInstalled)})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !(run > inst) {
+				t.Fatalf("running must strictly outrank installed at priority %d kev=%v: run=%d inst=%d", p, kev, run, inst)
+			}
+		}
+	}
+}
+
+func TestFuseResultInRange(t *testing.T) {
+	for p := 1; p <= 5; p++ {
+		for _, kev := range []bool{false, true} {
+			for _, pr := range []Presence{PresenceRunning, PresenceInstalled} {
+				s, err := Fuse([]ComponentExposure{ce("x", p, kev, pr)})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !s.Valid() {
+					t.Fatalf("score %d out of range for p=%d kev=%v presence=%s", s, p, kev, pr)
+				}
+			}
+		}
+	}
+}
+
+func TestFuseValidation(t *testing.T) {
+	bad := []struct {
+		name string
+		c    ComponentExposure
+	}{
+		{"no component", ComponentExposure{AdvisoryID: "a", Priority: 1, Severity: shared.SeverityHigh, Presence: PresenceRunning}},
+		{"no advisory", ComponentExposure{ComponentID: "c", Priority: 1, Severity: shared.SeverityHigh, Presence: PresenceRunning}},
+		{"priority 0", ComponentExposure{ComponentID: "c", AdvisoryID: "a", Priority: 0, Severity: shared.SeverityHigh, Presence: PresenceRunning}},
+		{"priority 6", ComponentExposure{ComponentID: "c", AdvisoryID: "a", Priority: 6, Severity: shared.SeverityHigh, Presence: PresenceRunning}},
+		{"bad presence", ComponentExposure{ComponentID: "c", AdvisoryID: "a", Priority: 1, Severity: shared.SeverityHigh, Presence: "bogus"}},
+	}
+	for _, tc := range bad {
+		if _, err := Fuse([]ComponentExposure{tc.c}); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("%s must be rejected", tc.name)
+		}
+	}
+}
+
+// TestFactorFeedsRiskContext confirms a fused score is a legal RiskContext.Exposure value.
+func TestFactorFeedsRiskContext(t *testing.T) {
+	s, _ := Fuse([]ComponentExposure{ce("a", 1, true, PresenceRunning)})
+	rc := riskassessment.RiskContext{Exposure: s}
+	if err := rc.Validate(); err != nil {
+		t.Fatalf("fused exposure must be a valid RiskContext factor: %v", err)
+	}
+}


### PR DESCRIPTION
## X5a — continuous-exposure fusion domain core (#634)

The pure-domain fusion for **cross-cutting X5 (#634)**: fuse per-component vulnerability exposures for one asset into a single `riskassessment.RiskContext.Exposure` factor (0..100) — the **twin of Phase D's Behavior factor**, and the second of the two producers the tri-score scorer reserves (`ExposureWeight`, 0 until now).

### `internal/domain/exposure/`
- **`ComponentExposure`** carries the **already-evaluated** risk output (`vulnerabilityrisk` Priority 1-highest..5-background + KEV) plus running/installed **Presence** — X5 reuses that evaluation, never recomputing KEV/EPSS/CVSS. Severity is evidence-only, not a fusion input.
- **`Fuse`** = the **worst** component's weighted exposure: priority base → KEV floor (a Known-Exploited vuln is ≥90) → halved when only installed. So the **running-vs-installed** precision holds — the same CVE ranks strictly above its running counterpart at every priority (acceptance criterion). Deterministic, order-independent (max), integer-only, fail-closed. Empty ⇒ 0 (the abstain/"no data" distinction is X5b's job). A **factor, never a verdict**.

### Scope
This is the fusion math only. The producer usecase — read the shipped occurrence/risk engine, join running processes (B1) to installed components, emit per-asset `RiskContext.Exposure` with coverage-honesty — is **X5b** (next PR).

### Review + verification
Dual-reviewed — **go-arch MERGEABLE, security SHIP**, no findings above informational (security: "the fusion math cannot be gamed to score a genuinely-severe running exposure as safe"). Folded in the Severity-evidence-only note + an all-priorities running>installed invariant test. `gofmt`/`build`/`vet` clean, `-race` green at **93.8%**. Pure domain (imports only `domain/shared` + `domain/riskassessment`).

Part of #634. CI is off by request — validated locally.
