### PR TITLE
feat(fleet): wire real Coverage into the tri-score assembler (#594)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -1693,7 +1693,7 @@ func main() {
 				incidentSvc,
 				riskscorebridge.NewExposure(exposureSvc),
 				riskscorebridge.AbstainingBehavior("behavior: baselineuc per-asset read path not yet wired"),
-				riskscorebridge.AbstainingCoverage(),
+				riskscorebridge.NewCoverage(coverageWindowStore),
 				scorer, auditLog, ids, func() time.Time { return clock.Now().UTC() },
 			)
 			if aerr != nil {
@@ -1702,7 +1702,7 @@ func main() {
 			}
 			triScore = assembler
 			router.SetIncidentRiskReassessor(assembler)
-			log.Warn("tri-score risk reassessment ENABLED (Threat + Exposure live; Behavior/Coverage abstaining until their producers are wired) - POST /api/v1/fleet/incidents/{id}/risk/reassess")
+			log.Warn("tri-score risk reassessment ENABLED (Threat + Exposure + Coverage live; Behavior abstaining until its producer is wired) - POST /api/v1/fleet/incidents/{id}/risk/reassess")
 		}
 		if cfg.FleetCorrelationEnabled {
 			// Correlation orchestration (#594 C2/C3): fold an engagement's sealed detections into incidents,

--- a/internal/usecase/fleet/riskscorebridge/bridge.go
+++ b/internal/usecase/fleet/riskscorebridge/bridge.go
@@ -5,19 +5,20 @@
 // into the CoverageVector, so a not-yet-wired factor lowers coverage/confidence and NEVER fabricates risk.
 //
 // This lets the deterministic Scorer run in production on the factors that ARE wired while the remaining
-// producers are swapped in as isolated follow-ups. Exposure is wired via NewExposure (over exposureuc);
-// Behavior and Coverage still abstain until their producers are integrated (Behavior → a baselineuc
-// per-asset read path, Coverage → coveragewindow). Each swap replaces one Abstaining* here with a real
-// bridge.
+// producers are swapped in as isolated follow-ups. Exposure is wired via NewExposure (over exposureuc) and
+// Coverage via NewCoverage (over the coverage-window store); Behavior still abstains until its producer (a
+// baselineuc per-asset read path) is integrated. Each swap replaces one Abstaining* here with a real bridge.
 package riskscorebridge
 
 import (
 	"context"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sensorstate"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/exposureuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/riskscoreuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 // ExposureProducer is the exposureuc surface the real Exposure bridge adapts. exposureuc.Service
@@ -56,14 +57,29 @@ func (a abstainingBehavior) BehaviorFor(context.Context, shared.ID) (riskscoreuc
 	return riskscoreuc.FactorInput{Scoreable: false, Reasons: []string{a.reason}}, nil
 }
 
-// abstainingCoverage reports no per-class detection coverage — used until coveragewindow is bridged. The
-// assembler then treats every class as an observation gap, which is the honest state when detection
-// coverage is not yet wired.
-type abstainingCoverage struct{}
+// CoverageWindowReader lists an asset's composed coverage windows (tenant-scoped via ctx).
+// ports.CoverageWindowStore satisfies it.
+type CoverageWindowReader interface {
+	ListCoverageWindows(ctx context.Context, q ports.CoverageWindowQuery) ([]sensorstate.CoverageWindow, error)
+}
 
-// AbstainingCoverage returns a CoverageSource that yields no class coverage (every class reads as a gap).
-func AbstainingCoverage() riskscoreuc.CoverageSource { return abstainingCoverage{} }
+type coverageBridge struct{ reader CoverageWindowReader }
 
-func (abstainingCoverage) ClassCoverageForAsset(context.Context, shared.ID) ([]detection.ClassCoverage, error) {
-	return nil, nil
+// NewCoverage bridges the real coverage-window store to the assembler's CoverageSource port: it returns
+// the per-class coverage of the asset's MOST RECENT composed window (windows are listed newest-first).
+// When the asset has no window yet, it returns nil — the assembler then reads every class as a gap, the
+// honest state when no coverage has been observed. This feeds the CoverageVector only, never Risk.
+func NewCoverage(reader CoverageWindowReader) riskscoreuc.CoverageSource {
+	return coverageBridge{reader: reader}
+}
+
+func (b coverageBridge) ClassCoverageForAsset(ctx context.Context, assetID shared.ID) ([]detection.ClassCoverage, error) {
+	windows, err := b.reader.ListCoverageWindows(ctx, ports.CoverageWindowQuery{AssetID: assetID, Limit: 1})
+	if err != nil {
+		return nil, err
+	}
+	if len(windows) == 0 {
+		return nil, nil
+	}
+	return windows[0].States, nil
 }

--- a/internal/usecase/fleet/riskscorebridge/bridge_test.go
+++ b/internal/usecase/fleet/riskscorebridge/bridge_test.go
@@ -5,8 +5,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sensorstate"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/exposureuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
 type fakeExposureProducer struct {
@@ -55,12 +58,32 @@ func TestAbstainingBehaviorAlwaysAbstains(t *testing.T) {
 	}
 }
 
-func TestAbstainingCoverageYieldsNoClasses(t *testing.T) {
-	classes, err := AbstainingCoverage().ClassCoverageForAsset(context.Background(), "asset-1")
+type fakeCoverageReader struct {
+	windows []sensorstate.CoverageWindow
+	err     error
+}
+
+func (f fakeCoverageReader) ListCoverageWindows(_ context.Context, _ ports.CoverageWindowQuery) ([]sensorstate.CoverageWindow, error) {
+	return f.windows, f.err
+}
+
+func TestNewCoverageReturnsLatestWindowStates(t *testing.T) {
+	states := []detection.ClassCoverage{{Class: detection.ClassProcess, HostID: "h1", State: detection.StateActive}}
+	cov, err := NewCoverage(fakeCoverageReader{windows: []sensorstate.CoverageWindow{{AssetID: "asset-1", States: states}}}).ClassCoverageForAsset(context.Background(), "asset-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(classes) != 0 {
-		t.Fatalf("abstaining coverage must yield no class coverage (all classes read as gaps), got %d", len(classes))
+	if len(cov) != 1 || cov[0].Class != detection.ClassProcess {
+		t.Fatalf("coverage must be the latest window's states: %+v", cov)
+	}
+}
+
+func TestNewCoverageEmptyWhenNoWindow(t *testing.T) {
+	cov, err := NewCoverage(fakeCoverageReader{}).ClassCoverageForAsset(context.Background(), "asset-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cov) != 0 {
+		t.Fatalf("no window must yield no coverage (all classes read as gaps), got %d", len(cov))
 	}
 }


### PR DESCRIPTION
feat(fleet): wire real Coverage into the tri-score assembler (#594)

Swaps the abstaining Coverage source for the real coverage-window store, so the
tri-score CoverageVector reflects actual per-class sensor coverage (Threat +
Exposure + Coverage now live; only Behavior still abstains).

- riskscorebridge.NewCoverage returns the per-class coverage of an asset's most
  recent composed coverage window (windows are listed newest-first); when the asset
  has no window, it returns nil so the assembler reads every class as an observation
  gap — the honest state when nothing has been observed. Feeds the CoverageVector
  only, never Risk.
- cmd/synapse-api: pass NewCoverage(coverageWindowStore) to the assembler; removed
  the now-unused AbstainingCoverage.

Tests: NewCoverage returns the latest window's states, and empty when no window.
build/vet/gofmt/arch clean.
