### PR TITLE
feat(exposure): X5b AssetVulnerabilityReader adapter over the SCA stores (#634)

### DIFF
--- a/internal/usecase/fleet/exposurereader/service.go
+++ b/internal/usecase/fleet/exposurereader/service.go
@@ -1,0 +1,210 @@
+// Package exposurereader adapts the shipped SCA stores (asset↔component membership, vulnerability
+// occurrences, and per-occurrence risk assessments) into the exposureuc.AssetVulnerabilityReader port —
+// the missing join that lets the X5 Exposure producer read an asset's open vulnerable components with their
+// evaluated Priority/KEV/Severity. It reuses the already-evaluated risk (vulnerabilityrisk.Assessment); it
+// recomputes nothing. Every read is tenant-scoped from ctx. Running presence is not yet available (the B5
+// per-asset process-entity snapshot store is deferred), so it reports installed-only — the producer notes
+// the reduced running-vs-installed precision.
+package exposurereader
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityoccurrence"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityrisk"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/exposureuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// The shipped store interfaces satisfy the narrow reader views this adapter needs — asserted here so a
+// signature drift in ports breaks the build rather than the composition-root wiring.
+var (
+	_ MembershipReader = ports.BusinessAssetRepository(nil)
+	_ OccurrenceReader = ports.VulnerabilityOccurrenceStore(nil)
+	_ RiskReader       = ports.VulnerabilityRiskAssessmentStore(nil)
+)
+
+// MembershipReader is the asset-side view: which engagements an asset belongs to and which components make
+// it up. ports.BusinessAssetRepository satisfies it. (Occurrences carry no AssetID, so the component
+// membership is the bridge from an asset to its vulnerabilities.)
+type MembershipReader interface {
+	ListEngagementsByBusinessAsset(ctx context.Context, tenantID, assetID shared.ID) ([]*engagement.Engagement, error)
+	ListBusinessAssetProjects(ctx context.Context, tenantID, assetID shared.ID) ([]asset.ComponentMembership, error)
+	ListBusinessAssetTechnicalAssets(ctx context.Context, tenantID, assetID shared.ID) ([]asset.ComponentMembership, error)
+}
+
+// OccurrenceReader lists an engagement's vulnerability occurrences by state. ports.VulnerabilityOccurrenceStore satisfies it.
+type OccurrenceReader interface {
+	ListByEngagement(ctx context.Context, tenantID, engagementID shared.ID, states []vulnerabilityoccurrence.State) ([]vulnerabilityoccurrence.Occurrence, error)
+}
+
+// RiskReader returns the current risk evaluation for one occurrence. ports.VulnerabilityRiskAssessmentStore satisfies it.
+type RiskReader interface {
+	Current(ctx context.Context, tenantID, occurrenceID shared.ID) (vulnerabilityrisk.Assessment, error)
+}
+
+// Reader implements exposureuc.AssetVulnerabilityReader over the SCA stores.
+type Reader struct {
+	memberships MembershipReader
+	occurrences OccurrenceReader
+	risk        RiskReader
+}
+
+var _ exposureuc.AssetVulnerabilityReader = (*Reader)(nil)
+
+// NewReader constructs the adapter. All three stores are required.
+func NewReader(memberships MembershipReader, occurrences OccurrenceReader, risk RiskReader) (*Reader, error) {
+	switch {
+	case memberships == nil:
+		return nil, fmt.Errorf("%w: exposure reader requires a membership store", shared.ErrValidation)
+	case occurrences == nil:
+		return nil, fmt.Errorf("%w: exposure reader requires an occurrence store", shared.ErrValidation)
+	case risk == nil:
+		return nil, fmt.Errorf("%w: exposure reader requires a risk store", shared.ErrValidation)
+	}
+	return &Reader{memberships: memberships, occurrences: occurrences, risk: risk}, nil
+}
+
+func tenantIDFrom(ctx context.Context) (shared.ID, error) {
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok || tenantID.IsZero() {
+		return "", fmt.Errorf("%w: tenant is required in context", shared.ErrValidation)
+	}
+	return tenantID, nil
+}
+
+// ListAssetVulnerableComponents resolves, for one asset: the engagements it is scoped into, the components
+// that make it up, and the currently-open vulnerability occurrences on those components (with their
+// evaluated risk). It ABSTAINS with shared.ErrNotFound when the asset has no exposure data to assess (not
+// in any engagement, or no component inventory) — never reporting absence as clean. An asset that IS
+// scanned but has no open occurrences returns (nil, nil) = a trustworthy clean. Presence is installed-only
+// (B5 running snapshots deferred).
+func (r *Reader) ListAssetVulnerableComponents(ctx context.Context, assetID shared.ID) ([]exposureuc.AssetVulnerableComponent, error) {
+	tenant, err := tenantIDFrom(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if assetID.IsZero() {
+		return nil, fmt.Errorf("%w: asset id is required", shared.ErrValidation)
+	}
+
+	engs, err := r.memberships.ListEngagementsByBusinessAsset(ctx, tenant, assetID)
+	if err != nil {
+		return nil, fmt.Errorf("list engagements for asset %s: %w", assetID, err) // ErrNotFound → abstain
+	}
+	if len(engs) == 0 {
+		return nil, fmt.Errorf("%w: asset %s is not scoped into any engagement", shared.ErrNotFound, assetID)
+	}
+
+	components, err := r.componentSet(ctx, tenant, assetID)
+	if err != nil {
+		return nil, err
+	}
+	if len(components) == 0 {
+		return nil, fmt.Errorf("%w: asset %s has no component inventory", shared.ErrNotFound, assetID)
+	}
+
+	// Dedup by (component, advisory): the same vulnerable component can appear under more than one of the
+	// asset's engagements, each with its own (possibly divergent) risk evaluation. Keep the WORST — the
+	// exposure factor must never be under-reported — via a deterministic risk order (not first-seen, which
+	// would depend on engagement iteration order).
+	type key struct{ comp, adv shared.ID }
+	byKey := make(map[key]exposureuc.AssetVulnerableComponent)
+	skippedUnscored := false
+	for _, eng := range engs {
+		if eng == nil {
+			continue // defensive: the store never appends nil, but don't deref one if it ever did
+		}
+		occs, err := r.occurrences.ListByEngagement(ctx, tenant, eng.ID, []vulnerabilityoccurrence.State{vulnerabilityoccurrence.StateDetected})
+		if err != nil {
+			return nil, fmt.Errorf("list occurrences for engagement %s: %w", eng.ID, err)
+		}
+		for _, occ := range occs {
+			if _, ok := components[occ.ComponentID]; !ok {
+				continue
+			}
+			ra, err := r.risk.Current(ctx, tenant, occ.ID)
+			if err != nil {
+				if errors.Is(err, shared.ErrNotFound) {
+					skippedUnscored = true // detected but not yet risk-evaluated
+					continue
+				}
+				return nil, fmt.Errorf("current risk for occurrence %s: %w", occ.ID, err)
+			}
+			cand := exposureuc.AssetVulnerableComponent{
+				ComponentID: occ.ComponentID,
+				AdvisoryID:  shared.ID(occ.AdvisoryID),
+				Severity:    ra.Severity,
+				Priority:    ra.Priority,
+				KEV:         ra.KEV,
+				Running:     false, // installed-only until B5 process-entity snapshots land
+			}
+			k := key{comp: cand.ComponentID, adv: cand.AdvisoryID}
+			if prev, ok := byKey[k]; !ok || riskWorse(cand, prev) {
+				byKey[k] = cand
+			}
+		}
+	}
+
+	if len(byKey) == 0 {
+		if skippedUnscored {
+			// Detected vulnerabilities exist on the asset's components but none is risk-evaluated yet — we
+			// cannot honestly score it, so abstain rather than report a false clean.
+			return nil, fmt.Errorf("%w: asset %s has detected vulnerabilities awaiting risk evaluation", shared.ErrNotFound, assetID)
+		}
+		return nil, nil // scanned, no open vulnerabilities — a trustworthy clean
+	}
+
+	out := make([]exposureuc.AssetVulnerableComponent, 0, len(byKey))
+	for _, v := range byKey {
+		out = append(out, v)
+	}
+	// Deterministic order (component, then advisory) so repeated reads are reproducible.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].ComponentID != out[j].ComponentID {
+			return out[i].ComponentID < out[j].ComponentID
+		}
+		return out[i].AdvisoryID < out[j].AdvisoryID
+	})
+	return out, nil
+}
+
+// componentSet unions the asset's project and technical-asset component memberships into a lookup set.
+func (r *Reader) componentSet(ctx context.Context, tenant, assetID shared.ID) (map[shared.ID]struct{}, error) {
+	set := make(map[shared.ID]struct{})
+	projects, err := r.memberships.ListBusinessAssetProjects(ctx, tenant, assetID)
+	if err != nil {
+		return nil, fmt.Errorf("list project components for asset %s: %w", assetID, err)
+	}
+	technical, err := r.memberships.ListBusinessAssetTechnicalAssets(ctx, tenant, assetID)
+	if err != nil {
+		return nil, fmt.Errorf("list technical components for asset %s: %w", assetID, err)
+	}
+	for _, m := range projects {
+		set[m.ComponentID] = struct{}{}
+	}
+	for _, m := range technical {
+		set[m.ComponentID] = struct{}{}
+	}
+	return set, nil
+}
+
+// riskWorse reports whether exposure a represents a strictly higher risk than b, by a deterministic total
+// order over the risk-relevant fields: KEV (known-exploited) beats non-KEV; then a lower Priority number
+// (1 = most urgent); then a higher severity rank. Used to keep the worst of two occurrences for the same
+// (component, advisory) so the exposure factor is never under-reported and the choice is order-independent.
+func riskWorse(a, b exposureuc.AssetVulnerableComponent) bool {
+	if a.KEV != b.KEV {
+		return a.KEV
+	}
+	if a.Priority != b.Priority {
+		return a.Priority < b.Priority
+	}
+	return shared.SeverityRank(a.Severity) > shared.SeverityRank(b.Severity)
+}

