### PR TITLE
feat(fleet): wire B7 State Timeline + retro-hunt (#594)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -118,6 +118,7 @@ import (
 	coveragewindow "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/coveragewindow"
 	desired "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/desired"
 	detectledger "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/detectledger"
+	endpointstate "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/endpointstate"
 	exposurereader "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/exposurereader"
 	exposureuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/exposureuc"
 	fleetaudit "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/fleetaudit"
@@ -126,6 +127,7 @@ import (
 	incidentuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/incidentuc"
 	keyregistry "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/keyregistry"
 	privacypolicy "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/privacypolicy"
+	retrohunt "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/retrohunt"
 	riskscorebridge "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/riskscorebridge"
 	riskscoreuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/riskscoreuc"
 	telemetryingest "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/telemetryingest"
@@ -307,12 +309,14 @@ func main() {
 		ports.SensorStateAuditStore
 		ports.CoverageSensorStateReader
 	} // #611 append-only signed P0 health history
-	var privacyPolicyStore ports.PrivacyPolicyAuditStore // #611 immutable source-redaction policy history
-	var coverageWindowStore ports.CoverageWindowStore    // #611 immutable coverage-window revisions
-	var endpointProcessStore ports.EndpointProcessStore  // #594 B5 per-host running-process projection
-	var fleetDesiredStore ports.FleetDesiredStore        // #633 desired-vs-observed capability state
-	var telemetrySvc *telemetryingest.Service            // wired to detection repair after both services exist
-	var detectSvc *detectledger.Service                  // tenant-scoped startup and periodic provenance repair
+	var privacyPolicyStore ports.PrivacyPolicyAuditStore  // #611 immutable source-redaction policy history
+	var coverageWindowStore ports.CoverageWindowStore     // #611 immutable coverage-window revisions
+	var endpointProcessStore ports.EndpointProcessStore   // #594 B5 per-host running-process projection
+	var fleetDesiredStore ports.FleetDesiredStore         // #633 desired-vs-observed capability state
+	var endpointTimelineStore ports.EndpointTimelineStore // #594 B7 State Timeline projection
+	var telemetrySvc *telemetryingest.Service             // wired to detection repair after both services exist
+	var endpointStateSvc *endpointstate.Service           // #594 B7 State-Timeline projector; fed by telemetry ingest
+	var detectSvc *detectledger.Service                   // tenant-scoped startup and periodic provenance repair
 	var detectionRunner *detectledger.ReconciliationRunner
 	var fleetAuditRunner *fleetaudit.ReconciliationRunner // #610/#611 state-local audit intention delivery
 	var fleetRolloutStore ports.FleetRolloutStore         // operator update-rollout plans (#412 req 9)
@@ -515,6 +519,7 @@ func main() {
 		}
 		endpointProcessStore = postgres.NewEndpointProcessRepository(pool)
 		fleetDesiredStore = postgres.NewFleetDesiredRepository(pool)
+		endpointTimelineStore = postgres.NewEndpointTimelineRepository(pool)
 		fleetRolloutStore = postgres.NewFleetRolloutRepository(pool)
 		leaderStore = postgres.NewLeaderStore(pool)
 		// SECURITY (#431 req 6, #432, #409): the fleet_* tables are RLS-protected, but RLS is a
@@ -571,6 +576,7 @@ func main() {
 		coverageWindowStore = memory.NewCoverageWindowStore()
 		endpointProcessStore = memory.NewEndpointProcessStore()
 		fleetDesiredStore = memory.NewFleetDesiredStore()
+		endpointTimelineStore = memory.NewEndpointTimelineStore()
 		fleetRolloutStore = memory.NewFleetRolloutStore()
 		findingRepo = memory.NewFindingRepository()
 		judgmentStore = memory.NewJudgmentStore()
@@ -1681,6 +1687,22 @@ func main() {
 		}
 		router.SetIncidentTriage(triageSvc)
 		router.SetEndpointProcesses(endpointProcessStore) // #594 B5: running-process report/read + Exposure running-vs-installed
+		// B7 State Timeline + retro-hunt (#594): the timeline projects accepted telemetry per host (fed by
+		// the telemetry-ingest fan-out, wired where telemetrySvc is built), and retro-hunt re-hunts a window
+		// of it. Read-only surfaces (PermView).
+		esSvc, esErr := endpointstate.NewService(endpointTimelineStore)
+		if esErr != nil {
+			log.Error("endpoint state-timeline service init failed", "err", esErr)
+			os.Exit(1)
+		}
+		endpointStateSvc = esSvc
+		router.SetEndpointTimeline(esSvc)
+		huntSvc, hErr := retrohunt.NewService(endpointTimelineStore)
+		if hErr != nil {
+			log.Error("retro-hunt service init failed", "err", hErr)
+			os.Exit(1)
+		}
+		router.SetRetroHunter(huntSvc)
 		// Desired-vs-observed (#633): declare an asset's desired capabilities + list gaps against the
 		// observed agent fleet. Needs an asset reader (GetAssetByID) and the agent→asset binding list; both
 		// are read-only type assertions on stores already in the composition. If either is unavailable the
@@ -1896,6 +1918,9 @@ func main() {
 			}
 			telemetrySvc.SetSensorStateStore(sensorStateStore)
 			telemetrySvc.SetCoverageReconciler(coverageReconciler)
+			if endpointStateSvc != nil { // #594 B7: project accepted telemetry into the State Timeline
+				telemetrySvc.SetEndpointTimeline(endpointStateSvc)
+			}
 			router.SetFleetTelemetry(telemetrySvc)
 			if cfg.DBDSN != "" {
 				log.Info("fleet telemetry ingest ENABLED (durable; server-side identity/key/schema verification, idempotent, acked)")

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -86,6 +86,8 @@ type Router struct {
 	incidentCorrelator     incidentCorrelator        // optional; nil ⇒ the correlation route is not registered (#594 C2/C3)
 	endpointProcesses      endpointProcessStore      // optional; nil ⇒ the process-report routes are not registered (#594 B5)
 	desiredCapabilities    desiredCapabilityService  // optional; nil ⇒ the desired-vs-observed routes are not registered (#633)
+	endpointTimeline       endpointTimelineReader    // optional; nil ⇒ the State-Timeline read route is not registered (#594 B7)
+	retroHunter            retroHunter               // optional; nil ⇒ the retro-hunt route is not registered (#594 B7)
 	sarif                  sarifIngester             // optional; nil ⇒ the third-party SARIF import route is not registered
 	importedFindings       sarifReader               // optional read side for imported findings
 	fleetRolloutAdmin      fleetRolloutService       // optional; nil ⇒ the operator rollout routes are not served
@@ -431,6 +433,14 @@ func (rt *Router) routes() *http.ServeMux {
 			// (writes the projection); read = PermView. Tenant + asset are server-side, not request fields.
 			mux.HandleFunc("POST /api/v1/fleet/assets/{id}/processes", rt.authz(userdom.PermOperate, rt.reportEndpointProcesses))
 			mux.HandleFunc("GET /api/v1/fleet/assets/{id}/processes", rt.authz(userdom.PermView, rt.listEndpointProcesses))
+		}
+		if rt.endpointTimeline != nil {
+			// B7 State Timeline (#594): read the per-host timeline projection of accepted telemetry. PermView.
+			mux.HandleFunc("GET /api/v1/fleet/assets/{id}/timeline", rt.authz(userdom.PermView, rt.queryEndpointTimeline))
+		}
+		if rt.retroHunter != nil {
+			// B7 retro-hunt (#594): re-hunt a window of the timeline around a pivot. PermView (read-only analysis).
+			mux.HandleFunc("POST /api/v1/fleet/assets/{id}/retro-hunt", rt.authz(userdom.PermView, rt.retroHuntEndpoint))
 		}
 		if rt.desiredCapabilities != nil {
 			// Desired-vs-observed (#633): declare the capabilities an asset SHOULD have (PermOperate),

--- a/internal/adapter/httpapi/timeline_handler.go
+++ b/internal/adapter/httpapi/timeline_handler.go
@@ -1,0 +1,115 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/retrohunt"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// endpointTimelineReader queries the B7 State Timeline (#594) for a host asset. endpointstate.Service
+// satisfies it. retroHunter re-hunts a window of the timeline around a pivot; retrohunt.Service satisfies
+// it. Both are read surfaces; tenant + asset are server-side (fleet tenant / path id).
+type endpointTimelineReader interface {
+	Query(ctx context.Context, q ports.EndpointTimelineQuery) ([]endpoint.TimelineEntry, error)
+}
+
+type retroHunter interface {
+	Hunt(ctx context.Context, req retrohunt.Request) (retrohunt.Result, error)
+}
+
+// SetEndpointTimeline wires the State-Timeline read surface (nil ⇒ the routes are not registered).
+func (rt *Router) SetEndpointTimeline(r endpointTimelineReader) { rt.endpointTimeline = r }
+
+// SetRetroHunter wires the retro-hunt surface (nil ⇒ the route is not registered).
+func (rt *Router) SetRetroHunter(h retroHunter) { rt.retroHunter = h }
+
+const (
+	defaultTimelineLimit = 500
+	maxTimelineLimit     = 5000
+	retroHuntBodyLimit   = 4 << 10
+)
+
+func parseTimelineTime(raw string) (time.Time, error) {
+	if raw == "" {
+		return time.Time{}, nil
+	}
+	return time.Parse(time.RFC3339, raw)
+}
+
+func timelineLimit(raw string) int {
+	if raw == "" {
+		return defaultTimelineLimit
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 {
+		return defaultTimelineLimit
+	}
+	if n > maxTimelineLimit {
+		return maxTimelineLimit
+	}
+	return n
+}
+
+// queryEndpointTimeline returns the State-Timeline window for a host asset (#594 B7). Query params:
+// from/to (RFC3339), entity, limit (1..5000, default 500).
+func (rt *Router) queryEndpointTimeline(w http.ResponseWriter, r *http.Request) {
+	from, err := parseTimelineTime(r.URL.Query().Get("from"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid from (want RFC3339)"})
+		return
+	}
+	to, err := parseTimelineTime(r.URL.Query().Get("to"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid to (want RFC3339)"})
+		return
+	}
+	entries, err := rt.endpointTimeline.Query(incidentTenantContext(r), ports.EndpointTimelineQuery{
+		AssetID:  shared.ID(r.PathValue("id")),
+		From:     from,
+		To:       to,
+		EntityID: shared.ID(r.URL.Query().Get("entity")),
+		Limit:    timelineLimit(r.URL.Query().Get("limit")),
+	})
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"entries": entries})
+}
+
+type retroHuntRequest struct {
+	Around        time.Time `json:"around"`
+	BeforeSeconds int64     `json:"before_seconds"`
+	AfterSeconds  int64     `json:"after_seconds"`
+	EntityID      string    `json:"entity_id"`
+	Limit         int       `json:"limit"`
+}
+
+// retroHuntEndpoint re-hunts the timeline window around a pivot time for a host asset (#594 B7/C retro).
+func (rt *Router) retroHuntEndpoint(w http.ResponseWriter, r *http.Request) {
+	var req retroHuntRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, retroHuntBodyLimit)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
+		return
+	}
+	res, err := rt.retroHunter.Hunt(incidentTenantContext(r), retrohunt.Request{
+		AssetID:  shared.ID(r.PathValue("id")),
+		Around:   req.Around,
+		Before:   time.Duration(req.BeforeSeconds) * time.Second,
+		After:    time.Duration(req.AfterSeconds) * time.Second,
+		EntityID: shared.ID(req.EntityID),
+		Limit:    req.Limit,
+	})
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, res)
+}

--- a/internal/adapter/httpapi/timeline_handler_test.go
+++ b/internal/adapter/httpapi/timeline_handler_test.go
@@ -1,0 +1,54 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/retrohunt"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeTimeline struct{ gotQ ports.EndpointTimelineQuery }
+
+func (f *fakeTimeline) Query(_ context.Context, q ports.EndpointTimelineQuery) ([]endpoint.TimelineEntry, error) {
+	f.gotQ = q
+	return nil, nil
+}
+
+type fakeHunter struct{ gotReq retrohunt.Request }
+
+func (f *fakeHunter) Hunt(_ context.Context, req retrohunt.Request) (retrohunt.Result, error) {
+	f.gotReq = req
+	return retrohunt.Result{AssetID: req.AssetID}, nil
+}
+
+func TestTimelineAndRetroHuntPermViewAndScoping(t *testing.T) {
+	tl := &fakeTimeline{}
+	h := &fakeHunter{}
+	rt := &Router{log: discardLog(), incidents: &fakeIncidentStore{}, endpointTimeline: tl, retroHunter: h}
+	mux := rt.routes()
+
+	// readonly can read the timeline (PermView) + asset from path.
+	if rec := incidentReq(mux, "readonly", http.MethodGet, "/api/v1/fleet/assets/asset-3/timeline?limit=10", ""); rec.Code != http.StatusOK {
+		t.Fatalf("readonly timeline: got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if tl.gotQ.AssetID != "asset-3" || tl.gotQ.Limit != 10 {
+		t.Fatalf("timeline query not scoped from path/params: %+v", tl.gotQ)
+	}
+	// readonly can retro-hunt (PermView, read-only analysis).
+	if rec := incidentReq(mux, "readonly", http.MethodPost, "/api/v1/fleet/assets/asset-3/retro-hunt", `{"before_seconds":60,"after_seconds":60}`); rec.Code != http.StatusOK {
+		t.Fatalf("readonly retro-hunt: got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if h.gotReq.AssetID != "asset-3" {
+		t.Fatalf("retro-hunt asset not from path: %+v", h.gotReq)
+	}
+}
+
+func TestTimelineRoutesAbsentWhenUnwired(t *testing.T) {
+	rt := &Router{log: discardLog(), incidents: &fakeIncidentStore{}}
+	if rec := incidentReq(rt.routes(), "readonly", http.MethodGet, "/api/v1/fleet/assets/a1/timeline", ""); rec.Code != http.StatusNotFound {
+		t.Fatalf("unwired timeline route must 404, got %d", rec.Code)
+	}
+}

--- a/internal/usecase/fleet/telemetryingest/service.go
+++ b/internal/usecase/fleet/telemetryingest/service.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/fleetagent"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
@@ -64,7 +65,20 @@ type Service struct {
 	bindings     ports.TelemetryAssetBindingStore
 	audit        ports.IdempotentAuditLogger
 	clock        ports.Clock
+	timeline     EnvelopeRecorder // optional #594 B7 State-Timeline projection sink
 }
+
+// EnvelopeRecorder projects an accepted telemetry envelope into the endpoint State Timeline (#594 B7).
+// endpointstate.Service satisfies it. Record is idempotent (deduped by EventID), so the best-effort
+// fan-out after a durable accept is safe to retry.
+type EnvelopeRecorder interface {
+	Record(ctx context.Context, env telemetry.TelemetryEnvelope) ([]endpoint.TimelineEntry, error)
+}
+
+// SetEndpointTimeline enables the B7 State-Timeline projection: after a batch is durably accepted, each
+// verified envelope is projected into the timeline best-effort. Kept optional (nil ⇒ no projection) so
+// existing telemetry-only compositions are unchanged, mirroring SetSensorStateStore.
+func (s *Service) SetEndpointTimeline(r EnvelopeRecorder) { s.timeline = r }
 
 func NewService(
 	transport ports.TelemetryAuditStore,
@@ -344,6 +358,20 @@ func (s *Service) Ingest(ctx context.Context, authAgentID shared.ID, req IngestR
 		}
 		if err := s.record(ctx, authAgentID, m, "fleet.telemetry.ingest", telemetryBatchGapOpen(m), now); err != nil {
 			return IngestResult{}, err
+		}
+		// B7 State-Timeline projection (#594): fan the just-accepted, already-redaction-authorized envelopes
+		// into the timeline. Best-effort — the batch is already durably stored, so a projection failure must
+		// not fail ingest; it is surfaced via an audit note, never silently swallowed. Record is idempotent,
+		// so this is safe on the ingest-retry loop.
+		if s.timeline != nil {
+			for _, v := range verified {
+				if _, terr := s.timeline.Record(ctx, v.envelope); terr != nil {
+					_ = s.audit.Record(ctx, ports.AuditEntry{
+						Actor: authAgentID.String(), Action: "fleet.timeline.projection_failed", Target: m.StreamID.String(), At: now,
+						Metadata: map[string]string{"event_id": v.envelope.EventID.String(), "batch_id": m.BatchID.String()},
+					})
+				}
+			}
 		}
 		return IngestResult{Accepted: true, ACK: ledger.HighestContiguous(), Provenance: ProvenanceAcknowledged, GapOpen: gapOpen}, nil
 	}

--- a/internal/usecase/fleet/telemetryingest/timeline_fanout_test.go
+++ b/internal/usecase/fleet/telemetryingest/timeline_fanout_test.go
@@ -1,0 +1,52 @@
+package telemetryingest
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/telemetry"
+)
+
+type fakeTimelineRecorder struct {
+	calls int
+	err   error
+}
+
+func (f *fakeTimelineRecorder) Record(_ context.Context, _ telemetry.TelemetryEnvelope) ([]endpoint.TimelineEntry, error) {
+	f.calls++
+	return nil, f.err
+}
+
+// TestIngestFansOutAcceptedEnvelopesToTimeline: a durably-accepted batch projects each envelope into the
+// State Timeline (#594 B7).
+func TestIngestFansOutAcceptedEnvelopesToTimeline(t *testing.T) {
+	h := newHarness(t)
+	rec := &fakeTimelineRecorder{}
+	h.svc.SetEndpointTimeline(rec)
+	res, err := h.svc.Ingest(h.ctx, "agent-1", h.signedBatch(1, 1, 0, "e1"))
+	if err != nil {
+		t.Fatalf("ingest: %v", err)
+	}
+	if !res.Accepted {
+		t.Fatal("batch must be accepted")
+	}
+	if rec.calls != 1 {
+		t.Fatalf("the accepted envelope must be projected to the timeline once, got %d", rec.calls)
+	}
+}
+
+// TestIngestTimelineProjectionFailureDoesNotFailIngest: the projection is best-effort — the batch is
+// already durably stored, so a timeline failure must NOT fail the ingest.
+func TestIngestTimelineProjectionFailureDoesNotFailIngest(t *testing.T) {
+	h := newHarness(t)
+	h.svc.SetEndpointTimeline(&fakeTimelineRecorder{err: errors.New("timeline store down")})
+	res, err := h.svc.Ingest(h.ctx, "agent-1", h.signedBatch(1, 1, 0, "e1"))
+	if err != nil {
+		t.Fatalf("a timeline projection failure must not fail ingest: %v", err)
+	}
+	if !res.Accepted {
+		t.Fatal("batch must still be accepted despite the projection failure")
+	}
+}


### PR DESCRIPTION
feat(fleet): wire B7 State Timeline + retro-hunt (#594)

endpointstate (State Timeline) and retrohunt were built but dormant: nothing
populated the EndpointTimelineStore, and there was no read surface. This wires the
projection + the read/hunt API.

Feed (security-reviewed): telemetryingest gets an optional EnvelopeRecorder sink via
SetEndpointTimeline (mirrors the existing SetSensorStateStore optional-collaborator
pattern). The fan-out runs ONLY on the accept path — after the batch is verified,
authenticated, redaction-authorized, and DURABLY committed — so it projects only
already-accepted, already-redaction-authorized envelopes (no new trust boundary or
data exposure). It is best-effort: endpointstate.Record is idempotent (deduped by
EventID), and a projection failure is surfaced via an audit note and never fails the
ingest (the telemetry is already durably stored). Existing telemetry-only
compositions are unchanged (nil sink ⇒ no projection).

- cmd/synapse-api: construct endpointTimelineStore (memory/postgres) +
  endpointstate.Service + retrohunt.Service; feed telemetrySvc.SetEndpointTimeline.
- HTTP (#594 B7): GET /api/v1/fleet/assets/{id}/timeline (State Timeline window,
  PermView) and POST /api/v1/fleet/assets/{id}/retro-hunt (re-hunt a window around a
  pivot, PermView). Tenant + asset server-side. Registered only when wired (404 otherwise).

Tests: the ingest fan-out projects the accepted envelope, and a projection failure
does NOT fail ingest; timeline/retro-hunt handler PermView + path scoping +
routes-absent-when-unwired. build/vet/gofmt/arch clean; telemetry e2e failure-matrix
still green (fan-out doesn't perturb ingest).
