### PR TITLE
feat(fleet): correlation orchestration — detections → incidents → auto tri-score (#594 C2/C3)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -29,6 +30,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
 	ap "github.com/KKloudTarus/synapse-ce/internal/domain/attackpath"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/cloudposture"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/correlation"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
@@ -111,6 +113,7 @@ import (
 	exportuc "github.com/KKloudTarus/synapse-ce/internal/usecase/export"
 	findingsuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findings"
 	clusterinventoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/clusterinventory"
+	correlationuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/correlationuc"
 	coverageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/coverage"
 	coveragewindow "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/coveragewindow"
 	detectledger "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectledger"
@@ -1657,12 +1660,16 @@ func main() {
 		} else {
 			log.Warn("incident read + analyst-triage surface ENABLED but NOT DURABLE - incidents and their triage history live in memory and are lost on restart; configure SYNAPSE_DB_DSN for a durable store")
 		}
+		// The tri-score assembler is shared: it backs both the manual reassess route and the auto-reassess
+		// pass in correlation. It stays nil unless tri-score is enabled, in which case correlation passes it
+		// as a real reassessor (a nil *Service must NOT be boxed into the interface, so guard on the pointer).
+		var triScore *riskscoreuc.Service
 		if cfg.TriScoreReassessEnabled {
 			// Tri-score assembler (#594 C3/D/X5): the deterministic Scorer, run live on an incident's factors.
 			// Threat comes from the incident's own correlated severity (DefaultPolicy treats it as dominant);
-			// Exposure/Behavior/Coverage abstain honestly until their producers (exposureuc / baselineuc /
-			// coveragewindow) are wired — an abstaining factor contributes 0 and records its reason in the
-			// CoverageVector, never fabricating risk. incidentSvc satisfies the assembler's IncidentStore.
+			// Exposure is the real X5 producer; Behavior/Coverage abstain honestly until their producers
+			// (baselineuc / coveragewindow) are wired — an abstaining factor contributes 0 and records its
+			// reason in the CoverageVector, never fabricating risk. incidentSvc satisfies the IncidentStore.
 			scorer, serr := riskassessment.NewScorer(riskassessment.DefaultPolicy())
 			if serr != nil {
 				log.Error("tri-score scorer init failed", "err", serr)
@@ -1693,8 +1700,25 @@ func main() {
 				log.Error("tri-score assembler init failed", "err", aerr)
 				os.Exit(1)
 			}
+			triScore = assembler
 			router.SetIncidentRiskReassessor(assembler)
 			log.Warn("tri-score risk reassessment ENABLED (Threat + Exposure live; Behavior/Coverage abstaining until their producers are wired) - POST /api/v1/fleet/incidents/{id}/risk/reassess")
+		}
+		if cfg.FleetCorrelationEnabled {
+			// Correlation orchestration (#594 C2/C3): fold an engagement's sealed detections into incidents,
+			// and — when tri-score is enabled — auto-score each freshly created incident. This is the caller
+			// that turns detection ingest → incident → risk into a running pipeline.
+			var reassessor correlationuc.RiskReassessor
+			if triScore != nil {
+				reassessor = triScore
+			}
+			corr, cerr := correlationuc.NewService(detectionRecordStore, incidentSvc, reassessor, correlation.Config{Window: cfg.FleetCorrelationWindow, MaxPerIncident: cfg.FleetCorrelationMaxPerIncident}, auditLog, func() time.Time { return clock.Now().UTC() })
+			if cerr != nil {
+				log.Error("correlation service init failed", "err", cerr)
+				os.Exit(1)
+			}
+			router.SetIncidentCorrelator(corr)
+			log.Warn("fleet correlation ENABLED (detections -> incidents; auto-reassess=" + strconv.FormatBool(triScore != nil) + ") - POST /api/v1/fleet/engagements/{id}/correlate")
 		}
 	}
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -235,6 +235,9 @@ All off by default. The fleet needs PostgreSQL + `synapse-worker`; agents run on
 | `SYNAPSE_FLEET_TELEMETRY_INGEST_ENABLED` | `false` | Accept signed agent telemetry batches (A3, `POST /api/v1/fleet/telemetry`); verified + idempotently sequenced server-side. |
 | `SYNAPSE_FLEET_DETECTION_INGEST_ENABLED` | `false` | Accept signed agent detection batches (A4, `POST /api/v1/fleet/detections`); sealed once into the evidence chain. |
 | `SYNAPSE_FLEET_DETECTION_RECONCILE_INTERVAL` | `1m` | How often the tenant-scoped reconciler repairs pending attributed detections. |
+| `SYNAPSE_FLEET_CORRELATION_ENABLED` | `false` | Correlation orchestration (`POST /api/v1/fleet/engagements/{id}/correlate`): folds an engagement's sealed detections into incidents, auto-scoring each when tri-score is enabled. |
+| `SYNAPSE_FLEET_CORRELATION_WINDOW` | `30m` | Session gap for correlation — detections on one (asset, host) more than this apart start a new incident. |
+| `SYNAPSE_FLEET_CORRELATION_MAX_PER_INCIDENT` | `100` | Cap on detections one incident reflects individually before a storm is suppressed to a single note. |
 | `SYNAPSE_FLEET_KEY_REGISTRATION_ENABLED` | `false` | Serve agent signing-key registration (`POST /api/v1/fleet/keys`) + operator key list/revoke (A4, A0.2). |
 | `SYNAPSE_FLEET_STALE_AFTER` | `10m` | An agent older than this reads as stale (`<=0` disables the staleness view). |
 | `SYNAPSE_FLEET_COVERAGE_FRESHNESS_TARGET` | `24h` | Coverage freshness SLO. |

--- a/internal/adapter/httpapi/incident_handler.go
+++ b/internal/adapter/httpapi/incident_handler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/correlationuc"
 )
 
 // incidentReader is the read side of the Phase-C incident store this API surfaces (#594 C7):
@@ -39,8 +40,18 @@ type incidentRiskReassessor interface {
 	Reassess(ctx context.Context, actor string, incidentID shared.ID) (incident.Incident, error)
 }
 
+// incidentCorrelator folds an engagement's detections into incidents (#594 C2/C3), auto-scoring each when
+// a tri-score reassessor is wired. correlationuc.Service satisfies it. The actor is the FIRST arg after
+// ctx: the server-side authenticated principal.
+type incidentCorrelator interface {
+	CorrelateEngagement(ctx context.Context, actor string, engagementID shared.ID) (correlationuc.Result, error)
+}
+
 // SetIncidents wires the incident read surface (nil ⇒ the routes are not registered).
 func (rt *Router) SetIncidents(r incidentReader) { rt.incidents = r }
+
+// SetIncidentCorrelator wires the correlation surface (nil ⇒ the route is not registered).
+func (rt *Router) SetIncidentCorrelator(c incidentCorrelator) { rt.incidentCorrelator = c }
 
 // SetIncidentRiskReassessor wires the tri-score reassessment surface (nil ⇒ the route is not registered).
 func (rt *Router) SetIncidentRiskReassessor(r incidentRiskReassessor) { rt.incidentRiskReassessor = r }
@@ -193,6 +204,24 @@ func (rt *Router) changeIncidentStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, inc)
+}
+
+// correlationResponse renders a correlation pass: the incidents created + how many were tri-scored.
+type correlationResponse struct {
+	Created        []incident.Incident `json:"created"`
+	Reassessed     int                 `json:"reassessed"`
+	ReassessFailed int                 `json:"reassess_failed"`
+}
+
+// correlateEngagement folds the engagement's detections into incidents (auto-scoring each when tri-score
+// is wired) and returns the incidents created this pass. No request body: detections are read server-side.
+func (rt *Router) correlateEngagement(w http.ResponseWriter, r *http.Request) {
+	res, err := rt.incidentCorrelator.CorrelateEngagement(incidentTenantContext(r), PrincipalFrom(r.Context()), shared.ID(r.PathValue("id")))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, correlationResponse{Created: res.Created, Reassessed: res.Reassessed, ReassessFailed: res.ReassessFailed})
 }
 
 // reassessIncidentRisk runs the tri-score assembler for the incident and returns the updated incident

