### PR TITLE
feat(fleet): first-class signing-key Rotate (register-new + revoke-old) (#594 #607)

### DIFF
--- a/internal/usecase/fleet/keyregistry/service.go
+++ b/internal/usecase/fleet/keyregistry/service.go
@@ -117,6 +117,27 @@ func (s *Service) Revoke(ctx context.Context, agentID shared.ID, keyID, actor st
 	return nil
 }
 
+// Rotate performs the standard signing-key rotation as one audited operation: register a NEW key for the
+// authenticated agent (same proof-of-possession + validity checks as Register), then revoke the OLD key.
+// The store keeps multiple keys per agent, so the overlap window lets batches signed with the old key
+// still verify until it is revoked — no gap. If the new key registers but the old revocation fails, the
+// error names both so the operator can complete the revoke; the new key stays valid (fail-safe: never
+// leave the agent with no usable key). actor attributes the revoke.
+func (s *Service) Rotate(ctx context.Context, authAgentID shared.ID, newKey RegisterRequest, oldKeyID, actor string) (fleetagent.AgentSigningKey, error) {
+	if strings.TrimSpace(oldKeyID) == "" {
+		return fleetagent.AgentSigningKey{}, fmt.Errorf("%w: rotate needs the old key id to revoke", shared.ErrValidation)
+	}
+	registered, err := s.Register(ctx, authAgentID, newKey)
+	if err != nil {
+		return fleetagent.AgentSigningKey{}, err
+	}
+	if err := s.Revoke(ctx, authAgentID, oldKeyID, actor); err != nil {
+		return fleetagent.AgentSigningKey{}, fmt.Errorf("rotate: new key %s registered but revoking old key %s failed: %w", registered.KeyID, oldKeyID, err)
+	}
+	s.record(ctx, actor, registered.KeyID, "fleet.key.rotated", map[string]string{"agent_id": authAgentID.String(), "old_key_id": oldKeyID})
+	return registered, nil
+}
+
 func (s *Service) record(ctx context.Context, actor, keyID, action string, meta map[string]string) {
 	if meta == nil {
 		meta = map[string]string{}

--- a/internal/usecase/fleet/keyregistry/service_test.go
+++ b/internal/usecase/fleet/keyregistry/service_test.go
@@ -188,3 +188,56 @@ func mustDecode(t *testing.T, b64 string) ed25519.PublicKey {
 	}
 	return ed25519.PublicKey(raw)
 }
+
+func TestRotateRegistersNewAndRevokesOld(t *testing.T) {
+	svc, audit, ctx := newHarness(t)
+	agent := shared.ID("agent-1")
+
+	// Existing (old) key.
+	oldReq, _, _ := proofFor(t, agent, fleetagent.PurposeDetectionBatch)
+	oldKey, err := svc.Register(ctx, agent, oldReq)
+	if err != nil {
+		t.Fatalf("register old: %v", err)
+	}
+
+	// Rotate: register a NEW key + revoke the old, in one audited op.
+	newReq, _, _ := proofFor(t, agent, fleetagent.PurposeDetectionBatch)
+	newKey, err := svc.Rotate(ctx, agent, newReq, oldKey.KeyID, "operator")
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if newKey.KeyID == oldKey.KeyID {
+		t.Fatal("rotation must mint a distinct new key id")
+	}
+
+	keys, err := svc.List(ctx, agent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var oldRevoked, newActive bool
+	for _, k := range keys {
+		if k.KeyID == oldKey.KeyID && !k.RevokedAt.IsZero() {
+			oldRevoked = true
+		}
+		if k.KeyID == newKey.KeyID && k.RevokedAt.IsZero() {
+			newActive = true
+		}
+	}
+	if !oldRevoked {
+		t.Fatal("rotation must revoke the old key")
+	}
+	if !newActive {
+		t.Fatal("rotation must leave the new key active")
+	}
+	if !audit.has("fleet.key.rotated") {
+		t.Fatal("rotation must be audited (fleet.key.rotated)")
+	}
+}
+
+func TestRotateNeedsOldKeyID(t *testing.T) {
+	svc, _, ctx := newHarness(t)
+	req, _, _ := proofFor(t, "agent-1", fleetagent.PurposeDetectionBatch)
+	if _, err := svc.Rotate(ctx, "agent-1", req, "", "operator"); err == nil {
+		t.Fatal("rotate without an old key id must be rejected")
+	}
+}


### PR DESCRIPTION
feat(fleet): first-class signing-key Rotate (register-new + revoke-old) (#594 #607)

Completes A0.2's enroll/ROTATE/revoke: Register (enrol) and Revoke were present;
rotation was achievable as two calls but not a first-class audited operation. Adds
keyregistry.Rotate(authAgentID, newKey, oldKeyID, actor): registers the new key with
the SAME proof-of-possession + validity checks as Register, then revokes the old.

- Overlap window by construction: the store keeps multiple keys per agent, so batches
  signed with the old key still verify until it is revoked — no signing gap.
- Fail-safe ordering: register first, then revoke; if the revoke fails the error names
  both keys and the NEW key stays valid, so the agent is never left with no usable key.
- Audited as fleet.key.rotated (agent + old key id).

Tests: Rotate mints a distinct new key, leaves it active, revokes the old, and audits;
rotate without an old key id is rejected. build/vet/gofmt clean.