--- a/internal/usecase/fleet/exposurereader/service_test.go
+++ b/internal/usecase/fleet/exposurereader/service_test.go
@@ -1,0 +1,218 @@
+package exposurereader
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityoccurrence"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityrisk"
+)
+
+type fakeMembership struct {
+	engs      []*engagement.Engagement
+	projects  []asset.ComponentMembership
+	technical []asset.ComponentMembership
+	engErr    error
+	projErr   error
+	techErr   error
+}
+
+func (m fakeMembership) ListEngagementsByBusinessAsset(_ context.Context, _, _ shared.ID) ([]*engagement.Engagement, error) {
+	return m.engs, m.engErr
+}
+func (m fakeMembership) ListBusinessAssetProjects(_ context.Context, _, _ shared.ID) ([]asset.ComponentMembership, error) {
+	return m.projects, m.projErr
+}
+func (m fakeMembership) ListBusinessAssetTechnicalAssets(_ context.Context, _, _ shared.ID) ([]asset.ComponentMembership, error) {
+	return m.technical, m.techErr
+}
+
+type fakeOccurrences struct {
+	byEng     map[shared.ID][]vulnerabilityoccurrence.Occurrence
+	err       error
+	gotStates []vulnerabilityoccurrence.State
+}
+
+func (o *fakeOccurrences) ListByEngagement(_ context.Context, _, engagementID shared.ID, states []vulnerabilityoccurrence.State) ([]vulnerabilityoccurrence.Occurrence, error) {
+	o.gotStates = states
+	return o.byEng[engagementID], o.err
+}
+
+type fakeRisk struct {
+	byOcc map[shared.ID]vulnerabilityrisk.Assessment
+	err   error
+}
+
+func (r fakeRisk) Current(_ context.Context, _, occurrenceID shared.ID) (vulnerabilityrisk.Assessment, error) {
+	if r.err != nil {
+		return vulnerabilityrisk.Assessment{}, r.err
+	}
+	a, ok := r.byOcc[occurrenceID]
+	if !ok {
+		return vulnerabilityrisk.Assessment{}, shared.ErrNotFound
+	}
+	return a, nil
+}
+
+func ctxT() context.Context { return shared.WithTenant(context.Background(), "t1") }
+
+func member(comp string) asset.ComponentMembership {
+	return asset.ComponentMembership{TenantID: "t1", AssetID: "asset-1", ComponentID: shared.ID(comp), Role: asset.MembershipRole("dependency")}
+}
+func occ(id, comp, adv string) vulnerabilityoccurrence.Occurrence {
+	return vulnerabilityoccurrence.Occurrence{TenantID: "t1", ID: shared.ID(id), EngagementID: "eng-1", AdvisoryID: adv, ComponentID: shared.ID(comp), State: vulnerabilityoccurrence.StateDetected}
+}
+func assess(pri int, kev bool) vulnerabilityrisk.Assessment {
+	return vulnerabilityrisk.Assessment{Severity: shared.SeverityHigh, Priority: pri, KEV: kev}
+}
+
+func mustReader(t *testing.T, m MembershipReader, o OccurrenceReader, r RiskReader) *Reader {
+	t.Helper()
+	rd, err := NewReader(m, o, r)
+	if err != nil {
+		t.Fatalf("new reader: %v", err)
+	}
+	return rd
+}
+
+func oneEngagement() []*engagement.Engagement { return []*engagement.Engagement{{ID: "eng-1"}} }
+
+func TestAbstainNoEngagements(t *testing.T) {
+	rd := mustReader(t, fakeMembership{engs: nil}, &fakeOccurrences{}, fakeRisk{})
+	if _, err := rd.ListAssetVulnerableComponents(ctxT(), "asset-1"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("no engagements must abstain with ErrNotFound, got %v", err)
+	}
+}
+
+func TestAbstainNoComponents(t *testing.T) {
+	rd := mustReader(t, fakeMembership{engs: oneEngagement()}, &fakeOccurrences{}, fakeRisk{})
+	if _, err := rd.ListAssetVulnerableComponents(ctxT(), "asset-1"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("no component inventory must abstain with ErrNotFound, got %v", err)
+	}
+}
+
+func TestScannedCleanReturnsEmpty(t *testing.T) {
+	m := fakeMembership{engs: oneEngagement(), projects: []asset.ComponentMembership{member("c1")}}
+	occs := &fakeOccurrences{byEng: map[shared.ID][]vulnerabilityoccurrence.Occurrence{}} // no open occurrences
+	rd := mustReader(t, m, occs, fakeRisk{})
+	got, err := rd.ListAssetVulnerableComponents(ctxT(), "asset-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("scanned-clean must return empty (nil,nil semantics), got %+v", got)
+	}
+	// It queried for the open (detected) state only.
+	if len(occs.gotStates) != 1 || occs.gotStates[0] != vulnerabilityoccurrence.StateDetected {
+		t.Fatalf("must query only StateDetected, got %v", occs.gotStates)
+	}
+}
+
+func TestJoinFiltersToAssetComponentsAndMapsRisk(t *testing.T) {
+	m := fakeMembership{engs: oneEngagement(), projects: []asset.ComponentMembership{member("c1")}, technical: []asset.ComponentMembership{member("c2")}}
+	occs := &fakeOccurrences{byEng: map[shared.ID][]vulnerabilityoccurrence.Occurrence{
+		"eng-1": {
+			occ("o1", "c1", "CVE-1"), // member -> included
+			occ("o2", "c2", "CVE-2"), // member -> included
+			occ("o3", "c9", "CVE-9"), // NOT a member -> filtered out
+			occ("o4", "c1", "CVE-4"), // member, no risk assessment -> skipped
+		},
+	}}
+	risk := fakeRisk{byOcc: map[shared.ID]vulnerabilityrisk.Assessment{
+		"o1": assess(1, true),
+		"o2": assess(3, false),
+		// o4 intentionally absent -> Current returns ErrNotFound -> skipped
+	}}
+	rd := mustReader(t, m, occs, risk)
+	got, err := rd.ListAssetVulnerableComponents(ctxT(), "asset-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 vulnerable components (c1,c2), got %d: %+v", len(got), got)
+	}
+	// Deterministic order by component id: c1 then c2.
+	if got[0].ComponentID != "c1" || got[0].AdvisoryID != "CVE-1" || got[0].Priority != 1 || !got[0].KEV || got[0].Running {
+		t.Fatalf("c1 entry wrong: %+v", got[0])
+	}
+	if got[1].ComponentID != "c2" || got[1].Priority != 3 {
+		t.Fatalf("c2 entry wrong: %+v", got[1])
+	}
+}
+
+func TestDedupKeepsWorstRiskAcrossEngagements(t *testing.T) {
+	m := fakeMembership{
+		engs:     []*engagement.Engagement{{ID: "eng-1"}, {ID: "eng-2"}},
+		projects: []asset.ComponentMembership{member("c1")},
+	}
+	o1 := occ("o1", "c1", "CVE-1")
+	o1b := occ("o1b", "c1", "CVE-1")
+	o1b.EngagementID = "eng-2"
+	occs := &fakeOccurrences{byEng: map[shared.ID][]vulnerabilityoccurrence.Occurrence{
+		"eng-1": {o1},
+		"eng-2": {o1b},
+	}}
+	// Divergent risk for the same (component, advisory): eng-1 sees a mild P3 non-KEV, eng-2 a P1 KEV.
+	// The dedup must keep the WORST (P1 KEV) so the exposure factor is never under-reported.
+	risk := fakeRisk{byOcc: map[shared.ID]vulnerabilityrisk.Assessment{
+		"o1":  assess(3, false),
+		"o1b": assess(1, true),
+	}}
+	rd := mustReader(t, m, occs, risk)
+	got, err := rd.ListAssetVulnerableComponents(ctxT(), "asset-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("same (component,advisory) across engagements must dedup to 1, got %d", len(got))
+	}
+	if got[0].Priority != 1 || !got[0].KEV {
+		t.Fatalf("dedup must keep the worst risk (P1 KEV), got %+v", got[0])
+	}
+}
+
+func TestAbstainWhenAllOccurrencesUnscored(t *testing.T) {
+	m := fakeMembership{engs: oneEngagement(), projects: []asset.ComponentMembership{member("c1")}}
+	// Detected occurrence on a member component, but no risk assessment exists for it yet.
+	occs := &fakeOccurrences{byEng: map[shared.ID][]vulnerabilityoccurrence.Occurrence{"eng-1": {occ("o1", "c1", "CVE-1")}}}
+	rd := mustReader(t, m, occs, fakeRisk{byOcc: map[shared.ID]vulnerabilityrisk.Assessment{}})
+	if _, err := rd.ListAssetVulnerableComponents(ctxT(), "asset-1"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("all-unscored detected occurrences must abstain (ErrNotFound), not read as clean, got %v", err)
+	}
+}
+
+func TestValidationAndErrorPropagation(t *testing.T) {
+	if _, err := NewReader(nil, &fakeOccurrences{}, fakeRisk{}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("nil membership rejected")
+	}
+	rd := mustReader(t, fakeMembership{engs: oneEngagement(), projects: []asset.ComponentMembership{member("c1")}}, &fakeOccurrences{}, fakeRisk{})
+	// no tenant in ctx
+	if _, err := rd.ListAssetVulnerableComponents(context.Background(), "asset-1"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("missing tenant rejected")
+	}
+	// empty asset id
+	if _, err := rd.ListAssetVulnerableComponents(ctxT(), ""); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("empty asset id rejected")
+	}
+	// occurrence store error propagates
+	boom := errors.New("db down")
+	rd2 := mustReader(t, fakeMembership{engs: oneEngagement(), projects: []asset.ComponentMembership{member("c1")}}, &fakeOccurrences{err: boom}, fakeRisk{})
+	if _, err := rd2.ListAssetVulnerableComponents(ctxT(), "asset-1"); !errors.Is(err, boom) {
+		t.Fatalf("occurrence error must propagate, got %v", err)
+	}
+	// risk store non-NotFound error propagates
+	occs := &fakeOccurrences{byEng: map[shared.ID][]vulnerabilityoccurrence.Occurrence{"eng-1": {occ("o1", "c1", "CVE-1")}}}
+	rd3 := mustReader(t, fakeMembership{engs: oneEngagement(), projects: []asset.ComponentMembership{member("c1")}}, occs, fakeRisk{err: boom})
+	if _, err := rd3.ListAssetVulnerableComponents(ctxT(), "asset-1"); !errors.Is(err, boom) {
+		t.Fatalf("risk error must propagate, got %v", err)
+	}
+	// membership (engagements) error propagates
+	rd4 := mustReader(t, fakeMembership{engErr: boom}, &fakeOccurrences{}, fakeRisk{})
+	if _, err := rd4.ListAssetVulnerableComponents(ctxT(), "asset-1"); !errors.Is(err, boom) {
+		t.Fatalf("engagement lookup error must propagate, got %v", err)
+	}
+}


