### PR TITLE
feat(fleet): wire the tri-score risk assembler live at the composition root (#594)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -31,6 +31,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/cloudposture"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/taint"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityreconcile"
@@ -119,6 +120,8 @@ import (
 	incidentuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/incidentuc"
 	keyregistry "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/keyregistry"
 	privacypolicy "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/privacypolicy"
+	riskscorebridge "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/riskscorebridge"
+	riskscoreuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/riskscoreuc"
 	telemetryingest "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/telemetryingest"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetagentuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleetrolloutuc"
@@ -1651,6 +1654,31 @@ func main() {
 			log.Info("incident read + analyst-triage surface ENABLED (durable; append-only event log; tenant-scoped; RBAC-gated)")
 		} else {
 			log.Warn("incident read + analyst-triage surface ENABLED but NOT DURABLE - incidents and their triage history live in memory and are lost on restart; configure SYNAPSE_DB_DSN for a durable store")
+		}
+		if cfg.TriScoreReassessEnabled {
+			// Tri-score assembler (#594 C3/D/X5): the deterministic Scorer, run live on an incident's factors.
+			// Threat comes from the incident's own correlated severity (DefaultPolicy treats it as dominant);
+			// Exposure/Behavior/Coverage abstain honestly until their producers (exposureuc / baselineuc /
+			// coveragewindow) are wired — an abstaining factor contributes 0 and records its reason in the
+			// CoverageVector, never fabricating risk. incidentSvc satisfies the assembler's IncidentStore.
+			scorer, serr := riskassessment.NewScorer(riskassessment.DefaultPolicy())
+			if serr != nil {
+				log.Error("tri-score scorer init failed", "err", serr)
+				os.Exit(1)
+			}
+			assembler, aerr := riskscoreuc.NewService(
+				incidentSvc,
+				riskscorebridge.AbstainingExposure("exposure: exposureuc not yet wired at the composition root"),
+				riskscorebridge.AbstainingBehavior("behavior: baselineuc per-asset read path not yet wired"),
+				riskscorebridge.AbstainingCoverage(),
+				scorer, auditLog, ids, func() time.Time { return clock.Now().UTC() },
+			)
+			if aerr != nil {
+				log.Error("tri-score assembler init failed", "err", aerr)
+				os.Exit(1)
+			}
+			router.SetIncidentRiskReassessor(assembler)
+			log.Warn("tri-score risk reassessment ENABLED (Threat live; Exposure/Behavior/Coverage abstaining until their producers are wired) - POST /api/v1/fleet/incidents/{id}/risk/reassess")
 		}
 	}
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -217,6 +217,7 @@ reports whether traversal was truncated; lowering a bound never produces a resul
 | `SYNAPSE_PYREACH_ENABLED` | `false` | Python Tier-1 import-reachability (a dead dependency becomes an OpenVEX `not_affected`). |
 | `SYNAPSE_PYREACH_TIER2_ENABLED` | `false` | Python Tier-2 affected-symbol semantic reachability. Requires Tier-1, judgments, and a CGO-enabled `synapse-ast`. |
 | `SYNAPSE_PYTAINT_ENABLED` | `false` | Python interprocedural semantic taint proposals. Requires judgments and a CGO-enabled `synapse-ast`; it does not require the target-compilation sandbox. |
+| `SYNAPSE_TRISCORE_REASSESS_ENABLED` | `false` | Tri-score risk reassessment surface (`POST /api/v1/fleet/incidents/{id}/risk/reassess`): re-scores an incident's RiskAssessment via the deterministic Scorer. Threat is live; Exposure/Behavior/Coverage abstain until their producers are wired. |
 | `SYNAPSE_AST_BIN` | bundled / `PATH` | Optional path to the `synapse-ast` sidecar used by Python Tier-2 reachability, Python taint, and code-quality analysis. |
 | `SYNAPSE_JSREACH_ENABLED` | `false` | JS/TS Tier-1 import-level reachability. |
 | `SYNAPSE_JSREACH_TIER2_ENABLED` | `false` | JS/TS Tier-2 symbol-level reachability. |
@@ -233,6 +234,7 @@ All off by default. The fleet needs PostgreSQL + `synapse-worker`; agents run on
 | `SYNAPSE_FLEET_CLUSTER_INGEST_ENABLED` | `false` | Accept Kubernetes inventory from `synapse-cluster-agent`. |
 | `SYNAPSE_FLEET_TELEMETRY_INGEST_ENABLED` | `false` | Accept signed agent telemetry batches (A3, `POST /api/v1/fleet/telemetry`); verified + idempotently sequenced server-side. |
 | `SYNAPSE_FLEET_DETECTION_INGEST_ENABLED` | `false` | Accept signed agent detection batches (A4, `POST /api/v1/fleet/detections`); sealed once into the evidence chain. |
+| `SYNAPSE_FLEET_DETECTION_RECONCILE_INTERVAL` | `1m` | How often the tenant-scoped reconciler repairs pending attributed detections. |
 | `SYNAPSE_FLEET_KEY_REGISTRATION_ENABLED` | `false` | Serve agent signing-key registration (`POST /api/v1/fleet/keys`) + operator key list/revoke (A4, A0.2). |
 | `SYNAPSE_FLEET_STALE_AFTER` | `10m` | An agent older than this reads as stale (`<=0` disables the staleness view). |
 | `SYNAPSE_FLEET_COVERAGE_FRESHNESS_TARGET` | `24h` | Coverage freshness SLO. |

--- a/internal/adapter/httpapi/incident_handler.go
+++ b/internal/adapter/httpapi/incident_handler.go
@@ -31,8 +31,19 @@ type incidentTriager interface {
 	SetDisposition(ctx context.Context, actor string, id shared.ID, disposition incident.Disposition) (incident.Incident, error)
 }
 
+// incidentRiskReassessor runs the tri-score assembler for one incident (#594 C3/D/X5):
+// re-gather Threat + Exposure + Behavior + telemetry Coverage, run the deterministic Scorer, and
+// record the RiskAssessment on the append-only incident log. riskscoreuc.Service satisfies it. The actor
+// is the FIRST arg after ctx: it must be the server-side authenticated principal, never a body field.
+type incidentRiskReassessor interface {
+	Reassess(ctx context.Context, actor string, incidentID shared.ID) (incident.Incident, error)
+}
+
 // SetIncidents wires the incident read surface (nil ⇒ the routes are not registered).
 func (rt *Router) SetIncidents(r incidentReader) { rt.incidents = r }
+
+// SetIncidentRiskReassessor wires the tri-score reassessment surface (nil ⇒ the route is not registered).
+func (rt *Router) SetIncidentRiskReassessor(r incidentRiskReassessor) { rt.incidentRiskReassessor = r }
 
 // SetIncidentTriage wires the incident triage surface (nil ⇒ the triage routes are not registered).
 func (rt *Router) SetIncidentTriage(t incidentTriager) { rt.incidentTriage = t }
@@ -177,6 +188,17 @@ func (rt *Router) changeIncidentStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	inc, err := rt.incidentTriage.ChangeStatus(incidentTenantContext(r), PrincipalFrom(r.Context()), shared.ID(r.PathValue("id")), incident.State(req.To))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, inc)
+}
+
+// reassessIncidentRisk runs the tri-score assembler for the incident and returns the updated incident
+// (whose .Risk now carries the RiskAssessment). No request body: the factors are gathered server-side.
+func (rt *Router) reassessIncidentRisk(w http.ResponseWriter, r *http.Request) {
+	inc, err := rt.incidentRiskReassessor.Reassess(incidentTenantContext(r), PrincipalFrom(r.Context()), shared.ID(r.PathValue("id")))
 	if err != nil {
 		writeError(w, rt.log, err)
 		return

--- a/internal/adapter/httpapi/incident_reassess_test.go
+++ b/internal/adapter/httpapi/incident_reassess_test.go
@@ -1,0 +1,71 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// fakeReassessor records the actor + id it was called with and returns a fixed incident.
+type fakeReassessor struct {
+	gotActor string
+	gotID    shared.ID
+	calls    int
+}
+
+func (f *fakeReassessor) Reassess(_ context.Context, actor string, id shared.ID) (incident.Incident, error) {
+	f.calls++
+	f.gotActor = actor
+	f.gotID = id
+	return incident.Incident{ID: id, State: incident.StateOpen}, nil
+}
+
+func newReassessRouter(f *fakeReassessor) *http.ServeMux {
+	rt := &Router{log: discardLog(), incidents: &fakeIncidentStore{}, incidentRiskReassessor: f}
+	return rt.routes()
+}
+
+func TestReassessIncidentRiskRBAC(t *testing.T) {
+	cases := []struct {
+		role string
+		want int
+	}{
+		{"readonly", http.StatusForbidden}, // reassess writes the incident → needs PermOperate
+		{"consultant", http.StatusOK},
+		{"admin", http.StatusOK},
+	}
+	for _, c := range cases {
+		t.Run(c.role, func(t *testing.T) {
+			f := &fakeReassessor{}
+			rec := incidentReq(newReassessRouter(f), c.role, http.MethodPost, "/api/v1/fleet/incidents/inc-1/risk/reassess", "")
+			if rec.Code != c.want {
+				t.Fatalf("as %s: got %d, want %d (%s)", c.role, rec.Code, c.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+// TestReassessIncidentRiskActorIsPrincipal proves the reassessment actor is the authenticated principal
+// (never a body field) and the path id is threaded through — the attributability property.
+func TestReassessIncidentRiskActorIsPrincipal(t *testing.T) {
+	f := &fakeReassessor{}
+	rec := incidentReq(newReassessRouter(f), "consultant", http.MethodPost, "/api/v1/fleet/incidents/inc-42/risk/reassess", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("reassess: got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if f.calls != 1 || f.gotActor != "analyst-1" || f.gotID != "inc-42" {
+		t.Fatalf("actor/id not threaded from principal + path: calls=%d actor=%q id=%q", f.calls, f.gotActor, f.gotID)
+	}
+}
+
+// TestReassessRouteAbsentWhenUnwired: the route is registered only when a reassessor is set (nil ⇒ 404).
+func TestReassessRouteAbsentWhenUnwired(t *testing.T) {
+	rt := &Router{log: discardLog(), incidents: &fakeIncidentStore{}} // no reassessor
+	rec := incidentReq(rt.routes(), "consultant", http.MethodPost, "/api/v1/fleet/incidents/inc-1/risk/reassess", "")
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unwired reassess route must 404, got %d", rec.Code)
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -82,6 +82,7 @@ type Router struct {
 	privacyPolicies        privacyPolicyService      // optional; nil ⇒ tenant source-privacy policy routes are not registered
 	incidents              incidentReader            // optional; nil ⇒ incident read routes are not registered (#594 C7)
 	incidentTriage         incidentTriager           // optional; nil ⇒ incident triage routes are not registered (#594 C5)
+	incidentRiskReassessor incidentRiskReassessor    // optional; nil ⇒ the tri-score reassess route is not registered (#594 C3/D/X5)
 	sarif                  sarifIngester             // optional; nil ⇒ the third-party SARIF import route is not registered
 	importedFindings       sarifReader               // optional read side for imported findings
 	fleetRolloutAdmin      fleetRolloutService       // optional; nil ⇒ the operator rollout routes are not served
@@ -408,6 +409,13 @@ func (rt *Router) routes() *http.ServeMux {
 			mux.HandleFunc("POST /api/v1/fleet/incidents/{id}/comments", rt.authz(userdom.PermTriage, rt.commentIncident))
 			mux.HandleFunc("POST /api/v1/fleet/incidents/{id}/status", rt.authz(userdom.PermTriage, rt.changeIncidentStatus))
 			mux.HandleFunc("POST /api/v1/fleet/incidents/{id}/disposition", rt.authz(userdom.PermReview, rt.setIncidentDisposition))
+		}
+		if rt.incidentRiskReassessor != nil {
+			// Tri-score risk reassessment (#594 C3/D/X5): re-gather the incident's factors (Threat +
+			// wired Exposure/Behavior + telemetry Coverage), run the deterministic Scorer, and record the
+			// RiskAssessment on the append-only incident log. Operator action (writes the incident), actor
+			// from the authenticated principal.
+			mux.HandleFunc("POST /api/v1/fleet/incidents/{id}/risk/reassess", rt.authz(userdom.PermOperate, rt.reassessIncidentRisk))
 		}
 	}
 	if rt.projects != nil {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -442,6 +442,11 @@ type Config struct {
 	// sidecar extracts bounded facts, but unlike Go taint this pass never compiles or imports target code.
 	// Positive paths become gated CapSAST proposals; incomplete coverage never produces a clean verdict.
 	PythonTaintEnabled bool
+	// TriScoreReassessEnabled turns on the tri-score risk reassessment surface (#594 C3/D/X5): an operator
+	// route that re-scores an incident's RiskAssessment from its factors (Threat now; Exposure/Behavior/
+	// Coverage as their producers are wired) via the deterministic Scorer. Off by default while the
+	// Exposure/Behavior/Coverage producers are still being integrated.
+	TriScoreReassessEnabled bool
 
 	// JSReachabilityEnabled turns on deterministic Tier-1 JavaScript/TypeScript import-reachability: a
 	// declared npm dependency that first-party source never imports becomes not_reachable, which the
@@ -706,6 +711,7 @@ func Load() Config {
 		PySemanticReachabilityEnabled:         getbool("SYNAPSE_PYREACH_TIER2_ENABLED", false),
 		ASTBin:                                os.Getenv("SYNAPSE_AST_BIN"),
 		PythonTaintEnabled:                    getbool("SYNAPSE_PYTAINT_ENABLED", false),
+		TriScoreReassessEnabled:               getbool("SYNAPSE_TRISCORE_REASSESS_ENABLED", false),
 		JSReachabilityEnabled:                 getbool("SYNAPSE_JSREACH_ENABLED", false),
 		JSSymbolReachabilityEnabled:           getbool("SYNAPSE_JSREACH_TIER2_ENABLED", false),
 		RustReachabilityEnabled:               getbool("SYNAPSE_REACH_RUST", false),

--- a/internal/usecase/fleet/riskscorebridge/bridge.go
+++ b/internal/usecase/fleet/riskscorebridge/bridge.go
@@ -1,0 +1,55 @@
+// Package riskscorebridge provides honest-abstaining factor sources for the tri-score assembler
+// (riskscoreuc) at the composition root. The assembler REQUIRES a non-nil ExposureAssessor,
+// BehaviorAssessor and CoverageSource; where a producer is not yet integrated, an abstaining source keeps
+// the seam live and coverage-honest — an abstaining factor contributes 0 to Risk and carries its reason
+// into the CoverageVector, so a not-yet-wired factor lowers coverage/confidence and NEVER fabricates risk.
+//
+// This lets the deterministic Scorer run in production on the factors that ARE wired (Threat, from the
+// incident's own correlated severity, which DefaultPolicy treats as dominant) while the remaining
+// producers are swapped in as isolated follow-ups: Exposure → exposureuc, Behavior → baselineuc,
+// Coverage → coveragewindow. Each swap replaces one Abstaining* here with the real bridge.
+package riskscorebridge
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/riskscoreuc"
+)
+
+// abstainingExposure always abstains — used until exposureuc is wired at the composition root.
+type abstainingExposure struct{ reason string }
+
+// AbstainingExposure returns an ExposureAssessor that always abstains with a fixed reason.
+func AbstainingExposure(reason string) riskscoreuc.ExposureAssessor {
+	return abstainingExposure{reason: reason}
+}
+
+func (a abstainingExposure) ExposureFor(context.Context, shared.ID) (riskscoreuc.FactorInput, error) {
+	return riskscoreuc.FactorInput{Scoreable: false, Reasons: []string{a.reason}}, nil
+}
+
+// abstainingBehavior always abstains — used until baselineuc exposes a per-asset behavior read path.
+type abstainingBehavior struct{ reason string }
+
+// AbstainingBehavior returns a BehaviorAssessor that always abstains with a fixed reason.
+func AbstainingBehavior(reason string) riskscoreuc.BehaviorAssessor {
+	return abstainingBehavior{reason: reason}
+}
+
+func (a abstainingBehavior) BehaviorFor(context.Context, shared.ID) (riskscoreuc.FactorInput, error) {
+	return riskscoreuc.FactorInput{Scoreable: false, Reasons: []string{a.reason}}, nil
+}
+
+// abstainingCoverage reports no per-class detection coverage — used until coveragewindow is bridged. The
+// assembler then treats every class as an observation gap, which is the honest state when detection
+// coverage is not yet wired.
+type abstainingCoverage struct{}
+
+// AbstainingCoverage returns a CoverageSource that yields no class coverage (every class reads as a gap).
+func AbstainingCoverage() riskscoreuc.CoverageSource { return abstainingCoverage{} }
+
+func (abstainingCoverage) ClassCoverageForAsset(context.Context, shared.ID) ([]detection.ClassCoverage, error) {
+	return nil, nil
+}

--- a/internal/usecase/fleet/riskscorebridge/bridge_test.go
+++ b/internal/usecase/fleet/riskscorebridge/bridge_test.go
@@ -1,0 +1,42 @@
+package riskscorebridge
+
+import (
+	"context"
+	"testing"
+)
+
+func TestAbstainingExposureAlwaysAbstains(t *testing.T) {
+	f, err := AbstainingExposure("exposure not wired").ExposureFor(context.Background(), "asset-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Scoreable {
+		t.Fatal("abstaining exposure must not be scoreable")
+	}
+	if f.Score != 0 {
+		t.Fatalf("an abstaining factor must contribute 0, got %d", f.Score)
+	}
+	if len(f.Reasons) != 1 || f.Reasons[0] != "exposure not wired" {
+		t.Fatalf("reason not carried: %v", f.Reasons)
+	}
+}
+
+func TestAbstainingBehaviorAlwaysAbstains(t *testing.T) {
+	f, err := AbstainingBehavior("behavior not wired").BehaviorFor(context.Background(), "asset-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Scoreable || f.Score != 0 || len(f.Reasons) != 1 {
+		t.Fatalf("abstaining behavior must be 0/not-scoreable with a reason: %+v", f)
+	}
+}
+
+func TestAbstainingCoverageYieldsNoClasses(t *testing.T) {
+	classes, err := AbstainingCoverage().ClassCoverageForAsset(context.Background(), "asset-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(classes) != 0 {
+		t.Fatalf("abstaining coverage must yield no class coverage (all classes read as gaps), got %d", len(classes))
+	}
+}


### PR DESCRIPTION
feat(fleet): wire the tri-score risk assembler live at the composition root (#594)

The tri-score assembler (riskscoreuc) + its Scorer had no production caller — the
deterministic risk scoring built for Phase C/D/X5 was dormant, invoked only in
tests. This wires the seam end-to-end so the Scorer runs live.

- internal/usecase/fleet/riskscorebridge: honest-abstaining factor sources
  (Exposure/Behavior/Coverage) for the assembler's required ports. An abstaining
  factor contributes 0 to Risk and carries its reason into the CoverageVector, so a
  not-yet-wired factor lowers coverage/confidence and NEVER fabricates risk — the
  assembler's own coverage-honesty discipline. This lets the Scorer run on the
  factors that ARE wired (Threat, from the incident's correlated severity, which
  DefaultPolicy treats as dominant) while Exposure/Behavior/Coverage are swapped in
  as isolated follow-ups (exposureuc / baselineuc read-path / coveragewindow).
- HTTP: an operator route POST /api/v1/fleet/incidents/{id}/risk/reassess
  (PermOperate, tenant-scoped, actor = authenticated principal, no request body)
  that runs riskscoreuc.Reassess and records the RiskAssessment on the append-only
  incident log. Registered only when the reassessor is wired (nil ⇒ 404), mirroring
  the incident read/triage surfaces.
- cmd/synapse-api: construct the Scorer (DefaultPolicy) + assembler (incidentSvc as
  the IncidentStore) behind SYNAPSE_TRISCORE_REASSESS_ENABLED (default off), inside
  the existing incident-surface block.

Tests: abstaining bridges (0/not-scoreable/reason); the reassess route's RBAC
(readonly forbidden, consultant/admin ok), actor-is-principal + path-id threading,
and route-absent-when-unwired. build/vet/gofmt/arch clean; config + docs-drift
green (documented the new env, and the pre-existing undocumented
SYNAPSE_FLEET_DETECTION_RECONCILE_INTERVAL from #758).

Follow-ups (each a local swap of one Abstaining* bridge): real Exposure via
exposureuc over exposurereader; Behavior via a baselineuc per-asset read path;
Coverage via coveragewindow → detection.ClassCoverage; and an auto-reassess
trigger on correlation.
