### PR TITLE
feat(fleet): wire B5 running-vs-installed exposure + process-report ingest (#594)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -290,6 +290,7 @@ func main() {
 	} // #611 append-only signed P0 health history
 	var privacyPolicyStore ports.PrivacyPolicyAuditStore // #611 immutable source-redaction policy history
 	var coverageWindowStore ports.CoverageWindowStore    // #611 immutable coverage-window revisions
+	var endpointProcessStore ports.EndpointProcessStore  // #594 B5 per-host running-process projection
 	var telemetrySvc *telemetryingest.Service            // wired to detection repair after both services exist
 	var detectSvc *detectledger.Service                  // tenant-scoped startup and periodic provenance repair
 	var detectionRunner *detectledger.ReconciliationRunner
@@ -492,6 +493,7 @@ func main() {
 			log.Error("postgres coverage-window store init failed", "err", err)
 			os.Exit(1)
 		}
+		endpointProcessStore = postgres.NewEndpointProcessRepository(pool)
 		fleetRolloutStore = postgres.NewFleetRolloutRepository(pool)
 		leaderStore = postgres.NewLeaderStore(pool)
 		// SECURITY (#431 req 6, #432, #409): the fleet_* tables are RLS-protected, but RLS is a
@@ -546,6 +548,7 @@ func main() {
 		privacyPolicyStore = memory.NewPrivacyPolicyStore()
 		sensorStateStore = memory.NewSensorStateStore()
 		coverageWindowStore = memory.NewCoverageWindowStore()
+		endpointProcessStore = memory.NewEndpointProcessStore()
 		fleetRolloutStore = memory.NewFleetRolloutStore()
 		findingRepo = memory.NewFindingRepository()
 		judgmentStore = memory.NewJudgmentStore()
@@ -1655,6 +1658,7 @@ func main() {
 			os.Exit(1)
 		}
 		router.SetIncidentTriage(triageSvc)
+		router.SetEndpointProcesses(endpointProcessStore) // #594 B5: running-process report/read + Exposure running-vs-installed
 		if cfg.DBDSN != "" {
 			log.Info("incident read + analyst-triage surface ENABLED (durable; append-only event log; tenant-scoped; RBAC-gated)")
 		} else {
@@ -1675,11 +1679,20 @@ func main() {
 				log.Error("tri-score scorer init failed", "err", serr)
 				os.Exit(1)
 			}
-			// Exposure (X5, #634): the real producer over the SCA stores — installed-based exposure from the
-			// asset's open vulnerability occurrences + their risk. Running-vs-installed refinement (the B5
-			// process store) is a further follow-up; NewReader (no runtime) scores installed exposures and
-			// records that running-vs-installed precision is limited, an honest coverage note.
-			exposureReader, xrerr := exposurereader.NewReader(businessAssetStore, vulnerabilityOccurrences, vulnerabilityAssessments)
+			// Exposure (X5, #634): the real producer over the SCA stores. When the component inventory
+			// exposes ListCurrentComponentsByEngagement, wire the RUNNING-vs-installed reader (B5): it marks
+			// which vulnerable components are actually running (endpointProcessStore) so exposure reflects
+			// runtime reachability, not just installed presence. Otherwise fall back to installed-only, which
+			// records that running-vs-installed precision is limited (an honest coverage note, never a Risk
+			// discount).
+			var exposureReader *exposurereader.Reader
+			var xrerr error
+			if componentLister, ok := vulnerabilityInventory.(exposurereader.ComponentLister); ok {
+				exposureReader, xrerr = exposurereader.NewReaderWithRuntime(businessAssetStore, vulnerabilityOccurrences, vulnerabilityAssessments, endpointProcessStore, componentLister)
+				log.Info("exposure: running-vs-installed ENABLED (B5 process store + component inventory)")
+			} else {
+				exposureReader, xrerr = exposurereader.NewReader(businessAssetStore, vulnerabilityOccurrences, vulnerabilityAssessments)
+			}
 			if xrerr != nil {
 				log.Error("exposure reader init failed", "err", xrerr)
 				os.Exit(1)

--- a/internal/adapter/httpapi/endpoint_process_handler.go
+++ b/internal/adapter/httpapi/endpoint_process_handler.go
@@ -1,0 +1,83 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// endpointProcessStore is the B5 per-host running-process projection this API surfaces (#594): an operator
+// (or a scanner/agent tool) reports the processes running on a host asset, and Exposure's
+// running-vs-installed refinement reads them. ports.EndpointProcessStore satisfies it. Snapshots are
+// tenant-scoped server-side (from ctx), never from a request field.
+type endpointProcessStore interface {
+	SaveProcesses(ctx context.Context, snapshots []ports.ProcessSnapshot) error
+	ListRunningByAsset(ctx context.Context, assetID shared.ID) ([]ports.ProcessSnapshot, error)
+}
+
+// SetEndpointProcesses wires the process-projection surface (nil ⇒ the routes are not registered).
+func (rt *Router) SetEndpointProcesses(s endpointProcessStore) { rt.endpointProcesses = s }
+
+const (
+	// endpointProcessBodyLimit caps a process-report body. A host reports a bounded process list; a very
+	// large body is refused rather than read unbounded.
+	endpointProcessBodyLimit = 1 << 20
+	maxEndpointProcesses     = 10000
+)
+
+type processReport struct {
+	EntityID   string    `json:"entity_id"`
+	PID        int       `json:"pid"`
+	Comm       string    `json:"comm"`
+	Path       string    `json:"path"`
+	Running    bool      `json:"running"`
+	LastSeenAt time.Time `json:"last_seen_at"`
+}
+
+type reportProcessesRequest struct {
+	Processes []processReport `json:"processes"`
+}
+
+// reportEndpointProcesses upserts the reported running-process snapshots for one host asset (#594 B5). The
+// tenant is the authenticated fleet tenant and the asset is the path id — never request fields, so a
+// report cannot claim another tenant's or asset's processes.
+func (rt *Router) reportEndpointProcesses(w http.ResponseWriter, r *http.Request) {
+	var req reportProcessesRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, endpointProcessBodyLimit)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
+		return
+	}
+	if len(req.Processes) > maxEndpointProcesses {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "too many processes in one report"})
+		return
+	}
+	ctx := incidentTenantContext(r)
+	tenant := fleetTenant(r.Context())
+	assetID := shared.ID(r.PathValue("id"))
+	snapshots := make([]ports.ProcessSnapshot, 0, len(req.Processes))
+	for _, p := range req.Processes {
+		snapshots = append(snapshots, ports.ProcessSnapshot{
+			TenantID: tenant, AssetID: assetID, EntityID: shared.ID(p.EntityID),
+			PID: p.PID, Comm: p.Comm, Path: p.Path, Running: p.Running, LastSeenAt: p.LastSeenAt,
+		})
+	}
+	if err := rt.endpointProcesses.SaveProcesses(ctx, snapshots); err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]int{"saved": len(snapshots)})
+}
+
+// listEndpointProcesses returns the currently-running processes for one host asset (#594 B5).
+func (rt *Router) listEndpointProcesses(w http.ResponseWriter, r *http.Request) {
+	running, err := rt.endpointProcesses.ListRunningByAsset(incidentTenantContext(r), shared.ID(r.PathValue("id")))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"processes": running})
+}

