### PR TITLE
feat(risk): tri-score assembler — RiskContext -> Scorer -> incident.Risk (#594)

### DIFF
--- a/internal/domain/riskassessment/threat.go
+++ b/internal/domain/riskassessment/threat.go
@@ -1,0 +1,25 @@
+package riskassessment
+
+import "github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+
+// ThreatFromSeverity maps a runtime-detection severity (the label an incident carries, derived from the
+// max severity of its correlated detections) to the RiskContext.Threat factor (0..100). It is the
+// severity→factor projection the tri-score assembler uses for the Threat axis — a deterministic policy
+// mapping, mirroring the shape of the exposure factor's priority bands. Unknown severity yields 0 (which
+// lowers Coverage/Confidence, never Risk — the honest "we don't know" value).
+func ThreatFromSeverity(sev shared.Severity) Score {
+	switch sev {
+	case shared.SeverityCritical:
+		return 100
+	case shared.SeverityHigh:
+		return 80
+	case shared.SeverityMedium:
+		return 55
+	case shared.SeverityLow:
+		return 30
+	case shared.SeverityInfo:
+		return 10
+	default: // SeverityUnknown or any unrecognized value
+		return 0
+	}
+}

--- a/internal/domain/riskassessment/threat_test.go
+++ b/internal/domain/riskassessment/threat_test.go
@@ -1,0 +1,38 @@
+package riskassessment
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestThreatFromSeverity(t *testing.T) {
+	cases := map[shared.Severity]Score{
+		shared.SeverityCritical:  100,
+		shared.SeverityHigh:      80,
+		shared.SeverityMedium:    55,
+		shared.SeverityLow:       30,
+		shared.SeverityInfo:      10,
+		shared.SeverityUnknown:   0,
+		shared.Severity("bogus"): 0,
+	}
+	for sev, want := range cases {
+		got := ThreatFromSeverity(sev)
+		if got != want {
+			t.Fatalf("ThreatFromSeverity(%q) = %d, want %d", sev, got, want)
+		}
+		if !got.Valid() {
+			t.Fatalf("ThreatFromSeverity(%q) = %d out of range", sev, got)
+		}
+	}
+	// Monotonic in rank: critical > high > medium > low > info > unknown.
+	order := []shared.Severity{shared.SeverityUnknown, shared.SeverityInfo, shared.SeverityLow, shared.SeverityMedium, shared.SeverityHigh, shared.SeverityCritical}
+	last := Score(-1)
+	for _, sev := range order {
+		s := ThreatFromSeverity(sev)
+		if s < last {
+			t.Fatalf("threat not monotonic in severity rank at %q: %d < %d", sev, s, last)
+		}
+		last = s
+	}
+}

--- a/internal/usecase/fleet/riskscoreuc/service.go
+++ b/internal/usecase/fleet/riskscoreuc/service.go
@@ -1,0 +1,243 @@
+// Package riskscoreuc is the tri-score ASSEMBLER (#594, C3/D/X5 integration): the seam that gathers the
+// three independent risk factors for an incident — Threat (from the incident's own correlated severity),
+// Exposure (X5, exposureuc), Behavior (D, baselineuc) — plus per-class telemetry Coverage, runs the
+// deterministic riskassessment.Scorer (previously called only in tests), and records the resulting
+// RiskAssessment onto the incident via an EventRiskReassessed event. The composition-root wiring that
+// bridges its consumer-side ports to exposureuc / baselineuc / a detection coverage source, and the caller
+// that triggers a reassessment, are the remaining step to run this in production.
+//
+// Discipline: each factor is placed ONLY when its producer says it is scoreable; an abstaining factor
+// contributes 0 to Risk and its reason is carried into the CoverageVector, so a missing factor lowers
+// Coverage/Confidence, never fabricates Risk (the scorer enforces this — coverage is never a Risk term).
+// The producers stay propose-only; this assembler does no scoring math of its own beyond the factor
+// mappings, and the LLM is nowhere in this path.
+package riskscoreuc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// FactorInput is one coverage-honest factor from a producer: its 0..100 Score, whether it is trustworthy
+// (Scoreable), and any human reasons for an abstain/limitation. It is the local shape both the Exposure
+// and Behavior producers are bridged to, so this assembler depends on no sibling usecase.
+type FactorInput struct {
+	Score     riskassessment.Score
+	Scoreable bool
+	Reasons   []string
+}
+
+// IncidentStore is the read+append view of the incident log this assembler needs. incidentuc.Service
+// satisfies it structurally (defined here so the assembler does not import a sibling usecase).
+type IncidentStore interface {
+	Get(ctx context.Context, id shared.ID) (incident.Incident, error)
+	Append(ctx context.Context, id shared.ID, expectedRevision int, events []incident.IncidentEvent) (incident.Incident, error)
+}
+
+// ExposureAssessor yields the RiskContext.Exposure factor for an asset (bridged to exposureuc at the
+// composition root). BehaviorAssessor likewise yields RiskContext.Behavior (bridged to baselineuc). Both
+// return a coverage-honest FactorInput; a real error propagates, an abstain is Scoreable=false.
+//
+// CONTRACT for all consumer-side ports here: the implementing adapter MUST scope by the tenant derived
+// from ctx (tenant isolation is the adapter's responsibility), and MUST return factor Reasons in a
+// deterministic order — the scored RiskAssessment's InputSnapshotHash is order-sensitive on the assembled
+// reasons, so a producer backed by a map must sort before returning.
+type ExposureAssessor interface {
+	ExposureFor(ctx context.Context, assetID shared.ID) (FactorInput, error)
+}
+
+// BehaviorAssessor yields the RiskContext.Behavior factor for an asset.
+type BehaviorAssessor interface {
+	BehaviorFor(ctx context.Context, assetID shared.ID) (FactorInput, error)
+}
+
+// CoverageSource yields the per-telemetry-class detection coverage for an asset's host. It is the
+// detection engine's honest coverage (active vs gap), not the fleet capability coverage model. Duplicate
+// class records are tolerated (the assembler dedups gap-preferring), but the adapter should prefer to
+// return already-normalized coverage (e.g. via detection.NewHostCoverage).
+type CoverageSource interface {
+	ClassCoverageForAsset(ctx context.Context, assetID shared.ID) ([]detection.ClassCoverage, error)
+}
+
+// Service assembles the tri-score for an incident.
+type Service struct {
+	incidents IncidentStore
+	exposure  ExposureAssessor
+	behavior  BehaviorAssessor
+	coverage  CoverageSource
+	scorer    *riskassessment.Scorer
+	audit     ports.AuditLogger
+	ids       ports.IDGenerator
+	now       func() time.Time
+}
+
+// NewService constructs the assembler. All collaborators are required.
+func NewService(incidents IncidentStore, exposure ExposureAssessor, behavior BehaviorAssessor, coverage CoverageSource, scorer *riskassessment.Scorer, audit ports.AuditLogger, ids ports.IDGenerator, now func() time.Time) (*Service, error) {
+	switch {
+	case incidents == nil:
+		return nil, fmt.Errorf("%w: assembler requires an incident store", shared.ErrValidation)
+	case exposure == nil:
+		return nil, fmt.Errorf("%w: assembler requires an exposure assessor", shared.ErrValidation)
+	case behavior == nil:
+		return nil, fmt.Errorf("%w: assembler requires a behavior assessor", shared.ErrValidation)
+	case coverage == nil:
+		return nil, fmt.Errorf("%w: assembler requires a coverage source", shared.ErrValidation)
+	case scorer == nil:
+		return nil, fmt.Errorf("%w: assembler requires a scorer", shared.ErrValidation)
+	case audit == nil:
+		return nil, fmt.Errorf("%w: assembler requires an audit logger", shared.ErrValidation)
+	case ids == nil:
+		return nil, fmt.Errorf("%w: assembler requires an id generator", shared.ErrValidation)
+	case now == nil:
+		return nil, fmt.Errorf("%w: assembler requires a clock", shared.ErrValidation)
+	}
+	return &Service{incidents: incidents, exposure: exposure, behavior: behavior, coverage: coverage, scorer: scorer, audit: audit, ids: ids, now: now}, nil
+}
+
+// Reassess gathers the three factors + coverage for the incident, scores them deterministically, and
+// records the RiskAssessment onto the incident as an EventRiskReassessed event under optimistic
+// concurrency (the incident's current revision). It returns the updated incident (whose .Risk now carries
+// the assessment). The event IS the primary attributable record (Actor + At on the append-only log); the
+// audit logger is a secondary trail written AFTER the durable append — on an audit error the reassessment
+// is committed, so the caller must NOT blindly retry (a retry would append a duplicate assessment).
+func (s *Service) Reassess(ctx context.Context, actor string, incidentID shared.ID) (incident.Incident, error) {
+	if actor == "" {
+		return incident.Incident{}, fmt.Errorf("%w: risk reassessment requires an actor", shared.ErrValidation)
+	}
+	if incidentID.IsZero() {
+		return incident.Incident{}, fmt.Errorf("%w: incident id is required", shared.ErrValidation)
+	}
+	inc, err := s.incidents.Get(ctx, incidentID)
+	if err != nil {
+		return incident.Incident{}, fmt.Errorf("load incident: %w", err)
+	}
+
+	var reasons []string
+
+	// Threat: the incident's own correlated severity. Unknown severity abstains (0 + reason).
+	threat := riskassessment.ThreatFromSeverity(inc.Severity)
+	if !inc.Severity.Valid() || inc.Severity == shared.SeverityUnknown {
+		reasons = append(reasons, "threat: incident severity unknown")
+	}
+
+	// Exposure (X5).
+	exp, err := s.exposure.ExposureFor(ctx, inc.AssetID)
+	if err != nil {
+		return incident.Incident{}, fmt.Errorf("exposure factor: %w", err)
+	}
+	var exposureScore riskassessment.Score
+	if exp.Scoreable {
+		exposureScore = exp.Score
+	} else {
+		reasons = append(reasons, "exposure: not scoreable")
+	}
+	reasons = append(reasons, exp.Reasons...)
+
+	// Behavior (D).
+	beh, err := s.behavior.BehaviorFor(ctx, inc.AssetID)
+	if err != nil {
+		return incident.Incident{}, fmt.Errorf("behavior factor: %w", err)
+	}
+	var behaviorScore riskassessment.Score
+	if beh.Scoreable {
+		behaviorScore = beh.Score
+	} else {
+		reasons = append(reasons, "behavior: not scoreable")
+	}
+	reasons = append(reasons, beh.Reasons...)
+
+	// Coverage: per-class detection coverage for the asset's host.
+	cc, err := s.coverage.ClassCoverageForAsset(ctx, inc.AssetID)
+	if err != nil {
+		return incident.Incident{}, fmt.Errorf("coverage: %w", err)
+	}
+	cv := coverageVector(cc)
+	cv.Reasons = append(cv.Reasons, reasons...)
+
+	at := s.now().UTC()
+	ra, err := s.scorer.Score(riskassessment.ScoreInput{
+		AssessmentID:     s.ids.NewID(),
+		IncidentRevision: inc.Revision,
+		Context:          riskassessment.RiskContext{Threat: threat, Exposure: exposureScore, Behavior: behaviorScore},
+		Coverage:         cv,
+		CreatedAt:        at,
+	})
+	if err != nil {
+		return incident.Incident{}, fmt.Errorf("score: %w", err)
+	}
+
+	updated, err := s.incidents.Append(ctx, incidentID, inc.Revision, []incident.IncidentEvent{{
+		IncidentID: incidentID,
+		Kind:       incident.EventRiskReassessed,
+		At:         at,
+		Actor:      actor,
+		Risk:       &ra,
+	}})
+	if err != nil {
+		return incident.Incident{}, err
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{
+		Actor:  actor,
+		Action: "incident.risk_reassessed",
+		Target: incidentID.String(),
+		At:     at,
+		Metadata: map[string]string{
+			"risk":       fmt.Sprintf("%d", ra.Risk),
+			"confidence": fmt.Sprintf("%d", ra.Confidence),
+			"coverage":   fmt.Sprintf("%d", ra.Coverage),
+		},
+	}); err != nil {
+		return incident.Incident{}, fmt.Errorf("audit incident.risk_reassessed: %w", err)
+	}
+	return updated, nil
+}
+
+// coverageVector maps per-class detection coverage into a riskassessment.CoverageVector: an actively
+// observing class scores 100, an observation gap or an unreported class scores 0 and contributes a reason.
+// It iterates the FIXED detection.Classes() order (deterministic, so the scorer's order-sensitive input
+// hash is reproducible), and dedups duplicate class records GAP-PREFERRING — a class once seen as a gap is
+// never upgraded to observing by a later duplicate (mirroring detection.NewHostCoverage's refusal to let a
+// duplicate silently erase a gap, which would read as over-confident on a partial view).
+func coverageVector(cc []detection.ClassCoverage) riskassessment.CoverageVector {
+	seen := make(map[detection.Class]detection.ClassCoverage, len(cc))
+	for _, c := range cc {
+		if prev, ok := seen[c.Class]; ok && !prev.Observing() {
+			continue // keep the gap; a later duplicate cannot erase it
+		}
+		seen[c.Class] = c
+	}
+	var v riskassessment.CoverageVector
+	for _, cls := range detection.Classes() {
+		c, reported := seen[cls]
+		observing := reported && c.Observing()
+		var score riskassessment.Score
+		if observing {
+			score = 100
+		}
+		switch cls {
+		case detection.ClassProcess:
+			v.Process = score
+		case detection.ClassNetwork:
+			v.Network = score
+		case detection.ClassFile:
+			v.File = score
+		case detection.ClassPrivilege:
+			v.Privilege = score
+		}
+		if !observing {
+			reason := "no report"
+			if reported && c.Reason != "" {
+				reason = c.Reason
+			}
+			v.Reasons = append(v.Reasons, string(cls)+": "+reason)
+		}
+	}
+	return v
+}

--- a/internal/usecase/fleet/riskscoreuc/service_test.go
+++ b/internal/usecase/fleet/riskscoreuc/service_test.go
@@ -1,0 +1,248 @@
+package riskscoreuc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeIncidents struct {
+	inc         incident.Incident
+	getErr      error
+	appendErr   error
+	appended    []incident.IncidentEvent
+	appendedRev int
+}
+
+func (f *fakeIncidents) Get(_ context.Context, _ shared.ID) (incident.Incident, error) {
+	if f.getErr != nil {
+		return incident.Incident{}, f.getErr
+	}
+	return f.inc, nil
+}
+
+func (f *fakeIncidents) Append(_ context.Context, id shared.ID, expectedRevision int, events []incident.IncidentEvent) (incident.Incident, error) {
+	if f.appendErr != nil {
+		return incident.Incident{}, f.appendErr
+	}
+	f.appended = events
+	f.appendedRev = expectedRevision
+	updated := f.inc
+	if len(events) > 0 && events[0].Risk != nil {
+		r := *events[0].Risk
+		updated.Risk = &r
+		updated.Revision = expectedRevision + len(events)
+	}
+	return updated, nil
+}
+
+type fakeFactor struct {
+	f   FactorInput
+	err error
+}
+
+func (x fakeFactor) ExposureFor(_ context.Context, _ shared.ID) (FactorInput, error) {
+	return x.f, x.err
+}
+func (x fakeFactor) BehaviorFor(_ context.Context, _ shared.ID) (FactorInput, error) {
+	return x.f, x.err
+}
+
+type fakeCoverage struct {
+	cc  []detection.ClassCoverage
+	err error
+}
+
+func (c fakeCoverage) ClassCoverageForAsset(_ context.Context, _ shared.ID) ([]detection.ClassCoverage, error) {
+	return c.cc, c.err
+}
+
+type fakeAudit struct{ n int }
+
+func (a *fakeAudit) Record(_ context.Context, _ ports.AuditEntry) error { a.n++; return nil }
+
+type fixedIDs struct{}
+
+func (fixedIDs) NewID() shared.ID { return "assess-1" }
+
+func fullCoverage() []detection.ClassCoverage {
+	out := make([]detection.ClassCoverage, 0, 4)
+	for _, cl := range detection.Classes() {
+		out = append(out, detection.ClassCoverage{Class: cl, State: detection.StateActive})
+	}
+	return out
+}
+
+func newSvc(t *testing.T, inc *fakeIncidents, exp, beh fakeFactor, cov fakeCoverage) (*Service, *fakeAudit) {
+	t.Helper()
+	scorer, err := riskassessment.NewScorer(riskassessment.DefaultPolicy())
+	if err != nil {
+		t.Fatalf("scorer: %v", err)
+	}
+	audit := &fakeAudit{}
+	svc, err := NewService(inc, exp, beh, cov, scorer, audit, fixedIDs{}, func() time.Time { return time.Unix(1_800_000_000, 0).UTC() })
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	return svc, audit
+}
+
+func baseIncident() incident.Incident {
+	return incident.Incident{ID: "inc-1", AssetID: "asset-1", Severity: shared.SeverityHigh, State: incident.StateOpen, Revision: 3}
+}
+
+func TestReassessHappyPath(t *testing.T) {
+	inc := &fakeIncidents{inc: baseIncident()}
+	exp := fakeFactor{f: FactorInput{Score: 60, Scoreable: true}}
+	beh := fakeFactor{f: FactorInput{Score: 40, Scoreable: true}}
+	svc, audit := newSvc(t, inc, exp, beh, fakeCoverage{cc: fullCoverage()})
+
+	updated, err := svc.Reassess(context.Background(), "analyst", "inc-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated.Risk == nil {
+		t.Fatal("incident.Risk must be populated")
+	}
+	// Threat(high=80) dominates the weighted sum; Risk must be > 0 and in range.
+	if !updated.Risk.Risk.Valid() || updated.Risk.Risk == 0 {
+		t.Fatalf("risk must be a positive valid score, got %d", updated.Risk.Risk)
+	}
+	// Full coverage + all three factors present => high coverage/confidence.
+	if updated.Risk.Coverage != 100 {
+		t.Fatalf("full class coverage must yield Coverage 100, got %d", updated.Risk.Coverage)
+	}
+	// Appended under the incident's current revision, as a risk_reassessed event, attributed to the actor.
+	if inc.appendedRev != 3 || len(inc.appended) != 1 || inc.appended[0].Kind != incident.EventRiskReassessed || inc.appended[0].Actor != "analyst" {
+		t.Fatalf("append wrong: rev=%d events=%+v", inc.appendedRev, inc.appended)
+	}
+	if audit.n != 1 {
+		t.Fatalf("reassessment must be audited once, got %d", audit.n)
+	}
+}
+
+func TestReassessAbstainingFactorsLowerCoverageNotThreat(t *testing.T) {
+	inc := &fakeIncidents{inc: baseIncident()}
+	// Exposure + Behavior abstain; only Threat contributes.
+	exp := fakeFactor{f: FactorInput{Scoreable: false, Reasons: []string{"no inventory data"}}}
+	beh := fakeFactor{f: FactorInput{Scoreable: false}}
+	svc, _ := newSvc(t, inc, exp, beh, fakeCoverage{cc: fullCoverage()})
+
+	updated, err := svc.Reassess(context.Background(), "analyst", "inc-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Threat (high) still drives a real Risk — a missing factor never lowers Risk.
+	if updated.Risk.Risk == 0 {
+		t.Fatal("threat alone must still produce a non-zero Risk")
+	}
+	// The abstain reasons must surface as ReasonCodes on the assessment.
+	joined := ""
+	for _, r := range updated.Risk.ReasonCodes {
+		joined += r + "|"
+	}
+	if joined == "" {
+		t.Fatal("abstaining factors must contribute reason codes")
+	}
+}
+
+func TestReassessCoverageGapLowersCoverage(t *testing.T) {
+	inc := &fakeIncidents{inc: baseIncident()}
+	exp := fakeFactor{f: FactorInput{Score: 60, Scoreable: true}}
+	beh := fakeFactor{f: FactorInput{Score: 40, Scoreable: true}}
+	// Network class is a gap.
+	cc := []detection.ClassCoverage{
+		{Class: detection.ClassProcess, State: detection.StateActive},
+		{Class: detection.ClassNetwork, State: detection.StateDegraded, Reason: "sensor degraded"},
+		{Class: detection.ClassFile, State: detection.StateActive},
+		{Class: detection.ClassPrivilege, State: detection.StateActive},
+	}
+	svc, _ := newSvc(t, inc, exp, beh, fakeCoverage{cc: cc})
+	updated, err := svc.Reassess(context.Background(), "analyst", "inc-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Coverage floor is the weakest class (network gap = 0), so Coverage must be 0.
+	if updated.Risk.Coverage != 0 {
+		t.Fatalf("a class gap must drop Coverage to the floor (0), got %d", updated.Risk.Coverage)
+	}
+	// Risk (from Threat/Exposure/Behavior) is unaffected by the coverage gap.
+	if updated.Risk.Risk == 0 {
+		t.Fatal("coverage gap must not zero Risk")
+	}
+}
+
+func TestCoverageVectorDedupGapPreferringAndMissingClasses(t *testing.T) {
+	// Duplicate network records (gap then active): the gap must NOT be erased.
+	dup := []detection.ClassCoverage{
+		{Class: detection.ClassNetwork, State: detection.StateDegraded, Reason: "degraded"},
+		{Class: detection.ClassNetwork, State: detection.StateActive},
+	}
+	v := coverageVector(dup)
+	if v.Network != 0 {
+		t.Fatalf("a duplicate must not upgrade a network gap to observing, got %d", v.Network)
+	}
+	// Only network was reported; the other three classes are absent -> 0 with a "no report" reason each.
+	if v.Process != 0 || v.File != 0 || v.Privilege != 0 {
+		t.Fatalf("unreported classes must be 0, got %+v", v)
+	}
+	if len(v.Reasons) != 4 {
+		t.Fatalf("every non-observing class (all 4 here) must carry a reason, got %d: %v", len(v.Reasons), v.Reasons)
+	}
+	// Reverse duplicate order (active then gap) is identical (deterministic, gap-preferring).
+	rev := []detection.ClassCoverage{dup[1], dup[0]}
+	if coverageVector(rev).Network != 0 {
+		t.Fatal("dedup must be order-independent (gap wins regardless of order)")
+	}
+}
+
+func TestReassessValidationAndErrorPropagation(t *testing.T) {
+	inc := &fakeIncidents{inc: baseIncident()}
+	exp := fakeFactor{f: FactorInput{Score: 10, Scoreable: true}}
+	beh := fakeFactor{f: FactorInput{Score: 10, Scoreable: true}}
+	svc, _ := newSvc(t, inc, exp, beh, fakeCoverage{cc: fullCoverage()})
+
+	if _, err := svc.Reassess(context.Background(), "", "inc-1"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("empty actor must be rejected")
+	}
+	if _, err := svc.Reassess(context.Background(), "a", ""); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("empty incident id must be rejected")
+	}
+	// A factor error propagates.
+	boom := errors.New("db down")
+	svc2, _ := newSvc(t, &fakeIncidents{inc: baseIncident()}, fakeFactor{err: boom}, beh, fakeCoverage{cc: fullCoverage()})
+	if _, err := svc2.Reassess(context.Background(), "a", "inc-1"); !errors.Is(err, boom) {
+		t.Fatalf("exposure error must propagate, got %v", err)
+	}
+	// A Get error propagates.
+	svc3, _ := newSvc(t, &fakeIncidents{getErr: shared.ErrNotFound}, exp, beh, fakeCoverage{cc: fullCoverage()})
+	if _, err := svc3.Reassess(context.Background(), "a", "inc-1"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("get error must propagate, got %v", err)
+	}
+}
+
+func TestNewServiceValidation(t *testing.T) {
+	scorer, _ := riskassessment.NewScorer(riskassessment.DefaultPolicy())
+	inc := &fakeIncidents{}
+	exp := fakeFactor{}
+	beh := fakeFactor{}
+	cov := fakeCoverage{}
+	audit := &fakeAudit{}
+	now := func() time.Time { return time.Unix(1, 0) }
+	if _, err := NewService(nil, exp, beh, cov, scorer, audit, fixedIDs{}, now); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("nil incidents rejected")
+	}
+	if _, err := NewService(inc, exp, beh, cov, nil, audit, fixedIDs{}, now); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("nil scorer rejected")
+	}
+	if _, err := NewService(inc, exp, beh, cov, scorer, audit, fixedIDs{}, nil); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("nil clock rejected")
+	}
+}


