### PR TITLE
fix(sca): don't claim osv.dev in the evidence snapshot on an offline scan

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -1192,14 +1192,16 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 			"go-enry": buildinfo.Module("github.com/go-enry/go-enry/v2"),
 			"synapse": buildinfo.App(),
 		},
-		VulnDBSource: "osv.dev",
 	}
 	// Grype (offline DB) always; live OSV unless --offline / SYNAPSE_OFFLINE (air-gapped / fast path).
 	detectionSources := []ports.DetectionSource{grype.New(cfg.GrypeBin, cfg.GrypeDBDir)}
 	if offline || cfg.Offline {
-		// Make the reduced-coverage mode visible: the operator chose lower recall for speed.
+		// Make the reduced-coverage mode visible: the operator chose lower recall for speed. Leave
+		// VulnDBSource empty so the evidence snapshot does NOT claim osv.dev was queried when it wasn't
+		// (Grype's DB version is recorded separately in GrypeDBVersion).
 		fmt.Fprintln(os.Stderr, "synapse-cli: offline mode – live OSV disabled; detecting with Grype's offline DB only")
 	} else {
+		prov.VulnDBSource = "osv.dev"
 		detectionSources = append([]ports.DetectionSource{osv.New(cfg.OSVBaseURL, nil)}, detectionSources...)
 	}
 	sca := scauc.NewService(

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -2175,7 +2175,7 @@ func (s *Service) runImportedSBOMPipeline(ctx context.Context, actor string, eng
 			sourceWarnings = append(sourceWarnings, fmt.Sprintf("detection source %q did not run (tool/DB missing or errored) – its vulnerabilities are NOT included", src.Name()))
 		}
 	}
-	snap := ports.ScanSnapshot{ToolVersions: toolVersions, VulnDBSnapshot: s.prov.VulnDBSource + "@" + now.UTC().Format(time.RFC3339), GrypeDBVersion: grypeDB}
+	snap := ports.ScanSnapshot{ToolVersions: toolVersions, VulnDBSnapshot: vulnDBSnapshot(s.prov.VulnDBSource, now), GrypeDBVersion: grypeDB}
 	sourceWarnings = append(sourceWarnings, dbFreshnessWarnings(toolVersions, now, s.dbMaxAgeDays)...) // stale-DB freshness policy
 	manifest := buildManifest(toolVersions, snap.VulnDBSnapshot, grypeDB, doc)
 	manifest.SBOMSHA256 = record.SHA256
@@ -2884,7 +2884,7 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	}
 	snap := ports.ScanSnapshot{
 		ToolVersions:   toolVersions,
-		VulnDBSnapshot: s.prov.VulnDBSource + "@" + now.UTC().Format(time.RFC3339),
+		VulnDBSnapshot: vulnDBSnapshot(s.prov.VulnDBSource, now),
 		GrypeDBVersion: grypeDB,
 	}
 	sourceWarnings = append(sourceWarnings, dbFreshnessWarnings(toolVersions, now, s.dbMaxAgeDays)...) // stale-DB freshness policy
@@ -4193,6 +4193,17 @@ func (s *Service) newRunID() string {
 // buildManifest assembles the reproducibility manifest + score. The
 // repro score is the fraction of detection inputs that are version-pinned; the
 // live OSV.dev query is honestly counted as unpinned.
+// vulnDBSnapshot builds the "<source>@<time>" evidence marker for the online vulnerability feed. It
+// returns "" when no online source was queried (e.g. an --offline / air-gapped scan), so the evidence
+// never asserts a feed — like osv.dev — that was never contacted. Grype's offline DB version is recorded
+// separately in GrypeDBVersion, so offline scans still carry honest DB provenance.
+func vulnDBSnapshot(source string, t time.Time) string {
+	if source == "" {
+		return ""
+	}
+	return source + "@" + t.UTC().Format(time.RFC3339)
+}
+
 func buildManifest(toolVersions map[string]string, vulnDBSnapshot, grypeDB string, doc *sbom.SBOM) ports.ScanManifest {
 	m := ports.ScanManifest{
 		ToolVersions:       toolVersions,

--- a/internal/usecase/sca/service_test.go
+++ b/internal/usecase/sca/service_test.go
@@ -1780,6 +1780,34 @@ func TestSecretScanTruncationWarning(t *testing.T) {
 	}
 }
 
+func TestVulnDBSnapshotHonestWhenOffline(t *testing.T) {
+	ts := time.Unix(0, 0).UTC()
+	if got := vulnDBSnapshot("", ts); got != "" {
+		t.Fatalf("an offline scan (no online source queried) must yield an empty snapshot, got %q", got)
+	}
+	if got := vulnDBSnapshot("osv.dev", ts); got != "osv.dev@1970-01-01T00:00:00Z" {
+		t.Fatalf("online snapshot = %q, want osv.dev@<time>", got)
+	}
+}
+
+// TestScanOfflineSnapshotDoesNotClaimOSV: a scan whose provenance names no online vuln source (the
+// --offline / air-gapped CLI path) must NOT record vuln_db_snapshot="osv.dev@…" — that would assert a
+// feed that was never queried.
+func TestScanOfflineSnapshotDoesNotClaimOSV(t *testing.T) {
+	// newSvc builds the Service with ports.Provenance{} (empty VulnDBSource) = the offline shape.
+	svc := newSvc(&fakeEngRepo{eng: engagementWithScope(t, "myrepo")}, fakeClock{t: time.Unix(0, 0).UTC()}, &fakeAcquirer{dir: t.TempDir()}, &fakeAudit{}, &fakeDetector{})
+	res, err := svc.Scan(context.Background(), "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.VulnDBSnapshot != "" {
+		t.Fatalf("offline scan must not claim an online vuln feed, got vuln_db_snapshot=%q", res.VulnDBSnapshot)
+	}
+	if res.Manifest.VulnDBSnapshot != "" {
+		t.Fatalf("offline scan manifest must not claim an online vuln feed, got %q", res.Manifest.VulnDBSnapshot)
+	}
+}
+
 type erroringSBOM struct{}
 
 func (erroringSBOM) Generate(context.Context, string) (*sbom.SBOM, error) {


### PR DESCRIPTION
fix(sca): don't claim osv.dev in the evidence snapshot on an offline scan

vuln_db_snapshot recorded "osv.dev@<time>" even under --offline / --network none,
where OSV.dev is never queried — a false provenance line for a product that sells
"tamper-evident evidence" and "hash-chained custody".

The CLI now leaves Provenance.VulnDBSource empty in offline mode (it only sets
"osv.dev" when the live OSV source is actually wired), and the sca service builds
the snapshot via a helper that returns "" when no online source was queried.
Grype's offline DB version is still recorded separately in GrypeDBVersion, so an
offline scan keeps honest DB provenance without asserting a feed it never touched.

Tests cover the helper and a scan-level assertion that an offline-shaped provenance
yields an empty vuln_db_snapshot (result + manifest). build/vet/gofmt clean.
