### PR TITLE
feat(fleet): wire desired-vs-observed capability management (#594/#633)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -116,6 +116,7 @@ import (
 	correlationuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/correlationuc"
 	coverageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/coverage"
 	coveragewindow "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/coveragewindow"
+	desired "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/desired"
 	detectledger "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectledger"
 	exposurereader "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/exposurereader"
 	exposureuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/exposureuc"
@@ -215,6 +216,24 @@ func metricsAddrIsLoopback(addr string) bool {
 	return ip.IsLoopback()
 }
 
+// telemetryBindingReader adapts the telemetry transport store's agent→asset binding list to the
+// desired-vs-observed BindingReader (#633), mapping ports.TelemetryAssetBinding to desired.CurrentBinding.
+type telemetryBindingReader struct {
+	list func(context.Context) ([]ports.TelemetryAssetBinding, error)
+}
+
+func (b telemetryBindingReader) ListCurrentBindings(ctx context.Context, _ shared.ID) ([]desired.CurrentBinding, error) {
+	raw, err := b.list(ctx)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]desired.CurrentBinding, 0, len(raw))
+	for _, r := range raw {
+		out = append(out, desired.CurrentBinding{TenantID: r.TenantID, AssetID: r.AssetID, AgentID: r.AgentID})
+	}
+	return out, nil
+}
+
 func main() {
 	cfg := config.Load()
 	if cfg.CSPMEnabled && !cfg.FleetAssetsEnabled {
@@ -291,6 +310,7 @@ func main() {
 	var privacyPolicyStore ports.PrivacyPolicyAuditStore // #611 immutable source-redaction policy history
 	var coverageWindowStore ports.CoverageWindowStore    // #611 immutable coverage-window revisions
 	var endpointProcessStore ports.EndpointProcessStore  // #594 B5 per-host running-process projection
+	var fleetDesiredStore ports.FleetDesiredStore        // #633 desired-vs-observed capability state
 	var telemetrySvc *telemetryingest.Service            // wired to detection repair after both services exist
 	var detectSvc *detectledger.Service                  // tenant-scoped startup and periodic provenance repair
 	var detectionRunner *detectledger.ReconciliationRunner
@@ -494,6 +514,7 @@ func main() {
 			os.Exit(1)
 		}
 		endpointProcessStore = postgres.NewEndpointProcessRepository(pool)
+		fleetDesiredStore = postgres.NewFleetDesiredRepository(pool)
 		fleetRolloutStore = postgres.NewFleetRolloutRepository(pool)
 		leaderStore = postgres.NewLeaderStore(pool)
 		// SECURITY (#431 req 6, #432, #409): the fleet_* tables are RLS-protected, but RLS is a
@@ -549,6 +570,7 @@ func main() {
 		sensorStateStore = memory.NewSensorStateStore()
 		coverageWindowStore = memory.NewCoverageWindowStore()
 		endpointProcessStore = memory.NewEndpointProcessStore()
+		fleetDesiredStore = memory.NewFleetDesiredStore()
 		fleetRolloutStore = memory.NewFleetRolloutStore()
 		findingRepo = memory.NewFindingRepository()
 		judgmentStore = memory.NewJudgmentStore()
@@ -1659,6 +1681,25 @@ func main() {
 		}
 		router.SetIncidentTriage(triageSvc)
 		router.SetEndpointProcesses(endpointProcessStore) // #594 B5: running-process report/read + Exposure running-vs-installed
+		// Desired-vs-observed (#633): declare an asset's desired capabilities + list gaps against the
+		// observed agent fleet. Needs an asset reader (GetAssetByID) and the agent→asset binding list; both
+		// are read-only type assertions on stores already in the composition. If either is unavailable the
+		// surface is simply not registered (the routes 404) rather than booting a half-wired feature.
+		assetReader, assetReaderOK := assetStore.(desired.AssetReader)
+		bindingLister, bindingOK := telemetryTransportStore.(interface {
+			ListTelemetryAssetBindings(context.Context) ([]ports.TelemetryAssetBinding, error)
+		})
+		if assetReaderOK && bindingOK {
+			desiredSvc, derr := desired.NewService(fleetDesiredStore, assetReader, telemetryBindingReader{list: bindingLister.ListTelemetryAssetBindings}, fleetAgentStore, auditLog, clock, ids, cfg.FleetAgentStaleAfter)
+			if derr != nil {
+				log.Error("desired-vs-observed service init failed", "err", derr)
+				os.Exit(1)
+			}
+			router.SetDesiredCapabilities(desiredSvc)
+			log.Info("desired-vs-observed ENABLED (#633) - /api/v1/fleet/assets/{id}/desired-capabilities + /api/v1/fleet/desired-capabilities/gaps")
+		} else {
+			log.Warn("desired-vs-observed NOT wired: asset reader or telemetry binding list unavailable", "asset_reader", assetReaderOK, "binding_list", bindingOK)
+		}
 		if cfg.DBDSN != "" {
 			log.Info("incident read + analyst-triage surface ENABLED (durable; append-only event log; tenant-scoped; RBAC-gated)")
 		} else {

--- a/internal/adapter/httpapi/desired_handler.go
+++ b/internal/adapter/httpapi/desired_handler.go
@@ -1,0 +1,80 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetdesired"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	desireduc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/desired"
+)
+
+// desiredCapabilityService is the #633 desired-vs-observed surface: declare the capabilities an asset
+// SHOULD have, read them, clear them, and list the gaps against the observed agent fleet. desired.Service
+// satisfies it. Actor + tenant + asset are server-side (principal / fleet tenant / path id), never body.
+type desiredCapabilityService interface {
+	SetDesiredCapabilities(ctx context.Context, in desireduc.SetInput) (*fleetdesired.State, error)
+	Get(ctx context.Context, tenantID, assetID shared.ID) (*fleetdesired.State, error)
+	ClearDesiredCapabilities(ctx context.Context, in desireduc.ClearInput) error
+	Gaps(ctx context.Context, tenantID shared.ID) ([]desireduc.ReconciliationRow, error)
+}
+
+// SetDesiredCapabilities wires the desired-vs-observed surface (nil ⇒ the routes are not registered).
+func (rt *Router) SetDesiredCapabilities(s desiredCapabilityService) { rt.desiredCapabilities = s }
+
+type setDesiredRequest struct {
+	Capabilities []string `json:"capabilities"`
+}
+
+const desiredBodyLimit = 16 << 10
+
+func (rt *Router) setDesiredCapabilities(w http.ResponseWriter, r *http.Request) {
+	var req setDesiredRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, desiredBodyLimit)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
+		return
+	}
+	state, err := rt.desiredCapabilities.SetDesiredCapabilities(incidentTenantContext(r), desireduc.SetInput{
+		TenantID:     fleetTenant(r.Context()),
+		AssetID:      shared.ID(r.PathValue("id")),
+		Capabilities: req.Capabilities,
+		Actor:        shared.ID(PrincipalFrom(r.Context())),
+	})
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, state)
+}
+
+func (rt *Router) getDesiredCapabilities(w http.ResponseWriter, r *http.Request) {
+	state, err := rt.desiredCapabilities.Get(incidentTenantContext(r), fleetTenant(r.Context()), shared.ID(r.PathValue("id")))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, state)
+}
+
+func (rt *Router) clearDesiredCapabilities(w http.ResponseWriter, r *http.Request) {
+	err := rt.desiredCapabilities.ClearDesiredCapabilities(incidentTenantContext(r), desireduc.ClearInput{
+		TenantID: fleetTenant(r.Context()),
+		AssetID:  shared.ID(r.PathValue("id")),
+		Actor:    shared.ID(PrincipalFrom(r.Context())),
+	})
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (rt *Router) listDesiredGaps(w http.ResponseWriter, r *http.Request) {
+	rows, err := rt.desiredCapabilities.Gaps(incidentTenantContext(r), fleetTenant(r.Context()))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"gaps": rows})
+}

