### PR TITLE
feat(endpoint): B5 per-host process snapshot store (#667 tail)

### DIFF
--- a/internal/infrastructure/persistence/memory/endpoint_process_store.go
+++ b/internal/infrastructure/persistence/memory/endpoint_process_store.go
@@ -1,0 +1,89 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// EndpointProcessStore is the in-memory twin of the per-host process snapshot projection (B5). It is
+// tenant-bucketed and upholds the same upsert-by-(tenant,asset,entity) contract as the Postgres tier.
+// Reached only through ports.EndpointProcessStore.
+type EndpointProcessStore struct {
+	mu   sync.Mutex
+	recs map[shared.ID]map[shared.ID]map[shared.ID]ports.ProcessSnapshot // tenant -> asset -> entity -> snapshot
+}
+
+var _ ports.EndpointProcessStore = (*EndpointProcessStore)(nil)
+
+// NewEndpointProcessStore creates an empty in-memory process snapshot store.
+func NewEndpointProcessStore() *EndpointProcessStore {
+	return &EndpointProcessStore{recs: make(map[shared.ID]map[shared.ID]map[shared.ID]ports.ProcessSnapshot)}
+}
+
+func requireProcessTenant(ctx context.Context) (shared.ID, error) {
+	if t, ok := shared.TenantFrom(ctx); ok && t != "" {
+		return t, nil
+	}
+	return "", fmt.Errorf("%w: endpoint process store operation requires a tenant in context", shared.ErrValidation)
+}
+
+// SaveProcesses upserts snapshots by (tenant, asset, entity).
+func (s *EndpointProcessStore) SaveProcesses(ctx context.Context, snapshots []ports.ProcessSnapshot) error {
+	tenant, err := requireProcessTenant(ctx)
+	if err != nil {
+		return err
+	}
+	if len(snapshots) == 0 {
+		return nil
+	}
+	for _, p := range snapshots {
+		if err := p.Validate(); err != nil {
+			return err
+		}
+		if p.TenantID != tenant {
+			return fmt.Errorf("%w: snapshot tenant %q does not match context tenant %q", shared.ErrValidation, p.TenantID, tenant)
+		}
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	byAsset := s.recs[tenant]
+	if byAsset == nil {
+		byAsset = make(map[shared.ID]map[shared.ID]ports.ProcessSnapshot)
+		s.recs[tenant] = byAsset
+	}
+	for _, p := range snapshots {
+		byEntity := byAsset[p.AssetID]
+		if byEntity == nil {
+			byEntity = make(map[shared.ID]ports.ProcessSnapshot)
+			byAsset[p.AssetID] = byEntity
+		}
+		byEntity[p.EntityID] = p
+	}
+	return nil
+}
+
+// ListRunningByAsset returns the running snapshots for an asset, ordered by EntityID.
+func (s *EndpointProcessStore) ListRunningByAsset(ctx context.Context, assetID shared.ID) ([]ports.ProcessSnapshot, error) {
+	tenant, err := requireProcessTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if assetID.IsZero() {
+		return nil, fmt.Errorf("%w: asset id is required", shared.ErrValidation)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]ports.ProcessSnapshot, 0)
+	for _, p := range s.recs[tenant][assetID] {
+		if p.Running {
+			out = append(out, p)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].EntityID < out[j].EntityID })
+	return out, nil
+}