### PR DESCRIPTION
feat(exposure): X5b AssetVulnerabilityReader adapter over the SCA stores (#634)

Wires the X5 Exposure producer to real data: internal/usecase/fleet/exposurereader
implements exposureuc.AssetVulnerabilityReader by joining the shipped SCA stores.
For an asset it resolves the engagements it is scoped into + its component
memberships (project ∪ technical-asset), lists each engagement's OPEN
(StateDetected) vulnerability occurrences filtered to the asset's components
(Occurrence carries no AssetID — component membership is the bridge), and reads
each occurrence's current vulnerabilityrisk.Assessment for Priority/KEV/Severity.
It reuses the already-evaluated risk; it recomputes nothing.

Coverage-honest + fail-closed:
- ABSTAIN (shared.ErrNotFound) when the asset is in no engagement, has no
  component inventory, OR has detected occurrences that are ALL still awaiting
  risk evaluation — a never/partly-scored asset is never reported as clean.
- A scanned asset with no open occurrences returns (nil, nil) — a trustworthy 0.
- Store errors propagate (wrapped with context, preserving ErrNotFound); only a
  single occurrence's missing risk assessment is skipped, not the whole asset.
- Dedup of a (component, advisory) seen under multiple engagements keeps the
  WORST risk (deterministic order: KEV, then lower Priority, then higher
  severity) so the exposure factor is never under-reported nor order-dependent.

Tenant-scoped: tenant resolved from ctx (fail-closed) and passed to every store
call — no cross-tenant path (a foreign assetID yields no engagements → abstain).
Narrow consumer-side reader interfaces; the broad ports.* interfaces are asserted
to satisfy them so a signature drift breaks the build here, not at wiring time.
Running=false until the B5 per-asset process-entity snapshot store lands (the
producer already notes the reduced running-vs-installed precision).

Dual-reviewed (go-arch + security). Folded every finding: merge-max dedup
(blocking — was first-seen, under-reporting + non-deterministic), abstain when all
occurrences unscored, error wrapping, nil-engagement guard. Tenant isolation
confirmed clean (no IDOR). race-green, 86.7% coverage.

The composition-root wiring (construct the reader from the concrete stores, pass
it to exposureuc.NewService) is the remaining step to run in production.
