### PR TITLE
feat(cli): scan --base scopes line-anchored findings to new code

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -994,7 +994,7 @@ func gradeNum(g rating.Grade) float64 {
 func usage() {
 	fmt.Fprintln(os.Stderr, "usage:")
 	fmt.Fprintln(os.Stderr, "  synapse-cli doctor [path] [--json]       # offline pre-scan readiness: toolchain, markers, and dimension coverage")
-	fmt.Fprintln(os.Stderr, "  synapse-cli scan <path|image-ref> [--image] [--offline] [--json] [--sarif] [--mode full|vulnerabilities|licenses] [--fail-on critical|high|medium|low|info] [--min-confidence low|medium|high|very_high] [--include-test] [--ignore-unfixed] [--detection-priority comprehensive|precise]")
+	fmt.Fprintln(os.Stderr, "  synapse-cli scan <path|image-ref> [--image] [--offline] [--json] [--sarif] [--mode full|vulnerabilities|licenses] [--fail-on critical|high|medium|low|info] [--min-confidence low|medium|high|very_high] [--base REF] [--include-test] [--ignore-unfixed] [--detection-priority comprehensive|precise]")
 	fmt.Fprintln(os.Stderr, "      --sarif    write a SARIF 2.1.0 report to stdout (for GitHub code-scanning upload); --fail-on still sets the exit code")
 	fmt.Fprintln(os.Stderr, "      --image    treat the argument as a container image reference (pulled via crane) instead of a local path")
 	fmt.Fprintln(os.Stderr, "      --offline  skip the live OSV.dev source; detect with Grype's offline DB only (air-gapped / fast)")
@@ -1033,6 +1033,7 @@ func runScan() {
 	sbomOut := false
 	includeTest := false
 	minConfidence := ""
+	baseRef := ""
 	for i := 3; i < len(os.Args); i++ {
 		switch {
 		case os.Args[i] == "--fail-on" && i+1 < len(os.Args):
@@ -1040,6 +1041,9 @@ func runScan() {
 			i++
 		case os.Args[i] == "--min-confidence" && i+1 < len(os.Args):
 			minConfidence = os.Args[i+1]
+			i++
+		case os.Args[i] == "--base" && i+1 < len(os.Args):
+			baseRef = os.Args[i+1]
 			i++
 		case os.Args[i] == "--include-test":
 			includeTest = true
@@ -1078,6 +1082,10 @@ func runScan() {
 		fmt.Fprintf(os.Stderr, "synapse-cli: invalid --min-confidence %q (want low|medium|high|very_high)\n", minConfidence)
 		os.Exit(2)
 	}
+	if baseRef != "" && image {
+		fmt.Fprintln(os.Stderr, "synapse-cli: --base scopes to new code in a local git repo; it cannot be combined with --image")
+		os.Exit(2)
+	}
 	if priority == "" { // resolve the configured default here so an invalid env value gets this same exit-2 message
 		priority = os.Getenv("SYNAPSE_DETECTION_PRIORITY")
 	}
@@ -1097,7 +1105,7 @@ func runScan() {
 		fmt.Fprintln(os.Stderr, "synapse-cli: choose only one of --json, --sarif or --sbom")
 		os.Exit(2)
 	}
-	if err := run(os.Args[2], failOn, mode, priority, minConfidence, ignoreUnfixed, image, offline, jsonOut, sarifOut, sbomOut, includeTest); err != nil {
+	if err := run(os.Args[2], failOn, mode, priority, minConfidence, baseRef, ignoreUnfixed, image, offline, jsonOut, sarifOut, sbomOut, includeTest); err != nil {
 		fmt.Fprintln(os.Stderr, "synapse-cli:", err)
 		os.Exit(1)
 	}
@@ -1205,7 +1213,26 @@ func filterByConfidence(findings []finding.Finding, min string) []finding.Findin
 	return out
 }
 
-func run(path string, failOn shared.Severity, mode, priority, minConfidence string, ignoreUnfixed, image, offline, jsonOut, sarifOut, sbomOut, includeTest bool) error {
+// scopeToNewCode keeps only line-anchored findings (SAST/secret/misconfig) that fall on a line changed
+// vs the base ref, so a scan of a repo with a backlog can gate a pipeline on what THIS change introduced.
+// Findings that are NOT line-attributable (SCA vulnerabilities, licenses) are KEPT: dropping them would
+// falsely report clean when a change adds a vulnerable dependency. Baseline those via .synapseignore.
+func scopeToNewCode(findings []finding.Finding, changed gitdiff.ChangedLines) []finding.Finding {
+	out := make([]finding.Finding, 0, len(findings))
+	for _, f := range findings {
+		file, line, ok := findingFileLine(f)
+		if !ok {
+			out = append(out, f)
+			continue
+		}
+		if changed.Has(file, line) {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+func run(path string, failOn shared.Severity, mode, priority, minConfidence, baseRef string, ignoreUnfixed, image, offline, jsonOut, sarifOut, sbomOut, includeTest bool) error {
 	// An image target is an OCI reference (acquired via crane → OCI layout); a local
 	// target is a filesystem path that must be absolute for the scope check.
 	target := strings.TrimSpace(path)
@@ -1473,6 +1500,15 @@ func run(path string, failOn shared.Severity, mode, priority, minConfidence stri
 	}
 	if minConfidence != "" {
 		res.Findings = filterByConfidence(res.Findings, minConfidence)
+	}
+	if baseRef != "" {
+		changed, derr := gitdiff.Changed(ctx, target, baseRef)
+		if derr != nil {
+			return fmt.Errorf("new-code diff vs %q: %w", baseRef, derr)
+		}
+		before := len(res.Findings)
+		res.Findings = scopeToNewCode(res.Findings, changed)
+		fmt.Fprintf(os.Stderr, "synapse-cli: scoped to new code vs %s (%d of %d findings on changed lines; dependency/license findings kept)\n", baseRef, len(res.Findings), before)
 	}
 
 	// Report advisory opinions separately from the smaller policy-authorized gate-exempt set.

--- a/cmd/synapse-cli/main_test.go
+++ b/cmd/synapse-cli/main_test.go
@@ -99,3 +99,26 @@ func TestFilterByConfidence(t *testing.T) {
 		t.Fatalf("--min-confidence high must drop medium/low: %+v", titles)
 	}
 }
+
+func TestScopeToNewCodeKeepsUnanchoredFindings(t *testing.T) {
+	changed := gitdiff.ChangedLines{"app.go": {10: true}}
+	findings := []finding.Finding{
+		{Title: "sast on changed line", SourceLocation: &finding.SourceLocation{File: "app.go", StartLine: 10, EndLine: 10}},
+		{Title: "sast on unchanged line", SourceLocation: &finding.SourceLocation{File: "app.go", StartLine: 99, EndLine: 99}},
+		{Title: "sca vuln (no line)", Kind: finding.KindSCA, DedupKey: "CVE-2024-1:pkg:1.0"},
+	}
+	out := scopeToNewCode(findings, changed)
+	got := map[string]bool{}
+	for _, f := range out {
+		got[f.Title] = true
+	}
+	if !got["sast on changed line"] {
+		t.Error("a line-anchored finding on a changed line must be kept")
+	}
+	if got["sast on unchanged line"] {
+		t.Error("a line-anchored finding on an unchanged line must be dropped")
+	}
+	if !got["sca vuln (no line)"] {
+		t.Error("a non-line-anchored SCA finding must be KEPT (dropping it would falsely report clean)")
+	}
+}

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -81,6 +81,8 @@ synapse-cli scan <path|image-ref> [flags]
 | `--image` | Treat the argument as a container image reference, pulled via crane, instead of a local path. |
 | `--offline` | Skip the live advisory source and detect with the offline database only. |
 | `--ignore-unfixed` | Ignore vulnerabilities that have no fix available. |
+| `--min-confidence low\|medium\|high\|very_high` | Drop findings below this confidence. Findings that carry no confidence (SAST/misconfig) are kept. Useful to cut lower-signal secret matches. |
+| `--base <ref>` | Scope line-anchored findings (SAST, secret, misconfig) to code changed vs this git ref (Clean-as-You-Code), so a repo with a backlog gates the pipeline only on what a change introduces. Dependency/license findings are not line-attributable and are kept — baseline those with `.synapseignore`. Local git repos only (not `--image`). |
 | `--detection-priority comprehensive\|precise` | `comprehensive` (default) reports every match. `precise` moves single-source, non-KEV findings into a needs-verify queue that does not trip `--fail-on`. |
 | `--include-test` | Also gate on findings in test, fixture, and example paths. They are reported but gate-exempt by default. |
 | `--json` | Print the full scan result as JSON to stdout, for machine consumption in CI. |


### PR DESCRIPTION
feat(cli): scan --base scopes line-anchored findings to new code

Docs point CI at `scan`, but a repo with a backlog (e.g. 477 findings) fails the
pipeline immediately with no baseline. `gate` has --base/--new-code-only, but it
only covers code-quality + SAST — not SCA vulns, secrets, or misconfig — so it is
not a drop-in for the full scan.

Add `scan --base <ref>`: line-anchored findings (SAST/secret/misconfig) are scoped
to lines changed vs the ref (Clean-as-You-Code), so the pipeline gates on what a
change introduces, not the backlog. Findings that are NOT line-attributable (SCA
vulnerabilities, licenses) are KEPT — dropping them would falsely report clean
when a change adds a vulnerable dependency; baseline those with .synapseignore.
--base is local-git only and cannot be combined with --image.

Test asserts new-code scoping keeps line-anchored-on-changed + all unanchored SCA
findings and drops line-anchored-on-unchanged. Also documents --min-confidence.
build/vet/gofmt clean; cli suite green.
