### PR TITLE
feat(judgment): AI investigation-hypothesis propose-only via judgment (#594 E)

### DIFF
--- a/internal/domain/judgment/claim.go
+++ b/internal/domain/judgment/claim.go
@@ -460,6 +460,69 @@ func (c ThreatClaim) Validate() error {
 	return nil
 }
 
+// InvestigationTactic is the closed hypothesis category for an incident — an ATT&CK-style tactic token,
+// never free prose. It is the ONLY semantic payload of an AI investigation hypothesis.
+type InvestigationTactic string
+
+const (
+	TacticLateralMovement     InvestigationTactic = "lateral_movement"
+	TacticDataExfiltration    InvestigationTactic = "data_exfiltration"
+	TacticPrivilegeEscalation InvestigationTactic = "privilege_escalation"
+	TacticCredentialAccess    InvestigationTactic = "credential_access"
+	TacticPersistence         InvestigationTactic = "persistence"
+	TacticCommandAndControl   InvestigationTactic = "command_and_control"
+	TacticDefenseEvasion      InvestigationTactic = "defense_evasion"
+	TacticExecution           InvestigationTactic = "execution"
+	TacticBenign              InvestigationTactic = "benign" // the hypothesis that the incident is NOT malicious
+)
+
+// Valid reports whether t is a known tactic (fail-closed).
+func (t InvestigationTactic) Valid() bool {
+	switch t {
+	case TacticLateralMovement, TacticDataExfiltration, TacticPrivilegeEscalation, TacticCredentialAccess,
+		TacticPersistence, TacticCommandAndControl, TacticDefenseEvasion, TacticExecution, TacticBenign:
+		return true
+	}
+	return false
+}
+
+// InvestigationClaim is an AI-proposed HYPOTHESIS about an incident (#594 E): a single closed tactic
+// category, a confidence, and structured driver tokens (the signals that support it — never free prose).
+// It is propose-only and NOT gated: it never proves anything or drives a response on its own; it is
+// advisory context a human analyst accepts or rejects. The LLM proposes; a human decides.
+type InvestigationClaim struct {
+	IncidentID shared.ID           `json:"incident_id"`
+	Tactic     InvestigationTactic `json:"tactic"`
+	Confidence int                 `json:"confidence"` // 0..100
+	Drivers    []string            `json:"drivers"`    // closed signal tokens (e.g. "new_exec_paths", "network_fanout_spike"), no prose
+}
+
+// Capability identifies this claim's brain.
+func (InvestigationClaim) Capability() Capability { return CapInvestigation }
+
+// Validate enforces the closed tactic vocabulary, a bounded confidence, an incident reference, and
+// token-only drivers (no free prose ever reaches the record).
+func (c InvestigationClaim) Validate() error {
+	if c.IncidentID.IsZero() {
+		return fmt.Errorf("%w: investigation hypothesis requires an incident id", shared.ErrValidation)
+	}
+	if !c.Tactic.Valid() {
+		return fmt.Errorf("%w: investigation tactic must be a known ATT&CK-style token, got %q", shared.ErrValidation, c.Tactic)
+	}
+	if c.Confidence < 0 || c.Confidence > 100 {
+		return fmt.Errorf("%w: investigation confidence must be 0..100, got %d", shared.ErrValidation, c.Confidence)
+	}
+	if len(c.Drivers) > maxRiskDrivers {
+		return fmt.Errorf("%w: investigation hypothesis has too many drivers (%d > %d)", shared.ErrValidation, len(c.Drivers), maxRiskDrivers)
+	}
+	for _, d := range c.Drivers {
+		if len(d) > 64 || !driverRE.MatchString(d) {
+			return fmt.Errorf("%w: investigation driver %q must be a token (no free text)", shared.ErrValidation, d)
+		}
+	}
+	return nil
+}
+
 // CorrelationClaim is a cross-check DISAGREEMENT: on a vulnerability, which detection
 // sources reported it (Reporters) and which RAN but did not (Missing). It is the deterministic, descriptive
 // record that a human acknowledges – NEVER auto-resolved (the disagreement is itself the signal). Both lists
@@ -741,6 +804,12 @@ func UnmarshalClaim(data []byte) (Claim, error) {
 			return nil, err
 		}
 		c = vc
+	case CapInvestigation:
+		var ic InvestigationClaim
+		if err := strictDecode(env.Claim, &ic); err != nil {
+			return nil, err
+		}
+		c = ic
 	default:
 		// In the Valid() vocabulary but no decoder yet – registered alongside the capability.
 		return nil, fmt.Errorf("%w: no claim decoder for capability %q", shared.ErrValidation, env.Capability)

--- a/internal/domain/judgment/investigation_claim_test.go
+++ b/internal/domain/judgment/investigation_claim_test.go
@@ -1,0 +1,48 @@
+package judgment
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestInvestigationClaimValidate(t *testing.T) {
+	ok := InvestigationClaim{IncidentID: "inc-1", Tactic: TacticLateralMovement, Confidence: 70, Drivers: []string{"new_exec_paths", "network_fanout_spike"}}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("valid claim rejected: %v", err)
+	}
+	if ok.Capability() != CapInvestigation {
+		t.Fatalf("capability = %q, want investigation", ok.Capability())
+	}
+	if CapInvestigation.Gated() {
+		t.Fatal("investigation must be UNGATED (advisory hypothesis, human-accepted)")
+	}
+	if !CapInvestigation.Valid() {
+		t.Fatal("CapInvestigation must be a known capability")
+	}
+	for name, c := range map[string]InvestigationClaim{
+		"no incident":  {Tactic: TacticBenign, Confidence: 10},
+		"bad tactic":   {IncidentID: "inc-1", Tactic: "made_up", Confidence: 10},
+		"bad conf":     {IncidentID: "inc-1", Tactic: TacticBenign, Confidence: 101},
+		"prose driver": {IncidentID: "inc-1", Tactic: TacticBenign, Confidence: 10, Drivers: []string{"this is free prose"}},
+	} {
+		if err := c.Validate(); err == nil {
+			t.Errorf("%s: expected a validation error", name)
+		}
+	}
+}
+
+func TestInvestigationClaimRoundTrips(t *testing.T) {
+	data, err := MarshalClaim(InvestigationClaim{IncidentID: "inc-9", Tactic: TacticDataExfiltration, Confidence: 88})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	c, err := UnmarshalClaim(data)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	ic, ok := c.(InvestigationClaim)
+	if !ok || ic.Tactic != TacticDataExfiltration || ic.IncidentID != shared.ID("inc-9") {
+		t.Fatalf("round-trip wrong: %+v ok=%v", c, ok)
+	}
+}

