### PR TITLE
feat(cli): .synapseignore suppressions with a mandatory reason and expiry

### DIFF
--- a/cmd/synapse-cli/main.go
+++ b/cmd/synapse-cli/main.go
@@ -8,9 +8,11 @@
 package main
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,6 +30,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/rating"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/suppression"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/acquire"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/cache/sbomcache"
@@ -82,6 +85,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/slauc"
+	"gopkg.in/yaml.v3"
 )
 
 func main() {
@@ -1183,6 +1187,65 @@ func (stderrAudit) Record(_ context.Context, e ports.AuditEntry) error {
 
 var _ ports.AuditLogger = stderrAudit{}
 
+// loadSynapseignore reads <dir>/.synapseignore (YAML) into a suppression ruleset. Missing file => empty
+// ruleset, no error. Every entry is validated (a matcher, a reason, and a parseable expiry are required)
+// so a malformed suppression fails the scan loudly rather than silently ignoring nothing — or worse,
+// silently everything.
+func loadSynapseignore(dir string) (suppression.Ruleset, error) {
+	data, err := os.ReadFile(filepath.Join(dir, ".synapseignore"))
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read .synapseignore: %w", err)
+	}
+	var doc struct {
+		Suppress []struct {
+			Rule    string `yaml:"rule"`
+			Path    string `yaml:"path"`
+			Reason  string `yaml:"reason"`
+			Expires string `yaml:"expires"`
+		} `yaml:"suppress"`
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("parse .synapseignore: %w", err)
+	}
+	rs := make(suppression.Ruleset, 0, len(doc.Suppress))
+	for i, e := range doc.Suppress {
+		expires, perr := time.Parse("2006-01-02", strings.TrimSpace(e.Expires))
+		if perr != nil {
+			return nil, fmt.Errorf(".synapseignore entry %d: expires %q must be YYYY-MM-DD", i+1, e.Expires)
+		}
+		r := suppression.Rule{RuleKey: strings.TrimSpace(e.Rule), Path: strings.TrimSpace(e.Path), Reason: e.Reason, Expires: expires}
+		if verr := r.Validate(); verr != nil {
+			return nil, fmt.Errorf(".synapseignore entry %d: %w", i+1, verr)
+		}
+		rs = append(rs, r)
+	}
+	return rs, nil
+}
+
+// applySuppressions drops findings matched by an active .synapseignore rule and returns the kept set plus
+// the count suppressed. Non-line findings still match by rule key / advisory id.
+func applySuppressions(findings []finding.Finding, rs suppression.Ruleset, now time.Time) ([]finding.Finding, int) {
+	if len(rs) == 0 {
+		return findings, 0
+	}
+	kept := make([]finding.Finding, 0, len(findings))
+	suppressed := 0
+	for _, f := range findings {
+		file, _, _ := findingFileLine(f)
+		if _, ok := rs.Suppress([]string{f.RuleKey, string(f.AdvisoryID)}, file, now); ok {
+			suppressed++
+			continue
+		}
+		kept = append(kept, f)
+	}
+	return kept, suppressed
+}
+
 func confidenceRank(c string) int {
 	switch c {
 	case "very_high":
@@ -1509,6 +1572,21 @@ func run(path string, failOn shared.Severity, mode, priority, minConfidence, bas
 		before := len(res.Findings)
 		res.Findings = scopeToNewCode(res.Findings, changed)
 		fmt.Fprintf(os.Stderr, "synapse-cli: scoped to new code vs %s (%d of %d findings on changed lines; dependency/license findings kept)\n", baseRef, len(res.Findings), before)
+	}
+	if !image { // .synapseignore lives in the repo; not applicable to an image reference
+		ignoreRules, ierr := loadSynapseignore(target)
+		if ierr != nil {
+			return ierr
+		}
+		now := time.Now()
+		var suppressed int
+		res.Findings, suppressed = applySuppressions(res.Findings, ignoreRules, now)
+		if suppressed > 0 {
+			fmt.Fprintf(os.Stderr, "synapse-cli: .synapseignore suppressed %d finding(s)\n", suppressed)
+		}
+		for _, e := range ignoreRules.Expired(now) {
+			fmt.Fprintf(os.Stderr, "synapse-cli: WARNING .synapseignore suppression expired %s (rule=%q path=%q) — its findings are NOT suppressed; renew or remove it\n", e.Expires.Format("2006-01-02"), e.RuleKey, e.Path)
+		}
 	}
 
 	// Report advisory opinions separately from the smaller policy-authorized gate-exempt set.

--- a/cmd/synapse-cli/main_test.go
+++ b/cmd/synapse-cli/main_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/gitdiff"
@@ -120,5 +121,41 @@ func TestScopeToNewCodeKeepsUnanchoredFindings(t *testing.T) {
 	}
 	if !got["sca vuln (no line)"] {
 		t.Error("a non-line-anchored SCA finding must be KEPT (dropping it would falsely report clean)")
+	}
+}
+
+func TestLoadAndApplySynapseignore(t *testing.T) {
+	dir := t.TempDir()
+	yaml := "suppress:\n  - rule: github-token\n    reason: \"rotated test token\"\n    expires: \"2099-12-31\"\n  - rule: old-rule\n    reason: \"stale\"\n    expires: \"2020-01-01\"\n"
+	if err := os.WriteFile(filepath.Join(dir, ".synapseignore"), []byte(yaml), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	rs, err := loadSynapseignore(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(rs) != 2 {
+		t.Fatalf("want 2 rules, got %d", len(rs))
+	}
+	findings := []finding.Finding{
+		{Title: "gh", RuleKey: "github-token"},
+		{Title: "kept", RuleKey: "aws-access-key-id"},
+	}
+	kept, n := applySuppressions(findings, rs, time.Date(2026, 9, 1, 0, 0, 0, 0, time.UTC))
+	if n != 1 || len(kept) != 1 || kept[0].RuleKey != "aws-access-key-id" {
+		t.Fatalf("active suppression must drop github-token only: kept=%+v n=%d", kept, n)
+	}
+
+	// A malformed entry (no reason) fails loudly.
+	if err := os.WriteFile(filepath.Join(dir, ".synapseignore"), []byte("suppress:\n  - rule: x\n    expires: \"2099-01-01\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadSynapseignore(dir); err == nil {
+		t.Fatal("a suppression with no reason must be rejected")
+	}
+
+	// Missing file => empty ruleset, no error.
+	if rs, err := loadSynapseignore(t.TempDir()); err != nil || rs != nil {
+		t.Fatalf("missing .synapseignore must be (nil, nil), got %v %v", rs, err)
 	}
 }

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -92,6 +92,27 @@ synapse-cli scan <path|image-ref> [flags]
 `--json`, `--sarif`, and `--sbom` each take over stdout completely, so they are mutually exclusive.
 Passing more than one exits `2` rather than silently honoring the last flag.
 
+### Suppressing findings with `.synapseignore`
+
+Drop known/accepted findings by committing a `.synapseignore` file at the scan root. Every suppression
+**must** carry a `reason` and an `expires` date (`YYYY-MM-DD`) — after the expiry the suppression stops
+applying and the finding reappears (with a warning), so suppressions are periodically re-justified instead
+of rotting. Each entry matches by `rule` (a rule key or advisory id), by `path` (a file glob), or both:
+
+```yaml
+suppress:
+  - rule: generic-secret
+    path: "testdata/**"
+    reason: "test fixtures, not real credentials"
+    expires: "2026-12-31"
+  - rule: CVE-2024-1234
+    reason: "not exploitable in our configuration; tracked in JIRA-123"
+    expires: "2026-09-30"
+```
+
+A malformed entry (missing reason/expiry, or no matcher) fails the scan rather than silently ignoring
+nothing. Suppressed counts and any expired entries are printed to stderr.
+
 ### Examples
 
 ```bash

--- a/internal/domain/suppression/suppression.go
+++ b/internal/domain/suppression/suppression.go
@@ -1,0 +1,112 @@
+// Package suppression models .synapseignore: operator-declared suppressions that hide known/accepted
+// findings, each REQUIRING a reason and an expiry date. Expiry is the point — a suppression stops
+// applying after its date so the finding reappears and the suppression gets periodically re-justified,
+// unlike an open-ended ignore list that silently rots. The parsing/IO lives in the caller (YAML); this
+// package is the pure, deterministic matcher + validator.
+package suppression
+
+import (
+	"fmt"
+	"path"
+	"strings"
+	"time"
+)
+
+// Rule is one suppression entry. At least one of RuleKey / Path must be set; Reason and Expires are
+// mandatory.
+type Rule struct {
+	RuleKey string    // match a finding's rule key / advisory id (e.g. "generic-secret", "CVE-2024-1"); empty = any
+	Path    string    // match the finding's file with a glob (path.Match semantics); empty = any
+	Reason  string    // why this is accepted — mandatory (accountability)
+	Expires time.Time // last day the suppression applies (inclusive); after it, the finding reappears
+}
+
+// Validate enforces the mandatory fields and a usable matcher.
+func (r Rule) Validate() error {
+	if strings.TrimSpace(r.RuleKey) == "" && strings.TrimSpace(r.Path) == "" {
+		return fmt.Errorf("suppression needs a rule or a path to match")
+	}
+	if strings.TrimSpace(r.Reason) == "" {
+		return fmt.Errorf("suppression needs a reason")
+	}
+	if r.Expires.IsZero() {
+		return fmt.Errorf("suppression needs an expiry date")
+	}
+	if r.Path != "" {
+		if _, err := path.Match(r.Path, "x"); err != nil {
+			return fmt.Errorf("suppression path %q is not a valid glob: %w", r.Path, err)
+		}
+	}
+	return nil
+}
+
+// active reports whether the suppression still applies on the given day (inclusive of the expiry date).
+func (r Rule) active(now time.Time) bool {
+	return !dayOf(now).After(dayOf(r.Expires))
+}
+
+func dayOf(t time.Time) time.Time {
+	y, m, d := t.UTC().Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+}
+
+// Ruleset is a parsed .synapseignore.
+type Ruleset []Rule
+
+// Suppress reports the first ACTIVE rule that matches a finding identified by its rule keys (rule key,
+// advisory id, …) and its source file (empty for non-file findings). An expired rule never matches.
+func (rs Ruleset) Suppress(ruleKeys []string, file string, now time.Time) (Rule, bool) {
+	for _, r := range rs {
+		if !r.active(now) {
+			continue
+		}
+		if !r.matchesRule(ruleKeys) || !r.matchesPath(file) {
+			continue
+		}
+		return r, true
+	}
+	return Rule{}, false
+}
+
+// Expired returns the rules that are no longer active — surfaced so a stale suppression is visible, not
+// silently dropped.
+func (rs Ruleset) Expired(now time.Time) []Rule {
+	var out []Rule
+	for _, r := range rs {
+		if !r.active(now) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func (r Rule) matchesRule(ruleKeys []string) bool {
+	if r.RuleKey == "" {
+		return true
+	}
+	for _, k := range ruleKeys {
+		if k != "" && strings.EqualFold(k, r.RuleKey) {
+			return true
+		}
+	}
+	return false
+}
+
+func (r Rule) matchesPath(file string) bool {
+	if r.Path == "" {
+		return true
+	}
+	if file == "" {
+		return false
+	}
+	file = strings.ReplaceAll(file, "\\", "/")
+	if ok, _ := path.Match(r.Path, file); ok {
+		return true
+	}
+	// A trailing "/**" (or bare dir prefix) matches everything under the directory, which path.Match
+	// does not do across separators on its own.
+	if prefix, ok := strings.CutSuffix(r.Path, "/**"); ok {
+		return file == prefix || strings.HasPrefix(file, prefix+"/")
+	}
+	return false
+}

--- a/internal/domain/suppression/suppression_test.go
+++ b/internal/domain/suppression/suppression_test.go
@@ -1,0 +1,60 @@
+package suppression
+
+import (
+	"testing"
+	"time"
+)
+
+func day(s string) time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+func TestRuleValidate(t *testing.T) {
+	ok := Rule{RuleKey: "generic-secret", Reason: "test fixtures", Expires: day("2026-12-31")}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("valid rule rejected: %v", err)
+	}
+	for name, r := range map[string]Rule{
+		"no matcher": {Reason: "x", Expires: day("2026-12-31")},
+		"no reason":  {RuleKey: "x", Expires: day("2026-12-31")},
+		"no expiry":  {RuleKey: "x", Reason: "x"},
+		"bad glob":   {Path: "[", Reason: "x", Expires: day("2026-12-31")},
+	} {
+		if err := r.Validate(); err == nil {
+			t.Errorf("%s: expected a validation error", name)
+		}
+	}
+}
+
+func TestSuppressMatchAndExpiry(t *testing.T) {
+	rs := Ruleset{
+		{RuleKey: "generic-secret", Path: "testdata/**", Reason: "fixtures", Expires: day("2026-12-31")},
+		{RuleKey: "CVE-2024-1", Reason: "not exploitable", Expires: day("2026-06-30")}, // expired vs now below
+	}
+	now := day("2026-09-01")
+
+	// rule + path both match, active.
+	if _, ok := rs.Suppress([]string{"generic-secret"}, "testdata/fixture.py", now); !ok {
+		t.Error("active rule+path suppression must match")
+	}
+	// rule matches but path is outside the glob.
+	if _, ok := rs.Suppress([]string{"generic-secret"}, "src/main.py", now); ok {
+		t.Error("path outside the glob must NOT be suppressed")
+	}
+	// CVE rule is expired → must not suppress even though the key matches.
+	if _, ok := rs.Suppress([]string{"CVE-2024-1"}, "", now); ok {
+		t.Error("an expired suppression must not apply")
+	}
+	// Expired() surfaces it.
+	if exp := rs.Expired(now); len(exp) != 1 || exp[0].RuleKey != "CVE-2024-1" {
+		t.Errorf("Expired() = %+v, want the CVE rule", exp)
+	}
+	// On the expiry date itself the rule is still active (inclusive).
+	if _, ok := rs.Suppress([]string{"CVE-2024-1"}, "", day("2026-06-30")); !ok {
+		t.Error("a suppression must be active through its expiry date (inclusive)")
+	}
+}


### PR DESCRIPTION
feat(cli): .synapseignore suppressions with a mandatory reason and expiry

Teams need a way to suppress known/accepted findings to use a scanner long-term,
but an open-ended ignore list rots. Add a committed `.synapseignore` (YAML) at the
scan root where each suppression MUST carry a reason and an expiry date; after the
expiry it stops applying and the finding reappears with a warning, so suppressions
are periodically re-justified.

- internal/domain/suppression: pure matcher/validator — Rule{RuleKey, Path,
  Reason, Expires}, Ruleset.Suppress(ruleKeys, file, now) (expired rules never
  match; expiry inclusive), Expired(now), and Validate (a matcher + reason +
  expiry required).
- CLI: load `<root>/.synapseignore` (YAML, unknown-field-strict; missing file is a
  no-op), apply after the scan, print the suppressed count, and WARN for every
  expired entry (its findings are NOT suppressed). A malformed entry fails the
  scan loudly rather than silently ignoring nothing. Not applied to --image scans.

Matches by rule key / advisory id and/or a file glob; non-line findings (SCA) are
suppressible by rule/CVE. Tested at the domain level (match/expiry/validation) and
the CLI level (load + apply + malformed + missing). Documented in the CLI guide.
build/vet/gofmt clean; suppression + cli + platform (arch) suites green.