--- a/internal/adapter/httpapi/incident_reassess_test.go
+++ b/internal/adapter/httpapi/incident_reassess_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/correlationuc"
 )
 
 // fakeReassessor records the actor + id it was called with and returns a fixed incident.
@@ -67,5 +68,44 @@ func TestReassessRouteAbsentWhenUnwired(t *testing.T) {
 	rec := incidentReq(rt.routes(), "consultant", http.MethodPost, "/api/v1/fleet/incidents/inc-1/risk/reassess", "")
 	if rec.Code != http.StatusNotFound {
 		t.Fatalf("unwired reassess route must 404, got %d", rec.Code)
+	}
+}
+
+// fakeCorrelator records the actor + engagement id and returns a fixed result.
+type fakeCorrelator struct {
+	gotActor string
+	gotEng   shared.ID
+	calls    int
+}
+
+func (f *fakeCorrelator) CorrelateEngagement(_ context.Context, actor string, eng shared.ID) (correlationuc.Result, error) {
+	f.calls++
+	f.gotActor = actor
+	f.gotEng = eng
+	return correlationuc.Result{Created: []incident.Incident{{ID: "inc-new"}}, Reassessed: 1}, nil
+}
+
+func TestCorrelateEngagementRBACAndActor(t *testing.T) {
+	// readonly is forbidden (creates incidents → PermOperate); consultant is allowed + actor is the principal.
+	f := &fakeCorrelator{}
+	rt := &Router{log: discardLog(), incidents: &fakeIncidentStore{}, incidentCorrelator: f}
+	mux := rt.routes()
+
+	if rec := incidentReq(mux, "readonly", http.MethodPost, "/api/v1/fleet/engagements/eng-1/correlate", ""); rec.Code != http.StatusForbidden {
+		t.Fatalf("readonly must be forbidden, got %d", rec.Code)
+	}
+	rec := incidentReq(mux, "consultant", http.MethodPost, "/api/v1/fleet/engagements/eng-7/correlate", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("consultant correlate: got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if f.calls != 1 || f.gotActor != "analyst-1" || f.gotEng != "eng-7" {
+		t.Fatalf("actor/engagement not threaded: calls=%d actor=%q eng=%q", f.calls, f.gotActor, f.gotEng)
+	}
+}
+
+func TestCorrelateRouteAbsentWhenUnwired(t *testing.T) {
+	rt := &Router{log: discardLog(), incidents: &fakeIncidentStore{}} // no correlator
+	if rec := incidentReq(rt.routes(), "consultant", http.MethodPost, "/api/v1/fleet/engagements/eng-1/correlate", ""); rec.Code != http.StatusNotFound {
+		t.Fatalf("unwired correlate route must 404, got %d", rec.Code)
 	}
 }

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -83,6 +83,7 @@ type Router struct {
 	incidents              incidentReader            // optional; nil ⇒ incident read routes are not registered (#594 C7)
 	incidentTriage         incidentTriager           // optional; nil ⇒ incident triage routes are not registered (#594 C5)
 	incidentRiskReassessor incidentRiskReassessor    // optional; nil ⇒ the tri-score reassess route is not registered (#594 C3/D/X5)
+	incidentCorrelator     incidentCorrelator        // optional; nil ⇒ the correlation route is not registered (#594 C2/C3)
 	sarif                  sarifIngester             // optional; nil ⇒ the third-party SARIF import route is not registered
 	importedFindings       sarifReader               // optional read side for imported findings
 	fleetRolloutAdmin      fleetRolloutService       // optional; nil ⇒ the operator rollout routes are not served
@@ -416,6 +417,11 @@ func (rt *Router) routes() *http.ServeMux {
 			// RiskAssessment on the append-only incident log. Operator action (writes the incident), actor
 			// from the authenticated principal.
 			mux.HandleFunc("POST /api/v1/fleet/incidents/{id}/risk/reassess", rt.authz(userdom.PermOperate, rt.reassessIncidentRisk))
+		}
+		if rt.incidentCorrelator != nil {
+			// Correlation (#594 C2/C3): fold the engagement's sealed detections into incidents (auto-scoring
+			// each when tri-score is wired). Operator action (creates incidents), actor from the principal.
+			mux.HandleFunc("POST /api/v1/fleet/engagements/{id}/correlate", rt.authz(userdom.PermOperate, rt.correlateEngagement))
 		}
 	}
 	if rt.projects != nil {

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -447,6 +447,16 @@ type Config struct {
 	// Coverage as their producers are wired) via the deterministic Scorer. Off by default while the
 	// Exposure/Behavior/Coverage producers are still being integrated.
 	TriScoreReassessEnabled bool
+	// FleetCorrelationEnabled turns on the correlation orchestration (#594 C2/C3): an operator route that
+	// folds an engagement's sealed detections into incidents and (when tri-score is enabled) auto-scores
+	// each. Off by default.
+	FleetCorrelationEnabled bool
+	// FleetCorrelationWindow is the session gap for correlation: detections on one (asset, host) more than
+	// this apart start a new incident.
+	FleetCorrelationWindow time.Duration
+	// FleetCorrelationMaxPerIncident caps how many detections one incident reflects individually before a
+	// storm is suppressed to a single note.
+	FleetCorrelationMaxPerIncident int
 
 	// JSReachabilityEnabled turns on deterministic Tier-1 JavaScript/TypeScript import-reachability: a
 	// declared npm dependency that first-party source never imports becomes not_reachable, which the
@@ -712,6 +722,9 @@ func Load() Config {
 		ASTBin:                                os.Getenv("SYNAPSE_AST_BIN"),
 		PythonTaintEnabled:                    getbool("SYNAPSE_PYTAINT_ENABLED", false),
 		TriScoreReassessEnabled:               getbool("SYNAPSE_TRISCORE_REASSESS_ENABLED", false),
+		FleetCorrelationEnabled:               getbool("SYNAPSE_FLEET_CORRELATION_ENABLED", false),
+		FleetCorrelationWindow:                getduration("SYNAPSE_FLEET_CORRELATION_WINDOW", 30*time.Minute),
+		FleetCorrelationMaxPerIncident:        getint("SYNAPSE_FLEET_CORRELATION_MAX_PER_INCIDENT", 100),
 		JSReachabilityEnabled:                 getbool("SYNAPSE_JSREACH_ENABLED", false),
 		JSSymbolReachabilityEnabled:           getbool("SYNAPSE_JSREACH_TIER2_ENABLED", false),
 		RustReachabilityEnabled:               getbool("SYNAPSE_REACH_RUST", false),

--- a/internal/usecase/fleet/correlationuc/service.go
+++ b/internal/usecase/fleet/correlationuc/service.go
@@ -1,0 +1,153 @@
+// Package correlationuc is the Phase-C orchestration seam (#594 C2/C3): it reads an engagement's sealed
+// detections, folds them into incidents with the deterministic domain correlator, persists the new
+// incidents (idempotently), and — when a tri-score reassessor is wired — scores each freshly created
+// incident so a correlated incident lands with its RiskAssessment already computed. It is the caller that
+// turns the built-but-dormant correlator + incident store + tri-score assembler into a running
+// detection → incident → risk pipeline.
+//
+// Discipline: incident creation is the durable, must-succeed step; the tri-score pass is a best-effort
+// enhancement over an already-persisted incident, so a scoring failure never rolls back a recorded
+// incident — it is counted (ReassessFailed) and surfaced, never silently swallowed and never fatal.
+package correlationuc
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/correlation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// DetectionReader lists an engagement's sealed detection records (tenant-scoped via ctx).
+// ports.DetectionRecordStore satisfies it.
+type DetectionReader interface {
+	ListDetections(ctx context.Context, engagementID shared.ID) ([]detection.Record, error)
+}
+
+// IncidentRecorder persists correlator output as new incidents, idempotently. incidentuc.Service
+// satisfies it.
+type IncidentRecorder interface {
+	RecordCorrelation(ctx context.Context, events []incident.IncidentEvent) ([]incident.Incident, error)
+}
+
+// RiskReassessor runs the tri-score assembler for one incident. riskscoreuc.Service satisfies it. Optional:
+// a nil reassessor records incidents without a scoring pass (correlation still succeeds).
+type RiskReassessor interface {
+	Reassess(ctx context.Context, actor string, incidentID shared.ID) (incident.Incident, error)
+}
+
+// Result reports what one correlation pass produced. Created is the incidents newly recorded this pass;
+// Reassessed/ReassessFailed account for the best-effort tri-score pass over them.
+type Result struct {
+	Created        []incident.Incident
+	Reassessed     int
+	ReassessFailed int
+}
+
+// Service correlates an engagement's detections into scored incidents.
+type Service struct {
+	detections DetectionReader
+	incidents  IncidentRecorder
+	reassessor RiskReassessor // may be nil
+	cfg        correlation.Config
+	audit      ports.AuditLogger
+	now        func() time.Time
+}
+
+// NewService constructs the orchestrator. detections, incidents, audit and now are required; reassessor is
+// optional. cfg must be a valid correlation.Config (Window > 0, MaxPerIncident > 0).
+func NewService(detections DetectionReader, incidents IncidentRecorder, reassessor RiskReassessor, cfg correlation.Config, audit ports.AuditLogger, now func() time.Time) (*Service, error) {
+	switch {
+	case detections == nil:
+		return nil, fmt.Errorf("%w: correlation requires a detection reader", shared.ErrValidation)
+	case incidents == nil:
+		return nil, fmt.Errorf("%w: correlation requires an incident recorder", shared.ErrValidation)
+	case audit == nil:
+		return nil, fmt.Errorf("%w: correlation requires an audit logger", shared.ErrValidation)
+	case now == nil:
+		return nil, fmt.Errorf("%w: correlation requires a clock", shared.ErrValidation)
+	case cfg.Window <= 0:
+		return nil, fmt.Errorf("%w: correlation window must be positive", shared.ErrValidation)
+	case cfg.MaxPerIncident <= 0:
+		return nil, fmt.Errorf("%w: correlation max-per-incident must be positive", shared.ErrValidation)
+	}
+	return &Service{detections: detections, incidents: incidents, reassessor: reassessor, cfg: cfg, audit: audit, now: now}, nil
+}
+
+// CorrelateEngagement reads the engagement's detections, correlates them into incidents, records the new
+// ones, and (best-effort) tri-scores each. It is idempotent: the correlator mints deterministic incident
+// ids, so a re-run over the same detections records nothing new and reassesses nothing.
+func (s *Service) CorrelateEngagement(ctx context.Context, actor string, engagementID shared.ID) (Result, error) {
+	if actor == "" {
+		return Result{}, fmt.Errorf("%w: correlation requires an actor", shared.ErrValidation)
+	}
+	if engagementID.IsZero() {
+		return Result{}, fmt.Errorf("%w: engagement id is required", shared.ErrValidation)
+	}
+	records, err := s.detections.ListDetections(ctx, engagementID)
+	if err != nil {
+		return Result{}, fmt.Errorf("list detections: %w", err)
+	}
+	events, err := correlation.Correlate(s.cfg, signalsFromDetections(records))
+	if err != nil {
+		return Result{}, fmt.Errorf("correlate: %w", err)
+	}
+	created, err := s.incidents.RecordCorrelation(ctx, events)
+	if err != nil {
+		return Result{}, fmt.Errorf("record correlation: %w", err)
+	}
+
+	res := Result{Created: created}
+	// Best-effort tri-score pass. A scoring failure never rolls back a durably-recorded incident; it is
+	// counted so a caller sees that scoring was partial.
+	if s.reassessor != nil {
+		for i, inc := range created {
+			scored, rerr := s.reassessor.Reassess(ctx, actor, inc.ID)
+			if rerr != nil {
+				res.ReassessFailed++
+				continue
+			}
+			created[i] = scored
+			res.Reassessed++
+		}
+	}
+
+	entry := ports.AuditEntry{
+		Actor: actor, Action: "fleet.correlate_engagement", Target: engagementID.String(), At: s.now().UTC(),
+		Metadata: map[string]string{
+			"detections":      strconv.Itoa(len(records)),
+			"created":         strconv.Itoa(len(created)),
+			"reassessed":      strconv.Itoa(res.Reassessed),
+			"reassess_failed": strconv.Itoa(res.ReassessFailed),
+		},
+	}
+	if err := s.audit.Record(ctx, entry); err != nil {
+		return res, fmt.Errorf("audit correlate: %w", err)
+	}
+	return res, nil
+}
+
+// signalsFromDetections maps sealed detection records to correlation signals. The entity is the host the
+// detection was observed on, so detections on one host within the window fold into one incident; the
+// title is the detection's class + rule for a human-readable incident summary.
+func signalsFromDetections(records []detection.Record) []correlation.Signal {
+	signals := make([]correlation.Signal, 0, len(records))
+	for _, r := range records {
+		d := r.Detection
+		signals = append(signals, correlation.Signal{
+			ID:         r.ID,
+			AssetID:    r.AssetID,
+			EntityID:   d.HostID,
+			OccurredAt: d.Observed,
+			Severity:   d.Severity,
+			RuleID:     d.RuleID,
+			Title:      string(d.Class) + ": " + d.RuleID,
+		})
+	}
+	return signals
+}

--- a/internal/usecase/fleet/correlationuc/service_test.go
+++ b/internal/usecase/fleet/correlationuc/service_test.go
@@ -1,0 +1,125 @@
+package correlationuc
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/correlation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeDetections struct{ recs []detection.Record }
+
+func (f fakeDetections) ListDetections(context.Context, shared.ID) ([]detection.Record, error) {
+	return f.recs, nil
+}
+
+// fakeIncidents records correlator output into an in-memory map, honoring RecordCorrelation's batch
+// idempotency (an incident id seen before is skipped).
+type fakeIncidents struct{ seen map[shared.ID]bool }
+
+func (f *fakeIncidents) RecordCorrelation(_ context.Context, events []incident.IncidentEvent) ([]incident.Incident, error) {
+	if f.seen == nil {
+		f.seen = map[shared.ID]bool{}
+	}
+	var created []incident.Incident
+	for _, e := range events {
+		if f.seen[e.IncidentID] {
+			continue
+		}
+		f.seen[e.IncidentID] = true
+		created = append(created, incident.Incident{ID: e.IncidentID, State: incident.StateOpen})
+	}
+	return created, nil
+}
+
+type fakeReassessor struct {
+	calls int
+	err   error
+}
+
+func (f *fakeReassessor) Reassess(_ context.Context, _ string, id shared.ID) (incident.Incident, error) {
+	f.calls++
+	if f.err != nil {
+		return incident.Incident{}, f.err
+	}
+	return incident.Incident{ID: id, State: incident.StateOpen}, nil
+}
+
+type fakeAudit struct{ n int }
+
+func (f *fakeAudit) Record(context.Context, ports.AuditEntry) error { f.n++; return nil }
+
+func rec(id, host string, at time.Time) detection.Record {
+	return detection.Record{
+		ID: shared.ID(id), AssetID: "asset-1",
+		Detection: detection.Detection{RuleID: "r1", RuleVersion: 1, Class: detection.ClassProcess, Severity: shared.SeverityHigh, HostID: shared.ID(host), Observed: at},
+	}
+}
+
+func newSvc(t *testing.T, dets []detection.Record, re RiskReassessor) (*Service, *fakeAudit) {
+	t.Helper()
+	audit := &fakeAudit{}
+	s, err := NewService(fakeDetections{recs: dets}, &fakeIncidents{}, re, correlation.Config{Window: time.Hour, MaxPerIncident: 50}, audit, func() time.Time { return time.Unix(0, 0).UTC() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s, audit
+}
+
+func TestCorrelateCreatesAndReassesses(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	// Two detections on the same host within the window → one incident.
+	dets := []detection.Record{rec("d1", "host-1", base), rec("d2", "host-1", base.Add(time.Minute))}
+	re := &fakeReassessor{}
+	s, audit := newSvc(t, dets, re)
+
+	res, err := s.CorrelateEngagement(context.Background(), "operator", "eng-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Created) != 1 {
+		t.Fatalf("two same-host detections in-window must yield one incident, got %d", len(res.Created))
+	}
+	if res.Reassessed != 1 || res.ReassessFailed != 0 || re.calls != 1 {
+		t.Fatalf("the created incident must be auto-reassessed once: %+v calls=%d", res, re.calls)
+	}
+	if audit.n != 1 {
+		t.Fatalf("correlation must be audited once, got %d", audit.n)
+	}
+}
+
+func TestReassessFailureIsCountedNotFatal(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	s, _ := newSvc(t, []detection.Record{rec("d1", "host-1", base)}, &fakeReassessor{err: errors.New("scorer down")})
+	res, err := s.CorrelateEngagement(context.Background(), "operator", "eng-1")
+	if err != nil {
+		t.Fatalf("a reassess failure must NOT fail correlation (the incident is durably recorded): %v", err)
+	}
+	if len(res.Created) != 1 || res.Reassessed != 0 || res.ReassessFailed != 1 {
+		t.Fatalf("a scoring failure must be counted, not fatal: %+v", res)
+	}
+}
+
+func TestNilReassessorRecordsWithoutScoring(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	s, _ := newSvc(t, []detection.Record{rec("d1", "host-1", base)}, nil)
+	res, err := s.CorrelateEngagement(context.Background(), "operator", "eng-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Created) != 1 || res.Reassessed != 0 || res.ReassessFailed != 0 {
+		t.Fatalf("nil reassessor must record incidents without scoring: %+v", res)
+	}
+}
+
+func TestValidation(t *testing.T) {
+	if _, err := NewService(fakeDetections{}, &fakeIncidents{}, nil, correlation.Config{Window: 0, MaxPerIncident: 1}, &fakeAudit{}, func() time.Time { return time.Now() }); err == nil {
+		t.Fatal("a non-positive window must be rejected")
+	}
+}


### PR DESCRIPTION
feat(fleet): correlation orchestration — detections → incidents → auto tri-score (#594 C2/C3)

The domain correlator, the incident store, and the tri-score assembler existed but
nothing tied them together: sealed detections never became incidents. This adds the
missing orchestration so the detection → incident → risk pipeline runs.

- internal/usecase/fleet/correlationuc: reads an engagement's sealed detections
  (ports.DetectionRecordStore), folds them into incidents with the deterministic
  domain correlator, records the new ones (incidentuc.RecordCorrelation,
  idempotent), and — when a tri-score reassessor is wired — auto-scores each freshly
  created incident. Incident creation is the must-succeed step; the tri-score pass
  is best-effort over an already-durable incident, so a scoring failure is counted
  (ReassessFailed), never fatal and never a silent swallow.
- HTTP: POST /api/v1/fleet/engagements/{id}/correlate (PermOperate, tenant-scoped,
  actor = authenticated principal, no body). Registered only when wired (nil ⇒ 404).
- cmd/synapse-api: construct correlationuc over detectionRecordStore + incidentSvc,
  passing the tri-score assembler as the reassessor when tri-score is enabled (a nil
  *Service is never boxed into the interface). Behind SYNAPSE_FLEET_CORRELATION_ENABLED
  with tunable window / max-per-incident.

Tests: correlate creates + auto-reassesses; a reassess failure is counted not fatal;
a nil reassessor records without scoring; validation; the route's RBAC (readonly
forbidden), actor+engagement threading, and route-absent-when-unwired. Documented the
three new envs. build/vet/gofmt/arch/docs clean.
