### PR TITLE
fix(cli): don't emit RiskScore/EvidenceScore=0 as if the tool is broken

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -1695,7 +1695,13 @@ func printReport(target string, res *scauc.ScanResult) {
 		if f.KEV {
 			kev = " [KEV]"
 		}
-		fmt.Printf("    %-9s risk %5.2f  %s%s\n", f.Severity, f.RiskScore, f.Title, kev)
+		// Only show the risk column when it is actually computed (KEV→EPSS×CVSS enrichment). The CLI does
+		// not populate it, so printing "risk 0.00" for every finding reads as a broken tool.
+		risk := ""
+		if f.RiskScore > 0 {
+			risk = fmt.Sprintf(" risk %5.2f", f.RiskScore)
+		}
+		fmt.Printf("    %-9s%s  %s%s\n", f.Severity, risk, f.Title, kev)
 	}
 	if c := res.Compliance; c != nil {
 		scope := ""

--- a/internal/domain/finding/finding.go
+++ b/internal/domain/finding/finding.go
@@ -177,8 +177,10 @@ type Finding struct {
 
 	// Risk priority (CISA KEV -> EPSS x CVSS), copied from the source vuln so
 	// findings can be ordered by real risk. KEV findings rank above all.
-	KEV       bool
-	RiskScore float64
+	KEV bool
+	// RiskScore is the computed risk priority; omitted from JSON when unset (0) so a scan path that does
+	// not populate it — e.g. the CLI, which has no KEV/EPSS enrichment — does not emit a misleading 0.00.
+	RiskScore float64 `json:",omitempty"`
 
 	// Detection provenance: the sources that detected the underlying
 	// vulnerability and the multi-source confidence. Empty for non-SCA findings.
@@ -219,8 +221,9 @@ type Finding struct {
 
 	// EvidenceScore gates promotion: candidates below the threshold are not
 	// auto-promoted (deterministic evidence gating: AI-proposed findings are never
-	// auto-promoted).
-	EvidenceScore int
+	// auto-promoted). Omitted from JSON when unset (0), so a scan path that does not score evidence
+	// (e.g. the CLI) does not emit a meaningless 0.
+	EvidenceScore int `json:",omitempty"`
 
 	// ProposedBy is the actor that proposed an exploitation/AI finding (e.g. "agent:<sid>").
 	// It exists so the adversarial verifier that later raises the score CANNOT be the same

--- a/internal/domain/finding/riskscore_omitempty_test.go
+++ b/internal/domain/finding/riskscore_omitempty_test.go
@@ -1,0 +1,26 @@
+package finding
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestZeroRiskAndEvidenceOmittedFromJSON: a scan path that does not compute risk/evidence (e.g. the CLI)
+// must not emit "RiskScore":0 / "EvidenceScore":0, which reads as a broken tool; when computed they stay.
+func TestZeroRiskAndEvidenceOmittedFromJSON(t *testing.T) {
+	zero, err := json.Marshal(Finding{Title: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(zero), "RiskScore") || strings.Contains(string(zero), "EvidenceScore") {
+		t.Fatalf("zero RiskScore/EvidenceScore must be omitted from JSON: %s", zero)
+	}
+	scored, err := json.Marshal(Finding{Title: "x", RiskScore: 42, EvidenceScore: 80})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(scored), "RiskScore") || !strings.Contains(string(scored), "EvidenceScore") {
+		t.Fatalf("computed RiskScore/EvidenceScore must be present: %s", scored)
+	}
+}


### PR DESCRIPTION
fix(cli): don't emit RiskScore/EvidenceScore=0 as if the tool is broken

The CLI does not run the KEV→EPSS×CVSS risk enrichment or evidence scoring, so
every finding carried RiskScore 0 and EvidenceScore 0 — the text output printed
"risk 0.00" on every line and the JSON carried a constant 0, which reads as a
broken tool for a product that sells "reachability aware" risk ordering.

- JSON: add `json:",omitempty"` to RiskScore and EvidenceScore (mirrors the
  existing ClassReachability omitempty), so they appear only when actually computed
  (the server path) and are dropped when unset.
- Text: only print the risk column when RiskScore > 0.

Test asserts zero values are omitted and computed values are present. build/vet/
gofmt clean; finding/sca/httpapi/export suites green.