--- a/internal/domain/judgment/judgment.go
+++ b/internal/domain/judgment/judgment.go
@@ -30,12 +30,13 @@ const (
 	CapCorrelation      Capability = "correlation"       // NOT gated (a cross-check disagreement; human-acknowledged, never auto-resolved)
 	CapPromotion        Capability = "promotion"         // gated (cross-pillar priority change, distinct-verifier only)
 	CapVexJustification Capability = "vex_justification" // gated (AI-proposed OpenVEX not_affected justification, human-ratified)
+	CapInvestigation    Capability = "investigation"     // NOT gated (E: an AI investigation HYPOTHESIS about an incident; advisory, human-accepted, never auto-acted)
 )
 
 // Valid reports whether c is a known capability.
 func (c Capability) Valid() bool {
 	switch c {
-	case CapReachability, CapSAST, CapDAST, CapCritique, CapRiskNarrative, CapThreat, CapCorrelation, CapPromotion, CapVexJustification:
+	case CapReachability, CapSAST, CapDAST, CapCritique, CapRiskNarrative, CapThreat, CapCorrelation, CapPromotion, CapVexJustification, CapInvestigation:
 		return true
 	}
 	return false
@@ -80,12 +81,13 @@ const (
 	SubjectVulnerability SubjectKind = "vulnerability"
 	SubjectEngagement    SubjectKind = "engagement"
 	SubjectDataFlow      SubjectKind = "data_flow" // a threat-model data flow (a boundary crossing)
+	SubjectIncident      SubjectKind = "incident"  // a fleet incident (E: an AI investigation hypothesis is about one)
 )
 
 // Valid reports whether k is a known subject kind.
 func (k SubjectKind) Valid() bool {
 	switch k {
-	case SubjectFinding, SubjectComponent, SubjectVulnerability, SubjectEngagement, SubjectDataFlow:
+	case SubjectFinding, SubjectComponent, SubjectVulnerability, SubjectEngagement, SubjectDataFlow, SubjectIncident:
 		return true
 	}
 	return false

--- a/internal/usecase/agenttools/catalog.go
+++ b/internal/usecase/agenttools/catalog.go
@@ -66,6 +66,7 @@ const (
 	ToolProposeWriteupDraft     = "propose_writeup_draft"     // propose a finding write-up DRAFT (prose) awaiting human sign-off (NOT a judgment)
 	ToolProposeAttackChain      = "propose_attack_chain"      // propose an attack-chain HYPOTHESIS finding (score 0; gated until a human verifies)
 	ToolProposeVexJustification = "propose_vex_justification" // propose an OpenVEX not_affected justification Judgment (score 0; a human ratifies)
+	ToolProposeInvestigation    = "propose_investigation"     // propose an AI investigation HYPOTHESIS about an incident (E; ungated, a human accepts)
 )
 
 // MaxPlanNodes bounds how many nodes a single propose_plan may carry (mirrors the domain cap);
@@ -288,6 +289,11 @@ func (c *Catalog) Tools() []agent.ToolSchema {
 			Description: "Propose an OpenVEX JUSTIFICATION for why a finding is NOT AFFECTED – pick ONE of the closed OpenVEX justifications. This is a PROPOSAL recorded at score 0: you CANNOT confirm it; a distinct human ratifies it before any export trusts it (a false 'not affected' suppresses a real vuln). Pick the most specific justification you can support.",
 			Parameters:  json.RawMessage(`{"type":"object","properties":{"finding_id":{"type":"string","description":"the finding this justification is about (from list_findings)"},"justification":{"type":"string","description":"one of: component_not_present | vulnerable_code_not_present | vulnerable_code_not_in_execute_path | vulnerable_code_cannot_be_controlled_by_adversary | inline_mitigations_already_exist"}},"required":["finding_id","justification"],"additionalProperties":false}`),
 		})
+		schemas = append(schemas, agent.ToolSchema{
+			Name:        ToolProposeInvestigation,
+			Description: "Propose an INVESTIGATION HYPOTHESIS about an incident: pick ONE closed ATT&CK-style tactic that best explains what is happening, a confidence 0..100, and the STRUCTURED signal tokens that support it (never prose). This is a PROPOSAL recorded at score 0 that a human analyst ACCEPTS or REJECTS – it proves nothing and NEVER drives a response on its own; you cannot accept your own hypothesis. Use 'benign' when the evidence points to NOT malicious.",
+			Parameters:  json.RawMessage(`{"type":"object","properties":{"incident_id":{"type":"string","description":"the incident this hypothesis is about (from the incident list)"},"tactic":{"type":"string","description":"one of: lateral_movement | data_exfiltration | privilege_escalation | credential_access | persistence | command_and_control | defense_evasion | execution | benign"},"confidence":{"type":"integer","description":"0..100 confidence in the hypothesis"},"drivers":{"type":"array","items":{"type":"string"},"description":"the signal TOKENS that support it, e.g. new_exec_paths, network_fanout_spike, privilege_events (lowercase tokens, no spaces, no prose)"}},"required":["incident_id","tactic","confidence"],"additionalProperties":false}`),
+		})
 	}
 	if c.drafter != nil {
 		schemas = append(schemas, agent.ToolSchema{
@@ -371,6 +377,11 @@ func (c *Catalog) Dispatch(ctx context.Context, sess agent.Session, call agent.T
 			return Result{}, fmt.Errorf("%w: VEX justification proposals are not enabled", shared.ErrValidation)
 		}
 		return c.proposeVexJustification(ctx, sess, call.Arguments)
+	case ToolProposeInvestigation:
+		if c.jproposer == nil {
+			return Result{}, fmt.Errorf("%w: investigation proposals are not enabled", shared.ErrValidation)
+		}
+		return c.proposeInvestigation(ctx, sess, call.Arguments)
 	case ToolProposeWriteupDraft:
 		if c.drafter == nil {
 			return Result{}, fmt.Errorf("%w: writeup draft proposals are not enabled", shared.ErrValidation)
@@ -1210,6 +1221,48 @@ func (c *Catalog) proposeThreat(ctx context.Context, sess agent.Session, raw jso
 		"judgment_id": j.ID.String(), "state": string(j.State), "evidence_score": j.EvidenceScore,
 		"proposed_by": j.ProposedBy, "publishable": j.Publishable(),
 		"note": "recorded as a PROPOSED STRIDE threat (score 0); a distinct human reviewer must ratify it – you cannot confirm your own.",
+	})
+	if err != nil {
+		return Result{}, fmt.Errorf("marshal judgment: %w", err)
+	}
+	return Result{Data: payload}, nil
+}
+
+type proposeInvestigationArgs struct {
+	IncidentID string   `json:"incident_id"`
+	Tactic     string   `json:"tactic"`
+	Confidence int      `json:"confidence"`
+	Drivers    []string `json:"drivers"`
+}
+
+// proposeInvestigation records a PROPOSED investigation hypothesis about an incident (#594 E): a single
+// closed ATT&CK-style tactic + confidence + structured driver tokens, persisted at score 0 by the analysis
+// service. UNGATED and human-accepted — the agent CANNOT accept its own hypothesis (the propose-only
+// interface + the arch tripwire make that structural), and a hypothesis NEVER drives a response on its own.
+// The domain InvestigationClaim.Validate rejects free prose and an unknown tactic.
+func (c *Catalog) proposeInvestigation(ctx context.Context, sess agent.Session, raw json.RawMessage) (Result, error) {
+	var a proposeInvestigationArgs
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return Result{}, fmt.Errorf("%w: propose_investigation args: %w", shared.ErrValidation, err)
+	}
+	incidentID := shared.ID(strings.TrimSpace(a.IncidentID))
+	if incidentID.IsZero() {
+		return Result{}, fmt.Errorf("%w: incident_id is required", shared.ErrValidation)
+	}
+	claim := judgment.InvestigationClaim{
+		IncidentID: incidentID,
+		Tactic:     judgment.InvestigationTactic(strings.TrimSpace(a.Tactic)),
+		Confidence: a.Confidence,
+		Drivers:    a.Drivers,
+	}
+	j, err := c.jproposer.Propose(ctx, sess.AgentActor(), sess.EngagementID, judgment.CapInvestigation, judgment.SubjectIncident, incidentID, claim)
+	if err != nil {
+		return Result{}, err // domain validates the claim; the service persists at score 0 + audits
+	}
+	payload, err := json.Marshal(map[string]any{
+		"judgment_id": j.ID.String(), "state": string(j.State), "evidence_score": j.EvidenceScore,
+		"proposed_by": j.ProposedBy, "publishable": j.Publishable(),
+		"note": "recorded as a PROPOSED investigation hypothesis (score 0); a human analyst accepts or rejects it – you cannot accept your own, and it never drives a response.",
 	})
 	if err != nil {
 		return Result{}, fmt.Errorf("marshal judgment: %w", err)

--- a/internal/usecase/agenttools/investigation_tool_test.go
+++ b/internal/usecase/agenttools/investigation_tool_test.go
@@ -1,0 +1,63 @@
+package agenttools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+)
+
+func TestProposeInvestigation(t *testing.T) {
+	c, _ := newCatalog(t, nil, nil, subfinder())
+	fp := &fakeJudgmentProposer{}
+	c.EnableJudgments(fp)
+
+	advertised := false
+	for _, ts := range c.Tools() {
+		if ts.Name == ToolProposeInvestigation {
+			advertised = true
+			if !json.Valid(ts.Parameters) {
+				t.Error("propose_investigation has invalid JSON-schema parameters")
+			}
+		}
+	}
+	if !advertised {
+		t.Fatal("propose_investigation must be advertised after EnableJudgments")
+	}
+
+	res, err := c.Dispatch(context.Background(), session(), agent.ToolCall{
+		Name:      ToolProposeInvestigation,
+		Arguments: json.RawMessage(`{"incident_id":"inc-7","tactic":"lateral_movement","confidence":72,"drivers":["new_exec_paths","network_fanout_spike"]}`),
+	})
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if res.Data == nil {
+		t.Fatal("must return Data")
+	}
+	// PROPOSED, score 0, agent-attributed, scoped to the incident, ungated capability.
+	if fp.got.EvidenceScore != 0 || fp.got.State != judgment.StateProposed || fp.got.ProposedBy != "agent:s1" {
+		t.Fatalf("must record proposed/score-0/agent: %+v", fp.got)
+	}
+	if fp.got.Capability != judgment.CapInvestigation || fp.got.SubjectKind != judgment.SubjectIncident || fp.got.SubjectID != "inc-7" || fp.got.EngagementID != "eng-1" {
+		t.Fatalf("subject/scope wiring wrong: %+v", fp.got)
+	}
+	ic, ok := fp.got.Claim.(judgment.InvestigationClaim)
+	if !ok || ic.Tactic != judgment.TacticLateralMovement || ic.Confidence != 72 || len(ic.Drivers) != 2 {
+		t.Fatalf("claim built wrong: %#v", fp.got.Claim)
+	}
+}
+
+func TestProposeInvestigationDisabledFailsClosed(t *testing.T) {
+	c, _ := newCatalog(t, nil, nil, subfinder()) // no EnableJudgments
+	for _, ts := range c.Tools() {
+		if ts.Name == ToolProposeInvestigation {
+			t.Fatal("propose_investigation must not be advertised without a judgment proposer")
+		}
+	}
+	if _, err := c.Dispatch(context.Background(), session(), agent.ToolCall{Name: ToolProposeInvestigation, Arguments: json.RawMessage(`{}`)}); err == nil {
+		t.Fatal("dispatch must fail closed when judgments are disabled")
+	}
+}

--- a/internal/usecase/agenttools/wiring_test.go
+++ b/internal/usecase/agenttools/wiring_test.go
@@ -41,6 +41,7 @@ var toolsetControlled = []string{
 	ToolProposeRiskNarrative,
 	ToolProposeThreat,
 	ToolProposeVexJustification,
+	ToolProposeInvestigation,
 	ToolProposeWriteupDraft,
 }
 


### PR DESCRIPTION
feat(judgment): AI investigation-hypothesis propose-only via judgment (#594 E)

First slice of the AI-assisted EDR layer, unblocked now the deterministic C+D core
runs. An investigation hypothesis is an AI proposal about an incident, gated through
the existing judgment primitive: the LLM only PROPOSES; a human accepts or rejects.

- domain/judgment: new CapInvestigation (UNGATED — advisory, human-accepted, like
  risk_narrative/correlation, never score-gated) + InvestigationClaim = a single
  closed ATT&CK-style tactic token (lateral_movement / data_exfiltration /
  privilege_escalation / credential_access / persistence / command_and_control /
  defense_evasion / execution / benign), a 0..100 confidence, and structured driver
  tokens — NEVER free prose (Validate rejects it, mirroring the other typed claims).
  New SubjectIncident subject kind. Registered in the strict UnmarshalClaim switch.
- agenttools: propose_investigation tool (advertised only when a judgment proposer
  is wired; fail-closed otherwise). It is propose-only — the narrow judgmentProposer
  interface exposes only Propose, and the arch tripwire forbidding usecase/analysis
  from agenttools makes "can't confirm its own hypothesis" structural. Persisted at
  score 0; a human analyst accepts it via the existing judgment path; it NEVER drives
  a response on its own.

Tests: claim validation (closed tactic, bounded confidence, incident required,
prose-free drivers) + envelope round-trip + Gated()=false; the tool advertises +
dispatches, records proposed/score-0/agent-attributed/incident-scoped, and
fail-closes when judgments are disabled; the full-toolset parity test updated.
build/vet/gofmt/arch clean.
