### PR TITLE
feat(exposure): X5b per-asset RiskContext.Exposure producer (#634)

### DIFF
--- a/internal/usecase/fleet/exposureuc/service.go
+++ b/internal/usecase/fleet/exposureuc/service.go
@@ -1,0 +1,116 @@
+// Package exposureuc is the Phase-C/X5 (#634) producer of the coverage-honest RiskContext.Exposure factor:
+// it reads an asset's currently-open vulnerable components (with their already-evaluated vulnerabilityrisk
+// Priority/KEV and running/installed presence), fuses them via the pure-domain exposure.Fuse, and returns
+// an abstain-capable Assessment for the tri-score risk assembler to place into RiskContext.Exposure. It is
+// the twin of baselineuc (the Behavior producer): it produces a FACTOR, never a verdict, never sets Risk
+// or a disposition, never touches the Confidence axis, and ABSTAINS (lowers Coverage, not Risk) when an
+// asset has no inventory/exposure data. It REUSES the shipped continuous-exposure evaluation — it does not
+// recompute KEV/EPSS/CVSS.
+package exposureuc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/exposure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// AssetVulnerableComponent is one open (component × advisory) exposure on an asset, carrying the
+// already-evaluated risk (Priority 1-highest..5-background + KEV, from vulnerabilityrisk) and whether the
+// component was observed RUNNING. Running is false (installed-only) until per-asset process-entity
+// snapshots are persisted (the deferred B5 tail); the fusion still ranks it correctly, and the producer
+// notes the reduced running-vs-installed precision as a coverage reason.
+type AssetVulnerableComponent struct {
+	ComponentID shared.ID
+	AdvisoryID  shared.ID
+	Severity    shared.Severity
+	Priority    int
+	KEV         bool
+	Running     bool
+}
+
+// AssetVulnerabilityReader is the consumer-side view this producer needs: the currently-open vulnerable
+// components for one asset. A nil slice with a nil error means "inventory scanned, no open vulnerabilities"
+// (scored as a real 0 exposure); shared.ErrNotFound means "no inventory/exposure data for this asset" —
+// the producer ABSTAINS rather than reading absence as clean. An adapter implements this over the shipped
+// occurrence/risk stores joined to the asset via component membership.
+//
+// CONTRACT: the implementing adapter MUST scope the query by the tenant derived from ctx
+// (shared.TenantFrom) — the asset id alone is not a tenant boundary, and returning another tenant's
+// components here would leak them into that tenant's risk score.
+type AssetVulnerabilityReader interface {
+	ListAssetVulnerableComponents(ctx context.Context, assetID shared.ID) ([]AssetVulnerableComponent, error)
+}
+
+// Assessment is the coverage-honest Exposure factor for one asset. Exposure is 0 whenever Scoreable is
+// false; the assembler places Exposure into RiskContext.Exposure ONLY when Scoreable, and otherwise
+// reflects the gap in Coverage (never in Risk).
+type Assessment struct {
+	Exposure  riskassessment.Score
+	Scoreable bool
+	Reasons   []string
+}
+
+// Service produces the Exposure factor for an asset.
+type Service struct {
+	reader AssetVulnerabilityReader
+}
+
+// NewService constructs the exposure producer.
+func NewService(reader AssetVulnerabilityReader) (*Service, error) {
+	if reader == nil {
+		return nil, fmt.Errorf("%w: exposure service requires a vulnerability reader", shared.ErrValidation)
+	}
+	return &Service{reader: reader}, nil
+}
+
+// Assess computes the RiskContext.Exposure factor for one asset. It abstains (Scoreable=false, Exposure=0)
+// when the asset has no inventory/exposure data; scores a real 0 when inventory is present but clean; and
+// otherwise fuses the open exposures. When no vulnerable component was observed running (runtime telemetry
+// absent), it still scores the installed exposures but records that running-vs-installed precision is
+// limited — an honest coverage note, never a Risk discount.
+func (s *Service) Assess(ctx context.Context, assetID shared.ID) (Assessment, error) {
+	if assetID.IsZero() {
+		return Assessment{}, fmt.Errorf("%w: asset id is required", shared.ErrValidation)
+	}
+	comps, err := s.reader.ListAssetVulnerableComponents(ctx, assetID)
+	if err != nil {
+		if errors.Is(err, shared.ErrNotFound) {
+			return Assessment{Scoreable: false, Reasons: []string{"no inventory/exposure data for asset — abstaining"}}, nil
+		}
+		return Assessment{}, err
+	}
+	if len(comps) == 0 {
+		// Inventory present, nothing open: a genuine, trustworthy zero exposure.
+		return Assessment{Exposure: 0, Scoreable: true}, nil
+	}
+	exposures := make([]exposure.ComponentExposure, 0, len(comps))
+	anyRunning := false
+	for _, c := range comps {
+		presence := exposure.PresenceInstalled
+		if c.Running {
+			presence = exposure.PresenceRunning
+			anyRunning = true
+		}
+		exposures = append(exposures, exposure.ComponentExposure{
+			ComponentID: c.ComponentID,
+			AdvisoryID:  c.AdvisoryID,
+			Severity:    c.Severity,
+			Priority:    c.Priority,
+			KEV:         c.KEV,
+			Presence:    presence,
+		})
+	}
+	score, err := exposure.Fuse(exposures)
+	if err != nil {
+		return Assessment{}, err
+	}
+	a := Assessment{Exposure: score, Scoreable: true}
+	if !anyRunning {
+		a.Reasons = append(a.Reasons, "running-vs-installed precision limited: no runtime process telemetry for asset (exposures scored as installed)")
+	}
+	return a, nil
+}

--- a/internal/usecase/fleet/exposureuc/service_test.go
+++ b/internal/usecase/fleet/exposureuc/service_test.go
@@ -1,0 +1,129 @@
+package exposureuc
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type fakeReader struct {
+	comps []AssetVulnerableComponent
+	err   error
+}
+
+func (f *fakeReader) ListAssetVulnerableComponents(_ context.Context, _ shared.ID) ([]AssetVulnerableComponent, error) {
+	return f.comps, f.err
+}
+
+func mustService(t *testing.T, r AssetVulnerabilityReader) *Service {
+	t.Helper()
+	s, err := NewService(r)
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	return s
+}
+
+func comp(id string, priority int, kev, running bool) AssetVulnerableComponent {
+	return AssetVulnerableComponent{
+		ComponentID: shared.ID("comp-" + id),
+		AdvisoryID:  shared.ID("adv-" + id),
+		Severity:    shared.SeverityHigh,
+		Priority:    priority,
+		KEV:         kev,
+		Running:     running,
+	}
+}
+
+func TestAbstainWhenNoData(t *testing.T) {
+	s := mustService(t, &fakeReader{err: shared.ErrNotFound})
+	a, err := s.Assess(context.Background(), "asset-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.Scoreable || a.Exposure != 0 || len(a.Reasons) == 0 {
+		t.Fatalf("no data must abstain (Scoreable=false, Exposure=0, with a reason), got %+v", a)
+	}
+}
+
+func TestScoredCleanWhenNoOpenVulns(t *testing.T) {
+	s := mustService(t, &fakeReader{comps: nil})
+	a, err := s.Assess(context.Background(), "asset-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !a.Scoreable || a.Exposure != 0 {
+		t.Fatalf("inventory-present-but-clean must be a trustworthy 0 (Scoreable=true), got %+v", a)
+	}
+}
+
+func TestFusesOpenExposures(t *testing.T) {
+	// A running priority-1 dominates; result is the worst weighted exposure (100).
+	s := mustService(t, &fakeReader{comps: []AssetVulnerableComponent{
+		comp("a", 3, false, false), // installed P3 -> 27
+		comp("b", 1, false, true),  // running P1 -> 100
+	}})
+	a, err := s.Assess(context.Background(), "asset-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !a.Scoreable || a.Exposure != 100 {
+		t.Fatalf("expected Scoreable exposure=100, got %+v", a)
+	}
+	// One component was running, so the running-precision-limited note must be ABSENT.
+	for _, r := range a.Reasons {
+		if containsRunningLimited(r) {
+			t.Fatalf("must not flag running-precision-limited when a component is running: %q", r)
+		}
+	}
+}
+
+func TestInstalledOnlyNotesLimitedPrecision(t *testing.T) {
+	s := mustService(t, &fakeReader{comps: []AssetVulnerableComponent{
+		comp("a", 1, false, false), // installed P1 -> 50
+	}})
+	a, err := s.Assess(context.Background(), "asset-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !a.Scoreable || a.Exposure != 50 {
+		t.Fatalf("installed P1 must score 50, got %+v", a)
+	}
+	found := false
+	for _, r := range a.Reasons {
+		if containsRunningLimited(r) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("all-installed must record the running-vs-installed precision-limited reason")
+	}
+}
+
+func TestValidationAndErrorPropagation(t *testing.T) {
+	if _, err := NewService(nil); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("nil reader must be rejected")
+	}
+	s := mustService(t, &fakeReader{})
+	if _, err := s.Assess(context.Background(), ""); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("empty asset id must be rejected")
+	}
+	// A non-NotFound reader error propagates (not swallowed as abstain).
+	boom := errors.New("db down")
+	s2 := mustService(t, &fakeReader{err: boom})
+	if _, err := s2.Assess(context.Background(), "a"); !errors.Is(err, boom) {
+		t.Fatalf("reader error must propagate, got %v", err)
+	}
+	// A bad component (invalid priority) fails closed through Fuse.
+	s3 := mustService(t, &fakeReader{comps: []AssetVulnerableComponent{comp("x", 9, false, true)}})
+	if _, err := s3.Assess(context.Background(), "a"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("invalid component must fail closed, got %v", err)
+	}
+}
+
+func containsRunningLimited(s string) bool {
+	return strings.Contains(s, "running-vs-installed precision limited")
+}


