### PR TITLE
feat(fleet): wire real Behavior into the tri-score assembler — all 4 factors live (#594 D)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -112,6 +112,8 @@ import (
 	exploitationuc "github.com/KKloudTarus/synapse-ce/internal/usecase/exploitation"
 	exportuc "github.com/KKloudTarus/synapse-ce/internal/usecase/export"
 	findingsuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findings"
+	baselineuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/baselineuc"
+	behaviorbaseline "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/behaviorbaseline"
 	clusterinventoryuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/clusterinventory"
 	correlationuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/correlationuc"
 	coverageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/coverage"
@@ -314,6 +316,7 @@ func main() {
 	var endpointProcessStore ports.EndpointProcessStore   // #594 B5 per-host running-process projection
 	var fleetDesiredStore ports.FleetDesiredStore         // #633 desired-vs-observed capability state
 	var endpointTimelineStore ports.EndpointTimelineStore // #594 B7 State Timeline projection
+	var baselineStore ports.BaselineStore                 // #594 D behavioral baseline state
 	var telemetrySvc *telemetryingest.Service             // wired to detection repair after both services exist
 	var endpointStateSvc *endpointstate.Service           // #594 B7 State-Timeline projector; fed by telemetry ingest
 	var detectSvc *detectledger.Service                   // tenant-scoped startup and periodic provenance repair
@@ -520,6 +523,7 @@ func main() {
 		endpointProcessStore = postgres.NewEndpointProcessRepository(pool)
 		fleetDesiredStore = postgres.NewFleetDesiredRepository(pool)
 		endpointTimelineStore = postgres.NewEndpointTimelineRepository(pool)
+		baselineStore = postgres.NewBaselineRepository(pool)
 		fleetRolloutStore = postgres.NewFleetRolloutRepository(pool)
 		leaderStore = postgres.NewLeaderStore(pool)
 		// SECURITY (#431 req 6, #432, #409): the fleet_* tables are RLS-protected, but RLS is a
@@ -577,6 +581,7 @@ func main() {
 		endpointProcessStore = memory.NewEndpointProcessStore()
 		fleetDesiredStore = memory.NewFleetDesiredStore()
 		endpointTimelineStore = memory.NewEndpointTimelineStore()
+		baselineStore = memory.NewBaselineStore()
 		fleetRolloutStore = memory.NewFleetRolloutStore()
 		findingRepo = memory.NewFindingRepository()
 		judgmentStore = memory.NewJudgmentStore()
@@ -1686,7 +1691,21 @@ func main() {
 			os.Exit(1)
 		}
 		router.SetIncidentTriage(triageSvc)
+		// Behavioral baseline (#594 D): learn each asset's normal running-process profile at report time and
+		// score the current profile read-only at risk-assessment time (the assembler's Behavior factor). It
+		// is the ONLY place a behavior anomaly becomes a risk factor, and stays a factor (never sets Risk).
+		baselineSvc, blErr := baselineuc.NewService(baselineStore, auditLog, func() time.Time { return clock.Now().UTC() }, baselineuc.DefaultPolicy())
+		if blErr != nil {
+			log.Error("behavioral baseline service init failed", "err", blErr)
+			os.Exit(1)
+		}
+		behaviorSvc, bhErr := behaviorbaseline.NewService(baselineSvc, endpointProcessStore)
+		if bhErr != nil {
+			log.Error("behavior-baseline producer init failed", "err", bhErr)
+			os.Exit(1)
+		}
 		router.SetEndpointProcesses(endpointProcessStore) // #594 B5: running-process report/read + Exposure running-vs-installed
+		router.SetProcessLearner(behaviorSvc)             // #594 D: learn the process profile on each report
 		// B7 State Timeline + retro-hunt (#594): the timeline projects accepted telemetry per host (fed by
 		// the telemetry-ingest fan-out, wired where telemetrySvc is built), and retro-hunt re-hunts a window
 		// of it. Read-only surfaces (PermView).
@@ -1768,7 +1787,7 @@ func main() {
 			assembler, aerr := riskscoreuc.NewService(
 				incidentSvc,
 				riskscorebridge.NewExposure(exposureSvc),
-				riskscorebridge.AbstainingBehavior("behavior: baselineuc per-asset read path not yet wired"),
+				riskscorebridge.NewBehavior(behaviorSvc),
 				riskscorebridge.NewCoverage(coverageWindowStore),
 				scorer, auditLog, ids, func() time.Time { return clock.Now().UTC() },
 			)
@@ -1778,7 +1797,7 @@ func main() {
 			}
 			triScore = assembler
 			router.SetIncidentRiskReassessor(assembler)
-			log.Warn("tri-score risk reassessment ENABLED (Threat + Exposure + Coverage live; Behavior abstaining until its producer is wired) - POST /api/v1/fleet/incidents/{id}/risk/reassess")
+			log.Warn("tri-score risk reassessment ENABLED (all four factors live: Threat + Exposure + Behavior + Coverage) - POST /api/v1/fleet/incidents/{id}/risk/reassess")
 		}
 		if cfg.FleetCorrelationEnabled {
 			// Correlation orchestration (#594 C2/C3): fold an engagement's sealed detections into incidents,

--- a/internal/adapter/httpapi/endpoint_process_handler.go
+++ b/internal/adapter/httpapi/endpoint_process_handler.go
@@ -19,8 +19,17 @@ type endpointProcessStore interface {
 	ListRunningByAsset(ctx context.Context, assetID shared.ID) ([]ports.ProcessSnapshot, error)
 }
 
+// processLearner folds a just-reported process profile into the asset's behavioral baseline (#594 D).
+// behaviorbaseline.Service satisfies it. Optional: nil ⇒ reporting does not learn.
+type processLearner interface {
+	Learn(ctx context.Context, actor string, assetID shared.ID) error
+}
+
 // SetEndpointProcesses wires the process-projection surface (nil ⇒ the routes are not registered).
 func (rt *Router) SetEndpointProcesses(s endpointProcessStore) { rt.endpointProcesses = s }
+
+// SetProcessLearner wires the behavioral-baseline learner (nil ⇒ reported processes are not learned).
+func (rt *Router) SetProcessLearner(l processLearner) { rt.processLearner = l }
 
 const (
 	// endpointProcessBodyLimit caps a process-report body. A host reports a bounded process list; a very
@@ -68,6 +77,13 @@ func (rt *Router) reportEndpointProcesses(w http.ResponseWriter, r *http.Request
 	if err := rt.endpointProcesses.SaveProcesses(ctx, snapshots); err != nil {
 		writeError(w, rt.log, err)
 		return
+	}
+	// Best-effort: fold the reported profile into the asset's behavioral baseline (#594 D). The processes
+	// are already durably saved, so a learn failure must not fail the report; log it, never swallow silently.
+	if rt.processLearner != nil {
+		if err := rt.processLearner.Learn(ctx, PrincipalFrom(r.Context()), assetID); err != nil {
+			rt.log.Warn("behavior baseline learn failed", "asset", assetID, "err", err)
+		}
 	}
 	writeJSON(w, http.StatusOK, map[string]int{"saved": len(snapshots)})
 }

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -85,6 +85,7 @@ type Router struct {
 	incidentRiskReassessor incidentRiskReassessor    // optional; nil ⇒ the tri-score reassess route is not registered (#594 C3/D/X5)
 	incidentCorrelator     incidentCorrelator        // optional; nil ⇒ the correlation route is not registered (#594 C2/C3)
 	endpointProcesses      endpointProcessStore      // optional; nil ⇒ the process-report routes are not registered (#594 B5)
+	processLearner         processLearner            // optional; nil ⇒ reported processes are not folded into the behavior baseline (#594 D)
 	desiredCapabilities    desiredCapabilityService  // optional; nil ⇒ the desired-vs-observed routes are not registered (#633)
 	endpointTimeline       endpointTimelineReader    // optional; nil ⇒ the State-Timeline read route is not registered (#594 B7)
 	retroHunter            retroHunter               // optional; nil ⇒ the retro-hunt route is not registered (#594 B7)

--- a/internal/usecase/fleet/baselineuc/service.go
+++ b/internal/usecase/fleet/baselineuc/service.go
@@ -199,6 +199,31 @@ func (s *Service) Rebaseline(ctx context.Context, actor string, key baseline.Key
 }
 
 // load reads the persisted baseline + drift tracker, or fresh ones if none exists yet.
+// Score evaluates an observation against the CURRENT baseline WITHOUT learning from it — a read-only
+// anomaly for the risk scorer (#594 D). It abstains (Scoreable=false, Behavior=0) until the baseline is
+// active, exactly like Observe's scoring step, but never folds or persists, so it is safe to call on the
+// hot risk-assessment path (e.g. during an incident, when learning would poison the baseline anyway).
+func (s *Service) Score(ctx context.Context, key baseline.Key, obs baseline.Observation) (Assessment, error) {
+	if err := key.Validate(); err != nil {
+		return Assessment{}, err
+	}
+	if err := obs.Validate(); err != nil {
+		return Assessment{}, err
+	}
+	b, _, err := s.load(ctx, key)
+	if err != nil {
+		return Assessment{}, err
+	}
+	anomaly, scoreable := b.Anomaly(obs)
+	a := Assessment{State: b.State(), Behavior: 0}
+	if scoreable {
+		a.Behavior, a.Scoreable = anomaly, true
+	} else {
+		a.Reasons = append(a.Reasons, fmt.Sprintf("baseline not active (state=%s) — abstaining", b.State()))
+	}
+	return a, nil
+}
+
 func (s *Service) load(ctx context.Context, key baseline.Key) (*baseline.Baseline, *baseline.DriftTracker, error) {
 	rec, err := s.store.Load(ctx, key)
 	if errors.Is(err, shared.ErrNotFound) {

--- a/internal/usecase/fleet/behaviorbaseline/service.go
+++ b/internal/usecase/fleet/behaviorbaseline/service.go
@@ -1,0 +1,125 @@
+// Package behaviorbaseline turns the B5 per-host running-process projection into the coverage-honest
+// RiskContext.Behavior factor (#594 D). It maps a host's running processes to a baseline.Observation,
+// LEARNS the asset's normal process profile at report time (baselineuc.Observe — which scores-then-folds
+// with anti-poisoning), and SCORES the current profile read-only at risk-assessment time
+// (baselineuc.Score, no fold). Learning and scoring are separated so scoring never poisons the baseline —
+// and, critically, the risk-assessment path (an incident is active) never learns.
+//
+// It observes only the two features a process snapshot honestly carries — process count (spawn-rate proxy)
+// and distinct exec paths — leaving the network/privilege/file features at 0 (unobserved from processes),
+// so the baseline never invents a signal it did not measure.
+package behaviorbaseline
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/baseline"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/baselineuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// BaselineEngine is the baselineuc surface this producer needs: Observe (learn+score) and Score (read-only).
+type BaselineEngine interface {
+	Observe(ctx context.Context, actor string, key baseline.Key, obs baseline.Observation, window baseline.LearnWindow) (baselineuc.Assessment, error)
+	Score(ctx context.Context, key baseline.Key, obs baseline.Observation) (baselineuc.Assessment, error)
+}
+
+// ProcessLister returns an asset's currently-running processes. ports.EndpointProcessStore satisfies it.
+type ProcessLister interface {
+	ListRunningByAsset(ctx context.Context, assetID shared.ID) ([]ports.ProcessSnapshot, error)
+}
+
+// Factor is the coverage-honest Behavior factor for one asset.
+type Factor struct {
+	Behavior  int
+	Scoreable bool
+	Reasons   []string
+}
+
+// Service produces + learns the Behavior factor from process snapshots.
+type Service struct {
+	engine    BaselineEngine
+	processes ProcessLister
+}
+
+// NewService constructs the producer. Both collaborators are required.
+func NewService(engine BaselineEngine, processes ProcessLister) (*Service, error) {
+	if engine == nil || processes == nil {
+		return nil, fmt.Errorf("%w: behavior baseline needs a baseline engine and a process lister", shared.ErrValidation)
+	}
+	return &Service{engine: engine, processes: processes}, nil
+}
+
+// Learn folds the asset's current running-process profile into its behavior baseline. It is called at
+// process-report time — NOT during incident reassessment — so the baseline learns from ordinary activity;
+// baselineuc's anti-poisoning still refuses to fold an anomalous window. A learn failure is the caller's
+// to treat as best-effort (the process report itself already succeeded).
+func (s *Service) Learn(ctx context.Context, actor string, assetID shared.ID) error {
+	key, obs, err := s.observe(ctx, assetID)
+	if err != nil {
+		return err
+	}
+	// The window: we just received a process snapshot, so process-class coverage was active for it; the
+	// bad-condition flags are for the risk-assessment path, not ordinary reporting. Anti-poisoning in
+	// Observe still refuses to fold an anomalous observation.
+	window := baseline.LearnWindow{Coverage: 100, MinCoverage: 1}
+	_, err = s.engine.Observe(ctx, actor, key, obs, window)
+	return err
+}
+
+// BehaviorFor scores the asset's current running-process profile against its baseline, read-only. It is
+// the assembler's Behavior producer: abstains until the baseline is active, and never learns (scoring on
+// the incident path must not poison the baseline).
+func (s *Service) BehaviorFor(ctx context.Context, assetID shared.ID) (Factor, error) {
+	key, obs, err := s.observe(ctx, assetID)
+	if err != nil {
+		return Factor{}, err
+	}
+	a, err := s.engine.Score(ctx, key, obs)
+	if err != nil {
+		return Factor{}, err
+	}
+	return Factor{Behavior: int(a.Behavior), Scoreable: a.Scoreable, Reasons: a.Reasons}, nil
+}
+
+func (s *Service) observe(ctx context.Context, assetID shared.ID) (baseline.Key, baseline.Observation, error) {
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok || tenant == "" {
+		return baseline.Key{}, baseline.Observation{}, fmt.Errorf("%w: behavior baseline requires a tenant in context", shared.ErrValidation)
+	}
+	if assetID.IsZero() {
+		return baseline.Key{}, baseline.Observation{}, fmt.Errorf("%w: behavior baseline requires an asset id", shared.ErrValidation)
+	}
+	procs, err := s.processes.ListRunningByAsset(ctx, assetID)
+	if err != nil {
+		return baseline.Key{}, baseline.Observation{}, fmt.Errorf("list running processes: %w", err)
+	}
+	return baseline.Key{Tenant: tenant, Group: assetID.String()}, observationFrom(procs), nil
+}
+
+// observationFrom maps running processes to the two baseline features a process snapshot honestly carries:
+// process count (spawn-rate proxy) and distinct exec paths. Values are clamped to the feature max.
+func observationFrom(procs []ports.ProcessSnapshot) baseline.Observation {
+	paths := make(map[string]struct{}, len(procs))
+	for _, p := range procs {
+		if p.Path != "" {
+			paths[p.Path] = struct{}{}
+		}
+	}
+	var o baseline.Observation
+	o.Values[baseline.FeatureProcessSpawnRate] = clampFeature(int64(len(procs)))
+	o.Values[baseline.FeatureNewExecPaths] = clampFeature(int64(len(paths)))
+	return o
+}
+
+func clampFeature(v int64) int64 {
+	if v < 0 {
+		return 0
+	}
+	if v > baseline.MaxFeatureValue {
+		return baseline.MaxFeatureValue
+	}
+	return v
+}

--- a/internal/usecase/fleet/behaviorbaseline/service_test.go
+++ b/internal/usecase/fleet/behaviorbaseline/service_test.go
@@ -1,0 +1,82 @@
+package behaviorbaseline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/baseline"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/baselineuc"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeEngine struct {
+	learnedObs baseline.Observation
+	learnWin   baseline.LearnWindow
+	scoreObs   baseline.Observation
+	learnCalls int
+	scoreRet   baselineuc.Assessment
+}
+
+func (f *fakeEngine) Observe(_ context.Context, _ string, _ baseline.Key, obs baseline.Observation, w baseline.LearnWindow) (baselineuc.Assessment, error) {
+	f.learnCalls++
+	f.learnedObs = obs
+	f.learnWin = w
+	return baselineuc.Assessment{}, nil
+}
+func (f *fakeEngine) Score(_ context.Context, _ baseline.Key, obs baseline.Observation) (baselineuc.Assessment, error) {
+	f.scoreObs = obs
+	return f.scoreRet, nil
+}
+
+type fakeProcs struct{ procs []ports.ProcessSnapshot }
+
+func (f fakeProcs) ListRunningByAsset(context.Context, shared.ID) ([]ports.ProcessSnapshot, error) {
+	return f.procs, nil
+}
+
+func ctxT() context.Context { return shared.WithTenant(context.Background(), "tenant-a") }
+
+func TestObservationMapsProcessCountAndDistinctPaths(t *testing.T) {
+	eng := &fakeEngine{scoreRet: baselineuc.Assessment{Behavior: 40, Scoreable: true}}
+	procs := fakeProcs{procs: []ports.ProcessSnapshot{
+		{Path: "/usr/sbin/nginx", Running: true}, {Path: "/usr/sbin/nginx", Running: true}, {Path: "/bin/bash", Running: true},
+	}}
+	svc, err := NewService(eng, procs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Learn(ctxT(), "operator", "asset-1"); err != nil {
+		t.Fatal(err)
+	}
+	if eng.learnCalls != 1 {
+		t.Fatalf("Learn must Observe once, got %d", eng.learnCalls)
+	}
+	// 3 processes, 2 distinct paths.
+	if eng.learnedObs.Values[baseline.FeatureProcessSpawnRate] != 3 || eng.learnedObs.Values[baseline.FeatureNewExecPaths] != 2 {
+		t.Fatalf("observation mapping wrong: %+v", eng.learnedObs.Values)
+	}
+	// Unobserved features stay 0 (never invent a signal).
+	if eng.learnedObs.Values[baseline.FeatureNetworkFanout] != 0 || eng.learnedObs.Values[baseline.FeaturePrivilegeEvents] != 0 {
+		t.Fatalf("unobserved features must be 0: %+v", eng.learnedObs.Values)
+	}
+	// The learn window asserts process-class coverage but must be otherwise clean (no incident/emulation flags).
+	if eng.learnWin.IncidentActive || eng.learnWin.Emulation || eng.learnWin.MinCoverage < 1 {
+		t.Fatalf("learn window not clean: %+v", eng.learnWin)
+	}
+
+	f, err := svc.BehaviorFor(ctxT(), "asset-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !f.Scoreable || f.Behavior != 40 {
+		t.Fatalf("BehaviorFor must map the Score assessment: %+v", f)
+	}
+}
+
+func TestBehaviorForRequiresTenant(t *testing.T) {
+	svc, _ := NewService(&fakeEngine{}, fakeProcs{})
+	if _, err := svc.BehaviorFor(context.Background(), "asset-1"); err == nil {
+		t.Fatal("a missing tenant must be rejected")
+	}
+}

--- a/internal/usecase/fleet/riskscorebridge/bridge.go
+++ b/internal/usecase/fleet/riskscorebridge/bridge.go
@@ -1,21 +1,20 @@
-// Package riskscorebridge provides honest-abstaining factor sources for the tri-score assembler
-// (riskscoreuc) at the composition root. The assembler REQUIRES a non-nil ExposureAssessor,
-// BehaviorAssessor and CoverageSource; where a producer is not yet integrated, an abstaining source keeps
-// the seam live and coverage-honest — an abstaining factor contributes 0 to Risk and carries its reason
-// into the CoverageVector, so a not-yet-wired factor lowers coverage/confidence and NEVER fabricates risk.
-//
-// This lets the deterministic Scorer run in production on the factors that ARE wired while the remaining
-// producers are swapped in as isolated follow-ups. Exposure is wired via NewExposure (over exposureuc) and
-// Coverage via NewCoverage (over the coverage-window store); Behavior still abstains until its producer (a
-// baselineuc per-asset read path) is integrated. Each swap replaces one Abstaining* here with a real bridge.
+// Package riskscorebridge adapts the tri-score assembler's (riskscoreuc) three consumer-side factor ports
+// to their real producers. All three factors are now wired: Exposure via NewExposure (exposureuc, X5),
+// Behavior via NewBehavior (behaviorbaseline, D), and Coverage via NewCoverage (the coverage-window store).
+// Each bridge maps its producer's coverage-honest result to the assembler's FactorInput — a producer error
+// propagates, and an abstain (Scoreable=false, e.g. a cold-starting baseline) flows through unchanged so
+// the assembler keeps its discipline: an abstaining factor contributes 0 to Risk and its reason lowers
+// Coverage/confidence in the CoverageVector, NEVER fabricating risk.
 package riskscorebridge
 
 import (
 	"context"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sensorstate"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/behaviorbaseline"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/exposureuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/riskscoreuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
@@ -45,16 +44,27 @@ func (b exposureBridge) ExposureFor(ctx context.Context, assetID shared.ID) (ris
 	return riskscoreuc.FactorInput{Score: a.Exposure, Scoreable: a.Scoreable, Reasons: a.Reasons}, nil
 }
 
-// abstainingBehavior always abstains — used until baselineuc exposes a per-asset behavior read path.
-type abstainingBehavior struct{ reason string }
-
-// AbstainingBehavior returns a BehaviorAssessor that always abstains with a fixed reason.
-func AbstainingBehavior(reason string) riskscoreuc.BehaviorAssessor {
-	return abstainingBehavior{reason: reason}
+// BehaviorProducer is the behaviorbaseline surface the real Behavior bridge adapts. behaviorbaseline.Service
+// satisfies it.
+type BehaviorProducer interface {
+	BehaviorFor(ctx context.Context, assetID shared.ID) (behaviorbaseline.Factor, error)
 }
 
-func (a abstainingBehavior) BehaviorFor(context.Context, shared.ID) (riskscoreuc.FactorInput, error) {
-	return riskscoreuc.FactorInput{Scoreable: false, Reasons: []string{a.reason}}, nil
+type behaviorBridge struct{ producer BehaviorProducer }
+
+// NewBehavior bridges the real behaviorbaseline producer (D) to the assembler's BehaviorAssessor port,
+// mapping its Factor to FactorInput. A producer error propagates; an abstain (Scoreable=false, e.g. a
+// baseline still cold-starting) flows through unchanged.
+func NewBehavior(producer BehaviorProducer) riskscoreuc.BehaviorAssessor {
+	return behaviorBridge{producer: producer}
+}
+
+func (b behaviorBridge) BehaviorFor(ctx context.Context, assetID shared.ID) (riskscoreuc.FactorInput, error) {
+	f, err := b.producer.BehaviorFor(ctx, assetID)
+	if err != nil {
+		return riskscoreuc.FactorInput{}, err
+	}
+	return riskscoreuc.FactorInput{Score: riskassessment.Score(f.Behavior), Scoreable: f.Scoreable, Reasons: f.Reasons}, nil
 }
 
 // CoverageWindowReader lists an asset's composed coverage windows (tenant-scoped via ctx).

--- a/internal/usecase/fleet/riskscorebridge/bridge_test.go
+++ b/internal/usecase/fleet/riskscorebridge/bridge_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sensorstate"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/behaviorbaseline"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/exposureuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
@@ -48,13 +49,32 @@ func TestNewExposurePropagatesError(t *testing.T) {
 	}
 }
 
-func TestAbstainingBehaviorAlwaysAbstains(t *testing.T) {
-	f, err := AbstainingBehavior("behavior not wired").BehaviorFor(context.Background(), "asset-1")
+type fakeBehaviorProducer struct {
+	f   behaviorbaseline.Factor
+	err error
+}
+
+func (p fakeBehaviorProducer) BehaviorFor(context.Context, shared.ID) (behaviorbaseline.Factor, error) {
+	return p.f, p.err
+}
+
+func TestNewBehaviorMapsFactor(t *testing.T) {
+	got, err := NewBehavior(fakeBehaviorProducer{f: behaviorbaseline.Factor{Behavior: 55, Scoreable: true, Reasons: []string{"process spawn anomaly"}}}).BehaviorFor(context.Background(), "asset-1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if f.Scoreable || f.Score != 0 || len(f.Reasons) != 1 {
-		t.Fatalf("abstaining behavior must be 0/not-scoreable with a reason: %+v", f)
+	if !got.Scoreable || got.Score != 55 || len(got.Reasons) != 1 {
+		t.Fatalf("behavior not mapped: %+v", got)
+	}
+}
+
+func TestNewBehaviorPassesAbstainThrough(t *testing.T) {
+	got, err := NewBehavior(fakeBehaviorProducer{f: behaviorbaseline.Factor{Scoreable: false, Reasons: []string{"baseline cold-starting"}}}).BehaviorFor(context.Background(), "asset-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Scoreable || got.Score != 0 {
+		t.Fatalf("abstain must flow through as 0/not-scoreable: %+v", got)
 	}
 }
 


### PR DESCRIPTION
feat(fleet): wire real Behavior into the tri-score assembler — all 4 factors live (#594 D)

The Behavior factor was abstaining because nothing produced a per-asset behavioral
signal. Now that B5 process snapshots flow, this wires a deterministic behavioral
baseline over them, so the tri-score assembler runs on all four factors: Threat +
Exposure + Behavior + Coverage.

- internal/usecase/fleet/behaviorbaseline: maps a host's running processes to a
  baseline.Observation (process count → spawn-rate proxy; distinct exec paths → the
  new-exec-paths feature; the network/privilege/file features stay 0 — never invent
  a signal not measured). It LEARNS the asset's normal profile at report time
  (baselineuc.Observe, which scores-then-folds with anti-poisoning) and SCORES the
  current profile read-only at risk time (new baselineuc.Score — anomaly without
  folding). Learning and scoring are separated so scoring on the incident path never
  poisons the baseline.
- baselineuc.Score: read-only anomaly against the current baseline (abstains until
  active), safe on the hot risk path.
- riskscorebridge.NewBehavior bridges it to the assembler's BehaviorAssessor;
  removed AbstainingBehavior. The package doc now reflects all three producers wired.
- cmd/synapse-api: construct baselineStore (memory/postgres) + baselineuc +
  behaviorbaseline; the assembler uses NewBehavior, and the B5 process-report handler
  folds each report into the baseline (best-effort, logged on failure).

Tests: observation mapping (count + distinct paths, unobserved features 0, clean
learn window); read-only Score; the NewBehavior bridge maps + passes an abstain
through; tenant required. build/vet/gofmt/arch clean.