--- a/internal/adapter/httpapi/endpoint_process_handler_test.go
+++ b/internal/adapter/httpapi/endpoint_process_handler_test.go
@@ -1,0 +1,68 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeProcessStore struct {
+	saved []ports.ProcessSnapshot
+}
+
+func (f *fakeProcessStore) SaveProcesses(_ context.Context, s []ports.ProcessSnapshot) error {
+	f.saved = append(f.saved, s...)
+	return nil
+}
+
+func (f *fakeProcessStore) ListRunningByAsset(_ context.Context, assetID shared.ID) ([]ports.ProcessSnapshot, error) {
+	var out []ports.ProcessSnapshot
+	for _, p := range f.saved {
+		if p.AssetID == assetID && p.Running {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+func newProcessRouter(f *fakeProcessStore) *http.ServeMux {
+	rt := &Router{log: discardLog(), incidents: &fakeIncidentStore{}, endpointProcesses: f}
+	return rt.routes()
+}
+
+func TestReportProcessesRBACAndServerSideScoping(t *testing.T) {
+	f := &fakeProcessStore{}
+	mux := newProcessRouter(f)
+	body := `{"processes":[{"entity_id":"e1","pid":42,"comm":"nginx","path":"/usr/sbin/nginx","running":true}]}`
+
+	// readonly cannot report (writes the projection → PermOperate).
+	if rec := incidentReq(mux, "readonly", http.MethodPost, "/api/v1/fleet/assets/asset-9/processes", body); rec.Code != http.StatusForbidden {
+		t.Fatalf("readonly report must be forbidden, got %d", rec.Code)
+	}
+	// consultant can report; tenant + asset come from ctx/path, not the body.
+	if rec := incidentReq(mux, "consultant", http.MethodPost, "/api/v1/fleet/assets/asset-9/processes", body); rec.Code != http.StatusOK {
+		t.Fatalf("consultant report: got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if len(f.saved) != 1 || f.saved[0].AssetID != "asset-9" || f.saved[0].TenantID != "tenant-a" || f.saved[0].Comm != "nginx" {
+		t.Fatalf("snapshot not scoped server-side or not persisted: %+v", f.saved)
+	}
+}
+
+func TestListProcessesReadPerm(t *testing.T) {
+	f := &fakeProcessStore{saved: []ports.ProcessSnapshot{{AssetID: "asset-9", EntityID: "e1", Running: true}}}
+	mux := newProcessRouter(f)
+	rec := incidentReq(mux, "readonly", http.MethodGet, "/api/v1/fleet/assets/asset-9/processes", "")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("readonly list: got %d (%s)", rec.Code, rec.Body.String())
+	}
+}
+
+func TestProcessRoutesAbsentWhenUnwired(t *testing.T) {
+	rt := &Router{log: discardLog(), incidents: &fakeIncidentStore{}} // no process store
+	if rec := incidentReq(rt.routes(), "consultant", http.MethodPost, "/api/v1/fleet/assets/a1/processes", "{}"); rec.Code != http.StatusNotFound {
+		t.Fatalf("unwired process route must 404, got %d", rec.Code)
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -84,6 +84,7 @@ type Router struct {
 	incidentTriage         incidentTriager           // optional; nil ⇒ incident triage routes are not registered (#594 C5)
 	incidentRiskReassessor incidentRiskReassessor    // optional; nil ⇒ the tri-score reassess route is not registered (#594 C3/D/X5)
 	incidentCorrelator     incidentCorrelator        // optional; nil ⇒ the correlation route is not registered (#594 C2/C3)
+	endpointProcesses      endpointProcessStore      // optional; nil ⇒ the process-report routes are not registered (#594 B5)
 	sarif                  sarifIngester             // optional; nil ⇒ the third-party SARIF import route is not registered
 	importedFindings       sarifReader               // optional read side for imported findings
 	fleetRolloutAdmin      fleetRolloutService       // optional; nil ⇒ the operator rollout routes are not served
@@ -422,6 +423,13 @@ func (rt *Router) routes() *http.ServeMux {
 			// Correlation (#594 C2/C3): fold the engagement's sealed detections into incidents (auto-scoring
 			// each when tri-score is wired). Operator action (creates incidents), actor from the principal.
 			mux.HandleFunc("POST /api/v1/fleet/engagements/{id}/correlate", rt.authz(userdom.PermOperate, rt.correlateEngagement))
+		}
+		if rt.endpointProcesses != nil {
+			// B5 per-host running-process projection (#594): report the processes running on a host asset
+			// (feeds Exposure's running-vs-installed refinement), and read them back. Report = PermOperate
+			// (writes the projection); read = PermView. Tenant + asset are server-side, not request fields.
+			mux.HandleFunc("POST /api/v1/fleet/assets/{id}/processes", rt.authz(userdom.PermOperate, rt.reportEndpointProcesses))
+			mux.HandleFunc("GET /api/v1/fleet/assets/{id}/processes", rt.authz(userdom.PermView, rt.listEndpointProcesses))
 		}
 	}
 	if rt.projects != nil {


### PR DESCRIPTION
feat(fleet): wire B5 running-vs-installed exposure + process-report ingest (#594)

Exposure was installed-only because nothing populated the B5 process store — the
store (SaveProcesses/ListRunningByAsset) existed but had no ingest path. This adds
the ingest and switches Exposure to the running-vs-installed reader.

- cmd/synapse-api: construct endpointProcessStore (memory / postgres, migration
  0115). When the component inventory exposes ListCurrentComponentsByEngagement
  (type assertion), wire exposurereader.NewReaderWithRuntime so Exposure marks which
  vulnerable components are actually RUNNING (runtime reachability), not just
  installed; otherwise fall back to installed-only.
- HTTP (#594 B5): POST /api/v1/fleet/assets/{id}/processes reports a host's running
  processes (PermOperate) and GET returns them (PermView). Tenant + asset are taken
  server-side (fleet tenant + path id), never request fields, so a report cannot
  claim another tenant's/asset's processes; the store also fails closed on a
  tenant mismatch. Registered only when wired (nil ⇒ 404).

Tests: report RBAC (readonly forbidden) + server-side tenant/asset scoping + persist;
list read-perm; routes-absent-when-unwired. build/vet/gofmt/arch clean.
