### PR TITLE
feat(edr): complete governed AI investigation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -386,7 +386,8 @@ SYNAPSE_GOMODGRAPH_ENABLED=true      # transitive Go dep edges via `go mod graph
 # =============================================================================
 # MCP server (synapse-mcp) – read + propose-only; never executes
 # =============================================================================
-# Both are REQUIRED to start synapse-mcp. The token is never logged.
+# Token and engagement are REQUIRED. Tenant defaults to "default" and is never client-selectable.
 # SYNAPSE_MCP_TOKEN=
+# SYNAPSE_MCP_TENANT_ID=default
 # SYNAPSE_MCP_ENGAGEMENT_ID=
 # SYNAPSE_MCP_ADDR=:8081

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Governed AI-assisted EDR investigation.** Agent and MCP clients can list engagement-scoped
+  incidents, retrieve bounded secret-redacted endpoint context, and propose a structured tactic,
+  confidence, relevant-event, driver-token, and read-only next-step hypothesis into the judgment ledger.
+  The analyst review UI requires a distinct evidence-scored verdict; neither proposal nor verification
+  can mutate incident facts, risk, disposition, or response actions, and reports remain model-free.
+
 - **Python Tier-2 semantic reachability and interprocedural taint analysis.** An opt-in, source-only
   tree-sitter sidecar now emits bounded semantic facts without importing or executing target Python;
   pure Go resolution proves affected-symbol call paths and precise value flow across assignments,

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -319,6 +319,7 @@ func main() {
 	var baselineStore ports.BaselineStore                 // #594 D behavioral baseline state
 	var telemetrySvc *telemetryingest.Service             // wired to detection repair after both services exist
 	var endpointStateSvc *endpointstate.Service           // #594 B7 State-Timeline projector; fed by telemetry ingest
+	var incidentSvc *incidentuc.Service                   // #594 C7 incident projection; shared with AI investigation reads
 	var detectSvc *detectledger.Service                   // tenant-scoped startup and periodic provenance repair
 	var detectionRunner *detectledger.ReconciliationRunner
 	var fleetAuditRunner *fleetaudit.ReconciliationRunner // #610/#611 state-local audit intention delivery
@@ -1679,7 +1680,8 @@ func main() {
 	// event on that log + the tamper-evident audit trail. RBAC + tenant scoping are enforced at the
 	// HTTP edge (router). No agent transport needed — this is an operator surface.
 	{
-		incidentSvc, ierr := incidentuc.NewService(incidentEventStore)
+		var ierr error
+		incidentSvc, ierr = incidentuc.NewService(incidentEventStore)
 		if ierr != nil {
 			log.Error("incident read service init failed", "err", ierr)
 			os.Exit(1)
@@ -2307,6 +2309,9 @@ func main() {
 			Findings:     exploitationService, // record unproven findings (score 0)
 			Hypotheses:   exploitationService, // propose attack-chain hypotheses (score 0; gated until human-verified)
 			Reachability: scanResultStore,     // read dep-graph reachability facts (T0/T1)
+			Investigation: &agenttools.InvestigationToolset{
+				Incidents: incidentSvc, Detections: detectionRecordStore, Timeline: endpointStateSvc,
+			},
 		}
 		if judgmentSvc != nil { // PROPOSE reachability/critique/… judgments (score 0); verify stays human-only (PermReview)
 			toolset.Judgments = judgmentSvc

--- a/cmd/synapse-mcp/main.go
+++ b/cmd/synapse-mcp/main.go
@@ -25,6 +25,10 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/logging"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/agenttools"
+	analysisuc "github.com/KKloudTarus/synapse-ce/internal/usecase/analysis"
+	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/endpointstate"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/incidentuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -42,6 +46,10 @@ func main() {
 		log.Error("synapse-mcp requires SYNAPSE_MCP_ENGAGEMENT_ID (the engagement it is scoped to)")
 		os.Exit(1)
 	}
+	if cfg.MCPTenantID == "" {
+		log.Error("synapse-mcp requires SYNAPSE_MCP_TENANT_ID (tenant boundary for the pinned engagement)")
+		os.Exit(1)
+	}
 	if err := cfg.ValidateMigrationPosture(); err != nil {
 		log.Error("database migration posture invalid", "err", err)
 		os.Exit(1)
@@ -54,7 +62,11 @@ func main() {
 	// API) when configured, else in-memory/file for dev.
 	var findingRepo ports.FindingRepository
 	var evidenceStore ports.EvidenceStore
-	var auditLog ports.AuditLogger
+	var auditLog ports.IdempotentAuditLogger
+	var incidentStore ports.IncidentEventStore
+	var detectionStore ports.DetectionRecordStore
+	var timelineStore ports.EndpointTimelineStore
+	var judgmentStore analysisuc.Store
 	if cfg.DBDSN != "" {
 		startup, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 		defer cancel()
@@ -93,11 +105,19 @@ func main() {
 		findingRepo = postgres.NewFindingRepository(pool)
 		evidenceStore = postgres.NewEvidenceStore(pool)
 		auditLog = postgres.NewAuditLog(pool)
+		incidentStore = postgres.NewIncidentEventRepository(pool)
+		detectionStore = postgres.NewDetectionRecordRepository(pool)
+		timelineStore = postgres.NewEndpointTimelineRepository(pool)
+		judgmentStore = postgres.NewJudgmentRepository(pool)
 		log.Info("persistence: postgres")
 	} else {
 		findingRepo = memory.NewFindingRepository()
 		evidenceStore = memory.NewEvidenceStore()
 		auditLog = file.NewAuditLog(cfg.AuditFile)
+		incidentStore = memory.NewIncidentEventStore()
+		detectionStore = memory.NewDetectionRecordStore()
+		timelineStore = memory.NewEndpointTimelineStore()
+		judgmentStore = memory.NewJudgmentStore()
 		log.Warn("persistence: in-memory (set SYNAPSE_DB_DSN to serve the API's data)")
 	}
 
@@ -110,7 +130,36 @@ func main() {
 		log.Error("agent catalog init failed", "err", err)
 		os.Exit(1)
 	}
-	srv, err := mcpserver.New(catalog, shared.ID(cfg.MCPEngagementID), cfg.MCPToken, buildinfo.App(), log)
+	incidentSvc, err := incidentuc.NewService(incidentStore)
+	if err != nil {
+		log.Error("mcp incident reader init failed", "err", err)
+		os.Exit(1)
+	}
+	timelineSvc, err := endpointstate.NewService(timelineStore)
+	if err != nil {
+		log.Error("mcp timeline reader init failed", "err", err)
+		os.Exit(1)
+	}
+	if err := catalog.EnableInvestigation(agenttools.InvestigationToolset{
+		Incidents: incidentSvc, Detections: detectionStore, Timeline: timelineSvc,
+	}); err != nil {
+		log.Error("mcp investigation tools init failed", "err", err)
+		os.Exit(1)
+	}
+	if cfg.JudgmentsEnabled {
+		evidenceSvc, eerr := evidenceuc.NewService(evidenceStore, nil, auditLog, clock, ids)
+		if eerr != nil {
+			log.Error("mcp evidence sealer init failed", "err", eerr)
+			os.Exit(1)
+		}
+		judgmentSvc, jerr := analysisuc.NewService(judgmentStore, evidenceSvc, auditLog, clock, ids)
+		if jerr != nil {
+			log.Error("mcp judgment proposer init failed", "err", jerr)
+			os.Exit(1)
+		}
+		catalog.EnableJudgments(judgmentSvc)
+	}
+	srv, err := mcpserver.New(catalog, shared.ID(cfg.MCPTenantID), shared.ID(cfg.MCPEngagementID), cfg.MCPToken, buildinfo.App(), log)
 	if err != nil {
 		log.Error("mcp server init failed", "err", err)
 		os.Exit(1)
@@ -118,7 +167,7 @@ func main() {
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
-	log.Info("synapse-mcp listening", "addr", cfg.MCPAddr, "engagement", cfg.MCPEngagementID)
+	log.Info("synapse-mcp listening", "addr", cfg.MCPAddr, "tenant", cfg.MCPTenantID, "engagement", cfg.MCPEngagementID)
 	if err := httpserver.Run(ctx, cfg.MCPAddr, srv.Handler(), log); err != nil {
 		log.Error("mcp server error", "err", err)
 		os.Exit(1)

--- a/cmd/synapse-worker/main.go
+++ b/cmd/synapse-worker/main.go
@@ -60,6 +60,8 @@ import (
 	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/execution"
 	exploitationuc "github.com/KKloudTarus/synapse-ce/internal/usecase/exploitation"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/endpointstate"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/incidentuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/leaderuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/orchestrator"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
@@ -560,6 +562,19 @@ func main() {
 			Findings:     exploitSvc,
 			Hypotheses:   exploitSvc,
 			Reachability: postgres.NewScanResultStore(pool),
+		}
+		incidentSvc, ierr := incidentuc.NewService(postgres.NewIncidentEventRepository(pool))
+		if ierr != nil {
+			log.Error("agent incident reader init failed", "err", ierr)
+			os.Exit(1)
+		}
+		timelineSvc, terr := endpointstate.NewService(postgres.NewEndpointTimelineRepository(pool))
+		if terr != nil {
+			log.Error("agent timeline reader init failed", "err", terr)
+			os.Exit(1)
+		}
+		toolset.Investigation = &agenttools.InvestigationToolset{
+			Incidents: incidentSvc, Detections: postgres.NewDetectionRecordRepository(pool), Timeline: timelineSvc,
 		}
 		if cfg.JudgmentsEnabled {
 			judgmentSvc, jerr := analysisuc.NewService(postgres.NewJudgmentRepository(pool), evidenceService, auditLog, clock, ids)

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -448,11 +448,13 @@ The following variables are read by `synapse-agent` and `synapse-cluster-agent`,
 
 ## MCP server (synapse-mcp)
 
-Read and propose only. It never executes. The token and engagement ID are required to start it.
+Read and propose only. It never executes. The token and engagement ID are required to start it; tenant
+and engagement are fixed at process startup and cannot be supplied by an MCP client.
 
 | Variable | Default | Description |
 | --- | --- | --- |
 | `SYNAPSE_MCP_TOKEN` | (none) | Bearer token. Never logged. |
+| `SYNAPSE_MCP_TENANT_ID` | `default` | The tenant boundary for every MCP request. Set this explicitly when the deployment uses a non-default tenant; clients cannot override it. |
 | `SYNAPSE_MCP_ENGAGEMENT_ID` | (none) | The engagement the MCP server is scoped to. |
 | `SYNAPSE_MCP_ADDR` | `:8081` | Listen address. |
 

--- a/docs/guide/mcp-integration.md
+++ b/docs/guide/mcp-integration.md
@@ -11,6 +11,7 @@ code path through which it can run a tool.
 
 ```bash
 export SYNAPSE_MCP_TOKEN="$(openssl rand -hex 32)"
+export SYNAPSE_MCP_TENANT_ID="tenant_..."
 export SYNAPSE_MCP_ENGAGEMENT_ID="eng_..."
 ./bin/synapse-mcp
 ```
@@ -18,11 +19,14 @@ export SYNAPSE_MCP_ENGAGEMENT_ID="eng_..."
 | Variable | Default | Description |
 | --- | --- | --- |
 | `SYNAPSE_MCP_TOKEN` | (none) | Bearer token. Required. Never logged. |
+| `SYNAPSE_MCP_TENANT_ID` | `default` | The single tenant this server is scoped to. Clients cannot override it. |
 | `SYNAPSE_MCP_ENGAGEMENT_ID` | (none) | The single engagement this server is scoped to. Required. |
 | `SYNAPSE_MCP_ADDR` | `:8081` | Listen address. |
 
-The session is engagement-locked at construction. A client cannot select or reach another engagement's
-data, because the engagement is not a request parameter.
+The session is tenant- and engagement-locked at construction. A client cannot select or reach another
+tenant or engagement, because neither boundary is a request parameter. Incident access is narrower still:
+the server derives the allowed incident IDs by joining the engagement's detection ledger, rather than
+listing every incident in the tenant.
 
 ## Protocol surface
 
@@ -47,6 +51,8 @@ engagement cannot silently return a partial picture as if it were complete.
 | `reachability_context` | Dependency-graph reachability facts |
 | `evidence_sufficiency` | Advisory assessment of what a finding still needs to become publishable |
 | `plan_runtime_verification` | A safe, read-only verification plan for a SAST finding. Executes nothing |
+| `list_incidents` | Bounded incident summaries whose trigger detections belong to the configured engagement; no comments, owner, response records, or evidence content |
+| `get_incident_context` | A bounded, secret-redacted endpoint timeline around an allowed incident's server-derived asset and detection window |
 
 `evidence_sufficiency` is explicitly advisory. It sets no score; only a distinct verifier's sealed verdict
 moves a finding's evidence score.
@@ -69,11 +75,12 @@ can confirm itself.
 | `propose_threat` | A STRIDE threat over the architecture model |
 | `propose_vex_justification` | An OpenVEX `not_affected` justification |
 | `propose_writeup_draft` | Finding write-up prose awaiting human sign-off |
+| `propose_investigation` | A token-only incident hypothesis: tactic storyline, confidence, structured drivers, scoped relevant event IDs, and one closed read-only next-step suggestion. A distinct verifier must seal an above-threshold verdict; it cannot mutate facts, risk, disposition, or response actions |
 
 A `tools/call` response for a proposal carries `"proposal_requires_human_approval": true`. Treat it as a
 queued request for review, not as work that happened.
 
-Judgment proposal tools require `SYNAPSE_JUDGMENTS_ENABLED`, and `propose_writeup_draft` requires
+Judgment proposal tools, including `propose_investigation`, require `SYNAPSE_JUDGMENTS_ENABLED`, and `propose_writeup_draft` requires
 `SYNAPSE_WRITEUP_DRAFTS_ENABLED`. A tool whose dependency is not wired is simply absent from
 `tools/list` rather than present and failing.
 
@@ -91,5 +98,8 @@ Three independent controls hold, and none of them depends on the MCP client beha
 
 Secrets are never exposed to a client: credentials stay in the vault, substitution happens server-side at
 execution time, and evidence content is not a readable field in any tool result.
+
+Investigation judgments are deliberately absent from generated reports. Reports continue to render only
+their existing deterministic, typed projections; no MCP or LLM output is passed into the report path.
 
 Next: [Code quality rule authoring](code-quality-rules.md)

--- a/internal/adapter/mcpserver/server.go
+++ b/internal/adapter/mcpserver/server.go
@@ -4,9 +4,9 @@
 // tools/call – so it needs no third-party SDK and is fully testable offline. (The SDK can be
 // swapped in later behind the same Catalog seam.)
 //
-// Safety: the server is bearer-locked (role "mcp") and pinned to ONE engagement, so it can
-// never reach another engagement's data (the catalog is engagement-locked per session and an
-// engagement id is never accepted from the client). It dispatches through the SAME
+// Safety: the server is bearer-locked (role "mcp") and pinned to ONE tenant + engagement, so it can
+// never reach another scope (the catalog is locked per session and neither boundary is accepted from
+// the client). It dispatches through the SAME
 // agenttools.Catalog the in-process orchestrator uses, so read tools return data and an
 // execute proposal (start_recon) is returned as an approval-required envelope – the MCP path
 // has no executor and no gate, so it can never RUN a tool (it can only read + propose). All
@@ -30,9 +30,10 @@ import (
 // protocolVersion is the MCP revision this server speaks.
 const protocolVersion = "2024-11-05"
 
-// Server is an MCP endpoint over a fixed engagement.
+// Server is an MCP endpoint over a fixed tenant and engagement.
 type Server struct {
 	catalog      *agenttools.Catalog
+	tenantID     shared.ID
 	engagementID shared.ID
 	sessionID    shared.ID // synthetic session id used for catalog dispatch + audit attribution
 	token        string    // bearer token (role-locked "mcp"); never logged
@@ -41,13 +42,16 @@ type Server struct {
 	log          *slog.Logger
 }
 
-// New validates dependencies and returns an MCP server bound to one engagement.
-func New(catalog *agenttools.Catalog, engagementID shared.ID, token, version string, log *slog.Logger) (*Server, error) {
+// New validates dependencies and returns an MCP server bound to one tenant and engagement.
+func New(catalog *agenttools.Catalog, tenantID, engagementID shared.ID, token, version string, log *slog.Logger) (*Server, error) {
 	if catalog == nil {
 		return nil, fmt.Errorf("%w: mcp server needs a catalog", shared.ErrValidation)
 	}
 	if engagementID == "" {
 		return nil, fmt.Errorf("%w: mcp server needs an engagement id (SYNAPSE_MCP_ENGAGEMENT_ID)", shared.ErrValidation)
+	}
+	if tenantID.IsZero() {
+		return nil, fmt.Errorf("%w: mcp server needs a tenant id (SYNAPSE_MCP_TENANT_ID)", shared.ErrValidation)
 	}
 	if token == "" {
 		return nil, fmt.Errorf("%w: mcp server needs a bearer token (SYNAPSE_MCP_TOKEN)", shared.ErrValidation)
@@ -56,7 +60,7 @@ func New(catalog *agenttools.Catalog, engagementID shared.ID, token, version str
 		log = slog.Default()
 	}
 	return &Server{
-		catalog: catalog, engagementID: engagementID,
+		catalog: catalog, tenantID: tenantID, engagementID: engagementID,
 		sessionID: shared.ID("mcp-" + engagementID.String()),
 		token:     token, serverName: "synapse-mcp", version: version, log: log,
 	}, nil
@@ -174,8 +178,8 @@ func (s *Server) handleToolCall(ctx context.Context, w http.ResponseWriter, req 
 		writeJSON(w, http.StatusOK, errResp(req.ID, codeInvalidRequest, "tools/call needs a tool name"))
 		return
 	}
-	sess := agent.Session{ID: s.sessionID, EngagementID: s.engagementID, InitiatedBy: "mcp"}
-	res, err := s.catalog.Dispatch(ctx, sess, agent.ToolCall{ID: "mcp", Name: p.Name, Arguments: p.Arguments})
+	sess := agent.Session{ID: s.sessionID, TenantID: s.tenantID, EngagementID: s.engagementID, InitiatedBy: "mcp"}
+	res, err := s.catalog.Dispatch(shared.WithTenant(ctx, s.tenantID), sess, agent.ToolCall{ID: "mcp", Name: p.Name, Arguments: p.Arguments})
 	if err != nil {
 		// A tool/argument error is reported as an MCP tool error (isError), not a transport error.
 		writeJSON(w, http.StatusOK, okResp(req.ID, toolResult(err.Error(), true)))

--- a/internal/adapter/mcpserver/server_test.go
+++ b/internal/adapter/mcpserver/server_test.go
@@ -7,11 +7,16 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/adapter/mcpserver"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	devidence "github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
 	dfinding "github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 	drecon "github.com/KKloudTarus/synapse-ce/internal/domain/recon"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
@@ -49,17 +54,100 @@ func (reconTool) BuildArgs(t engagement.Target) (ports.ToolSpec, error) {
 	return ports.ToolSpec{Name: "subfinder", Args: []string{"-d", t.Value}}, nil
 }
 
+type investigationReader struct{ incident incident.Incident }
+
+func (r investigationReader) Get(ctx context.Context, id shared.ID) (incident.Incident, error) {
+	if tenant, ok := shared.TenantFrom(ctx); !ok || tenant != "tenant-1" {
+		return incident.Incident{}, shared.ErrForbidden
+	}
+	if id != r.incident.ID {
+		return incident.Incident{}, shared.ErrNotFound
+	}
+	return r.incident, nil
+}
+
+func (r investigationReader) ListByDetectionIDs(ctx context.Context, ids []shared.ID, _ int) ([]incident.Incident, error) {
+	if tenant, ok := shared.TenantFrom(ctx); !ok || tenant != "tenant-1" {
+		return nil, shared.ErrForbidden
+	}
+	for _, id := range ids {
+		if id == "det-1" {
+			return []incident.Incident{r.incident}, nil
+		}
+	}
+	return nil, nil
+}
+
+type investigationDetections struct{ observed time.Time }
+
+func (d investigationDetections) ListDetections(ctx context.Context, engagementID shared.ID) ([]detection.Record, error) {
+	if tenant, ok := shared.TenantFrom(ctx); !ok || tenant != "tenant-1" || engagementID != "eng-1" {
+		return nil, shared.ErrForbidden
+	}
+	return []detection.Record{{
+		ID: "det-1", TenantID: "tenant-1", EngagementID: "eng-1", AssetID: "asset-1",
+		Detection: detection.Detection{Observed: d.observed},
+	}}, nil
+}
+
+type investigationTimeline struct{ observed time.Time }
+
+func (t investigationTimeline) Query(ctx context.Context, q ports.EndpointTimelineQuery) ([]endpoint.TimelineEntry, error) {
+	if tenant, ok := shared.TenantFrom(ctx); !ok || tenant != "tenant-1" || q.AssetID != "asset-1" {
+		return nil, shared.ErrForbidden
+	}
+	return []endpoint.TimelineEntry{{
+		OccurredAt: t.observed, TenantID: "tenant-1", AssetID: "asset-1", EntityKind: endpoint.EntityProcess,
+		EntityID: "process-1", Kind: endpoint.TimelineProcessExec, EventID: "event-1", Summary: "exec token=secret-value",
+	}}, nil
+}
+
+type investigationProposer struct{ got judgment.Judgment }
+
+func (p *investigationProposer) Propose(_ context.Context, proposer string, engagementID shared.ID, capability judgment.Capability, subjectKind judgment.SubjectKind, subjectID shared.ID, claim judgment.Claim) (judgment.Judgment, error) {
+	j, err := judgment.New("judgment-1", engagementID, capability, subjectKind, subjectID, claim, proposer, time.Unix(2_000_000, 0).UTC())
+	p.got = j
+	return j, err
+}
+
 func newServer(t *testing.T) http.Handler {
 	t.Helper()
 	cat, err := agenttools.New(findReader{}, evReader{}, []ports.ReconTool{reconTool{}}, noAudit{}, idgen.SystemClock{}, idgen.RandomID{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	srv, err := mcpserver.New(cat, "eng-1", "secret-token", "test", nil)
+	srv, err := mcpserver.New(cat, "tenant-1", "eng-1", "secret-token", "test", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	return srv.Handler()
+}
+
+func newInvestigationServer(t *testing.T) (http.Handler, *investigationProposer) {
+	t.Helper()
+	cat, err := agenttools.New(findReader{}, evReader{}, []ports.ReconTool{reconTool{}}, noAudit{}, idgen.SystemClock{}, idgen.RandomID{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	observed := time.Unix(2_000_000, 0).UTC()
+	inc := incident.Incident{
+		ID: "incident-1", AssetID: "asset-1", Title: "Suspicious process", Severity: shared.SeverityHigh,
+		State: incident.StateInvestigating, Disposition: incident.DispositionUnknown,
+		DetectionIDs: []shared.ID{"det-1"}, CreatedAt: observed, UpdatedAt: observed,
+	}
+	if err := cat.EnableInvestigation(agenttools.InvestigationToolset{
+		Incidents: investigationReader{incident: inc}, Detections: investigationDetections{observed: observed},
+		Timeline: investigationTimeline{observed: observed},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	proposer := &investigationProposer{}
+	cat.EnableJudgments(proposer)
+	srv, err := mcpserver.New(cat, "tenant-1", "eng-1", "secret-token", "test", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv.Handler(), proposer
 }
 
 func rpc(t *testing.T, h http.Handler, token, body string) (int, map[string]any) {
@@ -160,6 +248,46 @@ func TestMCPToolsCallProposalNotExecuted(t *testing.T) {
 	text := contentText(t, res)
 	if !strings.Contains(text, "proposal_requires_human_approval") {
 		t.Errorf("start_recon over MCP must return a proposal envelope (not execute), got %q", text)
+	}
+}
+
+func TestMCPInvestigationIsScopedRedactedAndProposeOnly(t *testing.T) {
+	h, proposer := newInvestigationServer(t)
+	_, listed := rpc(t, h, "secret-token", `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+	tools := listed["result"].(map[string]any)["tools"].([]any)
+	want := map[string]bool{
+		agenttools.ToolListIncidents: false, agenttools.ToolGetIncidentContext: false, agenttools.ToolProposeInvestigation: false,
+	}
+	for _, raw := range tools {
+		name := raw.(map[string]any)["name"].(string)
+		if _, ok := want[name]; ok {
+			want[name] = true
+		}
+	}
+	for name, found := range want {
+		if !found {
+			t.Errorf("missing investigation tool %s", name)
+		}
+	}
+
+	_, contextOut := rpc(t, h, "secret-token", `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"get_incident_context","arguments":{"incident_id":"incident-1"}}}`)
+	contextText := contentText(t, contextOut["result"].(map[string]any))
+	if strings.Contains(contextText, "secret-value") || !strings.Contains(contextText, "[REDACTED]") {
+		t.Fatalf("MCP incident context was not redacted: %s", contextText)
+	}
+
+	_, proposed := rpc(t, h, "secret-token", `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"propose_investigation","arguments":{"incident_id":"incident-1","tactic":"lateral_movement","confidence":82,"drivers":["network_fanout_spike"],"relevant_event_ids":["event-1"],"suggested_next_step":"retro_hunt_similar_activity"}}}`)
+	proposalText := contentText(t, proposed["result"].(map[string]any))
+	if !strings.Contains(proposalText, `"state":"proposed"`) || proposer.got.EvidenceScore != 0 || proposer.got.State != judgment.StateProposed {
+		t.Fatalf("MCP must record only a score-0 proposed judgment: %s %+v", proposalText, proposer.got)
+	}
+	if proposer.got.Capability != judgment.CapInvestigation || proposer.got.SubjectID != "incident-1" {
+		t.Fatalf("wrong investigation judgment: %+v", proposer.got)
+	}
+
+	_, outside := rpc(t, h, "secret-token", `{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"get_incident_context","arguments":{"incident_id":"incident-other"}}}`)
+	if outside["result"].(map[string]any)["isError"] != true {
+		t.Fatalf("cross-scope incident should fail closed: %v", outside)
 	}
 }
 

--- a/internal/domain/judgment/claim.go
+++ b/internal/domain/judgment/claim.go
@@ -486,15 +486,42 @@ func (t InvestigationTactic) Valid() bool {
 	return false
 }
 
+// InvestigationNextStep is a closed analyst-action suggestion. It names a read-only investigation
+// activity, never a response action, command, target, or free-form instruction an agent could execute.
+type InvestigationNextStep string
+
+const (
+	NextInspectProcessTree     InvestigationNextStep = "inspect_process_tree"
+	NextInspectNetworkActivity InvestigationNextStep = "inspect_network_activity"
+	NextInspectFileActivity    InvestigationNextStep = "inspect_file_activity"
+	NextInspectIdentityEvents  InvestigationNextStep = "inspect_identity_events"
+	NextRetroHuntSimilar       InvestigationNextStep = "retro_hunt_similar_activity"
+	NextCollectTelemetry       InvestigationNextStep = "collect_additional_telemetry"
+	NextCloseAsBenign          InvestigationNextStep = "close_as_benign"
+)
+
+// Valid reports whether s is a known, non-executing investigation suggestion. Empty is allowed for
+// backwards compatibility with hypotheses persisted before next-step suggestions were introduced.
+func (s InvestigationNextStep) Valid() bool {
+	switch s {
+	case "", NextInspectProcessTree, NextInspectNetworkActivity, NextInspectFileActivity,
+		NextInspectIdentityEvents, NextRetroHuntSimilar, NextCollectTelemetry, NextCloseAsBenign:
+		return true
+	}
+	return false
+}
+
 // InvestigationClaim is an AI-proposed HYPOTHESIS about an incident (#594 E): a single closed tactic
 // category, a confidence, and structured driver tokens (the signals that support it — never free prose).
-// It is propose-only and NOT gated: it never proves anything or drives a response on its own; it is
-// advisory context a human analyst accepts or rejects. The LLM proposes; a human decides.
+// It is propose-only and evidence-gated: it never proves anything or drives a response on its own;
+// a distinct verifier must seal a verdict that clears the shared evidence threshold.
 type InvestigationClaim struct {
-	IncidentID shared.ID           `json:"incident_id"`
-	Tactic     InvestigationTactic `json:"tactic"`
-	Confidence int                 `json:"confidence"` // 0..100
-	Drivers    []string            `json:"drivers"`    // closed signal tokens (e.g. "new_exec_paths", "network_fanout_spike"), no prose
+	IncidentID        shared.ID             `json:"incident_id"`
+	Tactic            InvestigationTactic   `json:"tactic"`
+	Confidence        int                   `json:"confidence"`                    // 0..100
+	Drivers           []string              `json:"drivers"`                       // closed signal tokens, no prose
+	RelevantEventIDs  []shared.ID           `json:"relevant_event_ids,omitempty"`  // bounded event references from scoped context
+	SuggestedNextStep InvestigationNextStep `json:"suggested_next_step,omitempty"` // closed, read-only analyst suggestion
 }
 
 // Capability identifies this claim's brain.
@@ -519,6 +546,22 @@ func (c InvestigationClaim) Validate() error {
 		if len(d) > 64 || !driverRE.MatchString(d) {
 			return fmt.Errorf("%w: investigation driver %q must be a token (no free text)", shared.ErrValidation, d)
 		}
+	}
+	if len(c.RelevantEventIDs) > 32 {
+		return fmt.Errorf("%w: investigation hypothesis has too many relevant events (%d > 32)", shared.ErrValidation, len(c.RelevantEventIDs))
+	}
+	seenEvents := make(map[shared.ID]struct{}, len(c.RelevantEventIDs))
+	for _, id := range c.RelevantEventIDs {
+		if id.IsZero() || len(id) > 128 {
+			return fmt.Errorf("%w: investigation relevant event id must be non-empty and at most 128 bytes", shared.ErrValidation)
+		}
+		if _, duplicate := seenEvents[id]; duplicate {
+			return fmt.Errorf("%w: investigation relevant event id %q is duplicated", shared.ErrValidation, id)
+		}
+		seenEvents[id] = struct{}{}
+	}
+	if !c.SuggestedNextStep.Valid() {
+		return fmt.Errorf("%w: investigation suggested next step must be a known read-only token, got %q", shared.ErrValidation, c.SuggestedNextStep)
 	}
 	return nil
 }

--- a/internal/domain/judgment/investigation_claim_test.go
+++ b/internal/domain/judgment/investigation_claim_test.go
@@ -1,21 +1,28 @@
 package judgment
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/verdict"
 )
 
 func TestInvestigationClaimValidate(t *testing.T) {
-	ok := InvestigationClaim{IncidentID: "inc-1", Tactic: TacticLateralMovement, Confidence: 70, Drivers: []string{"new_exec_paths", "network_fanout_spike"}}
+	ok := InvestigationClaim{
+		IncidentID: "inc-1", Tactic: TacticLateralMovement, Confidence: 70,
+		Drivers: []string{"new_exec_paths", "network_fanout_spike"}, RelevantEventIDs: []shared.ID{"event-1"},
+		SuggestedNextStep: NextRetroHuntSimilar,
+	}
 	if err := ok.Validate(); err != nil {
 		t.Fatalf("valid claim rejected: %v", err)
 	}
 	if ok.Capability() != CapInvestigation {
 		t.Fatalf("capability = %q, want investigation", ok.Capability())
 	}
-	if CapInvestigation.Gated() {
-		t.Fatal("investigation must be UNGATED (advisory hypothesis, human-accepted)")
+	if !CapInvestigation.Gated() {
+		t.Fatal("investigation must require a distinct verifier's evidence-gated verdict")
 	}
 	if !CapInvestigation.Valid() {
 		t.Fatal("CapInvestigation must be a known capability")
@@ -25,6 +32,9 @@ func TestInvestigationClaimValidate(t *testing.T) {
 		"bad tactic":   {IncidentID: "inc-1", Tactic: "made_up", Confidence: 10},
 		"bad conf":     {IncidentID: "inc-1", Tactic: TacticBenign, Confidence: 101},
 		"prose driver": {IncidentID: "inc-1", Tactic: TacticBenign, Confidence: 10, Drivers: []string{"this is free prose"}},
+		"bad event":    {IncidentID: "inc-1", Tactic: TacticBenign, Confidence: 10, RelevantEventIDs: []shared.ID{""}},
+		"bad next step": {IncidentID: "inc-1", Tactic: TacticBenign, Confidence: 10,
+			SuggestedNextStep: "isolate_host"},
 	} {
 		if err := c.Validate(); err == nil {
 			t.Errorf("%s: expected a validation error", name)
@@ -32,8 +42,34 @@ func TestInvestigationClaimValidate(t *testing.T) {
 	}
 }
 
+func TestInvestigationHypothesisNeedsDistinctVerifier(t *testing.T) {
+	now := time.Unix(2_000_000, 0).UTC()
+	j, err := New("judgment-1", "eng-1", CapInvestigation, SubjectIncident, "inc-1", InvestigationClaim{
+		IncidentID: "inc-1", Tactic: TacticExecution, Confidence: 75,
+	}, "agent:session-1", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := j.Accept("analyst-1", now); err == nil {
+		t.Fatal("a gated investigation hypothesis must reject the ungated acceptance path")
+	}
+	if _, err := j.ApplyVerdict(verdict.Verdict{Score: 90, Verifier: "agent:session-1", Rationale: "same actor"}, now); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("self-verification must fail closed, got %v", err)
+	}
+	confirmed, err := j.ApplyVerdict(verdict.Verdict{Score: 90, Verifier: "analyst-1", Rationale: "events corroborated"}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if confirmed.State != StateConfirmed || !confirmed.Publishable() || confirmed.EvidenceScore != 90 {
+		t.Fatalf("distinct above-threshold verdict did not confirm: %+v", confirmed)
+	}
+}
+
 func TestInvestigationClaimRoundTrips(t *testing.T) {
-	data, err := MarshalClaim(InvestigationClaim{IncidentID: "inc-9", Tactic: TacticDataExfiltration, Confidence: 88})
+	data, err := MarshalClaim(InvestigationClaim{
+		IncidentID: "inc-9", Tactic: TacticDataExfiltration, Confidence: 88,
+		RelevantEventIDs: []shared.ID{"event-9"}, SuggestedNextStep: NextInspectNetworkActivity,
+	})
 	if err != nil {
 		t.Fatalf("marshal: %v", err)
 	}
@@ -42,7 +78,8 @@ func TestInvestigationClaimRoundTrips(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	ic, ok := c.(InvestigationClaim)
-	if !ok || ic.Tactic != TacticDataExfiltration || ic.IncidentID != shared.ID("inc-9") {
+	if !ok || ic.Tactic != TacticDataExfiltration || ic.IncidentID != shared.ID("inc-9") ||
+		len(ic.RelevantEventIDs) != 1 || ic.SuggestedNextStep != NextInspectNetworkActivity {
 		t.Fatalf("round-trip wrong: %+v ok=%v", c, ok)
 	}
 }

--- a/internal/domain/judgment/judgment.go
+++ b/internal/domain/judgment/judgment.go
@@ -30,7 +30,7 @@ const (
 	CapCorrelation      Capability = "correlation"       // NOT gated (a cross-check disagreement; human-acknowledged, never auto-resolved)
 	CapPromotion        Capability = "promotion"         // gated (cross-pillar priority change, distinct-verifier only)
 	CapVexJustification Capability = "vex_justification" // gated (AI-proposed OpenVEX not_affected justification, human-ratified)
-	CapInvestigation    Capability = "investigation"     // NOT gated (E: an AI investigation HYPOTHESIS about an incident; advisory, human-accepted, never auto-acted)
+	CapInvestigation    Capability = "investigation"     // gated (E: AI investigation HYPOTHESIS; distinct-verifier only, never auto-acted)
 )
 
 // Valid reports whether c is a known capability.
@@ -43,12 +43,12 @@ func (c Capability) Valid() bool {
 }
 
 // Gated reports whether a verdict gates this capability's publishability (R2). Adversarially-
-// refutable capabilities (reachability/sast/critique/threat/promotion/vex_justification) are gated: publishable only with a sealed
+// refutable capabilities (reachability/sast/critique/threat/promotion/vex_justification/investigation) are gated: publishable only with a sealed
 // verdict >= EvidenceThreshold. Descriptive ones (risk_narrative; correlation – a deterministic
 // cross-check disagreement) have no "refuted at 75" semantics; they are human-accepted, not score-gated.
 func (c Capability) Gated() bool {
 	switch c {
-	case CapReachability, CapSAST, CapDAST, CapCritique, CapThreat, CapPromotion, CapVexJustification:
+	case CapReachability, CapSAST, CapDAST, CapCritique, CapThreat, CapPromotion, CapVexJustification, CapInvestigation:
 		return true
 	}
 	return false

--- a/internal/infrastructure/persistence/memory/incident_event_store.go
+++ b/internal/infrastructure/persistence/memory/incident_event_store.go
@@ -117,6 +117,9 @@ func (s *IncidentEventStore) ListIncidentIDs(ctx context.Context, q ports.Incide
 		if !q.AssetID.IsZero() && log[0].AssetID != q.AssetID {
 			continue
 		}
+		if len(q.DetectionIDs) > 0 && !incidentLogReferencesAnyDetection(log, q.DetectionIDs) {
+			continue
+		}
 		ids = append(ids, id)
 	}
 	s.mu.Unlock()
@@ -130,4 +133,19 @@ func (s *IncidentEventStore) ListIncidentIDs(ctx context.Context, q ports.Incide
 		ids = ids[:limit]
 	}
 	return ids, nil
+}
+
+func incidentLogReferencesAnyDetection(log []incident.IncidentEvent, ids []shared.ID) bool {
+	wanted := make(map[shared.ID]struct{}, len(ids))
+	for _, id := range ids {
+		if !id.IsZero() {
+			wanted[id] = struct{}{}
+		}
+	}
+	for _, event := range log {
+		if _, ok := wanted[event.DetectionID]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/infrastructure/persistence/memory/incident_event_store_test.go
+++ b/internal/infrastructure/persistence/memory/incident_event_store_test.go
@@ -69,6 +69,12 @@ func TestIncidentEventStoreListAndTenantIsolation(t *testing.T) {
 	if err != nil || len(ids) != 1 || ids[0] != ieInc {
 		t.Fatalf("list by asset: %v err=%v", ids, err)
 	}
+	if ids, err := s.ListIncidentIDs(ieCtx(ieTenant), ports.IncidentQuery{DetectionIDs: []shared.ID{"d1"}}); err != nil || len(ids) != 1 || ids[0] != ieInc {
+		t.Fatalf("list by detection: %v err=%v", ids, err)
+	}
+	if ids, err := s.ListIncidentIDs(ieCtx(ieTenant), ports.IncidentQuery{DetectionIDs: []shared.ID{"d-other"}}); err != nil || len(ids) != 0 {
+		t.Fatalf("unrelated detection must match no incidents: %v err=%v", ids, err)
+	}
 	// Another tenant sees nothing, and cannot load the incident.
 	other := shared.ID("tenant-other")
 	if ids, _ := s.ListIncidentIDs(ieCtx(other), ports.IncidentQuery{}); len(ids) != 0 {

--- a/internal/infrastructure/persistence/postgres/incident_event_repo.go
+++ b/internal/infrastructure/persistence/postgres/incident_event_repo.go
@@ -132,7 +132,20 @@ func (r *IncidentEventRepository) ListIncidentIDs(ctx context.Context, q ports.I
 	args := []any{tenant.String()}
 	if !q.AssetID.IsZero() {
 		args = append(args, q.AssetID.String())
-		sql += ` AND asset_id=$2`
+		sql += fmt.Sprintf(` AND asset_id=$%d`, len(args))
+	}
+	if len(q.DetectionIDs) > 0 {
+		detectionIDs := make([]string, 0, len(q.DetectionIDs))
+		for _, id := range q.DetectionIDs {
+			if !id.IsZero() {
+				detectionIDs = append(detectionIDs, id.String())
+			}
+		}
+		if len(detectionIDs) == 0 {
+			return nil, nil
+		}
+		args = append(args, detectionIDs)
+		sql += fmt.Sprintf(` AND detection_id = ANY($%d)`, len(args))
 	}
 	args = append(args, limit)
 	sql += fmt.Sprintf(` GROUP BY incident_id ORDER BY incident_id COLLATE "C" LIMIT $%d`, len(args))

--- a/internal/infrastructure/persistence/postgres/incident_event_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/incident_event_repo_test.go
@@ -99,6 +99,13 @@ func TestIncidentEventRepository(t *testing.T) {
 	if err != nil || len(ids) != 1 || ids[0] != incID {
 		t.Fatalf("list by asset: %v err=%v", ids, err)
 	}
+	ids, err = repo.ListIncidentIDs(tctx, ports.IncidentQuery{DetectionIDs: []shared.ID{"d1"}})
+	if err != nil || len(ids) != 1 || ids[0] != incID {
+		t.Fatalf("list by detection: %v err=%v", ids, err)
+	}
+	if ids, err = repo.ListIncidentIDs(tctx, ports.IncidentQuery{DetectionIDs: []shared.ID{"d-other"}}); err != nil || len(ids) != 0 {
+		t.Fatalf("unrelated detection must match no incidents: %v err=%v", ids, err)
+	}
 
 	// Cross-tenant isolation: the other tenant sees nothing.
 	octx := shared.WithTenant(ctx, other)

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -580,9 +580,10 @@ type Config struct {
 	MeasureCursorSecret string
 
 	// MCP server: exposes the agent tool catalog to external MCP clients,
-	// bearer-locked (role "mcp") and pinned to one engagement. Token is never logged.
+	// bearer-locked (role "mcp") and pinned to one tenant + engagement. Token is never logged.
 	MCPToken        string
 	MCPAddr         string
+	MCPTenantID     string
 	MCPEngagementID string
 }
 
@@ -855,6 +856,7 @@ func Load() Config {
 
 		MCPToken:        getenv("SYNAPSE_MCP_TOKEN", ""),
 		MCPAddr:         getenv("SYNAPSE_MCP_ADDR", ":8081"),
+		MCPTenantID:     getenv("SYNAPSE_MCP_TENANT_ID", "default"),
 		MCPEngagementID: getenv("SYNAPSE_MCP_ENGAGEMENT_ID", ""),
 	}
 }

--- a/internal/usecase/agenttools/arch_test.go
+++ b/internal/usecase/agenttools/arch_test.go
@@ -21,9 +21,12 @@ func TestCatalogCannotReachAScoreSetter(t *testing.T) {
 	forbidden := []string{
 		mod + "/internal/usecase/exploitation",
 		mod + "/internal/usecase/findings",
-		mod + "/internal/usecase/analysis",       // judgment Verify (the score/state mover) – the agent must not reach it
-		mod + "/internal/usecase/writeupdraftuc", // draft Edit/Accept/Reject (the human sign-off) – agent reaches Propose only, via the narrow writeupdraftProposer
-		mod + "/internal/infrastructure",         // concrete repos hold SetEvidenceScore / SetScoreState (and the writeupdraft store)
+		mod + "/internal/usecase/analysis",             // judgment Verify (the score/state mover) – the agent must not reach it
+		mod + "/internal/usecase/writeupdraftuc",       // draft Edit/Accept/Reject (the human sign-off) – agent reaches Propose only, via the narrow writeupdraftProposer
+		mod + "/internal/usecase/fleet/incidenttriage", // incident fact/disposition writer – investigation is read + judgment proposal only
+		mod + "/internal/usecase/fleet/riskscoreuc",    // RiskAssessment writer/reassembler – AI cannot set risk
+		mod + "/internal/usecase/response",             // governed response execution – AI investigation cannot reach it
+		mod + "/internal/infrastructure",               // concrete repos hold SetEvidenceScore / SetScoreState (and the writeupdraft store)
 	}
 	// NOTE: domain/judgment is intentionally NOT forbidden – the catalog imports it for the
 	// ReachabilityTier consts and will for ReachabilityClaim. Its in-memory

--- a/internal/usecase/agenttools/catalog.go
+++ b/internal/usecase/agenttools/catalog.go
@@ -30,10 +30,14 @@ import (
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/privacy"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vex"
@@ -61,12 +65,14 @@ const (
 	ToolProposeSASTValidation   = "propose_sast_validation"   // propose a gated CapSAST judgment for verifier review; score 0, no execution
 	ToolProposeCritique         = "propose_critique"          // propose an adversarial critique Judgment against a finding (score 0)
 	ToolEvidenceSufficiency     = "evidence_sufficiency"      // read-only advisory – what's missing for a finding to reach the bar
+	ToolListIncidents           = "list_incidents"            // engagement-scoped incident projections backed by this engagement's detections
+	ToolGetIncidentContext      = "get_incident_context"      // bounded, redacted State-Timeline window around one scoped incident
 	ToolProposeRiskNarrative    = "propose_risk_narrative"    // propose a risk-narrative Judgment (ungated; a human accepts)
 	ToolProposeThreat           = "propose_threat"            // propose a STRIDE threat Judgment over the architecture model (score 0; a human ratifies)
 	ToolProposeWriteupDraft     = "propose_writeup_draft"     // propose a finding write-up DRAFT (prose) awaiting human sign-off (NOT a judgment)
 	ToolProposeAttackChain      = "propose_attack_chain"      // propose an attack-chain HYPOTHESIS finding (score 0; gated until a human verifies)
 	ToolProposeVexJustification = "propose_vex_justification" // propose an OpenVEX not_affected justification Judgment (score 0; a human ratifies)
-	ToolProposeInvestigation    = "propose_investigation"     // propose an AI investigation HYPOTHESIS about an incident (E; ungated, a human accepts)
+	ToolProposeInvestigation    = "propose_investigation"     // propose an evidence-gated AI investigation HYPOTHESIS (E; distinct verifier required)
 )
 
 // MaxPlanNodes bounds how many nodes a single propose_plan may carry (mirrors the domain cap);
@@ -86,6 +92,23 @@ type findingReader interface {
 
 type evidenceReader interface {
 	ListByEngagement(ctx context.Context, engagementID shared.ID) ([]evidence.Evidence, error)
+}
+
+// incidentReader + detectionReader + endpointTimelineReader form the read-only EDR investigation seam.
+// The detection reader supplies the authoritative engagement boundary; an incident is exposed only when
+// its append-only event log references a detection returned for the session's engagement. Timeline reads
+// then use the already-authorized incident's asset id, never an LLM-supplied asset id.
+type incidentReader interface {
+	Get(ctx context.Context, id shared.ID) (incident.Incident, error)
+	ListByDetectionIDs(ctx context.Context, detectionIDs []shared.ID, limit int) ([]incident.Incident, error)
+}
+
+type detectionReader interface {
+	ListDetections(ctx context.Context, engagementID shared.ID) ([]detection.Record, error)
+}
+
+type endpointTimelineReader interface {
+	Query(ctx context.Context, q ports.EndpointTimelineQuery) ([]endpoint.TimelineEntry, error)
 }
 
 // findingProposer is the narrow slice of the exploitation use-case the catalog needs to record
@@ -144,6 +167,27 @@ type Catalog struct {
 	reach       scanResultReader     // advertise + dispatch reachability_context (nil ⇒ tool absent)
 	jproposer   judgmentProposer     // advertise + dispatch propose_reachability/critique/risk_narrative/threat (nil ⇒ absent)
 	drafter     writeupdraftProposer // advertise + dispatch propose_writeup_draft (nil ⇒ absent)
+	incidents   incidentReader       // optional EDR read side; enabled atomically with detections + timeline
+	detections  detectionReader      // authoritative engagement-to-detection scope join
+	timeline    endpointTimelineReader
+}
+
+// InvestigationToolset is the complete read-only dependency set for AI/MCP incident investigation.
+// It is enabled atomically so the catalog never advertises a list tool without the scoped context tool.
+type InvestigationToolset struct {
+	Incidents  incidentReader
+	Detections detectionReader
+	Timeline   endpointTimelineReader
+}
+
+// EnableInvestigation turns on the engagement-scoped incident list and bounded timeline-context tools.
+// All dependencies are required; a partial read plane fails closed and changes no catalog state.
+func (c *Catalog) EnableInvestigation(t InvestigationToolset) error {
+	if t.Incidents == nil || t.Detections == nil || t.Timeline == nil {
+		return fmt.Errorf("%w: investigation tools require incident, detection, and timeline readers", shared.ErrValidation)
+	}
+	c.incidents, c.detections, c.timeline = t.Incidents, t.Detections, t.Timeline
+	return nil
 }
 
 // EnableFindingProposals turns on the propose_finding tool. The agent can then
@@ -230,6 +274,12 @@ func (c *Catalog) Tools() []agent.ToolSchema {
 		{Name: ToolStartRecon, Description: "Propose a reconnaissance run against a target. This does NOT run the tool: it creates an approval-required proposal that the scope/authorization gate and a human approver must clear before anything executes. Always include a one-line rationale.", Parameters: json.RawMessage(`{"type":"object","properties":{"tool":{"type":"string","description":"recon tool name, e.g. subfinder"},"target":{"type":"string","description":"the target to run against, e.g. app.example.com"},"rationale":{"type":"string","description":"one-line justification shown to the approver"}},"required":["tool","target"],"additionalProperties":false}`)},
 		{Name: ToolEvidenceSufficiency, Description: "Assess whether a finding has enough evidence to be PUBLISHABLE. Returns its evidence score vs the bar, whether it is gated (exploitation/AI claims need a distinct verifier's sealed verdict; SCA/recon/manual do not), how many evidence items it has, and structured ADVICE on what is missing. Read-only and ADVISORY – it sets no score; only a distinct human verifier's sealed verdict moves a finding's score.", Parameters: json.RawMessage(`{"type":"object","properties":{"finding_id":{"type":"string","description":"the finding id to assess (from list_findings)"}},"required":["finding_id"],"additionalProperties":false}`)},
 	}
+	if c.incidents != nil {
+		schemas = append(schemas,
+			agent.ToolSchema{Name: ToolListIncidents, Description: "List incident projections backed by detections from the current engagement. Returns bounded factual state, disposition, tri-score risk, and coverage metadata; no analyst comments, response actions, or cross-engagement detection ids. Read-only.", Parameters: empty},
+			agent.ToolSchema{Name: ToolGetIncidentContext, Description: "Get a bounded, redacted State-Timeline window around one incident from list_incidents. The server derives the asset and trigger times from the engagement-scoped incident; the client cannot select another asset or arbitrary time. Read-only and coverage-honest; it never mutates facts, risk, disposition, or responses.", Parameters: json.RawMessage(`{"type":"object","properties":{"incident_id":{"type":"string","description":"the incident id from list_incidents"},"before_seconds":{"type":"integer","minimum":0,"maximum":3600,"description":"extra look-back before the first incident detection; default 300"},"after_seconds":{"type":"integer","minimum":0,"maximum":3600,"description":"extra look-forward after the last incident detection; default 300"},"limit":{"type":"integer","minimum":1,"maximum":50,"description":"maximum timeline entries; default and hard maximum 50"}},"required":["incident_id"],"additionalProperties":false}`)},
+		)
+	}
 	if c.proposer != nil {
 		schemas = append(schemas, agent.ToolSchema{
 			Name:        ToolProposeFinding,
@@ -289,11 +339,13 @@ func (c *Catalog) Tools() []agent.ToolSchema {
 			Description: "Propose an OpenVEX JUSTIFICATION for why a finding is NOT AFFECTED – pick ONE of the closed OpenVEX justifications. This is a PROPOSAL recorded at score 0: you CANNOT confirm it; a distinct human ratifies it before any export trusts it (a false 'not affected' suppresses a real vuln). Pick the most specific justification you can support.",
 			Parameters:  json.RawMessage(`{"type":"object","properties":{"finding_id":{"type":"string","description":"the finding this justification is about (from list_findings)"},"justification":{"type":"string","description":"one of: component_not_present | vulnerable_code_not_present | vulnerable_code_not_in_execute_path | vulnerable_code_cannot_be_controlled_by_adversary | inline_mitigations_already_exist"}},"required":["finding_id","justification"],"additionalProperties":false}`),
 		})
-		schemas = append(schemas, agent.ToolSchema{
-			Name:        ToolProposeInvestigation,
-			Description: "Propose an INVESTIGATION HYPOTHESIS about an incident: pick ONE closed ATT&CK-style tactic that best explains what is happening, a confidence 0..100, and the STRUCTURED signal tokens that support it (never prose). This is a PROPOSAL recorded at score 0 that a human analyst ACCEPTS or REJECTS – it proves nothing and NEVER drives a response on its own; you cannot accept your own hypothesis. Use 'benign' when the evidence points to NOT malicious.",
-			Parameters:  json.RawMessage(`{"type":"object","properties":{"incident_id":{"type":"string","description":"the incident this hypothesis is about (from the incident list)"},"tactic":{"type":"string","description":"one of: lateral_movement | data_exfiltration | privilege_escalation | credential_access | persistence | command_and_control | defense_evasion | execution | benign"},"confidence":{"type":"integer","description":"0..100 confidence in the hypothesis"},"drivers":{"type":"array","items":{"type":"string"},"description":"the signal TOKENS that support it, e.g. new_exec_paths, network_fanout_spike, privilege_events (lowercase tokens, no spaces, no prose)"}},"required":["incident_id","tactic","confidence"],"additionalProperties":false}`),
-		})
+		if c.incidents != nil {
+			schemas = append(schemas, agent.ToolSchema{
+				Name:        ToolProposeInvestigation,
+				Description: "Propose an INVESTIGATION HYPOTHESIS about an incident from list_incidents: a closed tactic storyline, confidence, structured drivers, relevant event IDs from get_incident_context, and one read-only next step. The server rechecks incident/event scope. Recorded at score 0; only a DISTINCT verifier's sealed verdict can confirm it. It NEVER changes incident facts/risk/disposition and NEVER drives a response.",
+				Parameters:  json.RawMessage(`{"type":"object","properties":{"incident_id":{"type":"string","description":"the incident this hypothesis is about (from list_incidents)"},"tactic":{"type":"string","description":"one of: lateral_movement | data_exfiltration | privilege_escalation | credential_access | persistence | command_and_control | defense_evasion | execution | benign"},"confidence":{"type":"integer","minimum":0,"maximum":100,"description":"confidence in the hypothesis"},"drivers":{"type":"array","maxItems":32,"items":{"type":"string"},"description":"signal TOKENS, e.g. new_exec_paths or network_fanout_spike (lowercase tokens, no prose)"},"relevant_event_ids":{"type":"array","maxItems":32,"items":{"type":"string"},"description":"event IDs returned by get_incident_context that support the storyline"},"context_before_seconds":{"type":"integer","minimum":0,"maximum":3600,"description":"the before_seconds used to read relevant_event_ids; default 300"},"context_after_seconds":{"type":"integer","minimum":0,"maximum":3600,"description":"the after_seconds used to read relevant_event_ids; default 300"},"suggested_next_step":{"type":"string","description":"one of: inspect_process_tree | inspect_network_activity | inspect_file_activity | inspect_identity_events | retro_hunt_similar_activity | collect_additional_telemetry | close_as_benign"}},"required":["incident_id","tactic","confidence","suggested_next_step"],"additionalProperties":false}`),
+			})
+		}
 	}
 	if c.drafter != nil {
 		schemas = append(schemas, agent.ToolSchema{
@@ -327,6 +379,16 @@ func (c *Catalog) Dispatch(ctx context.Context, sess agent.Session, call agent.T
 		return c.startRecon(ctx, sess, call.Arguments)
 	case ToolEvidenceSufficiency:
 		return c.evidenceSufficiency(ctx, sess, call.Arguments)
+	case ToolListIncidents:
+		if c.incidents == nil {
+			return Result{}, fmt.Errorf("%w: investigation reads are not enabled", shared.ErrValidation)
+		}
+		return c.listIncidents(ctx, sess)
+	case ToolGetIncidentContext:
+		if c.incidents == nil {
+			return Result{}, fmt.Errorf("%w: investigation reads are not enabled", shared.ErrValidation)
+		}
+		return c.getIncidentContext(ctx, sess, call.Arguments)
 	case ToolProposePlan:
 		if !c.planning {
 			return Result{}, fmt.Errorf("%w: planning is not enabled", shared.ErrValidation)
@@ -378,8 +440,8 @@ func (c *Catalog) Dispatch(ctx context.Context, sess agent.Session, call agent.T
 		}
 		return c.proposeVexJustification(ctx, sess, call.Arguments)
 	case ToolProposeInvestigation:
-		if c.jproposer == nil {
-			return Result{}, fmt.Errorf("%w: investigation proposals are not enabled", shared.ErrValidation)
+		if c.jproposer == nil || c.incidents == nil {
+			return Result{}, fmt.Errorf("%w: scoped investigation proposals are not enabled", shared.ErrValidation)
 		}
 		return c.proposeInvestigation(ctx, sess, call.Arguments)
 	case ToolProposeWriteupDraft:
@@ -508,6 +570,285 @@ type runtimeVerificationPlan struct {
 	PromotionGate         string   `json:"promotion_gate"`
 	ArchitectureGuard     string   `json:"architecture_guard"`
 	Note                  string   `json:"note"`
+}
+
+type incidentRiskView struct {
+	Risk       int      `json:"risk"`
+	Confidence int      `json:"confidence"`
+	Coverage   int      `json:"coverage"`
+	Reasons    []string `json:"reason_codes,omitempty"`
+}
+
+type incidentView struct {
+	ID           string            `json:"id"`
+	AssetID      string            `json:"asset_id"`
+	Title        string            `json:"title"`
+	Severity     string            `json:"severity"`
+	State        string            `json:"state"`
+	Disposition  string            `json:"disposition"`
+	DetectionIDs []string          `json:"detection_ids"`
+	Risk         *incidentRiskView `json:"risk,omitempty"`
+	Revision     int               `json:"revision"`
+	CreatedAt    time.Time         `json:"created_at"`
+	UpdatedAt    time.Time         `json:"updated_at"`
+}
+
+type timelineEntryView struct {
+	OccurredAt time.Time `json:"occurred_at"`
+	EventID    string    `json:"event_id"`
+	EntityKind string    `json:"entity_kind"`
+	EntityID   string    `json:"entity_id"`
+	Kind       string    `json:"kind"`
+	Summary    string    `json:"summary"`
+}
+
+const (
+	defaultInvestigationMargin = 5 * time.Minute
+	maxInvestigationMargin     = time.Hour
+)
+
+func (c *Catalog) investigationScope(ctx context.Context, sess agent.Session) (context.Context, []detection.Record, error) {
+	if sess.EngagementID.IsZero() {
+		return nil, nil, fmt.Errorf("%w: investigation requires a session engagement", shared.ErrValidation)
+	}
+	tenant, tenantBound := shared.TenantFrom(ctx)
+	if sess.TenantID.IsZero() {
+		if !tenantBound {
+			return nil, nil, fmt.Errorf("%w: investigation requires a tenant-bound session", shared.ErrValidation)
+		}
+	} else {
+		if tenantBound && tenant != sess.TenantID {
+			return nil, nil, fmt.Errorf("%w: investigation session tenant does not match context", shared.ErrValidation)
+		}
+		if !tenantBound {
+			tenant = sess.TenantID
+			ctx = shared.WithTenant(ctx, tenant)
+		}
+	}
+	records, err := c.detections.ListDetections(ctx, sess.EngagementID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("list engagement detections: %w", err)
+	}
+	// Treat the persistence result as untrusted input too: an adapter bug must not widen an MCP session.
+	scoped := records[:0:0]
+	for _, record := range records {
+		if record.TenantID == tenant && record.EngagementID == sess.EngagementID {
+			scoped = append(scoped, record)
+		}
+	}
+	return ctx, scoped, nil
+}
+
+func detectionIDs(records []detection.Record) []shared.ID {
+	ids := make([]shared.ID, 0, len(records))
+	for _, record := range records {
+		if !record.ID.IsZero() {
+			ids = append(ids, record.ID)
+		}
+	}
+	return ids
+}
+
+func scopedIncidentView(inc incident.Incident, allowed map[shared.ID]struct{}) incidentView {
+	view := incidentView{
+		ID: inc.ID.String(), AssetID: inc.AssetID.String(), Title: redactInvestigationText(inc.Title),
+		Severity: string(inc.Severity), State: string(inc.State), Disposition: string(inc.Disposition),
+		Revision: inc.Revision, CreatedAt: inc.CreatedAt, UpdatedAt: inc.UpdatedAt,
+	}
+	for _, id := range inc.DetectionIDs {
+		if _, ok := allowed[id]; ok {
+			view.DetectionIDs = append(view.DetectionIDs, id.String())
+		}
+	}
+	if inc.Risk != nil {
+		reasons := make([]string, 0, len(inc.Risk.ReasonCodes))
+		for _, reason := range inc.Risk.ReasonCodes {
+			reasons = append(reasons, redactInvestigationText(reason))
+		}
+		view.Risk = &incidentRiskView{
+			Risk: int(inc.Risk.Risk), Confidence: int(inc.Risk.Confidence), Coverage: int(inc.Risk.Coverage), Reasons: reasons,
+		}
+	}
+	return view
+}
+
+func (c *Catalog) listIncidents(ctx context.Context, sess agent.Session) (Result, error) {
+	ctx, records, err := c.investigationScope(ctx, sess)
+	if err != nil {
+		return Result{}, err
+	}
+	ids := detectionIDs(records)
+	if len(ids) == 0 {
+		payload := json.RawMessage(`{"incidents":[],"returned":0,"scope":"detections_in_current_engagement","truncated":false}`)
+		if err := c.auditRead(ctx, sess, "agent.read.incidents", sess.EngagementID.String(), 0); err != nil {
+			return Result{}, err
+		}
+		return Result{Data: payload}, nil
+	}
+	incidents, err := c.incidents.ListByDetectionIDs(ctx, ids, maxRows+1)
+	if err != nil {
+		return Result{}, fmt.Errorf("list scoped incidents: %w", err)
+	}
+	allowed := make(map[shared.ID]struct{}, len(ids))
+	for _, id := range ids {
+		allowed[id] = struct{}{}
+	}
+	views := make([]incidentView, 0, len(incidents))
+	for _, inc := range incidents {
+		view := scopedIncidentView(inc, allowed)
+		if len(view.DetectionIDs) > 0 { // defense in depth if a reader violates its filter contract
+			views = append(views, view)
+		}
+	}
+	truncated := len(views) > maxRows
+	if truncated {
+		views = views[:maxRows]
+	}
+	payload, err := json.Marshal(map[string]any{
+		"incidents": views, "returned": len(views), "truncated": truncated,
+		"scope": "detections_in_current_engagement",
+	})
+	if err != nil {
+		return Result{}, fmt.Errorf("marshal incidents: %w", err)
+	}
+	if err := c.auditRead(ctx, sess, "agent.read.incidents", sess.EngagementID.String(), len(views)); err != nil {
+		return Result{}, err
+	}
+	return Result{Data: payload}, nil
+}
+
+type incidentContextArgs struct {
+	IncidentID   string `json:"incident_id"`
+	BeforeSecond *int   `json:"before_seconds"`
+	AfterSecond  *int   `json:"after_seconds"`
+	Limit        int    `json:"limit"`
+}
+
+func investigationMargin(value *int) (time.Duration, error) {
+	if value == nil {
+		return defaultInvestigationMargin, nil
+	}
+	d := time.Duration(*value) * time.Second
+	if d < 0 || d > maxInvestigationMargin {
+		return 0, fmt.Errorf("%w: investigation margin must be 0..3600 seconds", shared.ErrValidation)
+	}
+	return d, nil
+}
+
+func incidentInvestigationWindow(inc incident.Incident, records map[shared.ID]detection.Record, before, after time.Duration) (time.Time, time.Time, error) {
+	var from, to time.Time
+	for _, id := range inc.DetectionIDs {
+		record, ok := records[id]
+		if !ok || record.Detection.Observed.IsZero() {
+			continue
+		}
+		if from.IsZero() || record.Detection.Observed.Before(from) {
+			from = record.Detection.Observed
+		}
+		if to.IsZero() || record.Detection.Observed.After(to) {
+			to = record.Detection.Observed
+		}
+	}
+	if from.IsZero() {
+		from = inc.CreatedAt
+	}
+	if to.IsZero() {
+		to = from
+	}
+	if from.IsZero() {
+		return time.Time{}, time.Time{}, fmt.Errorf("%w: scoped incident has no trigger time", shared.ErrValidation)
+	}
+	return from.Add(-before), to.Add(after), nil
+}
+
+func (c *Catalog) getIncidentContext(ctx context.Context, sess agent.Session, raw json.RawMessage) (Result, error) {
+	var args incidentContextArgs
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return Result{}, fmt.Errorf("%w: get_incident_context args: %w", shared.ErrValidation, err)
+	}
+	incidentID := shared.ID(strings.TrimSpace(args.IncidentID))
+	if incidentID.IsZero() {
+		return Result{}, fmt.Errorf("%w: incident_id is required", shared.ErrValidation)
+	}
+	before, err := investigationMargin(args.BeforeSecond)
+	if err != nil {
+		return Result{}, err
+	}
+	after, err := investigationMargin(args.AfterSecond)
+	if err != nil {
+		return Result{}, err
+	}
+	limit := args.Limit
+	if limit == 0 {
+		limit = maxRows
+	}
+	if limit < 1 || limit > maxRows {
+		return Result{}, fmt.Errorf("%w: investigation context limit must be 1..%d", shared.ErrValidation, maxRows)
+	}
+
+	ctx, records, err := c.investigationScope(ctx, sess)
+	if err != nil {
+		return Result{}, err
+	}
+	inc, err := c.incidents.Get(ctx, incidentID)
+	if err != nil {
+		return Result{}, fmt.Errorf("get incident: %w", err)
+	}
+	allowed := make(map[shared.ID]struct{}, len(records))
+	byID := make(map[shared.ID]detection.Record, len(records))
+	for _, record := range records {
+		allowed[record.ID] = struct{}{}
+		byID[record.ID] = record
+	}
+	view := scopedIncidentView(inc, allowed)
+	if len(view.DetectionIDs) == 0 {
+		return Result{}, fmt.Errorf("%w: incident %s is outside the session engagement", shared.ErrNotFound, incidentID)
+	}
+
+	from, to, err := incidentInvestigationWindow(inc, byID, before, after)
+	if err != nil {
+		return Result{}, err
+	}
+	entries, err := c.timeline.Query(ctx, ports.EndpointTimelineQuery{AssetID: inc.AssetID, From: from, To: to, Limit: limit + 1})
+	if err != nil {
+		return Result{}, fmt.Errorf("query incident timeline: %w", err)
+	}
+	tenant, _ := shared.TenantFrom(ctx)
+	timeline := make([]timelineEntryView, 0, len(entries))
+	for _, entry := range entries {
+		if entry.TenantID != tenant || entry.AssetID != inc.AssetID {
+			continue // a broken adapter must not widen the incident's tenant/asset boundary
+		}
+		timeline = append(timeline, timelineEntryView{
+			OccurredAt: entry.OccurredAt, EventID: entry.EventID.String(), EntityKind: string(entry.EntityKind),
+			EntityID: entry.EntityID.String(), Kind: string(entry.Kind), Summary: redactInvestigationText(entry.Summary),
+		})
+	}
+	truncated := len(timeline) > limit
+	if truncated {
+		timeline = timeline[:limit]
+	}
+	payload, err := json.Marshal(map[string]any{
+		"incident": view, "window": map[string]time.Time{"from": from, "to": to},
+		"timeline": timeline, "returned": len(timeline), "truncated": truncated,
+		"note": "read-only context; a hypothesis remains a proposal and cannot mutate incident facts, risk, disposition, or responses",
+	})
+	if err != nil {
+		return Result{}, fmt.Errorf("marshal incident context: %w", err)
+	}
+	if err := c.auditRead(ctx, sess, "agent.read.incident_context", incidentID.String(), len(timeline)); err != nil {
+		return Result{}, err
+	}
+	return Result{Data: payload}, nil
+}
+
+// redactInvestigationText applies the source privacy policy's known-secret floor again at
+// the AI boundary. Timeline data should already be source-redacted, but older/imported
+// records may predate that invariant; platform redact additionally strips URL credentials.
+func redactInvestigationText(value string) string {
+	value, _ = privacy.DefaultPolicy().Classify(privacy.CategoryProcessArg, value)
+	value = strings.ReplaceAll(value, privacy.RedactionPlaceholder, redact.Placeholder)
+	return redact.String(value, nil)
 }
 
 func (c *Catalog) listFindings(ctx context.Context, sess agent.Session) (Result, error) {
@@ -1229,17 +1570,21 @@ func (c *Catalog) proposeThreat(ctx context.Context, sess agent.Session, raw jso
 }
 
 type proposeInvestigationArgs struct {
-	IncidentID string   `json:"incident_id"`
-	Tactic     string   `json:"tactic"`
-	Confidence int      `json:"confidence"`
-	Drivers    []string `json:"drivers"`
+	IncidentID        string   `json:"incident_id"`
+	Tactic            string   `json:"tactic"`
+	Confidence        int      `json:"confidence"`
+	Drivers           []string `json:"drivers"`
+	RelevantEventIDs  []string `json:"relevant_event_ids"`
+	ContextBefore     *int     `json:"context_before_seconds"`
+	ContextAfter      *int     `json:"context_after_seconds"`
+	SuggestedNextStep string   `json:"suggested_next_step"`
 }
 
 // proposeInvestigation records a PROPOSED investigation hypothesis about an incident (#594 E): a single
 // closed ATT&CK-style tactic + confidence + structured driver tokens, persisted at score 0 by the analysis
-// service. UNGATED and human-accepted — the agent CANNOT accept its own hypothesis (the propose-only
-// interface + the arch tripwire make that structural), and a hypothesis NEVER drives a response on its own.
-// The domain InvestigationClaim.Validate rejects free prose and an unknown tactic.
+// service. It is evidence-gated: the agent CANNOT verify its own hypothesis (the propose-only interface
+// + the arch tripwire make that structural), and a hypothesis NEVER drives a response on its own. The
+// domain InvestigationClaim.Validate rejects free prose, unknown tactics, and executable next steps.
 func (c *Catalog) proposeInvestigation(ctx context.Context, sess agent.Session, raw json.RawMessage) (Result, error) {
 	var a proposeInvestigationArgs
 	if err := json.Unmarshal(raw, &a); err != nil {
@@ -1249,20 +1594,74 @@ func (c *Catalog) proposeInvestigation(ctx context.Context, sess agent.Session, 
 	if incidentID.IsZero() {
 		return Result{}, fmt.Errorf("%w: incident_id is required", shared.ErrValidation)
 	}
-	claim := judgment.InvestigationClaim{
-		IncidentID: incidentID,
-		Tactic:     judgment.InvestigationTactic(strings.TrimSpace(a.Tactic)),
-		Confidence: a.Confidence,
-		Drivers:    a.Drivers,
+	if strings.TrimSpace(a.SuggestedNextStep) == "" {
+		return Result{}, fmt.Errorf("%w: suggested_next_step is required", shared.ErrValidation)
 	}
-	j, err := c.jproposer.Propose(ctx, sess.AgentActor(), sess.EngagementID, judgment.CapInvestigation, judgment.SubjectIncident, incidentID, claim)
+	scopedCtx, records, err := c.investigationScope(ctx, sess)
+	if err != nil {
+		return Result{}, err
+	}
+	inc, err := c.incidents.Get(scopedCtx, incidentID)
+	if err != nil {
+		return Result{}, fmt.Errorf("get proposed incident: %w", err)
+	}
+	allowed := make(map[shared.ID]struct{}, len(records))
+	for _, record := range records {
+		allowed[record.ID] = struct{}{}
+	}
+	if len(scopedIncidentView(inc, allowed).DetectionIDs) == 0 {
+		return Result{}, fmt.Errorf("%w: incident %s is outside the session engagement", shared.ErrNotFound, incidentID)
+	}
+	relevantEventIDs := make([]shared.ID, 0, len(a.RelevantEventIDs))
+	if len(a.RelevantEventIDs) > 0 {
+		before, merr := investigationMargin(a.ContextBefore)
+		if merr != nil {
+			return Result{}, merr
+		}
+		after, merr := investigationMargin(a.ContextAfter)
+		if merr != nil {
+			return Result{}, merr
+		}
+		byID := make(map[shared.ID]detection.Record, len(records))
+		for _, record := range records {
+			byID[record.ID] = record
+		}
+		from, to, werr := incidentInvestigationWindow(inc, byID, before, after)
+		if werr != nil {
+			return Result{}, werr
+		}
+		entries, qerr := c.timeline.Query(scopedCtx, ports.EndpointTimelineQuery{AssetID: inc.AssetID, From: from, To: to, Limit: maxRows + 1})
+		if qerr != nil {
+			return Result{}, fmt.Errorf("query proposed incident events: %w", qerr)
+		}
+		tenant, _ := shared.TenantFrom(scopedCtx)
+		available := make(map[shared.ID]struct{}, len(entries))
+		for _, entry := range entries {
+			if entry.TenantID == tenant && entry.AssetID == inc.AssetID {
+				available[entry.EventID] = struct{}{}
+			}
+		}
+		for _, rawID := range a.RelevantEventIDs {
+			id := shared.ID(strings.TrimSpace(rawID))
+			if _, ok := available[id]; !ok {
+				return Result{}, fmt.Errorf("%w: relevant event %q is outside the bounded incident context", shared.ErrNotFound, id)
+			}
+			relevantEventIDs = append(relevantEventIDs, id)
+		}
+	}
+	claim := judgment.InvestigationClaim{
+		IncidentID: incidentID, Tactic: judgment.InvestigationTactic(strings.TrimSpace(a.Tactic)),
+		Confidence: a.Confidence, Drivers: a.Drivers, RelevantEventIDs: relevantEventIDs,
+		SuggestedNextStep: judgment.InvestigationNextStep(strings.TrimSpace(a.SuggestedNextStep)),
+	}
+	j, err := c.jproposer.Propose(scopedCtx, sess.AgentActor(), sess.EngagementID, judgment.CapInvestigation, judgment.SubjectIncident, incidentID, claim)
 	if err != nil {
 		return Result{}, err // domain validates the claim; the service persists at score 0 + audits
 	}
 	payload, err := json.Marshal(map[string]any{
 		"judgment_id": j.ID.String(), "state": string(j.State), "evidence_score": j.EvidenceScore,
 		"proposed_by": j.ProposedBy, "publishable": j.Publishable(),
-		"note": "recorded as a PROPOSED investigation hypothesis (score 0); a human analyst accepts or rejects it – you cannot accept your own, and it never drives a response.",
+		"note": "recorded as a PROPOSED investigation hypothesis (score 0); only a distinct verifier's sealed verdict can confirm it, and it never drives a response.",
 	})
 	if err != nil {
 		return Result{}, fmt.Errorf("marshal judgment: %w", err)

--- a/internal/usecase/agenttools/catalog_test.go
+++ b/internal/usecase/agenttools/catalog_test.go
@@ -94,7 +94,7 @@ func newCatalog(t *testing.T, finds []finding.Finding, evs []evidence.Evidence, 
 }
 
 func session() agent.Session {
-	return agent.Session{ID: "s1", EngagementID: "eng-1", InitiatedBy: "alice"}
+	return agent.Session{ID: "s1", TenantID: "tenant-1", EngagementID: "eng-1", InitiatedBy: "alice"}
 }
 
 // TestToolsExposesOnlyAllowedTools is the anti-self-escalation guard: the advertised

--- a/internal/usecase/agenttools/investigation_tool_test.go
+++ b/internal/usecase/agenttools/investigation_tool_test.go
@@ -3,16 +3,98 @@ package agenttools
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/endpoint"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/incident"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/riskassessment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
+
+type fakeIncidentReader struct {
+	items     []incident.Incident
+	get       map[shared.ID]incident.Incident
+	listCalls int
+}
+
+func (f *fakeIncidentReader) Get(_ context.Context, id shared.ID) (incident.Incident, error) {
+	if inc, ok := f.get[id]; ok {
+		return inc, nil
+	}
+	return incident.Incident{}, shared.ErrNotFound
+}
+
+func (f *fakeIncidentReader) ListByDetectionIDs(_ context.Context, ids []shared.ID, limit int) ([]incident.Incident, error) {
+	f.listCalls++
+	wanted := make(map[shared.ID]struct{}, len(ids))
+	for _, id := range ids {
+		wanted[id] = struct{}{}
+	}
+	var out []incident.Incident
+	for _, inc := range f.items {
+		for _, id := range inc.DetectionIDs {
+			if _, ok := wanted[id]; ok {
+				out = append(out, inc)
+				break
+			}
+		}
+	}
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+
+type fakeDetectionReader struct{ items []detection.Record }
+
+func (f *fakeDetectionReader) ListDetections(_ context.Context, _ shared.ID) ([]detection.Record, error) {
+	return append([]detection.Record(nil), f.items...), nil
+}
+
+type fakeTimelineReader struct {
+	items []endpoint.TimelineEntry
+	got   ports.EndpointTimelineQuery
+}
+
+func (f *fakeTimelineReader) Query(_ context.Context, q ports.EndpointTimelineQuery) ([]endpoint.TimelineEntry, error) {
+	f.got = q
+	return append([]endpoint.TimelineEntry(nil), f.items...), nil
+}
+
+func fakeInvestigationToolset() *InvestigationToolset {
+	now := time.Unix(2_000_000, 0).UTC()
+	inc := incident.Incident{
+		ID: "inc-7", AssetID: "asset-1", Title: "Suspicious process", Severity: shared.SeverityHigh,
+		State: incident.StateInvestigating, Disposition: incident.DispositionUnknown,
+		DetectionIDs: []shared.ID{"det-1"}, Revision: 2, CreatedAt: now, UpdatedAt: now.Add(time.Minute),
+		Risk: &riskassessment.RiskAssessment{Risk: 88, Confidence: 61, Coverage: 43, ReasonCodes: []string{"network_fanout"}},
+	}
+	incidents := &fakeIncidentReader{items: []incident.Incident{inc}, get: map[shared.ID]incident.Incident{inc.ID: inc}}
+	detections := &fakeDetectionReader{items: []detection.Record{{
+		ID: "det-1", TenantID: "tenant-1", EngagementID: "eng-1", AssetID: "asset-1",
+		Detection: detection.Detection{Observed: now},
+	}}}
+	timeline := &fakeTimelineReader{items: []endpoint.TimelineEntry{{
+		OccurredAt: now, TenantID: "tenant-1", AssetID: "asset-1", EntityKind: endpoint.EntityProcess,
+		EntityID: "proc-1", Kind: endpoint.TimelineProcessExec, EventID: "event-1", Summary: "exec token=secret-value",
+	}}}
+	return &InvestigationToolset{Incidents: incidents, Detections: detections, Timeline: timeline}
+}
 
 func TestProposeInvestigation(t *testing.T) {
 	c, _ := newCatalog(t, nil, nil, subfinder())
 	fp := &fakeJudgmentProposer{}
 	c.EnableJudgments(fp)
+	if err := c.EnableInvestigation(*fakeInvestigationToolset()); err != nil {
+		t.Fatal(err)
+	}
 
 	advertised := false
 	for _, ts := range c.Tools() {
@@ -29,7 +111,7 @@ func TestProposeInvestigation(t *testing.T) {
 
 	res, err := c.Dispatch(context.Background(), session(), agent.ToolCall{
 		Name:      ToolProposeInvestigation,
-		Arguments: json.RawMessage(`{"incident_id":"inc-7","tactic":"lateral_movement","confidence":72,"drivers":["new_exec_paths","network_fanout_spike"]}`),
+		Arguments: json.RawMessage(`{"incident_id":"inc-7","tactic":"lateral_movement","confidence":72,"drivers":["new_exec_paths","network_fanout_spike"],"relevant_event_ids":["event-1"],"suggested_next_step":"retro_hunt_similar_activity"}`),
 	})
 	if err != nil {
 		t.Fatalf("dispatch: %v", err)
@@ -37,7 +119,7 @@ func TestProposeInvestigation(t *testing.T) {
 	if res.Data == nil {
 		t.Fatal("must return Data")
 	}
-	// PROPOSED, score 0, agent-attributed, scoped to the incident, ungated capability.
+	// PROPOSED, score 0, agent-attributed, scoped to the incident, evidence-gated capability.
 	if fp.got.EvidenceScore != 0 || fp.got.State != judgment.StateProposed || fp.got.ProposedBy != "agent:s1" {
 		t.Fatalf("must record proposed/score-0/agent: %+v", fp.got)
 	}
@@ -45,7 +127,8 @@ func TestProposeInvestigation(t *testing.T) {
 		t.Fatalf("subject/scope wiring wrong: %+v", fp.got)
 	}
 	ic, ok := fp.got.Claim.(judgment.InvestigationClaim)
-	if !ok || ic.Tactic != judgment.TacticLateralMovement || ic.Confidence != 72 || len(ic.Drivers) != 2 {
+	if !ok || ic.Tactic != judgment.TacticLateralMovement || ic.Confidence != 72 || len(ic.Drivers) != 2 ||
+		len(ic.RelevantEventIDs) != 1 || ic.RelevantEventIDs[0] != "event-1" || ic.SuggestedNextStep != judgment.NextRetroHuntSimilar {
 		t.Fatalf("claim built wrong: %#v", fp.got.Claim)
 	}
 }
@@ -59,5 +142,130 @@ func TestProposeInvestigationDisabledFailsClosed(t *testing.T) {
 	}
 	if _, err := c.Dispatch(context.Background(), session(), agent.ToolCall{Name: ToolProposeInvestigation, Arguments: json.RawMessage(`{}`)}); err == nil {
 		t.Fatal("dispatch must fail closed when judgments are disabled")
+	}
+}
+
+func TestInvestigationReadsAreEngagementScopedRedactedAndReadOnly(t *testing.T) {
+	c, audit := newCatalog(t, nil, nil, subfinder())
+	tools := fakeInvestigationToolset()
+	// This incident/detection belongs to a different engagement and must never cross the session boundary.
+	foreign := incident.Incident{ID: "inc-foreign", AssetID: "asset-2", DetectionIDs: []shared.ID{"det-foreign"}}
+	tools.Incidents.(*fakeIncidentReader).items = append(tools.Incidents.(*fakeIncidentReader).items, foreign)
+	tools.Incidents.(*fakeIncidentReader).get[foreign.ID] = foreign
+	tools.Detections.(*fakeDetectionReader).items = append(tools.Detections.(*fakeDetectionReader).items, detection.Record{
+		ID: "det-foreign", TenantID: "tenant-1", EngagementID: "eng-other", AssetID: "asset-2",
+	})
+	foreignTenant := incident.Incident{ID: "inc-foreign-tenant", AssetID: "asset-1", DetectionIDs: []shared.ID{"det-foreign-tenant"}}
+	tools.Incidents.(*fakeIncidentReader).items = append(tools.Incidents.(*fakeIncidentReader).items, foreignTenant)
+	tools.Incidents.(*fakeIncidentReader).get[foreignTenant.ID] = foreignTenant
+	tools.Detections.(*fakeDetectionReader).items = append(tools.Detections.(*fakeDetectionReader).items, detection.Record{
+		ID: "det-foreign-tenant", TenantID: "tenant-other", EngagementID: "eng-1", AssetID: "asset-1",
+	})
+	tools.Timeline.(*fakeTimelineReader).items = append(tools.Timeline.(*fakeTimelineReader).items, endpoint.TimelineEntry{
+		OccurredAt: time.Unix(2_000_000, 0).UTC(), TenantID: "tenant-other", AssetID: "asset-1",
+		EntityKind: endpoint.EntityProcess, EntityID: "foreign-process", Kind: endpoint.TimelineProcessExec,
+		EventID: "foreign-event", Summary: "FOREIGN_TENANT_EVENT",
+	})
+	if err := c.EnableInvestigation(*tools); err != nil {
+		t.Fatal(err)
+	}
+
+	listed, err := c.Dispatch(context.Background(), session(), agent.ToolCall{Name: ToolListIncidents})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if listed.Proposal != nil || strings.Contains(string(listed.Data), "inc-foreign") || !strings.Contains(string(listed.Data), "inc-7") {
+		t.Fatalf("incident list crossed scope or became executable: %s", listed.Data)
+	}
+
+	contextResult, err := c.Dispatch(context.Background(), session(), agent.ToolCall{
+		Name: ToolGetIncidentContext, Arguments: json.RawMessage(`{"incident_id":"inc-7","before_seconds":60,"after_seconds":120,"limit":10}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contextResult.Proposal != nil {
+		t.Fatal("incident context must be read-only")
+	}
+	body := string(contextResult.Data)
+	if strings.Contains(body, "secret-value") || strings.Contains(body, "FOREIGN_TENANT_EVENT") || !strings.Contains(body, "[REDACTED]") {
+		t.Fatalf("timeline summary was not redacted: %s", body)
+	}
+	timeline := tools.Timeline.(*fakeTimelineReader)
+	if timeline.got.AssetID != "asset-1" || timeline.got.Limit != 11 {
+		t.Fatalf("timeline query was not server-scoped/bounded: %+v", timeline.got)
+	}
+	if len(audit.recs) != 2 || audit.recs[0].Action != "agent.read.incidents" || audit.recs[1].Action != "agent.read.incident_context" {
+		t.Fatalf("investigation reads must be audited: %+v", audit.recs)
+	}
+
+	_, err = c.Dispatch(context.Background(), session(), agent.ToolCall{
+		Name: ToolGetIncidentContext, Arguments: json.RawMessage(`{"incident_id":"inc-foreign"}`),
+	})
+	if !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-engagement incident must fail as not found, got %v", err)
+	}
+}
+
+func TestListIncidentsWithNoScopedDetectionsDoesNotQueryTenantIncidents(t *testing.T) {
+	c, _ := newCatalog(t, nil, nil, subfinder())
+	incidents := &fakeIncidentReader{items: []incident.Incident{{ID: "tenant-incident", DetectionIDs: []shared.ID{"tenant-detection"}}}}
+	if err := c.EnableInvestigation(InvestigationToolset{
+		Incidents: incidents, Detections: &fakeDetectionReader{}, Timeline: &fakeTimelineReader{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	result, err := c.Dispatch(context.Background(), session(), agent.ToolCall{Name: ToolListIncidents})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if incidents.listCalls != 0 || strings.Contains(string(result.Data), "tenant-incident") {
+		t.Fatalf("an empty engagement must not query or reveal tenant incidents: calls=%d data=%s", incidents.listCalls, result.Data)
+	}
+}
+
+func TestProposeInvestigationRejectsCrossEngagementIncident(t *testing.T) {
+	c, _ := newCatalog(t, nil, nil, subfinder())
+	c.EnableJudgments(&fakeJudgmentProposer{})
+	tools := fakeInvestigationToolset()
+	foreign := incident.Incident{ID: "inc-foreign", AssetID: "asset-2", DetectionIDs: []shared.ID{"det-foreign"}}
+	tools.Incidents.(*fakeIncidentReader).get[foreign.ID] = foreign
+	if err := c.EnableInvestigation(*tools); err != nil {
+		t.Fatal(err)
+	}
+	_, err := c.Dispatch(context.Background(), session(), agent.ToolCall{
+		Name:      ToolProposeInvestigation,
+		Arguments: json.RawMessage(`{"incident_id":"inc-foreign","tactic":"benign","confidence":80,"suggested_next_step":"close_as_benign"}`),
+	})
+	if !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-engagement proposal must fail as not found, got %v", err)
+	}
+}
+
+func TestProposeInvestigationRejectsEventOutsideBoundedContext(t *testing.T) {
+	c, _ := newCatalog(t, nil, nil, subfinder())
+	c.EnableJudgments(&fakeJudgmentProposer{})
+	if err := c.EnableInvestigation(*fakeInvestigationToolset()); err != nil {
+		t.Fatal(err)
+	}
+	_, err := c.Dispatch(context.Background(), session(), agent.ToolCall{
+		Name:      ToolProposeInvestigation,
+		Arguments: json.RawMessage(`{"incident_id":"inc-7","tactic":"execution","confidence":80,"relevant_event_ids":["event-forged"],"suggested_next_step":"inspect_process_tree"}`),
+	})
+	if !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("an event outside the server-derived context must fail closed, got %v", err)
+	}
+}
+
+func TestEnableInvestigationFailsClosedOnPartialDependencies(t *testing.T) {
+	c, _ := newCatalog(t, nil, nil)
+	err := c.EnableInvestigation(InvestigationToolset{Incidents: &fakeIncidentReader{}})
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("partial investigation wiring must fail validation, got %v", err)
+	}
+	for _, tool := range c.Tools() {
+		if tool.Name == ToolListIncidents || tool.Name == ToolGetIncidentContext {
+			t.Fatalf("partial investigation wiring advertised %s", tool.Name)
+		}
 	}
 }

--- a/internal/usecase/agenttools/wiring.go
+++ b/internal/usecase/agenttools/wiring.go
@@ -14,17 +14,18 @@ import (
 // toolset when driven durably — a correctness bug (issue #161).
 //
 // Findings, Hypotheses and Reachability are REQUIRED: a durable run must never silently advertise fewer
-// PROPOSAL tools than the inline run. Judgments and WriteupDrafts are OPTIONAL and mirror their feature
-// flags — a nil field leaves that tool off in BOTH binaries (they are gated by SYNAPSE_JUDGMENTS_ENABLED /
+// PROPOSAL tools than the inline run. Investigation, Judgments and WriteupDrafts are OPTIONAL and mirror
+// their feature flags — a nil field leaves that tool off in BOTH binaries (they are gated by SYNAPSE_JUDGMENTS_ENABLED /
 // SYNAPSE_WRITEUP_DRAFTS_ENABLED). To keep a tool off, the composition root leaves the field nil; it must
 // NOT assign a typed-nil service pointer (a non-nil interface wrapping a nil pointer), because that would
 // wire a tool backed by nothing. Each field is a propose/read-only slice — the agent can never confirm.
 type AgentToolset struct {
-	Findings      findingProposer      // required: propose_finding
-	Hypotheses    hypothesisProposer   // required: propose_attack_chain
-	Reachability  scanResultReader     // required: reachability_context (read-only)
-	Judgments     judgmentProposer     // optional (nil ⇒ off): propose_reachability/sast_validation/critique/risk_narrative/threat/vex_justification
-	WriteupDrafts writeupdraftProposer // optional (nil ⇒ off): propose_writeup_draft
+	Findings      findingProposer       // required: propose_finding
+	Hypotheses    hypothesisProposer    // required: propose_attack_chain
+	Reachability  scanResultReader      // required: reachability_context (read-only)
+	Investigation *InvestigationToolset // optional: engagement-scoped incident + timeline reads
+	Judgments     judgmentProposer      // optional (nil ⇒ off): propose_reachability/sast_validation/critique/risk_narrative/threat/vex_justification
+	WriteupDrafts writeupdraftProposer  // optional (nil ⇒ off): propose_writeup_draft
 }
 
 // EnableAgentToolset turns on planning + the proposal/read tools from a single dependency set, so the
@@ -44,6 +45,11 @@ func (c *Catalog) EnableAgentToolset(t AgentToolset) error {
 	c.EnableFindingProposals(t.Findings)
 	c.EnableHypotheses(t.Hypotheses)
 	c.EnableReachability(t.Reachability)
+	if t.Investigation != nil {
+		if err := c.EnableInvestigation(*t.Investigation); err != nil {
+			return err
+		}
+	}
 	if t.Judgments != nil {
 		c.EnableJudgments(t.Judgments)
 	}

--- a/internal/usecase/agenttools/wiring_test.go
+++ b/internal/usecase/agenttools/wiring_test.go
@@ -21,6 +21,7 @@ func fullToolset() AgentToolset {
 		Findings:      &fakeProposer{},
 		Hypotheses:    &fakeHypProposer{},
 		Reachability:  &fakeScanResults{},
+		Investigation: fakeInvestigationToolset(),
 		Judgments:     &fakeJudgmentProposer{},
 		WriteupDrafts: &fakeWriteupdraftProposer{},
 	}
@@ -35,6 +36,8 @@ var toolsetControlled = []string{
 	ToolProposeFinding,
 	ToolProposeAttackChain,
 	ToolReachabilityContext,
+	ToolListIncidents,
+	ToolGetIncidentContext,
 	ToolProposeReachability,
 	ToolProposeSASTValidation,
 	ToolProposeCritique,
@@ -96,6 +99,7 @@ func TestEnableAgentToolsetOptionalOff(t *testing.T) {
 		}
 	}
 	for _, n := range []string{
+		ToolListIncidents, ToolGetIncidentContext,
 		ToolProposeReachability, ToolProposeSASTValidation, ToolProposeCritique,
 		ToolProposeRiskNarrative, ToolProposeThreat, ToolProposeVexJustification, ToolProposeWriteupDraft,
 	} {

--- a/internal/usecase/fleet/incidentuc/service.go
+++ b/internal/usecase/fleet/incidentuc/service.go
@@ -73,7 +73,21 @@ func (s *Service) Append(ctx context.Context, id shared.ID, expectedRevision int
 // ListByAsset returns the projected incidents for an asset (all incidents in the tenant if assetID is
 // zero), ordered by incident id.
 func (s *Service) ListByAsset(ctx context.Context, assetID shared.ID, limit int) ([]incident.Incident, error) {
-	ids, err := s.store.ListIncidentIDs(ctx, ports.IncidentQuery{AssetID: assetID, Limit: limit})
+	return s.list(ctx, ports.IncidentQuery{AssetID: assetID, Limit: limit})
+}
+
+// ListByDetectionIDs returns incidents whose append-only log references at least one of the supplied
+// detections. This is the engagement-scoping seam used by AI/MCP investigation: detections are first
+// selected from one engagement, then only incidents backed by those ids may be exposed.
+func (s *Service) ListByDetectionIDs(ctx context.Context, detectionIDs []shared.ID, limit int) ([]incident.Incident, error) {
+	if len(detectionIDs) == 0 {
+		return []incident.Incident{}, nil
+	}
+	return s.list(ctx, ports.IncidentQuery{DetectionIDs: detectionIDs, Limit: limit})
+}
+
+func (s *Service) list(ctx context.Context, query ports.IncidentQuery) ([]incident.Incident, error) {
+	ids, err := s.store.ListIncidentIDs(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usecase/fleet/incidentuc/service_test.go
+++ b/internal/usecase/fleet/incidentuc/service_test.go
@@ -131,3 +131,18 @@ func TestListByAsset(t *testing.T) {
 		t.Fatalf("other asset must list nothing, got %d", len(other))
 	}
 }
+
+func TestListByDetectionIDs(t *testing.T) {
+	svc, ctx := newSvc(t)
+	created, err := svc.RecordCorrelation(ctx, correlate(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	incs, err := svc.ListByDetectionIDs(ctx, []shared.ID{"d2"}, 10)
+	if err != nil || len(incs) != 1 || incs[0].ID != created[0].ID {
+		t.Fatalf("list by detection ids: %+v err=%v", incs, err)
+	}
+	if none, err := svc.ListByDetectionIDs(ctx, nil, 10); err != nil || len(none) != 0 {
+		t.Fatalf("empty detection scope must return an empty result: %+v err=%v", none, err)
+	}
+}

--- a/internal/usecase/ports/incident_store.go
+++ b/internal/usecase/ports/incident_store.go
@@ -29,9 +29,11 @@ type IncidentEventStore interface {
 	ListIncidentIDs(ctx context.Context, q IncidentQuery) ([]shared.ID, error)
 }
 
-// IncidentQuery selects incidents. An empty AssetID matches all incidents in the tenant; Limit caps the
-// result (0 means the store default).
+// IncidentQuery selects incidents. An empty AssetID matches all incidents in the tenant; DetectionIDs,
+// when non-empty, keeps incidents whose append-only event log references at least one of those detection
+// ids. Limit caps the result (0 means the store default).
 type IncidentQuery struct {
-	AssetID shared.ID
-	Limit   int
+	AssetID      shared.ID
+	DetectionIDs []shared.ID
+	Limit        int
 }

--- a/internal/usecase/report/judgments_test.go
+++ b/internal/usecase/report/judgments_test.go
@@ -104,6 +104,21 @@ func TestReportSkipsUnacceptedAndSortsDeterministically(t *testing.T) {
 	}
 }
 
+func TestReportDoesNotProjectInvestigationHypotheses(t *testing.T) {
+	var insight ports.ReportInsight
+	projectAcceptedJudgments(context.Background(), fakeJudgments{list: []judgment.Judgment{{
+		Capability: judgment.CapInvestigation, State: judgment.StateConfirmed, EvidenceScore: 100,
+		SubjectKind: judgment.SubjectIncident, SubjectID: "incident-1",
+		Claim: judgment.InvestigationClaim{
+			IncidentID: "incident-1", Tactic: judgment.TacticExecution, Confidence: 90,
+			Drivers: []string{"new_exec_paths"}, SuggestedNextStep: judgment.NextInspectProcessTree,
+		},
+	}}}, "engagement-1", &insight)
+	if len(insight.RiskRationales) != 0 || len(insight.CorrelationNotes) != 0 {
+		t.Fatalf("investigation hypotheses must stay out of the deterministic report projection: %+v", insight)
+	}
+}
+
 // TestReportProjectionIsByteReproducible proves the projection is TOTALLY ordered: multiple accepted
 // judgments on the SAME subject (same priority, different drivers) sort deterministically regardless of
 // the store's return order — reports are hash-sealed, so an unstable permutation would change the bytes.

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -260,6 +260,37 @@ export interface ReachabilityClaim {
   confidence: number // 0..100
 }
 
+export type InvestigationTactic =
+  | 'lateral_movement'
+  | 'data_exfiltration'
+  | 'privilege_escalation'
+  | 'credential_access'
+  | 'persistence'
+  | 'command_and_control'
+  | 'defense_evasion'
+  | 'execution'
+  | 'benign'
+
+export type InvestigationNextStep =
+  | 'inspect_process_tree'
+  | 'inspect_network_activity'
+  | 'inspect_file_activity'
+  | 'inspect_identity_events'
+  | 'retro_hunt_similar_activity'
+  | 'collect_additional_telemetry'
+  | 'close_as_benign'
+
+// InvestigationClaim is advisory, structured AI output. Human acceptance records a
+// review decision; it does not mutate the incident or authorize a response.
+export interface InvestigationClaim {
+  incident_id: string
+  tactic: InvestigationTactic
+  confidence: number // 0..100
+  drivers: string[]
+  relevant_event_ids?: string[]
+  suggested_next_step?: InvestigationNextStep
+}
+
 // Judgment is one AI-proposed, human-ratified analysis over a subject (a finding, a data flow…).
 // Read-only here; proposed = unverified AI output (score 0), confirmed = a distinct human verified
 // (gated) or accepted (ungated) it. The UI labels the state – it never presents a proposal as fact.
@@ -273,7 +304,7 @@ export interface Judgment {
   evidenceScore: number // 0..100
   proposedBy: string
   version: number
-  claim: RiskNarrativeClaim | CritiqueClaim | ReachabilityClaim | Record<string, unknown>
+  claim: RiskNarrativeClaim | CritiqueClaim | ReachabilityClaim | InvestigationClaim | Record<string, unknown>
 }
 
 // FindingComment is a persisted collaboration note on a finding.

--- a/web/src/pages/EngagementDetail/ReviewsTab.tsx
+++ b/web/src/pages/EngagementDetail/ReviewsTab.tsx
@@ -229,7 +229,9 @@ export function JudgmentReviewForm({
       {gated ? (
         <div className="space-y-3">
           <p className="text-xs text-tertiary">
-            Record an adversarial verdict. Scores ≥ {EVIDENCE_BAR} confirm this claim; lower scores refute it. Either outcome is sealed.
+            {judgment.capability === 'investigation'
+              ? `Record a distinct analyst verdict on this AI hypothesis. Scores ≥ ${EVIDENCE_BAR} confirm it; lower scores refute it. Either outcome is sealed and cannot mutate incident facts, risk, disposition, or response actions.`
+              : `Record an adversarial verdict. Scores ≥ ${EVIDENCE_BAR} confirm this claim; lower scores refute it. Either outcome is sealed.`}
           </p>
           <Field label="Evidence score" hint="0–100">
             <Input

--- a/web/src/pages/EngagementDetail/components/FindingJudgments.test.tsx
+++ b/web/src/pages/EngagementDetail/components/FindingJudgments.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { Judgment } from '../../../lib/types'
+import { JudgmentReviewForm } from '../ReviewsTab'
+import { JudgmentClaim } from './FindingJudgments'
+
+const investigation: Judgment = {
+  id: 'judgment-1',
+  engagementId: 'engagement-1',
+  capability: 'investigation',
+  subjectKind: 'incident',
+  subjectId: 'incident-7',
+  state: 'proposed',
+  evidenceScore: 0,
+  proposedBy: 'agent:session-1',
+  version: 1,
+  claim: {
+    incident_id: 'incident-7',
+    tactic: 'lateral_movement',
+    confidence: 82,
+    drivers: ['new_exec_paths', 'network_fanout_spike'],
+    relevant_event_ids: ['event-1', 'event-2'],
+    suggested_next_step: 'retro_hunt_similar_activity',
+  },
+}
+
+describe('investigation judgment review', () => {
+  it('renders a structured AI hypothesis without presenting it as fact', () => {
+    render(<JudgmentClaim judgment={investigation} />)
+
+    expect(screen.getByText('AI investigation hypothesis')).toBeInTheDocument()
+    expect(screen.getByText('lateral movement')).toBeInTheDocument()
+    expect(screen.getByText('82% confidence')).toBeInTheDocument()
+    expect(screen.getByText('network_fanout_spike')).toBeInTheDocument()
+    expect(screen.getByText(/only a distinct reviewer's sealed verdict can confirm it/i)).toBeInTheDocument()
+    expect(screen.getByText(/cannot change incident facts, risk, disposition, or response actions/i)).toBeInTheDocument()
+    expect(screen.getByText(/event-1, event-2/)).toBeInTheDocument()
+    expect(screen.getByText('retro hunt similar activity')).toBeInTheDocument()
+  })
+
+  it('requires an evidence-scored analyst verdict without incident mutation authority', () => {
+    render(
+      <JudgmentReviewForm
+        engagementId="engagement-1"
+        judgment={investigation}
+        onCancel={vi.fn()}
+        onSettled={vi.fn()}
+        onConflict={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText(/Record a distinct analyst verdict on this AI hypothesis/i)).toBeInTheDocument()
+    expect(screen.getByText(/cannot mutate incident facts, risk, disposition, or response actions/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Seal verdict' })).toBeDisabled()
+  })
+})

--- a/web/src/pages/EngagementDetail/components/FindingJudgments.tsx
+++ b/web/src/pages/EngagementDetail/components/FindingJudgments.tsx
@@ -5,6 +5,7 @@ import { api } from '../../../lib/api'
 import type {
   CritiqueClaim,
   EvidenceItem,
+  InvestigationClaim,
   Judgment,
   ReachabilityClaim,
   RiskNarrativeClaim,
@@ -111,6 +112,55 @@ export function Reachability({ j }: { j: Judgment }) {
   )
 }
 
+export function InvestigationHypothesis({ j }: { j: Judgment }) {
+  const c = j.claim as Partial<InvestigationClaim>
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs font-semibold text-primary">AI investigation hypothesis</span>
+        <JudgmentStateBadge state={j.state} />
+        {c.tactic && (
+          <span className="rounded border border-brand-secondary bg-brand-primary px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-brand-secondary">
+            {c.tactic.replaceAll('_', ' ')}
+          </span>
+        )}
+        {typeof c.confidence === 'number' && (
+          <span className="font-mono text-xs tabular-nums text-tertiary">{c.confidence}% confidence</span>
+        )}
+      </div>
+      {c.incident_id && (
+        <p className="text-xs text-tertiary">
+          Incident <span className="break-all font-mono text-primary">{c.incident_id}</span>
+        </p>
+      )}
+      {(c.drivers?.length ?? 0) > 0 && (
+        <div className="flex flex-wrap gap-1" aria-label="Hypothesis drivers">
+          {c.drivers!.map((driver) => (
+            <span key={driver} className="rounded border border-secondary bg-secondary px-1.5 py-0.5 font-mono text-[11px] text-secondary">
+              {driver}
+            </span>
+          ))}
+        </div>
+      )}
+      {(c.relevant_event_ids?.length ?? 0) > 0 && (
+        <p className="text-xs text-tertiary">
+          Relevant events:{' '}
+          <span className="font-mono text-primary">{c.relevant_event_ids!.join(', ')}</span>
+        </p>
+      )}
+      {c.suggested_next_step && (
+        <p className="text-xs text-tertiary">
+          Suggested next step:{' '}
+          <span className="font-medium text-primary">{c.suggested_next_step.replaceAll('_', ' ')}</span>
+        </p>
+      )}
+      <p className="text-xs text-warning-primary">
+        Unverified AI suggestion — only a distinct reviewer's sealed verdict can confirm it. It cannot change incident facts, risk, disposition, or response actions.
+      </p>
+    </div>
+  )
+}
+
 export function ExplainJudgments({ engagementId, findingId }: { engagementId: string; findingId: string }) {
   const { data: judgments } = useFetch(
     () => api.judgments(engagementId).catch(() => [] as Judgment[]),
@@ -147,9 +197,10 @@ export function ExplainJudgments({ engagementId, findingId }: { engagementId: st
   )
 }
 
-export const GATED_JUDGMENT_CAPABILITIES = new Set(['reachability', 'sast', 'critique', 'threat', 'vex_justification'])
+export const GATED_JUDGMENT_CAPABILITIES = new Set(['reachability', 'sast', 'critique', 'threat', 'vex_justification', 'investigation'])
 
 export function JudgmentClaim({ judgment }: { judgment: Judgment }) {
+  if (judgment.capability === 'investigation') return <InvestigationHypothesis j={judgment} />
   if (judgment.capability === 'reachability') return <Reachability j={judgment} />
   if (judgment.capability === 'critique') return <Critique j={judgment} />
   if (judgment.capability === 'risk_narrative') return <RiskNarrative j={judgment} />


### PR DESCRIPTION
## Summary

- complete the #640 AI-assisted EDR slice on top of the existing InvestigationClaim primitive
- add tenant- and engagement-scoped list_incidents and get_incident_context tools with bounded, secret-redacted timeline data
- extend hypotheses with scoped relevant event IDs, a closed tactic storyline, confidence/driver tokens, and a closed read-only next-step suggestion
- make investigation evidence-gated: proposals start at score 0 and only a distinct verifier's sealed verdict at the shared threshold can confirm them
- wire the same investigation toolset into the API agent, durable worker, and synapse-mcp
- surface structured hypotheses in analyst review UI without presenting them as facts

## Safety invariants

- incident scope is derived server-side from the configured tenant, session engagement, and its detection ledger; clients cannot choose tenant, engagement, asset, or arbitrary timeline ranges
- MCP and agent paths expose narrow readers plus judgment Propose only; architecture tests forbid incident triage, risk scoring, response, analysis verification, and infrastructure writers
- hypotheses cannot mutate incident facts, RiskAssessment, disposition, or response actions
- investigation judgments are excluded from deterministic report projection; no LLM output enters reports

## Verification

- targeted Go packages, composition roots, MCP adapter, HTTP adapter, report, docs, memory, and Postgres tests pass
- web typecheck passes
- web tests pass 365/365 with one worker; the new investigation UI tests pass 2/2
- web production build passes
- git diff --check passes

## Existing baseline debt observed

- go test ./... reaches all packages but api/TestOpenAPIRouteCoverage fails for 10 fleet routes already registered on upstream main and absent from api/openapi.yaml; this PR changes neither those routes nor the spec
- default parallel Vitest mode times out in two App.rules routing tests; that file passes 12/12 alone and the entire suite passes 365/365 with maxWorkers=1

Closes #640