### PR TITLE
feat(fleet): wire real Exposure (X5) into the tri-score assembler (#594/#634)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -114,6 +114,8 @@ import (
 	coverageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/coverage"
 	coveragewindow "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/coveragewindow"
 	detectledger "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectledger"
+	exposurereader "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/exposurereader"
+	exposureuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/exposureuc"
 	fleetaudit "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/fleetaudit"
 	hostinventoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/hostinventory"
 	incidenttriage "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/incidenttriage"
@@ -1666,9 +1668,23 @@ func main() {
 				log.Error("tri-score scorer init failed", "err", serr)
 				os.Exit(1)
 			}
+			// Exposure (X5, #634): the real producer over the SCA stores — installed-based exposure from the
+			// asset's open vulnerability occurrences + their risk. Running-vs-installed refinement (the B5
+			// process store) is a further follow-up; NewReader (no runtime) scores installed exposures and
+			// records that running-vs-installed precision is limited, an honest coverage note.
+			exposureReader, xrerr := exposurereader.NewReader(businessAssetStore, vulnerabilityOccurrences, vulnerabilityAssessments)
+			if xrerr != nil {
+				log.Error("exposure reader init failed", "err", xrerr)
+				os.Exit(1)
+			}
+			exposureSvc, xerr := exposureuc.NewService(exposureReader)
+			if xerr != nil {
+				log.Error("exposure service init failed", "err", xerr)
+				os.Exit(1)
+			}
 			assembler, aerr := riskscoreuc.NewService(
 				incidentSvc,
-				riskscorebridge.AbstainingExposure("exposure: exposureuc not yet wired at the composition root"),
+				riskscorebridge.NewExposure(exposureSvc),
 				riskscorebridge.AbstainingBehavior("behavior: baselineuc per-asset read path not yet wired"),
 				riskscorebridge.AbstainingCoverage(),
 				scorer, auditLog, ids, func() time.Time { return clock.Now().UTC() },
@@ -1678,7 +1694,7 @@ func main() {
 				os.Exit(1)
 			}
 			router.SetIncidentRiskReassessor(assembler)
-			log.Warn("tri-score risk reassessment ENABLED (Threat live; Exposure/Behavior/Coverage abstaining until their producers are wired) - POST /api/v1/fleet/incidents/{id}/risk/reassess")
+			log.Warn("tri-score risk reassessment ENABLED (Threat + Exposure live; Behavior/Coverage abstaining until their producers are wired) - POST /api/v1/fleet/incidents/{id}/risk/reassess")
 		}
 	}
 

--- a/internal/usecase/fleet/riskscorebridge/bridge.go
+++ b/internal/usecase/fleet/riskscorebridge/bridge.go
@@ -4,10 +4,11 @@
 // the seam live and coverage-honest — an abstaining factor contributes 0 to Risk and carries its reason
 // into the CoverageVector, so a not-yet-wired factor lowers coverage/confidence and NEVER fabricates risk.
 //
-// This lets the deterministic Scorer run in production on the factors that ARE wired (Threat, from the
-// incident's own correlated severity, which DefaultPolicy treats as dominant) while the remaining
-// producers are swapped in as isolated follow-ups: Exposure → exposureuc, Behavior → baselineuc,
-// Coverage → coveragewindow. Each swap replaces one Abstaining* here with the real bridge.
+// This lets the deterministic Scorer run in production on the factors that ARE wired while the remaining
+// producers are swapped in as isolated follow-ups. Exposure is wired via NewExposure (over exposureuc);
+// Behavior and Coverage still abstain until their producers are integrated (Behavior → a baselineuc
+// per-asset read path, Coverage → coveragewindow). Each swap replaces one Abstaining* here with a real
+// bridge.
 package riskscorebridge
 
 import (
@@ -15,19 +16,32 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/exposureuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/riskscoreuc"
 )
 
