### PR TITLE
test(release): smoke-test the packaged synapse-cli tarball, not a from-source build

### DIFF
--- a/.github/workflows/release-scan-gate.yml
+++ b/.github/workflows/release-scan-gate.yml
@@ -89,3 +89,26 @@ jobs:
           # Fail closed: a release with no scannable artifact must NOT pass vacuously.
           test "${scanned}" -gt 0 || { echo "no artifacts were scanned — failing the release"; exit 1; }
           # The container image is scanned the same way once dockers_v2 image publishing is re-enabled.
+
+  tarball-smoke:
+    name: Smoke-test the packaged CLI tarball
+    runs-on: ubuntu-latest
+    needs: no-exit-swallow-lint
+    # Runs the shipped synapse-cli FROM the release tarball (not a from-source build) against a real
+    # sample, so a release whose packaged binary cannot complete a scan is caught — the v0.1.8 class
+    # (scan died at "persist scan: validation error: tenant context is required" while main was fine).
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Download + extract the Linux tarball, smoke-scan the packaged binary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="${{ github.event.release.tag_name || inputs.tag }}"
+          test -n "${tag}"
+          mkdir -p ./tarball ./tarball/extract
+          # goreleaser name_template is synapse_<ver>_Linux_<arch>.tar.gz; glob the arch string so this
+          # is robust whether goreleaser emits amd64 or x86_64.
+          gh release download "${tag}" --dir ./tarball --pattern 'synapse_*_Linux_*.tar.gz'
+          tar -xzf ./tarball/synapse_*_Linux_*.tar.gz -C ./tarball/extract
+          ./scripts/release/smoke-scan.sh ./tarball/extract

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help install tools dev build run test harness dataplane-e2e vet lint format typecheck tidy ebpf-generate ai-triage-eval ai-triage-compare ai-triage-release ai-triage-drift ai-triage-curate ai-triage-verify \
-        rulepack-verify rulepack-replay rulepack-gate docker-build docker-up docker-down clean web-dev web-build smoke
+        rulepack-verify rulepack-replay rulepack-gate docker-build docker-up docker-down clean web-dev web-build smoke release-smoke
 
 GO ?= go
 IMAGE ?= synapse-api:dev
@@ -113,3 +113,7 @@ web-build: ## Build the web app
 
 smoke: build ## Build then probe /healthz
 	./bin/synapse-api & sleep 1; curl -s localhost:8080/healthz; kill %1
+
+release-smoke: ## Build synapse-cli into ./bin and run a real scan from it (packaged-binary smoke)
+	$(GO) build -o bin/synapse-cli ./cmd/synapse-cli
+	./scripts/release/smoke-scan.sh bin

--- a/scripts/release/smoke-scan.sh
+++ b/scripts/release/smoke-scan.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Release smoke test: run a real scan from a PACKAGED synapse-cli and require it to complete and produce
+# findings. The release scan-gate builds the scanner from source, so it never exercised the shipped
+# tarball binary — which is how v0.1.8 shipped a scan that died at "persist scan: validation error:
+# tenant context is required" while main was fine. This closes that gap.
+#
+# Usage: smoke-scan.sh <dir-with-synapse-cli>
+#   <dir> is an extracted release tarball (or ./bin for a local `make build`). The sample is
+#   self-contained and exercises the IN-PROCESS analyzers, so no syft/grype is required.
+#
+# The default scan legitimately exits non-zero when it reports a high finding, so this does NOT assert
+# a zero exit — it asserts the scan COMPLETED without a hard error (the v0.1.8 class: a persist/validation
+# failure or a panic) and that the packaged binary actually produced a finding.
+set -euo pipefail
+
+BINDIR="${1:-bin}"
+CLI="$BINDIR/synapse-cli"
+if [ ! -x "$CLI" ]; then
+	echo "release-smoke: $CLI not found or not executable" >&2
+	exit 2
+fi
+
+SAMPLE="$(mktemp -d)"
+trap 'rm -rf "$SAMPLE"' EXIT
+
+# A finding the in-process analyzers detect with no external tools: a well-known AWS example access-key
+# id (assembled at runtime so this script is not itself flagged as carrying a live key).
+printf 'aws_access_key_id = %s%s\n' "AKIA" "IOSFODNN7EXAMPLE" > "$SAMPLE/config.ini"
+
+fail() {
+	echo "release-smoke: FAIL — $1" >&2
+	shift || true
+	[ "$#" -gt 0 ] && { echo "----- output -----" >&2; head -60 "$@" >&2; }
+	exit 1
+}
+
+# 1) Default scan (the exact path users run, which PERSISTS the scan — the step that regressed in v0.1.8).
+#    A high finding flips the exit code, so we don't check it; we require the scan to have COMPLETED
+#    without a hard error rather than aborting like v0.1.8 did.
+echo "release-smoke: running default scan (persist path)…"
+DEF="$SAMPLE/default.log"
+set +e
+"$CLI" scan "$SAMPLE" >"$DEF" 2>&1
+set -e
+if grep -qiE 'persist scan|validation error|panic:|runtime error' "$DEF"; then
+	fail "the packaged scan hit a hard error (v0.1.8 class)" "$DEF"
+fi
+if ! grep -qiE 'finding|sca.scan' "$DEF"; then
+	fail "the packaged scan did not complete a scan" "$DEF"
+fi
+
+# 2) JSON scan MUST report a finding for the planted key file, proving the packaged binary actually
+#    scanned (in-process; no syft/grype), not just exited cleanly on an empty result.
+echo "release-smoke: running JSON scan and checking for findings…"
+OUT="$SAMPLE/out.json"
+set +e
+"$CLI" scan "$SAMPLE" --json >"$OUT" 2>"$SAMPLE/json.err"
+set -e
+if ! grep -q 'config.ini' "$OUT"; then
+	fail "the packaged scanner produced no finding for the planted key file" "$OUT"
+fi
+
+echo "release-smoke: OK — packaged synapse-cli scanned and reported findings"


### PR DESCRIPTION
test(release): smoke-test the PACKAGED synapse-cli tarball, not a from-source build

The release scan-gate builds the scanner from source, so no test ever ran a scan
from the shipped tarball binary — which is how v0.1.8 shipped a scan that died at
"persist scan: validation error: tenant context is required" while main was fine.

Add a smoke test that extracts the release tarball and runs the packaged
synapse-cli against a sample:
- scripts/release/smoke-scan.sh <dir>: plants a well-known AWS example key (built
  at runtime so the script isn't itself flagged) in a sample repo, runs the default
  scan (the path that PERSISTS — the v0.1.8 regression point) and requires it to
  complete without a hard error (persist/validation failure or panic), then runs a
  --json scan and requires a finding for the planted file. Uses only the in-process
  analyzers, so no syft/grype needed. A high finding legitimately flips the exit
  code, so it checks for completion + a finding rather than a zero exit.
- `make release-smoke`: build synapse-cli into ./bin and run the smoke locally.
- release-scan-gate.yml gains a `tarball-smoke` job that downloads + extracts the
  Linux tarball and runs the smoke against the ACTUAL packaged binary.

Verified locally (`make release-smoke` green); the no-exit-swallow release lint
still passes.