### PR DESCRIPTION
feat(risk): tri-score assembler — RiskContext -> Scorer -> incident.Risk (#594)

The seam that was missing: riskassessment.Scorer was only ever called in tests.
This assembles the three independent risk factors for an incident and records a
deterministic RiskAssessment onto it.

- riskassessment.ThreatFromSeverity: deterministic severity -> Threat factor
  (critical 100 .. info 10, unknown 0) for the Threat axis.
- internal/usecase/fleet/riskscoreuc.Service.Reassess(ctx, actor, incidentID):
  loads the incident, derives Threat from its correlated severity, gathers
  Exposure (X5) + Behavior (D) via consumer-side ports (local FactorInput; no
  sibling-usecase import), maps per-class detection coverage into a
  CoverageVector, runs the deterministic Scorer, and appends an
  EventRiskReassessed event (populating incident.Risk) under optimistic
  concurrency, then audits.

Coverage-honest: a factor is placed ONLY when its producer says Scoreable; an
abstaining factor contributes 0 to the Context and its reason is carried into the
CoverageVector, so a missing factor lowers Coverage/Confidence, never Risk (the
scorer keeps coverage out of the Risk term). coverageVector iterates the fixed
detection.Classes() order (deterministic input hash) and dedups duplicate class
records GAP-PREFERRING so a duplicate can never erase a gap (over-confidence);
every non-observing/absent class carries a reason. The actor is server-supplied
and attributes both the append-only event (primary record) and the audit trail;
audit is after the durable append (no blind retry).

Consumer-side ports document the required tenant-from-ctx scoping + deterministic
reason ordering (the input hash is order-sensitive). The composition-root wiring
that bridges these ports to exposureuc / baselineuc / a detection coverage source
(and the reassessment trigger) is the remaining step to run in production.

Dual-reviewed (go-arch MERGEABLE, security SHIP) — folded in every finding:
gap-preferring coverage dedup + fixed-order + missing-class reasons (MEDIUM/LOW),
Get error %w, port contract docs, honest package doc. race-green (riskassessment
94.6%, riskscoreuc 85.3%).
