### PR TITLE
build(release): publish a slim synapse-cli-only archive for CI

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -114,6 +114,22 @@ archives:
       - README.md
       - CHANGELOG.md
 
+  # A slim CI archive: just synapse-cli. A scan/gate job needs only that one binary, so this avoids
+  # downloading the full ~44MB suite (synapse-agent, synapse-cspm, synapse-dast-helper, …) on every
+  # pipeline run across hundreds of projects.
+  - id: synapse-cli
+    ids:
+      - synapse-cli
+    name_template: "synapse-cli_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - LICENSE
+
 checksum:
   name_template: "checksums.txt"
   algorithm: sha256


### PR DESCRIPTION
build(release): publish a slim synapse-cli-only archive for CI

The only release archive bundled all six binaries (~44MB / ~125MB unpacked:
synapse-cli, -api, -worker, -mcp, -callgraph, -dast-helper). A CI scan/gate job
needs only synapse-cli, so every pipeline across hundreds of projects downloaded
the whole suite.

Add a second goreleaser archive `synapse-cli_<ver>_<os>_<arch>` that ships just
synapse-cli (+ LICENSE). The full `synapse_…` suite archive is unchanged, so
existing consumers are unaffected; CI can switch to the slim one. Validated with
`goreleaser check`. The distinct name prefix keeps it out of the full-suite
tarball-smoke glob.