-// abstainingExposure always abstains — used until exposureuc is wired at the composition root.
-type abstainingExposure struct{ reason string }
-
-// AbstainingExposure returns an ExposureAssessor that always abstains with a fixed reason.
-func AbstainingExposure(reason string) riskscoreuc.ExposureAssessor {
-	return abstainingExposure{reason: reason}
+// ExposureProducer is the exposureuc surface the real Exposure bridge adapts. exposureuc.Service
+// satisfies it. Kept narrow so the bridge depends on the producer's behavior, not its concrete type.
+type ExposureProducer interface {
+	Assess(ctx context.Context, assetID shared.ID) (exposureuc.Assessment, error)
 }
 
-func (a abstainingExposure) ExposureFor(context.Context, shared.ID) (riskscoreuc.FactorInput, error) {
-	return riskscoreuc.FactorInput{Scoreable: false, Reasons: []string{a.reason}}, nil
+type exposureBridge struct{ producer ExposureProducer }
+
+// NewExposure bridges the real exposureuc producer (X5) to the assembler's ExposureAssessor port,
+// mapping exposureuc.Assessment (Exposure/Scoreable/Reasons) to the assembler's FactorInput. A producer
+// error propagates; an abstain (Scoreable=false) flows through unchanged, so the assembler keeps its
+// coverage-honest handling.
+func NewExposure(producer ExposureProducer) riskscoreuc.ExposureAssessor {
+	return exposureBridge{producer: producer}
+}
+
+func (b exposureBridge) ExposureFor(ctx context.Context, assetID shared.ID) (riskscoreuc.FactorInput, error) {
+	a, err := b.producer.Assess(ctx, assetID)
+	if err != nil {
+		return riskscoreuc.FactorInput{}, err
+	}
+	return riskscoreuc.FactorInput{Score: a.Exposure, Scoreable: a.Scoreable, Reasons: a.Reasons}, nil
 }
 
 // abstainingBehavior always abstains — used until baselineuc exposes a per-asset behavior read path.

--- a/internal/usecase/fleet/riskscorebridge/bridge_test.go
+++ b/internal/usecase/fleet/riskscorebridge/bridge_test.go
@@ -2,22 +2,46 @@ package riskscorebridge
 
 import (
 	"context"
+	"errors"
 	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/exposureuc"
 )
 
-func TestAbstainingExposureAlwaysAbstains(t *testing.T) {
-	f, err := AbstainingExposure("exposure not wired").ExposureFor(context.Background(), "asset-1")
+type fakeExposureProducer struct {
+	a   exposureuc.Assessment
+	err error
+}
+
+func (f fakeExposureProducer) Assess(context.Context, shared.ID) (exposureuc.Assessment, error) {
+	return f.a, f.err
+}
+
+func TestNewExposureMapsAssessment(t *testing.T) {
+	f, err := NewExposure(fakeExposureProducer{a: exposureuc.Assessment{Exposure: 73, Scoreable: true, Reasons: []string{"2 open exposures"}}}).ExposureFor(context.Background(), "asset-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if f.Scoreable {
-		t.Fatal("abstaining exposure must not be scoreable")
+	if !f.Scoreable || f.Score != 73 || len(f.Reasons) != 1 || f.Reasons[0] != "2 open exposures" {
+		t.Fatalf("exposure not mapped to FactorInput: %+v", f)
 	}
-	if f.Score != 0 {
-		t.Fatalf("an abstaining factor must contribute 0, got %d", f.Score)
+}
+
+func TestNewExposurePassesAbstainThrough(t *testing.T) {
+	f, err := NewExposure(fakeExposureProducer{a: exposureuc.Assessment{Scoreable: false, Reasons: []string{"no inventory"}}}).ExposureFor(context.Background(), "asset-1")
+	if err != nil {
+		t.Fatal(err)
 	}
-	if len(f.Reasons) != 1 || f.Reasons[0] != "exposure not wired" {
-		t.Fatalf("reason not carried: %v", f.Reasons)
+	if f.Scoreable || f.Score != 0 {
+		t.Fatalf("abstain must flow through as 0/not-scoreable: %+v", f)
+	}
+}
+
+func TestNewExposurePropagatesError(t *testing.T) {
+	_, err := NewExposure(fakeExposureProducer{err: errors.New("store down")}).ExposureFor(context.Background(), "asset-1")
+	if err == nil {
+		t.Fatal("a producer error must propagate")
 	}
 }
 


### PR DESCRIPTION
feat(fleet): wire real Exposure (X5) into the tri-score assembler (#594/#634)

Follows the tri-score wiring PR: swaps the abstaining Exposure factor for the real
exposureuc producer, so the deterministic Scorer now runs on Threat + Exposure.

- riskscorebridge.NewExposure bridges exposureuc.Service (a narrow ExposureProducer
  interface) to the assembler's ExposureAssessor port, mapping exposureuc.Assessment
  (Exposure/Scoreable/Reasons) to FactorInput; a producer error propagates and an
  abstain flows through unchanged.
- cmd/synapse-api: construct exposurereader.NewReader over the SCA stores already in
  the composition (businessAssetStore = ports.BusinessAssetRepository satisfies
  MembershipReader; vulnerabilityOccurrences / vulnerabilityAssessments satisfy
  Occurrence/Risk readers) → exposureuc.NewService → NewExposure, replacing
  AbstainingExposure. This is installed-based exposure from the asset's open
  vulnerability occurrences + their risk; running-vs-installed refinement (the B5
  process store) stays a follow-up, and exposureuc honestly records that
  running-vs-installed precision is limited rather than discounting risk.
- Removed the now-unused AbstainingExposure. Behavior + Coverage still abstain
  (their producers are the remaining follow-ups).

Tests: NewExposure maps a scored assessment, passes an abstain through, and
propagates a producer error. build/vet/gofmt/arch clean; riskscorebridge /
riskscoreuc / httpapi / docs suites green.
