### PR TITLE
fix(sca): degrade to INCOMPLETE when SBOM generation fails, don't abort the scan

### DIFF
--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -2451,6 +2451,7 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	// analyzer-version invalidation). Best-effort – a miss/error just regenerates.
 	producerVer := sbomProducerVersion(s.prov.ToolVersions)
 	var doc *sbom.SBOM
+	var sbomGenErr error // non-nil ⇒ SBOM production failed; degrade to an empty inventory + INCOMPLETE
 	cacheHit := false
 	if s.sbomCache != nil {
 		if cached, ok, _ := s.sbomCache.Load(ctx, ws.Dir, producerVer); ok && cached != nil {
@@ -2460,10 +2461,15 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	if doc == nil {
 		doc, err = s.sbomGen.Generate(ctx, ws.Dir)
 		if err != nil {
+			// Degrade, don't abort. An SBOM producer (syft) failing or being absent must NOT discard the
+			// source-only analyzers (secret / SAST / misconfig) — they run in-process, need no SBOM, and
+			// doctor advertises them as available with no external setup. Continue with an empty inventory
+			// and mark the scan INCOMPLETE (below) so the missing dependency/vuln/license coverage is
+			// explicit, never a silent clean result.
 			trace.fail(step, err)
-			return nil, fmt.Errorf("generate sbom: %w", err)
-		}
-		if s.sbomCache != nil {
+			sbomGenErr = err
+			doc = &sbom.SBOM{}
+		} else if s.sbomCache != nil {
 			// Store re-fingerprints ws.Dir; this assumes the generator did NOT mutate the workspace (Syft +
 			// the owned parsers read only), so the stored key matches the next clean scan's Load key.
 			_ = s.sbomCache.Store(ctx, ws.Dir, producerVer, doc) // best-effort; a store error never fails the scan
@@ -2477,7 +2483,9 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 		doc.Audit.CreatedAt = now
 		doc.Audit.UpdatedAt = now
 	}
-	trace.succeed(step, "SBOM generated", map[string]int{"components": countComponents(doc), "dependencies": len(doc.Dependencies), "cache_hit": boolToInt(cacheHit)})
+	if sbomGenErr == nil {
+		trace.succeed(step, "SBOM generated", map[string]int{"components": countComponents(doc), "dependencies": len(doc.Dependencies), "cache_hit": boolToInt(cacheHit)})
+	}
 	// SBOM producer cross-check: when a 2nd producer is configured, diff the two RAW
 	// component sets – BEFORE enrichment, so it compares the PRODUCERS themselves, not a shared post-process –
 	// and record components only one producer emitted as ungated CapCorrelation judgments for human review.
@@ -2922,6 +2930,19 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 		LineCoverage:             opts.LineCoverage,
 		Gate:                     opts.Gate,
 		Comparison:               comparisonFromWorkspace(req, ws),
+	}
+	// SBOM production failed: force the scan INCOMPLETE and surface it, so the empty dependency/vuln/
+	// license coverage reads as a known gap rather than a clean result. The source-only analyzers below
+	// still run and contribute findings.
+	if sbomGenErr != nil {
+		const warn = "SBOM generation did not run (producer unavailable or errored); dependency, vulnerability and license coverage is EMPTY — the source-only analyzers (secret/SAST/misconfig) still ran"
+		result.Completeness.Confident = false
+		if result.Completeness.Warning == "" {
+			result.Completeness.Warning = warn
+		} else {
+			result.Completeness.Warning = warn + "; " + result.Completeness.Warning
+		}
+		result.SourceWarnings = append(result.SourceWarnings, warn)
 	}
 	// Container-image layer attribution (Epic D): join each vuln to the layer that introduced
 	// its component, and classify base vs application layers. No-op for non-image scans.

--- a/internal/usecase/sca/service_test.go
+++ b/internal/usecase/sca/service_test.go
@@ -1780,6 +1780,42 @@ func TestSecretScanTruncationWarning(t *testing.T) {
 	}
 }
 
+type erroringSBOM struct{}
+
+func (erroringSBOM) Generate(context.Context, string) (*sbom.SBOM, error) {
+	return nil, errors.New("syft not installed")
+}
+
+type countingSecretScanner struct{ calls int }
+
+func (*countingSecretScanner) Name() string { return "counting-secret-scanner" }
+func (c *countingSecretScanner) ScanFiles(context.Context, string) (ports.SecretScanReport, error) {
+	c.calls++
+	return ports.SecretScanReport{}, nil
+}
+
+// TestScanDegradesWhenSBOMGenerationFails: an SBOM producer failure must NOT abort the whole scan — the
+// source-only analyzers still run and the scan is marked INCOMPLETE rather than returning a silent clean
+// (zero-finding) result.
+func TestScanDegradesWhenSBOMGenerationFails(t *testing.T) {
+	sec := &countingSecretScanner{}
+	svc := NewService(&fakeEngRepo{eng: engagementWithScope(t, "myrepo")}, nil, nil, nil, nil, nil, nil, nil, ports.Provenance{}, fakeClock{t: time.Unix(0, 0).UTC()}, &fakeAudit{}, shared.SeverityHigh, 0, &fakeAcquirer{dir: t.TempDir()}, &fakeDetector{}, erroringSBOM{}, []ports.DetectionSource{fakeVuln{}}, nil, fakeLic{}, nil)
+	svc.SetSecretScanner(sec)
+	res, err := svc.Scan(context.Background(), "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"})
+	if err != nil {
+		t.Fatalf("SBOM-generation failure must degrade, not abort the scan: %v", err)
+	}
+	if res.Completeness.Confident {
+		t.Fatal("a scan without an SBOM must be marked INCOMPLETE (Confident=false)")
+	}
+	if res.Completeness.Warning == "" {
+		t.Fatal("expected an INCOMPLETE completeness warning when SBOM generation fails")
+	}
+	if sec.calls != 1 {
+		t.Fatalf("the source-only secret scanner must still run when SBOM generation fails (calls=%d)", sec.calls)
+	}
+}
+
 func TestEvidenceFailurePreventsPersistence(t *testing.T) {
 	ctx := context.Background()
 	findings := memory.NewFindingRepository()


### PR DESCRIPTION
fix(sca): degrade to INCOMPLETE when SBOM generation fails, don't abort the scan

When the SBOM producer (syft) errored or was absent, the whole scan aborted with
`generate sbom: …` and returned zero findings — even though the source-only
analyzers (secret, SAST, misconfig) run in-process, need no SBOM, and doctor
advertises them as available. On a repo with no dependency manifest (e.g. a pure
GitOps repo) that meant an empty result despite those three being ready.

Degrade instead of abort: on SBOM-generation failure, continue with an empty
inventory and mark the scan INCOMPLETE — set Completeness.Confident=false, add a
completeness warning, and a SourceWarning — so the missing dependency/vuln/license
coverage is explicit, never a silent clean result. The secret/SAST/misconfig
analyzers then still run and contribute findings.

Added a regression test (erroring SBOM generator + a counting secret scanner)
asserting the scan does not error, is marked INCOMPLETE, and the source-only
scanner still runs. build/vet/gofmt clean; sca suite green.