### PR DESCRIPTION
## X5b — per-asset RiskContext.Exposure producer (#634)

The usecase producer of the coverage-honest **Exposure** factor — the twin of `baselineuc` (the Behavior producer). `exposureuc.Assess(ctx, assetID)` reads an asset's currently-open vulnerable components via a narrow consumer-side `AssetVulnerabilityReader` port, maps each to the pure-domain `exposure.ComponentExposure` (reusing the shipped `vulnerabilityrisk` Priority/KEV — no recompute), and fuses them via **X5a's `exposure.Fuse`** into a `RiskContext.Exposure` Score.

### Coverage-honest (three outcomes)
- no inventory/exposure data (`ErrNotFound`) → **abstain** (`Scoreable=false`, `Exposure=0`, reason) — absence is never read as clean;
- inventory scanned, nothing open → a trustworthy `Scoreable` 0;
- open exposures → `Fuse`.

`Exposure` is 0 whenever `Scoreable` is false. It emits a **factor only** — never sets Risk/disposition, never touches the Confidence axis. A non-`ErrNotFound` reader error **propagates** (never swallowed as clean); an invalid component **fails closed** through `Fuse`.

### Running-vs-installed
A component observed running weights above the same CVE merely installed (via `Fuse`). Until per-asset process-entity snapshots are persisted (the **deferred B5 tail**), `Running` is false, so the producer scores the installed exposures and records that running-vs-installed precision is limited — an honest coverage note, never a Risk discount.

### Scope
Pure usecase (imports only domain `exposure`/`riskassessment`/`shared` + its own consumer-side port). The adapter over the occurrence/risk/membership stores is the **deferred wiring tail** — its port contract documents the required tenant-from-ctx scoping.

Dual-reviewed: **go-arch MERGEABLE, security SHIP** (coverage-honest on all three axes, fails closed, no fabricated safety). 100% coverage, `-race` green, gofmt/vet clean.

Part of #634. CI is off by request — validated locally.