--- a/internal/adapter/httpapi/desired_handler_test.go
+++ b/internal/adapter/httpapi/desired_handler_test.go
@@ -1,0 +1,67 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetdesired"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	desireduc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/desired"
+)
+
+type fakeDesired struct {
+	setIn   desireduc.SetInput
+	clearIn desireduc.ClearInput
+}
+
+func (f *fakeDesired) SetDesiredCapabilities(_ context.Context, in desireduc.SetInput) (*fleetdesired.State, error) {
+	f.setIn = in
+	return &fleetdesired.State{TenantID: in.TenantID, AssetID: in.AssetID, Capabilities: in.Capabilities}, nil
+}
+func (f *fakeDesired) Get(_ context.Context, tenantID, assetID shared.ID) (*fleetdesired.State, error) {
+	return &fleetdesired.State{TenantID: tenantID, AssetID: assetID}, nil
+}
+func (f *fakeDesired) ClearDesiredCapabilities(_ context.Context, in desireduc.ClearInput) error {
+	f.clearIn = in
+	return nil
+}
+func (f *fakeDesired) Gaps(_ context.Context, _ shared.ID) ([]desireduc.ReconciliationRow, error) {
+	return []desireduc.ReconciliationRow{{AssetID: "asset-1", Capability: "edr", Covered: false}}, nil
+}
+
+func newDesiredRouter(f *fakeDesired) *http.ServeMux {
+	rt := &Router{log: discardLog(), incidents: &fakeIncidentStore{}, desiredCapabilities: f}
+	return rt.routes()
+}
+
+func TestDesiredCapabilitiesRBACAndServerSideScoping(t *testing.T) {
+	f := &fakeDesired{}
+	mux := newDesiredRouter(f)
+
+	// readonly cannot set (writes desired state → PermOperate).
+	if rec := incidentReq(mux, "readonly", http.MethodPut, "/api/v1/fleet/assets/asset-7/desired-capabilities", `{"capabilities":["edr"]}`); rec.Code != http.StatusForbidden {
+		t.Fatalf("readonly set must be forbidden, got %d", rec.Code)
+	}
+	// consultant can set; tenant + asset + actor come from ctx/path/principal, not the body.
+	if rec := incidentReq(mux, "consultant", http.MethodPut, "/api/v1/fleet/assets/asset-7/desired-capabilities", `{"capabilities":["edr"]}`); rec.Code != http.StatusOK {
+		t.Fatalf("consultant set: got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if f.setIn.AssetID != "asset-7" || f.setIn.TenantID != "tenant-a" || f.setIn.Actor != "analyst-1" || len(f.setIn.Capabilities) != 1 {
+		t.Fatalf("set input not scoped server-side: %+v", f.setIn)
+	}
+	// readonly CAN read gaps + get (PermView).
+	if rec := incidentReq(mux, "readonly", http.MethodGet, "/api/v1/fleet/desired-capabilities/gaps", ""); rec.Code != http.StatusOK {
+		t.Fatalf("readonly gaps: got %d", rec.Code)
+	}
+	if rec := incidentReq(mux, "readonly", http.MethodGet, "/api/v1/fleet/assets/asset-7/desired-capabilities", ""); rec.Code != http.StatusOK {
+		t.Fatalf("readonly get: got %d", rec.Code)
+	}
+}
+
+func TestDesiredRoutesAbsentWhenUnwired(t *testing.T) {
+	rt := &Router{log: discardLog(), incidents: &fakeIncidentStore{}} // no desired service
+	if rec := incidentReq(rt.routes(), "consultant", http.MethodGet, "/api/v1/fleet/desired-capabilities/gaps", ""); rec.Code != http.StatusNotFound {
+		t.Fatalf("unwired desired route must 404, got %d", rec.Code)
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -85,6 +85,7 @@ type Router struct {
 	incidentRiskReassessor incidentRiskReassessor    // optional; nil ⇒ the tri-score reassess route is not registered (#594 C3/D/X5)
 	incidentCorrelator     incidentCorrelator        // optional; nil ⇒ the correlation route is not registered (#594 C2/C3)
 	endpointProcesses      endpointProcessStore      // optional; nil ⇒ the process-report routes are not registered (#594 B5)
+	desiredCapabilities    desiredCapabilityService  // optional; nil ⇒ the desired-vs-observed routes are not registered (#633)
 	sarif                  sarifIngester             // optional; nil ⇒ the third-party SARIF import route is not registered
 	importedFindings       sarifReader               // optional read side for imported findings
 	fleetRolloutAdmin      fleetRolloutService       // optional; nil ⇒ the operator rollout routes are not served
@@ -430,6 +431,15 @@ func (rt *Router) routes() *http.ServeMux {
 			// (writes the projection); read = PermView. Tenant + asset are server-side, not request fields.
 			mux.HandleFunc("POST /api/v1/fleet/assets/{id}/processes", rt.authz(userdom.PermOperate, rt.reportEndpointProcesses))
 			mux.HandleFunc("GET /api/v1/fleet/assets/{id}/processes", rt.authz(userdom.PermView, rt.listEndpointProcesses))
+		}
+		if rt.desiredCapabilities != nil {
+			// Desired-vs-observed (#633): declare the capabilities an asset SHOULD have (PermOperate),
+			// read/clear them, and list the gaps against the observed agent fleet (PermView). Actor + tenant
+			// + asset are server-side, never request fields.
+			mux.HandleFunc("PUT /api/v1/fleet/assets/{id}/desired-capabilities", rt.authz(userdom.PermOperate, rt.setDesiredCapabilities))
+			mux.HandleFunc("GET /api/v1/fleet/assets/{id}/desired-capabilities", rt.authz(userdom.PermView, rt.getDesiredCapabilities))
+			mux.HandleFunc("DELETE /api/v1/fleet/assets/{id}/desired-capabilities", rt.authz(userdom.PermOperate, rt.clearDesiredCapabilities))
+			mux.HandleFunc("GET /api/v1/fleet/desired-capabilities/gaps", rt.authz(userdom.PermView, rt.listDesiredGaps))
 		}
 	}
 	if rt.projects != nil {

--- a/internal/infrastructure/persistence/memory/telemetry_transport_store.go
+++ b/internal/infrastructure/persistence/memory/telemetry_transport_store.go
@@ -780,6 +780,23 @@ func (s *TelemetryTransportStore) ResolveTelemetryAsset(ctx context.Context, age
 	return binding.AssetID, nil
 }
 
+// ListTelemetryAssetBindings returns the tenant's current agent→asset bindings (#633 desired-vs-observed),
+// tenant-scoped from ctx and ordered by agent id for stability.
+func (s *TelemetryTransportStore) ListTelemetryAssetBindings(ctx context.Context) ([]ports.TelemetryAssetBinding, error) {
+	tenant, err := requireTelemetryTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]ports.TelemetryAssetBinding, 0, len(s.bindings[tenant]))
+	for _, b := range s.bindings[tenant] {
+		out = append(out, b)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].AgentID < out[j].AgentID })
+	return out, nil
+}
+
 // ResolveTelemetryReferences resolves causal references from the existing accepted-event facts.
 func (s *TelemetryTransportStore) ResolveTelemetryReferences(ctx context.Context, agentID, assetID shared.ID, redactionPolicyDigest string, refs []fleetagent.TelemetryReference) (ports.TelemetryReferenceStatus, error) {
 	tenant, err := requireTelemetryTenant(ctx)

--- a/internal/infrastructure/persistence/postgres/telemetry_transport_repo.go
+++ b/internal/infrastructure/persistence/postgres/telemetry_transport_repo.go
@@ -709,6 +709,33 @@ func (r *TelemetryTransportRepository) ResolveTelemetryAsset(ctx context.Context
 	return asset, err
 }
 
+// ListTelemetryAssetBindings returns the tenant's current agent→asset bindings (#633 desired-vs-observed),
+// tenant-scoped from ctx and ordered by agent id.
+func (r *TelemetryTransportRepository) ListTelemetryAssetBindings(ctx context.Context) ([]ports.TelemetryAssetBinding, error) {
+	if err := requireTransportTenant(ctx); err != nil {
+		return nil, err
+	}
+	var out []ports.TelemetryAssetBinding
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		tenant, _ := shared.TenantFrom(ctx)
+		rows, err := tx.Query(ctx, `SELECT agent_id, asset_id, updated_at FROM telemetry_asset_bindings WHERE tenant_id=$1 ORDER BY agent_id`, tenant.String())
+		if err != nil {
+			return fmt.Errorf("list telemetry asset bindings: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var agentID, assetID string
+			var updatedAt time.Time
+			if err := rows.Scan(&agentID, &assetID, &updatedAt); err != nil {
+				return fmt.Errorf("scan telemetry asset binding: %w", err)
+			}
+			out = append(out, ports.TelemetryAssetBinding{TenantID: tenant, AgentID: shared.ID(agentID), AssetID: shared.ID(assetID), UpdatedAt: updatedAt})
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
 // TelemetryReferencesDurable resolves a detection's causal references from telemetry_batch_events,
 // the existing accepted raw-telemetry fact store. Missing or mismatched facts are pending, never inferred.
 func (r *TelemetryTransportRepository) ResolveTelemetryReferences(ctx context.Context, agentID, assetID shared.ID, redactionPolicyDigest string, refs []fleetagent.TelemetryReference) (ports.TelemetryReferenceStatus, error) {


### PR DESCRIPTION
feat(fleet): wire desired-vs-observed capability management (#594/#633)

The fleetdesired service (declare an asset's desired capabilities, reconcile against
the observed agent fleet, list gaps) was built but had no composition-root wiring or
API. This wires it end-to-end.

- persistence: add a read-only ListTelemetryAssetBindings(ctx) to the memory +
  postgres telemetry transport stores (the server-authoritative agent→asset binding
  is the observed side of the reconcile). Read-only; it does not touch the
  security-critical bind write path.
- cmd/synapse-api: construct fleetDesiredStore (memory/postgres) and desired.Service
  over the stores already in the composition — AssetReader (assetStore.GetAssetByID)
  and the binding list are read-only type assertions; if either is unavailable the
  surface is simply not registered (routes 404) rather than half-wired.
- HTTP (#633): PUT/GET/DELETE /api/v1/fleet/assets/{id}/desired-capabilities and
  GET /api/v1/fleet/desired-capabilities/gaps. Set/clear = PermOperate, read/gaps =
  PermView. Actor + tenant + asset are server-side (principal / fleet tenant / path
  id), never request fields.

Tests: handler RBAC (readonly cannot set) + server-side scoping of the SetInput; gaps
+ get are PermView; routes-absent-when-unwired. build/vet/gofmt/arch clean.
