### PR TITLE
fix(secretscan): mask #, // and /* */ comments, not only VB comments

### DIFF
--- a/internal/infrastructure/tools/secretscan/comment_mask.go
+++ b/internal/infrastructure/tools/secretscan/comment_mask.go
@@ -1,0 +1,153 @@
+package secretscan
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// maskComments blanks comment regions of a source file BEFORE the secret rules run, so a secret that
+// lives only in a comment (a commented-out config line, an example key in a doc block, dead code) does
+// not surface as a live finding. Like maskVBComments it preserves every byte offset and newline — it
+// overwrites comment bytes with spaces — so reported line numbers and match offsets stay exact.
+//
+// It is deliberately CONSERVATIVE to avoid false NEGATIVES (masking a real secret in live code): a
+// marker inside a string literal is never treated as a comment, and a `#` is only a comment when it
+// starts a line or follows whitespace (the YAML/shell/Python/Ruby/TOML rule — so `url#frag` or
+// `a#b` is left intact and still scanned).
+func maskComments(rel string, data []byte) []byte {
+	switch {
+	case strings.EqualFold(filepath.Ext(rel), ".vb"):
+		return maskVBComments(data)
+	case hashCommentFile(rel):
+		return maskLineComments(data, "#", true)
+	case slashCommentFile(rel):
+		return maskBlockComments(maskLineComments(data, "//", false))
+	}
+	return data
+}
+
+// hashCommentExts are file types whose line comments start with '#'.
+var hashCommentExts = map[string]bool{
+	".yaml": true, ".yml": true, ".sh": true, ".bash": true, ".zsh": true, ".ksh": true,
+	".py": true, ".rb": true, ".toml": true, ".tf": true, ".tfvars": true, ".ini": true,
+	".cfg": true, ".conf": true, ".env": true, ".pl": true, ".pm": true, ".r": true,
+	".ps1": true, ".psm1": true, ".mk": true,
+}
+
+// hashCommentBases are extension-less files whose line comments start with '#'.
+var hashCommentBases = map[string]bool{
+	"dockerfile": true, "makefile": true, ".gitlab-ci.yml": true, ".env": true,
+}
+
+// slashCommentExts are file types with '//' line comments and '/* */' block comments.
+var slashCommentExts = map[string]bool{
+	".go": true, ".c": true, ".h": true, ".cpp": true, ".cc": true, ".cxx": true, ".hpp": true,
+	".java": true, ".js": true, ".jsx": true, ".mjs": true, ".cjs": true, ".ts": true, ".tsx": true,
+	".cs": true, ".kt": true, ".kts": true, ".rs": true, ".scala": true, ".swift": true, ".php": true,
+	".css": true, ".scss": true, ".less": true, ".dart": true, ".proto": true,
+}
+
+func hashCommentFile(rel string) bool {
+	base := strings.ToLower(filepath.Base(rel))
+	if hashCommentBases[base] || strings.HasPrefix(base, "dockerfile") {
+		return true
+	}
+	return hashCommentExts[strings.ToLower(filepath.Ext(rel))]
+}
+
+func slashCommentFile(rel string) bool {
+	return slashCommentExts[strings.ToLower(filepath.Ext(rel))]
+}
+
+// maskLineComments blanks each line from an unquoted comment marker to end-of-line, preserving offsets.
+// A marker inside a "…", '…' or `…` string is ignored (its opening quote is tracked, with backslash
+// escapes). When requireBoundary is set (the '#' family), the marker only starts a comment at line start
+// or after whitespace, matching those languages' rules so `key=val#frag` is not mistaken for a comment.
+// Quote state resets at each newline (single-line string semantics), which errs toward NOT masking.
+func maskLineComments(data []byte, marker string, requireBoundary bool) []byte {
+	out := append([]byte(nil), data...)
+	m0 := marker[0]
+	twoChar := len(marker) > 1
+	for start := 0; start < len(out); {
+		end := start
+		for end < len(out) && out[end] != '\n' {
+			end++
+		}
+		var quote byte // 0 = outside any string literal
+		atBoundary := true
+		for i := start; i < end; i++ {
+			c := out[i]
+			if quote != 0 {
+				if c == '\\' && i+1 < end {
+					i++
+					continue
+				}
+				if c == quote {
+					quote = 0
+				}
+				atBoundary = false
+				continue
+			}
+			if c == '"' || c == '\'' || c == '`' {
+				quote = c
+				atBoundary = false
+				continue
+			}
+			if c == m0 && (!twoChar || (i+1 < end && out[i+1] == marker[1])) && (!requireBoundary || atBoundary) {
+				for j := i; j < end; j++ {
+					out[j] = ' '
+				}
+				break
+			}
+			atBoundary = c == ' ' || c == '\t'
+		}
+		start = end + 1
+	}
+	return out
+}
+
+// maskBlockComments blanks C-style /* … */ block comments (which may span lines), preserving newlines and
+// byte offsets. A /* opening inside a string literal is ignored. Quote state resets at newline so an
+// unterminated single-line string cannot hide a block comment on a later line.
+func maskBlockComments(data []byte) []byte {
+	out := append([]byte(nil), data...)
+	var quote byte
+	for i := 0; i < len(out); i++ {
+		c := out[i]
+		if c == '\n' {
+			quote = 0
+			continue
+		}
+		if quote != 0 {
+			if c == '\\' && i+1 < len(out) && out[i+1] != '\n' {
+				i++
+				continue
+			}
+			if c == quote {
+				quote = 0
+			}
+			continue
+		}
+		if c == '"' || c == '\'' || c == '`' {
+			quote = c
+			continue
+		}
+		if c == '/' && i+1 < len(out) && out[i+1] == '*' {
+			j := i + 2
+			for j+1 < len(out) && !(out[j] == '*' && out[j+1] == '/') {
+				j++
+			}
+			blankEnd := j + 2
+			if blankEnd > len(out) {
+				blankEnd = len(out)
+			}
+			for k := i; k < blankEnd; k++ {
+				if out[k] != '\n' {
+					out[k] = ' '
+				}
+			}
+			i = blankEnd - 1
+		}
+	}
+	return out
+}