--- a/internal/infrastructure/persistence/memory/endpoint_process_store_test.go
+++ b/internal/infrastructure/persistence/memory/endpoint_process_store_test.go
@@ -1,0 +1,81 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func snap(tenant, asset, entity string, running bool) ports.ProcessSnapshot {
+	return ports.ProcessSnapshot{
+		TenantID: shared.ID(tenant), AssetID: shared.ID(asset), EntityID: shared.ID(entity),
+		PID: 100, Comm: "curl", Path: "/usr/bin/curl", Running: running, LastSeenAt: time.Unix(1_700_000_000, 0).UTC(),
+	}
+}
+
+func TestEndpointProcessStoreSaveListAndRunningFilter(t *testing.T) {
+	s := NewEndpointProcessStore()
+	ctx := shared.WithTenant(context.Background(), "ta")
+	if err := s.SaveProcesses(ctx, []ports.ProcessSnapshot{
+		snap("ta", "host-1", "e1", true),
+		snap("ta", "host-1", "e2", false), // exited
+		snap("ta", "host-1", "e3", true),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.ListRunningByAsset(ctx, "host-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].EntityID != "e1" || got[1].EntityID != "e3" {
+		t.Fatalf("running filter/order wrong: %+v", got)
+	}
+	// Upsert e1 to exited -> drops out of the running list.
+	if err := s.SaveProcesses(ctx, []ports.ProcessSnapshot{snap("ta", "host-1", "e1", false)}); err != nil {
+		t.Fatal(err)
+	}
+	got, _ = s.ListRunningByAsset(ctx, "host-1")
+	if len(got) != 1 || got[0].EntityID != "e3" {
+		t.Fatalf("upsert to exited must drop from running, got %+v", got)
+	}
+}
+
+func TestEndpointProcessStoreTenantIsolation(t *testing.T) {
+	s := NewEndpointProcessStore()
+	ctxA := shared.WithTenant(context.Background(), "ta")
+	ctxB := shared.WithTenant(context.Background(), "tb")
+	if err := s.SaveProcesses(ctxA, []ports.ProcessSnapshot{snap("ta", "host-1", "e1", true)}); err != nil {
+		t.Fatal(err)
+	}
+	// Tenant B sees nothing for the same asset id.
+	if got, _ := s.ListRunningByAsset(ctxB, "host-1"); len(got) != 0 {
+		t.Fatalf("tenant B must not see A's processes, got %d", len(got))
+	}
+	// A snapshot whose tenant disagrees with the ctx tenant is rejected.
+	if err := s.SaveProcesses(ctxA, []ports.ProcessSnapshot{snap("tb", "host-1", "e1", true)}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("cross-tenant snapshot must be rejected, got %v", err)
+	}
+	// No tenant in context is rejected.
+	if err := s.SaveProcesses(context.Background(), []ports.ProcessSnapshot{snap("ta", "host-1", "e1", true)}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing tenant must be rejected, got %v", err)
+	}
+	if _, err := s.ListRunningByAsset(context.Background(), "host-1"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("list without tenant must be rejected, got %v", err)
+	}
+}
+
+func TestEndpointProcessStoreValidation(t *testing.T) {
+	s := NewEndpointProcessStore()
+	ctx := shared.WithTenant(context.Background(), "ta")
+	bad := snap("ta", "host-1", "", true) // missing entity id
+	if err := s.SaveProcesses(ctx, []ports.ProcessSnapshot{bad}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing entity id must be rejected, got %v", err)
+	}
+	if err := s.SaveProcesses(ctx, nil); err != nil {
+		t.Fatalf("saving zero snapshots must be a no-op, got %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/endpoint_process_repo.go
+++ b/internal/infrastructure/persistence/postgres/endpoint_process_repo.go
@@ -1,0 +1,109 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// EndpointProcessRepository is the Postgres tier for the per-host process snapshot projection (B5). A
+// snapshot is a MUTABLE projection keyed by (tenant, asset, entity), upserted in place. Every method runs
+// under the authenticated ctx tenant via WithContextTenant (RLS) with an explicit tenant_id predicate as
+// defense-in-depth. Reached only through ports.EndpointProcessStore.
+type EndpointProcessRepository struct {
+	pool *pgxpool.Pool
+}
+
+var _ ports.EndpointProcessStore = (*EndpointProcessRepository)(nil)
+
+// NewEndpointProcessRepository constructs the process snapshot store over a pgx pool.
+func NewEndpointProcessRepository(pool *pgxpool.Pool) *EndpointProcessRepository {
+	return &EndpointProcessRepository{pool: pool}
+}
+
+func requireEndpointProcessTenant(ctx context.Context) (shared.ID, error) {
+	if t, ok := shared.TenantFrom(ctx); ok && t != "" {
+		return t, nil
+	}
+	return "", fmt.Errorf("%w: endpoint process store operation requires a tenant in context", shared.ErrValidation)
+}
+
+// SaveProcesses upserts snapshots by (tenant, asset, entity) in one transaction.
+func (r *EndpointProcessRepository) SaveProcesses(ctx context.Context, snapshots []ports.ProcessSnapshot) error {
+	tenant, err := requireEndpointProcessTenant(ctx)
+	if err != nil {
+		return err
+	}
+	if len(snapshots) == 0 {
+		return nil
+	}
+	for _, p := range snapshots {
+		if err := p.Validate(); err != nil {
+			return err
+		}
+		if p.TenantID != tenant {
+			return fmt.Errorf("%w: snapshot tenant %q does not match context tenant %q", shared.ErrValidation, p.TenantID, tenant)
+		}
+	}
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		for _, p := range snapshots {
+			_, err := tx.Exec(ctx, `INSERT INTO endpoint_processes
+				(tenant_id, asset_id, entity_id, pid, comm, path, running, last_seen_at)
+				VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+				ON CONFLICT (tenant_id, asset_id, entity_id) DO UPDATE SET
+					pid = EXCLUDED.pid,
+					comm = EXCLUDED.comm,
+					path = EXCLUDED.path,
+					running = EXCLUDED.running,
+					last_seen_at = EXCLUDED.last_seen_at`,
+				tenant.String(), p.AssetID.String(), p.EntityID.String(), p.PID, p.Comm, p.Path, p.Running, p.LastSeenAt.UTC())
+			if err != nil {
+				return fmt.Errorf("upsert process snapshot: %w", err)
+			}
+		}
+		return nil
+	})
+}
+
+// ListRunningByAsset returns the running snapshots for an asset, ordered by entity_id (COLLATE "C" so the
+// SQL order matches the memory twin's Go bytewise ordering).
+func (r *EndpointProcessRepository) ListRunningByAsset(ctx context.Context, assetID shared.ID) ([]ports.ProcessSnapshot, error) {
+	tenant, err := requireEndpointProcessTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if assetID.IsZero() {
+		return nil, fmt.Errorf("%w: asset id is required", shared.ErrValidation)
+	}
+	out := make([]ports.ProcessSnapshot, 0) // non-nil empty for parity with the memory twin
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT entity_id, pid, comm, path, last_seen_at
+			FROM endpoint_processes
+			WHERE tenant_id = $1 AND asset_id = $2 AND running = true
+			ORDER BY entity_id COLLATE "C"`, tenant.String(), assetID.String())
+		if err != nil {
+			return fmt.Errorf("list running processes: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			p := ports.ProcessSnapshot{TenantID: tenant, AssetID: assetID, Running: true}
+			var entityID string
+			if err := rows.Scan(&entityID, &p.PID, &p.Comm, &p.Path, &p.LastSeenAt); err != nil {
+				return fmt.Errorf("scan process snapshot: %w", err)
+			}
+			p.LastSeenAt = p.LastSeenAt.UTC() // normalize zone for parity with the write path
+			p.EntityID = shared.ID(entityID)
+			out = append(out, p)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/infrastructure/persistence/postgres/endpoint_process_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/endpoint_process_repo_test.go
@@ -1,0 +1,91 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestEndpointProcessRepository(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	id := randHex(t)
+	tenant := shared.ID("ep-" + id)
+	other := shared.ID("ep-other-" + id)
+	assetT := shared.ID("ep-asset-" + id)
+	assetO := shared.ID("ep-asset-other-" + id)
+	for _, tn := range []shared.ID{tenant, other} {
+		if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES($1,$1)`, tn.String()); err != nil {
+			t.Fatalf("seed tenant: %v", err)
+		}
+	}
+	seedAsset := func(a, tn shared.ID) {
+		if _, err := pool.Exec(ctx, `INSERT INTO fleet_assets(id,tenant_id,kind,"key",name) VALUES($1,$2,'host',$1,$1)`, a.String(), tn.String()); err != nil {
+			t.Fatalf("seed asset: %v", err)
+		}
+	}
+	seedAsset(assetT, tenant)
+	seedAsset(assetO, other)
+	t.Cleanup(func() {
+		bg := context.Background()
+		for _, tn := range []shared.ID{tenant, other} {
+			_, _ = pool.Exec(bg, `DELETE FROM endpoint_processes WHERE tenant_id=$1`, tn.String())
+			_, _ = pool.Exec(bg, `DELETE FROM fleet_assets WHERE tenant_id=$1`, tn.String())
+			_, _ = pool.Exec(bg, `DELETE FROM tenants WHERE id=$1`, tn.String())
+		}
+	})
+
+	repo := NewEndpointProcessRepository(pool)
+	tctx := shared.WithTenant(ctx, tenant)
+	octx := shared.WithTenant(ctx, other)
+	now := time.Unix(1_800_000_000, 0).UTC()
+	snap := func(entity string, running bool) ports.ProcessSnapshot {
+		return ports.ProcessSnapshot{TenantID: tenant, AssetID: assetT, EntityID: shared.ID(entity), PID: 42, Comm: "curl", Path: "/usr/bin/curl", Running: running, LastSeenAt: now}
+	}
+
+	if err := repo.SaveProcesses(tctx, []ports.ProcessSnapshot{snap("e1", true), snap("e2", false), snap("e3", true)}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := repo.ListRunningByAsset(tctx, assetT)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 || got[0].EntityID != "e1" || got[1].EntityID != "e3" {
+		t.Fatalf("running filter/order wrong: %+v", got)
+	}
+	if got[0].Comm != "curl" || got[0].Path != "/usr/bin/curl" || got[0].PID != 42 {
+		t.Fatalf("round-trip fields wrong: %+v", got[0])
+	}
+	// Upsert e1 -> exited, drops from running.
+	if err := repo.SaveProcesses(tctx, []ports.ProcessSnapshot{snap("e1", false)}); err != nil {
+		t.Fatal(err)
+	}
+	if got, _ := repo.ListRunningByAsset(tctx, assetT); len(got) != 1 || got[0].EntityID != "e3" {
+		t.Fatalf("upsert to exited must drop from running, got %+v", got)
+	}
+	// Tenant isolation.
+	if got, _ := repo.ListRunningByAsset(octx, assetO); len(got) != 0 {
+		t.Fatalf("other tenant must see nothing, got %d", len(got))
+	}
+	// Cross-tenant snapshot rejected before touching the DB.
+	if err := repo.SaveProcesses(tctx, []ports.ProcessSnapshot{{TenantID: other, AssetID: assetT, EntityID: "x", Running: true, LastSeenAt: now}}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("cross-tenant snapshot must be rejected, got %v", err)
+	}
+}

--- a/internal/usecase/ports/endpoint_process_store.go
+++ b/internal/usecase/ports/endpoint_process_store.go
@@ -1,0 +1,53 @@
+package ports
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// ProcessSnapshot is the persisted, lightweight projection of a running (or exited) process entity for one
+// host asset (Phase B / B5 #667 tail). It is deliberately NOT the full endpoint.ProcessEntity aggregate —
+// only the fields a consumer needs to answer "what is running on this host right now" (the running side of
+// running-vs-installed exposure, X5 #634): the stable A1 EntityID, the exec identity (comm/path), liveness,
+// and the last-seen time. AssetID is the HOST/fleet asset the process runs on.
+type ProcessSnapshot struct {
+	TenantID   shared.ID
+	AssetID    shared.ID
+	EntityID   shared.ID
+	PID        int
+	Comm       string
+	Path       string
+	Running    bool
+	LastSeenAt time.Time
+}
+
+// Validate enforces a well-formed snapshot.
+func (p ProcessSnapshot) Validate() error {
+	switch {
+	case p.TenantID.IsZero():
+		return fmt.Errorf("%w: process snapshot requires a tenant", shared.ErrValidation)
+	case p.AssetID.IsZero():
+		return fmt.Errorf("%w: process snapshot requires an asset id", shared.ErrValidation)
+	case p.EntityID.IsZero():
+		return fmt.Errorf("%w: process snapshot requires an entity id", shared.ErrValidation)
+	case p.PID < 0:
+		return fmt.Errorf("%w: process snapshot pid must be non-negative", shared.ErrValidation)
+	}
+	return nil
+}
+
+// EndpointProcessStore persists per-host process snapshots (B5). It is a MUTABLE projection keyed by
+// (tenant, asset, entity) — a re-observation upserts a process in place, flipping Running to false when it
+// exits — so it has no append-only trigger. Every method is tenant-scoped from the context.
+type EndpointProcessStore interface {
+	// SaveProcesses upserts the given snapshots idempotently by (tenant, asset, entity). Each snapshot's
+	// TenantID must equal the context tenant, else it fails closed with shared.ErrValidation (no
+	// cross-tenant write). Saving zero snapshots is a no-op.
+	SaveProcesses(ctx context.Context, snapshots []ProcessSnapshot) error
+	// ListRunningByAsset returns the currently-RUNNING process snapshots for one host asset, tenant-scoped,
+	// ordered by EntityID for stability. An asset with no running processes returns an empty slice.
+	ListRunningByAsset(ctx context.Context, assetID shared.ID) ([]ProcessSnapshot, error)
+}

--- a/migrations/0115_endpoint_processes.sql
+++ b/migrations/0115_endpoint_processes.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+-- Phase B / B5 (#667 tail): the per-host process snapshot projection — "what is running on this host right
+-- now" — the running side of running-vs-installed exposure (X5 #634). It is a MUTABLE projection (a
+-- re-observation upserts a process in place, flipping running=false when it exits), so no append-only
+-- trigger; one row per (tenant, asset, entity). asset_id is the HOST/fleet asset the process runs on.
+CREATE TABLE endpoint_processes (
+    tenant_id    TEXT NOT NULL,
+    asset_id     TEXT NOT NULL,
+    entity_id    TEXT NOT NULL,
+    pid          INT NOT NULL CHECK (pid >= 0),
+    comm         TEXT NOT NULL DEFAULT '',
+    path         TEXT NOT NULL DEFAULT '',
+    running      BOOLEAN NOT NULL,
+    last_seen_at TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, asset_id, entity_id),
+    -- composite FK to the host asset (fleet_assets has UNIQUE (tenant_id, id) from migration 0058).
+    FOREIGN KEY (tenant_id, asset_id) REFERENCES fleet_assets (tenant_id, id) ON DELETE CASCADE
+);
+-- Running processes are queried per asset; index that path (entity_id COLLATE "C" so the SQL order matches
+-- the memory twin's Go bytewise ordering).
+CREATE INDEX idx_endpoint_processes_running
+    ON endpoint_processes (tenant_id, asset_id, entity_id COLLATE "C")
+    WHERE running = true;
+CALL synapse_enable_tenant_rls('endpoint_processes');
+
+-- +goose Down
+DROP TABLE endpoint_processes;


### PR DESCRIPTION
feat(endpoint): B5 per-host process snapshot store (#667 tail)

The deferred B5 tail: persist "what is running on this host right now" so the
running side of running-vs-installed exposure (X5 #634) has a data source.

- ports.ProcessSnapshot: a lightweight per-host projection (EntityID/PID/Comm/
  Path/Running/LastSeenAt) — deliberately NOT the full endpoint.ProcessEntity
  aggregate (which has unexported bookkeeping), so there is no aggregate-reload
  problem (the reason B5 was deferred). AssetID is the HOST/fleet asset.
- ports.EndpointProcessStore: SaveProcesses (idempotent upsert by
  (tenant,asset,entity); running→exited flips in place) + ListRunningByAsset
  (running only, ordered by EntityID). Mutable projection, tenant-scoped.
- memory + postgres twins + migration 0115 (RLS, composite FK to
  fleet_assets(tenant_id,id) ON DELETE CASCADE, partial index on running,
  entity_id COLLATE "C" so SQL order == memory bytewise order).

Keyed on the A1 EntityID (not a bare PID), so a recycled PID cannot collide a
snapshot. Value-only projection => the shallow map store has no aliasing hazard.
Tenant fail-closed on both twins; the Postgres write binds the ctx tenant (not
the snapshot's), so a mismatched TenantID cannot write a foreign row.

Dual-reviewed (go-arch MERGEABLE, security SHIP — tenant-isolated/no-IDOR, no
injection, no PID-reuse collision, no secrets). Folded the two cosmetic notes
(nil→empty-slice + UTC-on-read parity with the memory twin). memory tests
race-green; PG integration green on a fresh DB (0115 applies + round-trip +
running-filter + upsert-flip + tenant isolation + FK).

The composition-root wiring (record snapshots from the endpoint projection) and
the running-vs-installed resolver that consumes this store are the next slice.
