### PR TITLE
feat(cli): high-confidence secret rules + a --min-confidence filter

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -994,7 +994,7 @@ func gradeNum(g rating.Grade) float64 {
 func usage() {
 	fmt.Fprintln(os.Stderr, "usage:")
 	fmt.Fprintln(os.Stderr, "  synapse-cli doctor [path] [--json]       # offline pre-scan readiness: toolchain, markers, and dimension coverage")
-	fmt.Fprintln(os.Stderr, "  synapse-cli scan <path|image-ref> [--image] [--offline] [--json] [--sarif] [--mode full|vulnerabilities|licenses] [--fail-on critical|high|medium|low|info] [--include-test] [--ignore-unfixed] [--detection-priority comprehensive|precise]")
+	fmt.Fprintln(os.Stderr, "  synapse-cli scan <path|image-ref> [--image] [--offline] [--json] [--sarif] [--mode full|vulnerabilities|licenses] [--fail-on critical|high|medium|low|info] [--min-confidence low|medium|high|very_high] [--include-test] [--ignore-unfixed] [--detection-priority comprehensive|precise]")
 	fmt.Fprintln(os.Stderr, "      --sarif    write a SARIF 2.1.0 report to stdout (for GitHub code-scanning upload); --fail-on still sets the exit code")
 	fmt.Fprintln(os.Stderr, "      --image    treat the argument as a container image reference (pulled via crane) instead of a local path")
 	fmt.Fprintln(os.Stderr, "      --offline  skip the live OSV.dev source; detect with Grype's offline DB only (air-gapped / fast)")
@@ -1032,10 +1032,14 @@ func runScan() {
 	sarifOut := false
 	sbomOut := false
 	includeTest := false
+	minConfidence := ""
 	for i := 3; i < len(os.Args); i++ {
 		switch {
 		case os.Args[i] == "--fail-on" && i+1 < len(os.Args):
 			failOn = shared.Severity(os.Args[i+1])
+			i++
+		case os.Args[i] == "--min-confidence" && i+1 < len(os.Args):
+			minConfidence = os.Args[i+1]
 			i++
 		case os.Args[i] == "--include-test":
 			includeTest = true
@@ -1068,6 +1072,12 @@ func runScan() {
 		fmt.Fprintf(os.Stderr, "synapse-cli: invalid --fail-on %q (want critical|high|medium|low|info)\n", failOn)
 		os.Exit(2)
 	}
+	switch minConfidence {
+	case "", "low", "medium", "high", "very_high":
+	default:
+		fmt.Fprintf(os.Stderr, "synapse-cli: invalid --min-confidence %q (want low|medium|high|very_high)\n", minConfidence)
+		os.Exit(2)
+	}
 	if priority == "" { // resolve the configured default here so an invalid env value gets this same exit-2 message
 		priority = os.Getenv("SYNAPSE_DETECTION_PRIORITY")
 	}
@@ -1087,7 +1097,7 @@ func runScan() {
 		fmt.Fprintln(os.Stderr, "synapse-cli: choose only one of --json, --sarif or --sbom")
 		os.Exit(2)
 	}
-	if err := run(os.Args[2], failOn, mode, priority, ignoreUnfixed, image, offline, jsonOut, sarifOut, sbomOut, includeTest); err != nil {
+	if err := run(os.Args[2], failOn, mode, priority, minConfidence, ignoreUnfixed, image, offline, jsonOut, sarifOut, sbomOut, includeTest); err != nil {
 		fmt.Fprintln(os.Stderr, "synapse-cli:", err)
 		os.Exit(1)
 	}
@@ -1165,7 +1175,37 @@ func (stderrAudit) Record(_ context.Context, e ports.AuditEntry) error {
 
 var _ ports.AuditLogger = stderrAudit{}
 
-func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfixed, image, offline, jsonOut, sarifOut, sbomOut, includeTest bool) error {
+func confidenceRank(c string) int {
+	switch c {
+	case "very_high":
+		return 4
+	case "high":
+		return 3
+	case "medium":
+		return 2
+	case "low":
+		return 1
+	default:
+		return 0 // unset / unknown
+	}
+}
+
+// filterByConfidence drops findings whose confidence is below min. A finding with no confidence (SAST /
+// misconfig do not carry one) is kept — --min-confidence targets the confidence-bearing SCA/secret
+// findings, not a blanket drop of everything unscored.
+func filterByConfidence(findings []finding.Finding, min string) []finding.Finding {
+	threshold := confidenceRank(min)
+	out := make([]finding.Finding, 0, len(findings))
+	for _, f := range findings {
+		if f.Confidence != "" && confidenceRank(f.Confidence) < threshold {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+func run(path string, failOn shared.Severity, mode, priority, minConfidence string, ignoreUnfixed, image, offline, jsonOut, sarifOut, sbomOut, includeTest bool) error {
 	// An image target is an OCI reference (acquired via crane → OCI layout); a local
 	// target is a filesystem path that must be absolute for the scope check.
 	target := strings.TrimSpace(path)
@@ -1430,6 +1470,9 @@ func run(path string, failOn shared.Severity, mode, priority string, ignoreUnfix
 	res, err := sca.ScanWithOptions(ctx, "synapse-cli", eng.ID, ports.AcquireRequest{Kind: acqKind, Value: target}, scauc.ScanOptions{Mode: mode, DetectionPriority: priority, PolicyDir: policyDir})
 	if err != nil {
 		return fmt.Errorf("scan: %w", err)
+	}
+	if minConfidence != "" {
+		res.Findings = filterByConfidence(res.Findings, minConfidence)
 	}
 
 	// Report advisory opinions separately from the smaller policy-authorized gate-exempt set.

--- a/cmd/synapse-cli/main_test.go
+++ b/cmd/synapse-cli/main_test.go
@@ -79,3 +79,23 @@ func TestRunGateFailsForRubyEvalRequestData(t *testing.T) {
 		t.Fatalf("runGate error = %v, want critical Ruby SAST finding to fail the gate", err)
 	}
 }
+
+func TestFilterByConfidence(t *testing.T) {
+	findings := []finding.Finding{
+		{Title: "high", Confidence: "high"},
+		{Title: "medium", Confidence: "medium"},
+		{Title: "low", Confidence: "low"},
+		{Title: "sast-no-confidence", Confidence: ""}, // SAST/misconfig carry none — must be kept
+	}
+	got := filterByConfidence(findings, "high")
+	titles := map[string]bool{}
+	for _, f := range got {
+		titles[f.Title] = true
+	}
+	if !titles["high"] || !titles["sast-no-confidence"] {
+		t.Fatalf("--min-confidence high must keep high + unscored findings: %+v", titles)
+	}
+	if titles["medium"] || titles["low"] {
+		t.Fatalf("--min-confidence high must drop medium/low: %+v", titles)
+	}
+}

--- a/internal/usecase/sca/findings.go
+++ b/internal/usecase/sca/findings.go
@@ -287,7 +287,7 @@ func buildSecretFindings(engagementID shared.ID, raws []ports.SecretRawFinding, 
 			Description:  secretDescription(sr),
 			Severity:     sr.Severity,
 			Sources:      []string{"synapse-secret-scan"},
-			Confidence:   vulnerability.ConfidenceForSources(1),
+			Confidence:   secretRuleConfidence(sr.RuleID),
 			Class:        finding.ClassFirstParty,
 			Scope:        scope,
 			// Reachability/Impact are left empty on purpose: a hardcoded secret is a PRESENCE fact, not a
@@ -302,6 +302,26 @@ func buildSecretFindings(engagementID shared.ID, raws []ports.SecretRawFinding, 
 		})
 	}
 	return out
+}
+
+// lowSignalSecretRules are the entropy/context-based secret rules whose matches carry more false
+// positives than the fixed-prefix vendor-token rules (AKIA…, ghp_…, glpat-…, xox…, PEM blocks, etc.).
+// Everything not listed here is a distinctive fixed-format token, so a match is high-confidence.
+var lowSignalSecretRules = map[string]bool{
+	"generic-secret":        true, // catch-all high-entropy assignment
+	"aws-secret-access-key": true, // entropy-only 40-char base64, no distinctive prefix
+	"db-connection-string":  true, // credential embedded in an otherwise ordinary URL
+	"jwt":                   true, // JWTs are common and frequently non-secret
+}
+
+// secretRuleConfidence tags a secret finding's confidence: high for the fixed-prefix vendor-token rules
+// (a match is structurally unambiguous), medium for the entropy/context-based rules above — so
+// --min-confidence can filter the noisier ones.
+func secretRuleConfidence(ruleID string) string {
+	if lowSignalSecretRules[ruleID] {
+		return vulnerability.ConfidenceMedium
+	}
+	return vulnerability.ConfidenceHigh
 }
 
 func secretDescription(sr ports.SecretRawFinding) string {

--- a/internal/usecase/sca/secret_confidence_test.go
+++ b/internal/usecase/sca/secret_confidence_test.go
@@ -1,0 +1,22 @@
+package sca
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+)
+
+func TestSecretRuleConfidence(t *testing.T) {
+	high := []string{"github-token", "gitlab-pat", "slack-token", "aws-access-key-id", "private-key", "stripe-secret-key"}
+	for _, id := range high {
+		if got := secretRuleConfidence(id); got != vulnerability.ConfidenceHigh {
+			t.Errorf("fixed-prefix rule %q confidence = %q, want high", id, got)
+		}
+	}
+	medium := []string{"generic-secret", "aws-secret-access-key", "db-connection-string", "jwt"}
+	for _, id := range medium {
+		if got := secretRuleConfidence(id); got != vulnerability.ConfidenceMedium {
+			t.Errorf("entropy/context rule %q confidence = %q, want medium", id, got)
+		}
+	}
+}


### PR DESCRIPTION
feat(cli): high-confidence secret rules + a --min-confidence filter

Every secret finding was tagged confidence "medium" (ConfidenceForSources(1)), so
the field carried no signal — a trial saw only medium/low, never high, and could
not filter by it.

- Tag fixed-prefix vendor-token rules (AKIA…, ghp_…, glpat-…, xox…, PEM blocks,
  sk_live…, etc.) as "high": a match is structurally unambiguous. The
  entropy/context-based rules (generic-secret, aws-secret-access-key,
  db-connection-string, jwt) stay "medium". Kept as a small low-signal set in the
  finding builder so new vendor-token rules default to high without per-rule edits.
- Add `synapse-cli scan --min-confidence low|medium|high|very_high` to drop
  findings below the threshold. A finding with no confidence (SAST/misconfig carry
  none) is kept, so the flag targets the confidence-bearing SCA/secret findings
  rather than blanket-dropping everything unscored.

Tests cover the rule→confidence mapping and the filter (keeps high + unscored,
drops medium/low). build/vet/gofmt clean; sca + cli suites green.
