### PR TITLE
feat(exposure): real running-vs-installed (B5 processes → RiskContext.Exposure) (#634/#667)

### DIFF
--- a/internal/infrastructure/persistence/memory/component_inventory_store.go
+++ b/internal/infrastructure/persistence/memory/component_inventory_store.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -50,6 +51,57 @@ func (s *ComponentInventoryStore) saveSnapshot(records []sbom.ComponentRecord) e
 	defer s.mu.Unlock()
 	s.items = append(s.items, records...)
 	return nil
+}
+
+// ListCurrentComponentsByEngagement returns the components of the engagement's LATEST SBOM (by
+// SBOMCreatedAt, then SBOMID), deduped by ComponentID and ordered by ComponentID — the same latest-SBOM
+// semantics as the Postgres twin. It is the by-engagement enumeration the running-vs-installed join needs
+// to resolve a vulnerable ComponentID to a package name (the keyed ListCurrentComponents query cannot,
+// since it requires a package/CPE key the caller does not have).
+func (s *ComponentInventoryStore) ListCurrentComponentsByEngagement(ctx context.Context, tenantID, engagementID shared.ID) ([]sbom.ComponentRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if tenantID.IsZero() || engagementID.IsZero() {
+		return nil, fmt.Errorf("%w: tenant and engagement are required", shared.ErrValidation)
+	}
+	// Defense-in-depth (mirrors ListCurrentComponents): the ctx tenant must match the requested tenant.
+	ctxTenant, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return nil, fmt.Errorf("%w: tenant context is required", shared.ErrValidation)
+	}
+	if shared.TenantOrDefault(ctxTenant) != shared.TenantOrDefault(tenantID) {
+		return nil, fmt.Errorf("%w: component query tenant does not match context", shared.ErrValidation)
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	// Pick the latest SBOM for (tenant, engagement) — newest SBOMCreatedAt, tie-broken by the larger SBOMID.
+	var latestID shared.ID
+	var latestAt time.Time
+	found := false
+	for _, it := range s.items {
+		if it.TenantID != tenantID || it.EngagementID != engagementID {
+			continue
+		}
+		if !found || it.SBOMCreatedAt.After(latestAt) || (it.SBOMCreatedAt.Equal(latestAt) && it.SBOMID > latestID) {
+			latestAt, latestID, found = it.SBOMCreatedAt, it.SBOMID, true
+		}
+	}
+	out := make([]sbom.ComponentRecord, 0)
+	if !found {
+		return out, nil
+	}
+	byID := make(map[shared.ID]sbom.ComponentRecord)
+	for _, it := range s.items {
+		if it.TenantID == tenantID && it.EngagementID == engagementID && it.SBOMID == latestID {
+			byID[it.ComponentID] = it
+		}
+	}
+	for _, r := range byID {
+		out = append(out, r)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ComponentID < out[j].ComponentID })
+	return out, nil
 }
 
 func (s *ComponentInventoryStore) ListCurrentComponents(ctx context.Context, query sbom.ComponentQuery) (sbom.ComponentPage, error) {

--- a/internal/infrastructure/persistence/memory/component_inventory_store_test.go
+++ b/internal/infrastructure/persistence/memory/component_inventory_store_test.go
@@ -48,3 +48,35 @@ func TestComponentInventoryStoreRejectsCrossTenantQuery(t *testing.T) {
 func inventoryRecord(tenantID, engagementID, sbomID, componentID string, createdAt time.Time, packageName, status string) sbom.ComponentRecord {
 	return sbom.ComponentRecord{TenantID: shared.ID(tenantID), EngagementID: shared.ID(engagementID), SBOMID: shared.ID(sbomID), ComponentID: shared.ID(componentID), Name: packageName, Version: "1.0.0", PURL: "pkg:golang/example.com/pkg@1.0.0", Ecosystem: "Go", Package: "example.com/pkg", IdentityHash: componentID, IdentityStatus: status, SBOMCreatedAt: createdAt}
 }
+
+func TestComponentInventoryStoreListByEngagement(t *testing.T) {
+	now := time.Date(2026, 8, 13, 10, 0, 0, 0, time.UTC)
+	store := NewComponentInventoryStore(
+		inventoryRecord("tenant-a", "eng-1", "sbom-old", "comp-stale", now, "stale", "resolved"),        // older SBOM
+		inventoryRecord("tenant-a", "eng-1", "sbom-new", "comp-b", now.Add(time.Hour), "b", "resolved"), // latest SBOM
+		inventoryRecord("tenant-a", "eng-1", "sbom-new", "comp-a", now.Add(time.Hour), "a", "resolved"), // latest SBOM
+		inventoryRecord("tenant-a", "eng-2", "sbom-2", "comp-other-eng", now, "x", "resolved"),
+		inventoryRecord("tenant-b", "eng-1", "sbom-3", "comp-other-tenant", now, "y", "resolved"),
+	)
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
+	got, err := store.ListCurrentComponentsByEngagement(ctx, "tenant-a", "eng-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only the LATEST SBOM's components (comp-stale from sbom-old excluded), deduped, ordered by ComponentID.
+	if len(got) != 2 || got[0].ComponentID != "comp-a" || got[1].ComponentID != "comp-b" {
+		t.Fatalf("list-by-engagement must return only the latest SBOM: %+v", got)
+	}
+	for _, r := range got {
+		if r.EngagementID != "eng-1" || r.TenantID != "tenant-a" {
+			t.Fatalf("leaked a foreign record: %+v", r)
+		}
+	}
+	if _, err := store.ListCurrentComponentsByEngagement(ctx, "", "eng-1"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("missing tenant must be rejected")
+	}
+	// ctx-tenant must match the requested tenant (defense-in-depth).
+	if _, err := store.ListCurrentComponentsByEngagement(ctx, "tenant-b", "eng-1"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("ctx/param tenant mismatch must be rejected")
+	}
+}

--- a/internal/infrastructure/persistence/postgres/component_inventory_store.go
+++ b/internal/infrastructure/persistence/postgres/component_inventory_store.go
@@ -20,6 +20,49 @@ func NewComponentInventoryStore(pool *pgxpool.Pool) *ComponentInventoryStore {
 
 var _ ports.ComponentInventoryStore = (*ComponentInventoryStore)(nil)
 
+// ListCurrentComponentsByEngagement returns the components of the engagement's latest SBOM (id + name +
+// package only — enough to resolve a vulnerable ComponentID to a package name for running-vs-installed
+// matching). Unlike ListCurrentComponents it takes no package/CPE key, so it can enumerate all components.
+// Tenant-scoped via WithTenant (RLS) + an explicit tenant_id predicate.
+func (s *ComponentInventoryStore) ListCurrentComponentsByEngagement(ctx context.Context, tenantID, engagementID shared.ID) ([]sbom.ComponentRecord, error) {
+	if tenantID.IsZero() || engagementID.IsZero() {
+		return nil, fmt.Errorf("%w: tenant and engagement are required", shared.ErrValidation)
+	}
+	out := make([]sbom.ComponentRecord, 0)
+	err := WithTenant(ctx, s.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			WITH latest_sbom AS (
+				SELECT id FROM sboms
+				WHERE tenant_id=$1 AND engagement_id=$2
+				ORDER BY created_at DESC, id DESC
+				LIMIT 1
+			)
+			SELECT c.id, c.name, c.package_name
+			FROM components c
+			JOIN latest_sbom s ON s.id=c.sbom_id
+			WHERE c.tenant_id=$1
+			ORDER BY c.id COLLATE "C"`, tenantID.String(), engagementID.String())
+		if err != nil {
+			return fmt.Errorf("list components by engagement: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			item := sbom.ComponentRecord{TenantID: tenantID, EngagementID: engagementID}
+			var id string
+			if err := rows.Scan(&id, &item.Name, &item.Package); err != nil {
+				return fmt.Errorf("scan component: %w", err)
+			}
+			item.ComponentID = shared.ID(id)
+			out = append(out, item)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (s *ComponentInventoryStore) ListCurrentComponents(ctx context.Context, query sbom.ComponentQuery) (sbom.ComponentPage, error) {
 	tenantID, ok := shared.TenantFrom(ctx)
 	if !ok {

--- a/internal/infrastructure/persistence/postgres/component_inventory_store_test.go
+++ b/internal/infrastructure/persistence/postgres/component_inventory_store_test.go
@@ -1,0 +1,56 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// TestComponentInventoryStoreListByEngagement validates the new by-engagement enumeration SQL against the
+// real schema (column names, the latest-SBOM join). It asserts an empty result for an engagement with no
+// SBOM (so it needs no component seeding) — the point is that the query parses and executes, and that
+// tenant/engagement validation fails closed.
+func TestComponentInventoryStoreListByEngagement(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := Migrate(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	tenant := shared.ID("ci-" + randHex(t))
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES($1,$1)`, tenant.String()); err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM tenants WHERE id=$1`, tenant.String())
+	})
+
+	store := NewComponentInventoryStore(pool)
+	tctx := shared.WithTenant(ctx, tenant)
+
+	got, err := store.ListCurrentComponentsByEngagement(tctx, tenant, "eng-none")
+	if err != nil {
+		t.Fatalf("query must execute against the schema: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("no SBOM for the engagement must yield no components, got %d", len(got))
+	}
+	// Fail-closed validation.
+	if _, err := store.ListCurrentComponentsByEngagement(tctx, "", "eng-none"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("missing tenant must be rejected")
+	}
+	if _, err := store.ListCurrentComponentsByEngagement(tctx, tenant, ""); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("missing engagement must be rejected")
+	}
+}

--- a/internal/usecase/fleet/exposurereader/service.go
+++ b/internal/usecase/fleet/exposurereader/service.go
@@ -2,19 +2,23 @@
 // occurrences, and per-occurrence risk assessments) into the exposureuc.AssetVulnerabilityReader port —
 // the missing join that lets the X5 Exposure producer read an asset's open vulnerable components with their
 // evaluated Priority/KEV/Severity. It reuses the already-evaluated risk (vulnerabilityrisk.Assessment); it
-// recomputes nothing. Every read is tenant-scoped from ctx. Running presence is not yet available (the B5
-// per-asset process-entity snapshot store is deferred), so it reports installed-only — the producer notes
-// the reduced running-vs-installed precision.
+// recomputes nothing. Every read is tenant-scoped from ctx. When constructed with NewReaderWithRuntime it
+// also resolves running-vs-installed — marking a vulnerable component Running if its package matches a
+// process observed executing on one of the asset's hosts (the B5 process store); constructed with NewReader
+// (no runtime signals) it reports installed-only and the producer notes the reduced precision.
 package exposurereader
 
 import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
 	"sort"
+	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityoccurrence"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityrisk"
@@ -49,14 +53,33 @@ type RiskReader interface {
 	Current(ctx context.Context, tenantID, occurrenceID shared.ID) (vulnerabilityrisk.Assessment, error)
 }
 
-// Reader implements exposureuc.AssetVulnerabilityReader over the SCA stores.
+// ProcessLister returns the running processes for a HOST/fleet asset (the running side of
+// running-vs-installed). ports.EndpointProcessStore satisfies it.
+type ProcessLister interface {
+	ListRunningByAsset(ctx context.Context, assetID shared.ID) ([]ports.ProcessSnapshot, error)
+}
+
+// ComponentLister enumerates an engagement's current components so a vulnerable ComponentID can be resolved
+// to a package name for process matching. The concrete ComponentInventoryStore satisfies it.
+type ComponentLister interface {
+	ListCurrentComponentsByEngagement(ctx context.Context, tenantID, engagementID shared.ID) ([]sbom.ComponentRecord, error)
+}
+
+// Reader implements exposureuc.AssetVulnerabilityReader over the SCA stores. processes + components are
+// OPTIONAL: when both are wired (NewReaderWithRuntime), the reader resolves the running-vs-installed
+// Presence; when nil (NewReader), every component is reported installed-only.
 type Reader struct {
 	memberships MembershipReader
 	occurrences OccurrenceReader
 	risk        RiskReader
+	processes   ProcessLister
+	components  ComponentLister
 }
 
-var _ exposureuc.AssetVulnerabilityReader = (*Reader)(nil)
+var (
+	_ exposureuc.AssetVulnerabilityReader = (*Reader)(nil)
+	_ ProcessLister                       = ports.EndpointProcessStore(nil)
+)
 
 // NewReader constructs the adapter. All three stores are required.
 func NewReader(memberships MembershipReader, occurrences OccurrenceReader, risk RiskReader) (*Reader, error) {
@@ -69,6 +92,22 @@ func NewReader(memberships MembershipReader, occurrences OccurrenceReader, risk 
 		return nil, fmt.Errorf("%w: exposure reader requires a risk store", shared.ErrValidation)
 	}
 	return &Reader{memberships: memberships, occurrences: occurrences, risk: risk}, nil
+}
+
+// NewReaderWithRuntime is NewReader plus the runtime signals needed to resolve running-vs-installed: the
+// B5 process store (running processes per host) and a component enumerator (ComponentID -> package name).
+// With both wired, a vulnerable component whose package matches a running process is marked Running.
+func NewReaderWithRuntime(memberships MembershipReader, occurrences OccurrenceReader, risk RiskReader, processes ProcessLister, components ComponentLister) (*Reader, error) {
+	r, err := NewReader(memberships, occurrences, risk)
+	if err != nil {
+		return nil, err
+	}
+	if processes == nil || components == nil {
+		return nil, fmt.Errorf("%w: runtime reader requires a process store and a component lister", shared.ErrValidation)
+	}
+	r.processes = processes
+	r.components = components
+	return r, nil
 }
 
 func tenantIDFrom(ctx context.Context) (shared.ID, error) {
@@ -102,9 +141,20 @@ func (r *Reader) ListAssetVulnerableComponents(ctx context.Context, assetID shar
 		return nil, fmt.Errorf("%w: asset %s is not scoped into any engagement", shared.ErrNotFound, assetID)
 	}
 
-	components, err := r.componentSet(ctx, tenant, assetID)
+	projects, err := r.memberships.ListBusinessAssetProjects(ctx, tenant, assetID)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("list project components for asset %s: %w", assetID, err)
+	}
+	technical, err := r.memberships.ListBusinessAssetTechnicalAssets(ctx, tenant, assetID)
+	if err != nil {
+		return nil, fmt.Errorf("list technical components for asset %s: %w", assetID, err)
+	}
+	components := make(map[shared.ID]struct{}, len(projects)+len(technical))
+	for _, m := range projects {
+		components[m.ComponentID] = struct{}{}
+	}
+	for _, m := range technical {
+		components[m.ComponentID] = struct{}{}
 	}
 	if len(components) == 0 {
 		return nil, fmt.Errorf("%w: asset %s has no component inventory", shared.ErrNotFound, assetID)
@@ -114,8 +164,7 @@ func (r *Reader) ListAssetVulnerableComponents(ctx context.Context, assetID shar
 	// asset's engagements, each with its own (possibly divergent) risk evaluation. Keep the WORST — the
 	// exposure factor must never be under-reported — via a deterministic risk order (not first-seen, which
 	// would depend on engagement iteration order).
-	type key struct{ comp, adv shared.ID }
-	byKey := make(map[key]exposureuc.AssetVulnerableComponent)
+	byKey := make(map[componentKey]exposureuc.AssetVulnerableComponent)
 	skippedUnscored := false
 	for _, eng := range engs {
 		if eng == nil {
@@ -145,7 +194,7 @@ func (r *Reader) ListAssetVulnerableComponents(ctx context.Context, assetID shar
 				KEV:         ra.KEV,
 				Running:     false, // installed-only until B5 process-entity snapshots land
 			}
-			k := key{comp: cand.ComponentID, adv: cand.AdvisoryID}
+			k := componentKey{comp: cand.ComponentID, adv: cand.AdvisoryID}
 			if prev, ok := byKey[k]; !ok || riskWorse(cand, prev) {
 				byKey[k] = cand
 			}
@@ -159,6 +208,14 @@ func (r *Reader) ListAssetVulnerableComponents(ctx context.Context, assetID shar
 			return nil, fmt.Errorf("%w: asset %s has detected vulnerabilities awaiting risk evaluation", shared.ErrNotFound, assetID)
 		}
 		return nil, nil // scanned, no open vulnerabilities — a trustworthy clean
+	}
+
+	// Resolve running-vs-installed when the runtime signals are wired (reusing the technical memberships
+	// already fetched above as the host bridge).
+	if r.processes != nil && r.components != nil {
+		if err := r.markRunning(ctx, tenant, technical, engs, byKey); err != nil {
+			return nil, err
+		}
 	}
 
 	out := make([]exposureuc.AssetVulnerableComponent, 0, len(byKey))
@@ -175,24 +232,87 @@ func (r *Reader) ListAssetVulnerableComponents(ctx context.Context, assetID shar
 	return out, nil
 }
 
-// componentSet unions the asset's project and technical-asset component memberships into a lookup set.
-func (r *Reader) componentSet(ctx context.Context, tenant, assetID shared.ID) (map[shared.ID]struct{}, error) {
-	set := make(map[shared.ID]struct{})
-	projects, err := r.memberships.ListBusinessAssetProjects(ctx, tenant, assetID)
+// componentKey dedups a vulnerable (component, advisory) across the asset's engagements.
+type componentKey struct{ comp, adv shared.ID }
+
+// markRunning sets Running=true on any vulnerable component whose package appears to be executing on one of
+// the asset's hosts. The running side is HOST-scoped (technical-asset memberships are fleet-asset ids), so
+// it gathers the running exec names across those hosts and matches them, case-insensitively, against each
+// vulnerable component's package name (resolved via the engagement's component inventory). Matching is
+// deliberately CONSERVATIVE — exact basename/comm == name/package, no substring — because Running scores
+// strictly higher than installed, so a false match would over-report risk; low recall (installed when
+// really running) is the safe failure mode, and exposureuc already notes the reduced precision.
+func (r *Reader) markRunning(ctx context.Context, tenant shared.ID, hosts []asset.ComponentMembership, engs []*engagement.Engagement, byKey map[componentKey]exposureuc.AssetVulnerableComponent) error {
+	running, err := r.runningExecNames(ctx, hosts)
 	if err != nil {
-		return nil, fmt.Errorf("list project components for asset %s: %w", assetID, err)
+		return err
 	}
-	technical, err := r.memberships.ListBusinessAssetTechnicalAssets(ctx, tenant, assetID)
+	if len(running) == 0 {
+		return nil // nothing observed running on any host — every component stays installed-only
+	}
+	names, err := r.componentPackageNames(ctx, tenant, engs)
 	if err != nil {
-		return nil, fmt.Errorf("list technical components for asset %s: %w", assetID, err)
+		return err
 	}
-	for _, m := range projects {
-		set[m.ComponentID] = struct{}{}
+	for k, comp := range byKey {
+		for _, n := range names[comp.ComponentID] {
+			if running[n] {
+				comp.Running = true
+				byKey[k] = comp
+				break
+			}
+		}
 	}
-	for _, m := range technical {
-		set[m.ComponentID] = struct{}{}
+	return nil
+}
+
+// runningExecNames gathers the lowercased exec basenames + comms of every running process across the
+// asset's host (technical) assets.
+func (r *Reader) runningExecNames(ctx context.Context, hosts []asset.ComponentMembership) (map[string]bool, error) {
+	names := make(map[string]bool)
+	for _, h := range hosts {
+		procs, err := r.processes.ListRunningByAsset(ctx, h.ComponentID) // ComponentID here is the host/fleet asset id
+		if err != nil {
+			return nil, fmt.Errorf("list running processes for host %s: %w", h.ComponentID, err)
+		}
+		for _, p := range procs {
+			if p.Path != "" {
+				names[strings.ToLower(path.Base(p.Path))] = true
+			}
+			if p.Comm != "" {
+				names[strings.ToLower(p.Comm)] = true
+			}
+		}
 	}
-	return set, nil
+	return names, nil
+}
+
+// componentPackageNames maps each component id (across the asset's engagements) to its lowercased match
+// candidates (name + package).
+func (r *Reader) componentPackageNames(ctx context.Context, tenant shared.ID, engs []*engagement.Engagement) (map[shared.ID][]string, error) {
+	out := make(map[shared.ID][]string)
+	for _, eng := range engs {
+		if eng == nil {
+			continue
+		}
+		recs, err := r.components.ListCurrentComponentsByEngagement(ctx, tenant, eng.ID)
+		if err != nil {
+			return nil, fmt.Errorf("list components for engagement %s: %w", eng.ID, err)
+		}
+		for _, rec := range recs {
+			var cands []string
+			if rec.Name != "" {
+				cands = append(cands, strings.ToLower(rec.Name))
+			}
+			if rec.Package != "" && !strings.EqualFold(rec.Package, rec.Name) {
+				cands = append(cands, strings.ToLower(rec.Package))
+			}
+			if len(cands) > 0 {
+				out[rec.ComponentID] = cands
+			}
+		}
+	}
+	return out, nil
 }
 
 // riskWorse reports whether exposure a represents a strictly higher risk than b, by a deterministic total

--- a/internal/usecase/fleet/exposurereader/service_test.go
+++ b/internal/usecase/fleet/exposurereader/service_test.go
@@ -4,13 +4,38 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityoccurrence"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityrisk"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
+
+type fakeProcesses struct {
+	byHost map[shared.ID][]ports.ProcessSnapshot
+	err    error
+}
+
+func (p fakeProcesses) ListRunningByAsset(_ context.Context, assetID shared.ID) ([]ports.ProcessSnapshot, error) {
+	return p.byHost[assetID], p.err
+}
+
+type fakeComponents struct {
+	byEng map[shared.ID][]sbom.ComponentRecord
+	err   error
+}
+
+func (c fakeComponents) ListCurrentComponentsByEngagement(_ context.Context, _, engagementID shared.ID) ([]sbom.ComponentRecord, error) {
+	return c.byEng[engagementID], c.err
+}
+
+func techHost(host string) asset.ComponentMembership {
+	return asset.ComponentMembership{TenantID: "t1", AssetID: "asset-1", ComponentID: shared.ID(host), Role: asset.MembershipRole("technical")}
+}
 
 type fakeMembership struct {
 	engs      []*engagement.Engagement
@@ -182,6 +207,53 @@ func TestAbstainWhenAllOccurrencesUnscored(t *testing.T) {
 	rd := mustReader(t, m, occs, fakeRisk{byOcc: map[shared.ID]vulnerabilityrisk.Assessment{}})
 	if _, err := rd.ListAssetVulnerableComponents(ctxT(), "asset-1"); !errors.Is(err, shared.ErrNotFound) {
 		t.Fatalf("all-unscored detected occurrences must abstain (ErrNotFound), not read as clean, got %v", err)
+	}
+}
+
+func TestRunningVsInstalledMarksRunning(t *testing.T) {
+	m := fakeMembership{
+		engs:      oneEngagement(),
+		projects:  []asset.ComponentMembership{member("c1"), member("c2")}, // vulnerable code components
+		technical: []asset.ComponentMembership{techHost("host-1")},         // the host bridge
+	}
+	occs := &fakeOccurrences{byEng: map[shared.ID][]vulnerabilityoccurrence.Occurrence{
+		"eng-1": {occ("o1", "c1", "CVE-1"), occ("o2", "c2", "CVE-2")},
+	}}
+	risk := fakeRisk{byOcc: map[shared.ID]vulnerabilityrisk.Assessment{"o1": assess(2, false), "o2": assess(2, false)}}
+	// host-1 runs /usr/bin/openssl; c1 is "openssl" (running), c2 is "leftpad" (installed-only).
+	procs := fakeProcesses{byHost: map[shared.ID][]ports.ProcessSnapshot{
+		"host-1": {{TenantID: "t1", AssetID: "host-1", EntityID: "e1", Path: "/usr/bin/openssl", Comm: "openssl", Running: true, LastSeenAt: time.Unix(1, 0)}},
+	}}
+	comps := fakeComponents{byEng: map[shared.ID][]sbom.ComponentRecord{
+		"eng-1": {{ComponentID: "c1", Name: "openssl"}, {ComponentID: "c2", Name: "leftpad"}},
+	}}
+	rd, err := NewReaderWithRuntime(m, occs, risk, procs, comps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := rd.ListAssetVulnerableComponents(ctxT(), "asset-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	byComp := map[shared.ID]bool{}
+	for _, g := range got {
+		byComp[g.ComponentID] = g.Running
+	}
+	if !byComp["c1"] {
+		t.Fatal("c1 (openssl) matches a running process → must be Running")
+	}
+	if byComp["c2"] {
+		t.Fatal("c2 (leftpad) has no running process → must be installed-only")
+	}
+}
+
+func TestRuntimeReaderRequiresBothDeps(t *testing.T) {
+	m := fakeMembership{}
+	if _, err := NewReaderWithRuntime(m, &fakeOccurrences{}, fakeRisk{}, nil, fakeComponents{}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("nil process store must be rejected")
+	}
+	if _, err := NewReaderWithRuntime(m, &fakeOccurrences{}, fakeRisk{}, fakeProcesses{}, nil); !errors.Is(err, shared.ErrValidation) {
+		t.Fatal("nil component lister must be rejected")
 	}
 }
 


### PR DESCRIPTION
feat(exposure): real running-vs-installed (B5 processes → RiskContext.Exposure) (#634/#667)

Sets the real Running flag on the exposure path, using the merged B5 process
snapshot store as the running side.

- Adds ListCurrentComponentsByEngagement to the memory + postgres
  ComponentInventoryStore concretes (id+name+package of the engagement's LATEST
  SBOM) — the shipped ListCurrentComponents requires a package/CPE key the caller
  doesn't have, so a vulnerable ComponentID could not be resolved to a name. Not
  added to ports.ComponentInventoryStore; exposurereader defines a narrow
  ComponentLister the concrete store satisfies. Both twins are latest-SBOM +
  tenant-fail-closed (memory now cross-checks ctx tenant like its sibling).
- exposurereader.NewReaderWithRuntime adds optional B5 ProcessLister +
  ComponentLister. When wired, markRunning resolves the asset's HOST assets via
  technical-asset memberships (the confirmed business→host bridge:
  technical_asset_id FKs fleet_assets), gathers running exec basenames/comms per
  host (ListRunningByAsset), and marks a vulnerable component Running when its
  package name matches (case-insensitive EXACT basename/comm == name/package).
  NewReader (no runtime) keeps installed-only.

Safety: the match only ever ESCALATES to Running (never clears), so a process
rename can at worst under-report (installed), never manipulate an already-Running
component down; exact-match keeps over-report narrow. Per-asset containment +
ctx-tenant on every store call (B5 ListRunningByAsset is itself ctx-scoped) — no
cross-tenant path. Attacker-influenceable Comm/Path are only string-compared,
never put in a query. markRunning errors propagate (never a silent false-clean).

Dual-reviewed (go-arch MERGEABLE, security SHIP — monotonic match, no IDOR, no
injection). Folded every finding: memory↔postgres latest-SBOM parity + memory
ctx-tenant check (both LOW), technical-memberships fetched once (no redundant
query), package doc. exposurereader 84.6% (running-match test: openssl→Running,
leftpad→installed); memory + PG enumeration tests green.

End-to-end note: the composition-root wiring (build the reader with
NewReaderWithRuntime + the concrete stores, feed exposureuc → the tri-score
assembler) is the remaining step to observe this in the running server.
