### PR TITLE
fix(finding): omit empty DetectionState from JSON (constant-blank on one-shot scans)

### DIFF
--- a/internal/domain/finding/detectionstate_omitempty_test.go
+++ b/internal/domain/finding/detectionstate_omitempty_test.go
@@ -1,0 +1,19 @@
+package finding
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestEmptyDetectionStateOmittedFromJSON: a one-shot scan (e.g. the CLI) leaves DetectionState empty; it
+// must be omitted from JSON so consumers don't build logic on a constant blank field. A populated value
+// (the continuous-intelligence projection) still serializes.
+func TestEmptyDetectionStateOmittedFromJSON(t *testing.T) {
+	if b, _ := json.Marshal(Finding{Title: "x"}); strings.Contains(string(b), "DetectionState") {
+		t.Fatalf("empty DetectionState must be omitted: %s", b)
+	}
+	if b, _ := json.Marshal(Finding{Title: "x", DetectionState: "detected"}); !strings.Contains(string(b), "DetectionState") {
+		t.Fatalf("populated DetectionState must be present: %s", b)
+	}
+}

--- a/internal/domain/finding/finding.go
+++ b/internal/domain/finding/finding.go
@@ -193,9 +193,12 @@ type Finding struct {
 	OccurrenceID         shared.ID
 	ComponentFingerprint string
 	FixedVersion         string
-	DetectionState       string
-	RiskAssessmentID     shared.ID
-	EvaluatedAt          *time.Time
+	// DetectionState is the continuous-intelligence projection's lifecycle state; empty on a one-shot
+	// scan (e.g. the CLI) that has no stored occurrence history. Omitted from JSON when empty so a
+	// consumer does not build logic on a field that is a constant blank on those paths.
+	DetectionState   string `json:",omitempty"`
+	RiskAssessmentID shared.ID
+	EvaluatedAt      *time.Time
 
 	// Class separates actionable third-party findings from historical
 	// advisories matched against the project's own unversioned modules.


### PR DESCRIPTION
fix(finding): omit empty DetectionState from JSON (constant-blank on one-shot scans)

DetectionState is the continuous-intelligence projection's lifecycle state; on a
one-shot scan (e.g. the CLI, with no stored occurrence history) it is a constant
blank for every finding, so consumers could build logic on a meaningless field.
Add `json:",omitempty"` so it appears only when actually populated.

Class is deliberately left as-is: unlike DetectionState it is genuinely populated
(first_party) and is consumed server-side (e.g. the dashboard's
first_party_historical split), so it is a correct classification, not a
constant-blank artifact.

Test asserts empty DetectionState is omitted and a populated one is present.
build/vet/gofmt clean; finding/sca/httpapi suites green.