--- a/internal/infrastructure/tools/secretscan/comment_mask_test.go
+++ b/internal/infrastructure/tools/secretscan/comment_mask_test.go
@@ -1,0 +1,57 @@
+package secretscan
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMaskCommentsBlanksCommentsButKeepsLiveCode(t *testing.T) {
+	secret := "AKIA" + "IOSFODNN7EXAMPLE"
+	cases := []struct {
+		name       string
+		rel        string
+		in         string
+		masked     bool // is the secret expected to be blanked?
+		keepOffset bool // must byte length + newline count be preserved?
+	}{
+		{"yaml full-line comment", "config.yml", "# key = " + secret + "\nname: app\n", true, true},
+		{"yaml inline comment", "config.yml", "name: app # note " + secret + "\n", true, true},
+		{"yaml live value not masked", "config.yml", "token: " + secret + "\n", false, true},
+		{"yaml hash-in-value not a comment", "config.yml", "url: value#" + secret + "\n", false, true},
+		{"yaml hash inside quotes not a comment", "config.yml", "token: \"" + secret + "#x\"\n", false, true},
+		{"shell full-line comment", "deploy.sh", "  # export KEY=" + secret + "\necho hi\n", true, true},
+		{"go slash comment", "main.go", "// key := \"" + secret + "\"\nfunc x() {}\n", true, true},
+		{"go slash inline comment", "main.go", "x := 1 // " + secret + "\n", true, true},
+		{"go url in string not masked", "main.go", "u := \"http://" + secret + "\"\n", false, true},
+		{"go live string secret not masked", "main.go", "k := \"" + secret + "\"\n", false, true},
+		{"c block comment", "a.c", "/* creds:\n" + secret + "\n*/\nint main(){}\n", true, true},
+		{"c block on one line", "a.c", "int x; /* " + secret + " */\n", true, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out := maskComments(tc.rel, []byte(tc.in))
+			if tc.keepOffset {
+				if len(out) != len(tc.in) {
+					t.Fatalf("byte length changed %d -> %d (offsets must be preserved)", len(tc.in), len(out))
+				}
+				if strings.Count(string(out), "\n") != strings.Count(tc.in, "\n") {
+					t.Fatalf("newline count changed (line numbers must be preserved)")
+				}
+			}
+			got := strings.Contains(string(out), secret)
+			if tc.masked && got {
+				t.Fatalf("secret in a comment must be blanked, but survived:\n%q", out)
+			}
+			if !tc.masked && !got {
+				t.Fatalf("secret in LIVE code/data must NOT be blanked (false negative):\n%q", out)
+			}
+		})
+	}
+}
+
+func TestMaskCommentsLeavesUnknownFileTypesUntouched(t *testing.T) {
+	in := []byte("plain text # not a known comment language\n")
+	if string(maskComments("notes.txt", in)) != string(in) {
+		t.Fatal("an unknown file type must be scanned verbatim")
+	}
+}

--- a/internal/infrastructure/tools/secretscan/scanner.go
+++ b/internal/infrastructure/tools/secretscan/scanner.go
@@ -208,9 +208,9 @@ func stableFileSnapshot(before, after fs.FileInfo, bytesRead int64) bool {
 }
 
 func (s *Scanner) scanContent(rel string, data []byte, seen map[string]bool, out *[]ports.SecretRawFinding, limit int) bool {
-	if strings.EqualFold(filepath.Ext(rel), ".vb") {
-		data = maskVBComments(data)
-	}
+	// Blank comment regions (VB, #-family, //-and-/* */-family) before the rules run, so a secret that
+	// lives only in a comment is not reported as a live finding. Offsets/newlines are preserved.
+	data = maskComments(rel, data)
 	text := string(data)
 	for i := range s.rules {
 		r := &s.rules[i]


### PR DESCRIPTION
fix(secretscan): mask #, // and /* */ comments, not only VB comments

A trial on a real GitOps repo surfaced 76/477 secret findings on commented-out
lines (critical 40/65 = 61%): private keys, connection strings, and credentials
sitting in dead comments were reported as live findings. The scanner only masked
VB comments (maskVBComments), so every other language's comments were scanned.

Generalize masking to the comment styles those findings live in, reusing the
offset-preserving approach (comment bytes overwritten with spaces, newlines kept,
so reported line numbers/offsets stay exact):
- '#' line comments (YAML, shell, Python, Ruby, TOML, tf, ini, Dockerfile, …),
  only when the '#' starts a line or follows whitespace — so `url#frag` / `a#b`
  and a '#' inside a quoted string are left intact and still scanned.
- '//' line comments and '/* */' block comments (Go, C/C++, Java, JS/TS, C#,
  Rust, …), string-aware so `"http://…"` in a live string is not masked.

Deliberately conservative to avoid false NEGATIVES: a marker inside a string
literal is never a comment, and quote state resets per line. Tests assert secrets
in comments are blanked AND secrets in live code/strings (and hash-in-value) are
NOT — the important direction for a security scanner. build/vet/gofmt clean.
