### PR TITLE
feat(fleet): legal hold — suspend retention expiry for held data (#594 #635)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -128,6 +128,7 @@ import (
 	incidenttriage "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/incidenttriage"
 	incidentuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/incidentuc"
 	keyregistry "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/keyregistry"
+	legalholduc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/legalholduc"
 	privacypolicy "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/privacypolicy"
 	retrohunt "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/retrohunt"
 	riskscorebridge "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/riskscorebridge"
@@ -317,6 +318,7 @@ func main() {
 	var fleetDesiredStore ports.FleetDesiredStore         // #633 desired-vs-observed capability state
 	var endpointTimelineStore ports.EndpointTimelineStore // #594 B7 State Timeline projection
 	var baselineStore ports.BaselineStore                 // #594 D behavioral baseline state
+	var legalHoldStore ports.LegalHoldStore               // #635 legal holds (suspend retention expiry)
 	var telemetrySvc *telemetryingest.Service             // wired to detection repair after both services exist
 	var endpointStateSvc *endpointstate.Service           // #594 B7 State-Timeline projector; fed by telemetry ingest
 	var detectSvc *detectledger.Service                   // tenant-scoped startup and periodic provenance repair
@@ -524,6 +526,7 @@ func main() {
 		fleetDesiredStore = postgres.NewFleetDesiredRepository(pool)
 		endpointTimelineStore = postgres.NewEndpointTimelineRepository(pool)
 		baselineStore = postgres.NewBaselineRepository(pool)
+		legalHoldStore = postgres.NewLegalHoldRepository(pool)
 		fleetRolloutStore = postgres.NewFleetRolloutRepository(pool)
 		leaderStore = postgres.NewLeaderStore(pool)
 		// SECURITY (#431 req 6, #432, #409): the fleet_* tables are RLS-protected, but RLS is a
@@ -582,6 +585,7 @@ func main() {
 		fleetDesiredStore = memory.NewFleetDesiredStore()
 		endpointTimelineStore = memory.NewEndpointTimelineStore()
 		baselineStore = memory.NewBaselineStore()
+		legalHoldStore = memory.NewLegalHoldStore()
 		fleetRolloutStore = memory.NewFleetRolloutStore()
 		findingRepo = memory.NewFindingRepository()
 		judgmentStore = memory.NewJudgmentStore()
@@ -1995,6 +1999,16 @@ func main() {
 			router.SetFleetDetectionIngest(detectSvc)
 			if telemetrySvc != nil {
 				telemetrySvc.SetDetectionReconciler(detectSvc)
+			}
+			// Legal holds (#635): a held engagement's data is exempt from retention expiry. Wire the guard
+			// into the detection ledger's Expire path + expose the operator surface.
+			if legalHoldSvc, lherr := legalholduc.NewService(legalHoldStore, auditLog, func() time.Time { return clock.Now().UTC() }); lherr != nil {
+				log.Error("legal-hold service init failed", "err", lherr)
+				os.Exit(1)
+			} else {
+				detectSvc.SetLegalHoldChecker(legalHoldSvc)
+				router.SetLegalHolds(legalHoldSvc)
+				log.Info("legal holds ENABLED (#635): a held engagement's retention-bounded data is preserved until released")
 			}
 			tenantStore, ok := repo.(ports.DetectionReconciliationTenantStore)
 			if !ok {

--- a/internal/adapter/httpapi/legal_hold_handler.go
+++ b/internal/adapter/httpapi/legal_hold_handler.go
@@ -1,0 +1,59 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/legalhold"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// legalHoldService is the #635 legal-hold surface: place/release a hold on an engagement's data and list
+// the active holds. legalholduc.Service satisfies it. Actor + tenant are server-side; a held engagement's
+// data is exempt from retention expiry.
+type legalHoldService interface {
+	Place(ctx context.Context, actor string, engagementID shared.ID, reason string) (legalhold.Hold, error)
+	Release(ctx context.Context, actor string, engagementID shared.ID) error
+	ListActive(ctx context.Context) ([]legalhold.Hold, error)
+}
+
+// SetLegalHolds wires the legal-hold surface (nil ⇒ the routes are not registered).
+func (rt *Router) SetLegalHolds(s legalHoldService) { rt.legalHolds = s }
+
+const legalHoldBodyLimit = 8 << 10
+
+type placeLegalHoldRequest struct {
+	Reason string `json:"reason"`
+}
+
+func (rt *Router) placeLegalHold(w http.ResponseWriter, r *http.Request) {
+	var req placeLegalHoldRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, legalHoldBodyLimit)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
+		return
+	}
+	hold, err := rt.legalHolds.Place(incidentTenantContext(r), PrincipalFrom(r.Context()), shared.ID(r.PathValue("id")), req.Reason)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, hold)
+}
+
+func (rt *Router) releaseLegalHold(w http.ResponseWriter, r *http.Request) {
+	if err := rt.legalHolds.Release(incidentTenantContext(r), PrincipalFrom(r.Context()), shared.ID(r.PathValue("id"))); err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (rt *Router) listLegalHolds(w http.ResponseWriter, r *http.Request) {
+	holds, err := rt.legalHolds.ListActive(incidentTenantContext(r))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"holds": holds})
+}

--- a/internal/adapter/httpapi/legal_hold_handler_test.go
+++ b/internal/adapter/httpapi/legal_hold_handler_test.go
@@ -1,0 +1,69 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/legalhold"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type fakeLegalHolds struct {
+	placedEng    shared.ID
+	placedBy     string
+	placedReason string
+	released     shared.ID
+}
+
+func (f *fakeLegalHolds) Place(_ context.Context, actor string, eng shared.ID, reason string) (legalhold.Hold, error) {
+	f.placedEng, f.placedBy, f.placedReason = eng, actor, reason
+	return legalhold.Hold{EngagementID: eng, PlacedBy: actor, Reason: reason}, nil
+}
+func (f *fakeLegalHolds) Release(_ context.Context, _ string, eng shared.ID) error {
+	f.released = eng
+	return nil
+}
+func (f *fakeLegalHolds) ListActive(context.Context) ([]legalhold.Hold, error) {
+	return []legalhold.Hold{{EngagementID: "eng-1"}}, nil
+}
+
+func newLegalHoldRouter(f *fakeLegalHolds) *http.ServeMux {
+	rt := &Router{log: discardLog(), incidents: &fakeIncidentStore{}, legalHolds: f}
+	return rt.routes()
+}
+
+func TestLegalHoldRBACAndServerSideScoping(t *testing.T) {
+	f := &fakeLegalHolds{}
+	mux := newLegalHoldRouter(f)
+
+	// consultant CANNOT place/release (a governance decision → PermReview).
+	if rec := incidentReq(mux, "consultant", http.MethodPut, "/api/v1/fleet/engagements/eng-7/legal-hold", `{"reason":"litigation"}`); rec.Code != http.StatusForbidden {
+		t.Fatalf("consultant place must be forbidden (needs review), got %d", rec.Code)
+	}
+	// reviewer can place; actor + engagement from principal/path, reason from body.
+	if rec := incidentReq(mux, "reviewer", http.MethodPut, "/api/v1/fleet/engagements/eng-7/legal-hold", `{"reason":"litigation JIRA-1"}`); rec.Code != http.StatusOK {
+		t.Fatalf("reviewer place: got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if f.placedEng != "eng-7" || f.placedBy != "analyst-1" || f.placedReason != "litigation JIRA-1" {
+		t.Fatalf("place not scoped server-side: %+v", f)
+	}
+	// reviewer can release.
+	if rec := incidentReq(mux, "reviewer", http.MethodDelete, "/api/v1/fleet/engagements/eng-7/legal-hold", ""); rec.Code != http.StatusNoContent {
+		t.Fatalf("reviewer release: got %d", rec.Code)
+	}
+	if f.released != "eng-7" {
+		t.Fatalf("release not scoped to path: %q", f.released)
+	}
+	// readonly can list (PermView).
+	if rec := incidentReq(mux, "readonly", http.MethodGet, "/api/v1/fleet/legal-holds", ""); rec.Code != http.StatusOK {
+		t.Fatalf("readonly list: got %d", rec.Code)
+	}
+}
+
+func TestLegalHoldRoutesAbsentWhenUnwired(t *testing.T) {
+	rt := &Router{log: discardLog(), incidents: &fakeIncidentStore{}}
+	if rec := incidentReq(rt.routes(), "reviewer", http.MethodGet, "/api/v1/fleet/legal-holds", ""); rec.Code != http.StatusNotFound {
+		t.Fatalf("unwired legal-hold route must 404, got %d", rec.Code)
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -87,6 +87,7 @@ type Router struct {
 	endpointProcesses      endpointProcessStore      // optional; nil ⇒ the process-report routes are not registered (#594 B5)
 	processLearner         processLearner            // optional; nil ⇒ reported processes are not folded into the behavior baseline (#594 D)
 	desiredCapabilities    desiredCapabilityService  // optional; nil ⇒ the desired-vs-observed routes are not registered (#633)
+	legalHolds             legalHoldService          // optional; nil ⇒ the legal-hold routes are not registered (#635)
 	endpointTimeline       endpointTimelineReader    // optional; nil ⇒ the State-Timeline read route is not registered (#594 B7)
 	retroHunter            retroHunter               // optional; nil ⇒ the retro-hunt route is not registered (#594 B7)
 	sarif                  sarifIngester             // optional; nil ⇒ the third-party SARIF import route is not registered
@@ -442,6 +443,14 @@ func (rt *Router) routes() *http.ServeMux {
 		if rt.retroHunter != nil {
 			// B7 retro-hunt (#594): re-hunt a window of the timeline around a pivot. PermView (read-only analysis).
 			mux.HandleFunc("POST /api/v1/fleet/assets/{id}/retro-hunt", rt.authz(userdom.PermView, rt.retroHuntEndpoint))
+		}
+		if rt.legalHolds != nil {
+			// Legal hold (#635): place/release a hold on an engagement's data (exempts it from retention
+			// expiry) and list active holds. Place/release = PermReview (a governance/compliance decision);
+			// list = PermView. Actor + tenant are server-side.
+			mux.HandleFunc("PUT /api/v1/fleet/engagements/{id}/legal-hold", rt.authz(userdom.PermReview, rt.placeLegalHold))
+			mux.HandleFunc("DELETE /api/v1/fleet/engagements/{id}/legal-hold", rt.authz(userdom.PermReview, rt.releaseLegalHold))
+			mux.HandleFunc("GET /api/v1/fleet/legal-holds", rt.authz(userdom.PermView, rt.listLegalHolds))
 		}
 		if rt.desiredCapabilities != nil {
 			// Desired-vs-observed (#633): declare the capabilities an asset SHOULD have (PermOperate),

--- a/internal/domain/legalhold/legalhold.go
+++ b/internal/domain/legalhold/legalhold.go
@@ -1,0 +1,46 @@
+// Package legalhold is the pure domain for a LEGAL HOLD on an engagement's data (#635 privacy &
+// data governance). A hold suspends retention expiry: while an engagement is held, its
+// retention-bounded projection rows must NOT be deleted, even after their retention window elapses —
+// preserving data that a legal/regulatory obligation requires kept. Placement and release are audited
+// operator actions; this package defines the record + its invariants, not the storage or the HTTP edge.
+package legalhold
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// Hold is a legal hold placed on one engagement's data within a tenant. Active while ReleasedAt is zero;
+// a released hold is retained (append-only history) so the hold+release trail is auditable.
+type Hold struct {
+	TenantID     shared.ID
+	EngagementID shared.ID
+	Reason       string // why the data must be preserved — mandatory (accountability)
+	PlacedBy     string // the operator who placed it — mandatory
+	PlacedAt     time.Time
+	ReleasedBy   string    // set on release
+	ReleasedAt   time.Time // zero = still active
+}
+
+// Active reports whether the hold currently suspends retention.
+func (h Hold) Active() bool { return h.ReleasedAt.IsZero() }
+
+// Validate enforces the mandatory fields for placing a hold.
+func (h Hold) Validate() error {
+	if h.TenantID.IsZero() {
+		return fmt.Errorf("%w: legal hold requires a tenant", shared.ErrValidation)
+	}
+	if h.EngagementID.IsZero() {
+		return fmt.Errorf("%w: legal hold requires an engagement id", shared.ErrValidation)
+	}
+	if strings.TrimSpace(h.Reason) == "" {
+		return fmt.Errorf("%w: legal hold requires a reason", shared.ErrValidation)
+	}
+	if strings.TrimSpace(h.PlacedBy) == "" {
+		return fmt.Errorf("%w: legal hold requires the placing operator", shared.ErrValidation)
+	}
+	return nil
+}

--- a/internal/infrastructure/persistence/memory/legal_hold_store.go
+++ b/internal/infrastructure/persistence/memory/legal_hold_store.go
@@ -1,0 +1,111 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/legalhold"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// LegalHoldStore is an in-memory legal-hold store (#635), tenant-scoped, keeping an append-only history
+// per (tenant, engagement) so hold+release is auditable.
+type LegalHoldStore struct {
+	mu   sync.Mutex
+	rows map[shared.ID]map[shared.ID][]legalhold.Hold // tenant -> engagement -> holds (newest last)
+}
+
+var _ ports.LegalHoldStore = (*LegalHoldStore)(nil)
+
+func NewLegalHoldStore() *LegalHoldStore {
+	return &LegalHoldStore{rows: map[shared.ID]map[shared.ID][]legalhold.Hold{}}
+}
+
+func (s *LegalHoldStore) tenant(ctx context.Context) (shared.ID, error) {
+	t, ok := shared.TenantFrom(ctx)
+	if !ok || t.IsZero() {
+		return "", fmt.Errorf("%w: legal hold requires a tenant in context", shared.ErrValidation)
+	}
+	return t, nil
+}
+
+func (s *LegalHoldStore) Place(ctx context.Context, h legalhold.Hold) (legalhold.Hold, error) {
+	tenant, err := s.tenant(ctx)
+	if err != nil {
+		return legalhold.Hold{}, err
+	}
+	if h.TenantID != tenant {
+		return legalhold.Hold{}, fmt.Errorf("%w: legal-hold tenant disagrees with context", shared.ErrForbidden)
+	}
+	if err := h.Validate(); err != nil {
+		return legalhold.Hold{}, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.rows[tenant] == nil {
+		s.rows[tenant] = map[shared.ID][]legalhold.Hold{}
+	}
+	for _, existing := range s.rows[tenant][h.EngagementID] {
+		if existing.Active() {
+			return existing, nil // idempotent: an active hold already exists
+		}
+	}
+	s.rows[tenant][h.EngagementID] = append(s.rows[tenant][h.EngagementID], h)
+	return h, nil
+}
+
+func (s *LegalHoldStore) Release(ctx context.Context, engagementID shared.ID, releasedBy string, at time.Time) error {
+	tenant, err := s.tenant(ctx)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	holds := s.rows[tenant][engagementID]
+	for i := range holds {
+		if holds[i].Active() {
+			holds[i].ReleasedBy = releasedBy
+			holds[i].ReleasedAt = at.UTC()
+			return nil
+		}
+	}
+	return nil // no active hold: release is a no-op
+}
+
+func (s *LegalHoldStore) IsHeld(ctx context.Context, engagementID shared.ID) (bool, error) {
+	tenant, err := s.tenant(ctx)
+	if err != nil {
+		return false, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, h := range s.rows[tenant][engagementID] {
+		if h.Active() {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *LegalHoldStore) ListActive(ctx context.Context) ([]legalhold.Hold, error) {
+	tenant, err := s.tenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var out []legalhold.Hold
+	for _, holds := range s.rows[tenant] {
+		for _, h := range holds {
+			if h.Active() {
+				out = append(out, h)
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].EngagementID < out[j].EngagementID })
+	return out, nil
+}

--- a/internal/infrastructure/persistence/postgres/legal_hold_repo.go
+++ b/internal/infrastructure/persistence/postgres/legal_hold_repo.go
@@ -1,0 +1,126 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/legalhold"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// LegalHoldRepository is the Postgres tier for legal holds (#635). Append-only history per (tenant,
+// engagement); at most one active hold per engagement (partial unique index). Every method runs under the
+// ctx tenant via WithContextTenant (RLS) with an explicit tenant_id predicate as defense-in-depth.
+type LegalHoldRepository struct {
+	pool *pgxpool.Pool
+}
+
+var _ ports.LegalHoldStore = (*LegalHoldRepository)(nil)
+
+func NewLegalHoldRepository(pool *pgxpool.Pool) *LegalHoldRepository {
+	return &LegalHoldRepository{pool: pool}
+}
+
+func requireLegalHoldTenant(ctx context.Context) (shared.ID, error) {
+	if t, ok := shared.TenantFrom(ctx); ok && t != "" {
+		return t, nil
+	}
+	return "", fmt.Errorf("%w: legal hold operation requires a tenant in context", shared.ErrValidation)
+}
+
+func (r *LegalHoldRepository) Place(ctx context.Context, h legalhold.Hold) (legalhold.Hold, error) {
+	tenant, err := requireLegalHoldTenant(ctx)
+	if err != nil {
+		return legalhold.Hold{}, err
+	}
+	if h.TenantID != tenant {
+		return legalhold.Hold{}, fmt.Errorf("%w: legal-hold tenant disagrees with context", shared.ErrForbidden)
+	}
+	if err := h.Validate(); err != nil {
+		return legalhold.Hold{}, err
+	}
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		// Idempotent: if an active hold already exists, keep it (return its identity via the caller's h).
+		var exists bool
+		if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM legal_holds WHERE tenant_id=$1 AND engagement_id=$2 AND released_at IS NULL)`,
+			tenant.String(), h.EngagementID.String()).Scan(&exists); err != nil {
+			return fmt.Errorf("check active hold: %w", err)
+		}
+		if exists {
+			return nil
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO legal_holds (tenant_id, engagement_id, reason, placed_by, placed_at)
+			VALUES ($1,$2,$3,$4,$5)`, tenant.String(), h.EngagementID.String(), h.Reason, h.PlacedBy, h.PlacedAt.UTC()); err != nil {
+			return fmt.Errorf("insert legal hold: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return legalhold.Hold{}, err
+	}
+	return h, nil
+}
+
+func (r *LegalHoldRepository) Release(ctx context.Context, engagementID shared.ID, releasedBy string, at time.Time) error {
+	tenant, err := requireLegalHoldTenant(ctx)
+	if err != nil {
+		return err
+	}
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `UPDATE legal_holds SET released_by=$3, released_at=$4
+			WHERE tenant_id=$1 AND engagement_id=$2 AND released_at IS NULL`,
+			tenant.String(), engagementID.String(), releasedBy, at.UTC())
+		if err != nil {
+			return fmt.Errorf("release legal hold: %w", err)
+		}
+		return nil
+	})
+}
+
+func (r *LegalHoldRepository) IsHeld(ctx context.Context, engagementID shared.ID) (bool, error) {
+	tenant, err := requireLegalHoldTenant(ctx)
+	if err != nil {
+		return false, err
+	}
+	var held bool
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM legal_holds WHERE tenant_id=$1 AND engagement_id=$2 AND released_at IS NULL)`,
+			tenant.String(), engagementID.String()).Scan(&held)
+	})
+	return held, err
+}
+
+func (r *LegalHoldRepository) ListActive(ctx context.Context) ([]legalhold.Hold, error) {
+	tenant, err := requireLegalHoldTenant(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var out []legalhold.Hold
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT engagement_id, reason, placed_by, placed_at FROM legal_holds
+			WHERE tenant_id=$1 AND released_at IS NULL ORDER BY engagement_id`, tenant.String())
+		if err != nil {
+			return fmt.Errorf("list legal holds: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var eng, reason, placedBy string
+			var placedAt time.Time
+			if err := rows.Scan(&eng, &reason, &placedBy, &placedAt); err != nil {
+				return fmt.Errorf("scan legal hold: %w", err)
+			}
+			out = append(out, legalhold.Hold{TenantID: tenant, EngagementID: shared.ID(eng), Reason: reason, PlacedBy: placedBy, PlacedAt: placedAt})
+		}
+		return rows.Err()
+	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return out, err
+}

--- a/internal/usecase/fleet/detectledger/service.go
+++ b/internal/usecase/fleet/detectledger/service.go
@@ -86,8 +86,18 @@ type Service struct {
 	audit      ports.IdempotentAuditLogger
 	clock      ports.Clock
 	ids        ports.IDGenerator
-	retention  time.Duration // 0 = keep the projection forever (the chain is always permanent)
+	retention  time.Duration    // 0 = keep the projection forever (the chain is always permanent)
+	holds      legalHoldChecker // optional (#635): when set, an active hold blocks retention expiry
 }
+
+// legalHoldChecker reports whether an engagement is under an active legal hold. legalholduc.Service
+// satisfies it. When wired, Expire refuses to delete a held engagement's data (fail-closed preservation).
+type legalHoldChecker interface {
+	IsHeld(ctx context.Context, engagementID shared.ID) (bool, error)
+}
+
+// SetLegalHoldChecker wires the #635 legal-hold guard (nil ⇒ retention expiry is not hold-gated).
+func (s *Service) SetLegalHoldChecker(h legalHoldChecker) { s.holds = h }
 
 // NewService validates its dependencies. Every one is required: a ledger that cannot seal, resolve an
 // agent key, persist, or audit is not producing attributable evidence.
@@ -650,6 +660,17 @@ func (s *Service) Expire(ctx context.Context, engagementID shared.ID, actor, rea
 	}
 	if strings.TrimSpace(reason) == "" {
 		return 0, fmt.Errorf("%w: expiry must carry a reason", shared.ErrValidation)
+	}
+	// Legal hold (#635): a held engagement's data must NOT be expired, even past its retention window.
+	// Fail-closed — a checker error blocks the deletion rather than risk destroying held evidence.
+	if s.holds != nil {
+		held, herr := s.holds.IsHeld(ctx, engagementID)
+		if herr != nil {
+			return 0, fmt.Errorf("legal-hold check before expiry: %w", herr)
+		}
+		if held {
+			return 0, fmt.Errorf("%w: engagement %s is under a legal hold; retention expiry is suspended", shared.ErrForbidden, engagementID)
+		}
 	}
 
 	expired, err := s.records.ListExpiredDetections(ctx, engagementID, s.clock.Now().UTC())

--- a/internal/usecase/fleet/detectledger/service_test.go
+++ b/internal/usecase/fleet/detectledger/service_test.go
@@ -1338,3 +1338,25 @@ func TestExpireAuditFailureDeletesNoProjection(t *testing.T) {
 		t.Fatalf("expiry audit must carry actor + reason, got %+v", e)
 	}
 }
+
+type fakeHoldChecker struct {
+	held bool
+	err  error
+}
+
+func (f fakeHoldChecker) IsHeld(context.Context, shared.ID) (bool, error) { return f.held, f.err }
+
+// TestExpireRefusedUnderLegalHold: a held engagement's retention expiry is refused (#635), so held data
+// is preserved past its retention window; releasing the hold lets expiry proceed.
+func TestExpireRefusedUnderLegalHold(t *testing.T) {
+	h := newHarness(t, time.Hour)
+	h.svc.SetLegalHoldChecker(fakeHoldChecker{held: true})
+	if _, err := h.svc.Expire(tctx(), "eng-1", "operator", "retention"); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("expiry under a legal hold must be forbidden, got %v", err)
+	}
+	// No hold → expiry proceeds (0 expired here, but not refused).
+	h.svc.SetLegalHoldChecker(fakeHoldChecker{held: false})
+	if _, err := h.svc.Expire(tctx(), "eng-1", "operator", "retention"); err != nil {
+		t.Fatalf("expiry without a hold must proceed: %v", err)
+	}
+}

--- a/internal/usecase/fleet/legalholduc/service.go
+++ b/internal/usecase/fleet/legalholduc/service.go
@@ -1,0 +1,81 @@
+// Package legalholduc is the application service for legal holds (#635): an operator places/releases a
+// hold on an engagement's data, and it exposes the IsHeld guard the retention deletion consults. Every
+// placement + release is audited. A hold SUSPENDS retention expiry — held data survives its retention
+// window until the hold is released — the mechanism a legal/regulatory preservation obligation needs.
+package legalholduc
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/legalhold"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type Service struct {
+	store ports.LegalHoldStore
+	audit ports.AuditLogger
+	now   func() time.Time
+}
+
+func NewService(store ports.LegalHoldStore, audit ports.AuditLogger, now func() time.Time) (*Service, error) {
+	if store == nil || audit == nil || now == nil {
+		return nil, fmt.Errorf("%w: legal-hold service is missing a dependency", shared.ErrValidation)
+	}
+	return &Service{store: store, audit: audit, now: now}, nil
+}
+
+// Place puts an active legal hold on the engagement (idempotent). actor is the operator; reason is
+// mandatory. Audited as fleet.legal_hold.placed.
+func (s *Service) Place(ctx context.Context, actor string, engagementID shared.ID, reason string) (legalhold.Hold, error) {
+	if actor == "" {
+		return legalhold.Hold{}, fmt.Errorf("%w: placing a legal hold requires an actor", shared.ErrValidation)
+	}
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok || tenant.IsZero() {
+		return legalhold.Hold{}, fmt.Errorf("%w: legal hold requires a tenant in context", shared.ErrValidation)
+	}
+	at := s.now().UTC()
+	hold := legalhold.Hold{TenantID: tenant, EngagementID: engagementID, Reason: reason, PlacedBy: actor, PlacedAt: at}
+	placed, err := s.store.Place(ctx, hold)
+	if err != nil {
+		return legalhold.Hold{}, err
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{
+		Actor: actor, Action: "fleet.legal_hold.placed", Target: engagementID.String(), At: at,
+		Metadata: map[string]string{"engagement": engagementID.String(), "reason": reason},
+	}); err != nil {
+		return legalhold.Hold{}, fmt.Errorf("audit legal-hold placement: %w", err)
+	}
+	return placed, nil
+}
+
+// Release closes the active hold on the engagement (no-op if none). Audited as fleet.legal_hold.released.
+func (s *Service) Release(ctx context.Context, actor string, engagementID shared.ID) error {
+	if actor == "" {
+		return fmt.Errorf("%w: releasing a legal hold requires an actor", shared.ErrValidation)
+	}
+	at := s.now().UTC()
+	if err := s.store.Release(ctx, engagementID, actor, at); err != nil {
+		return err
+	}
+	if err := s.audit.Record(ctx, ports.AuditEntry{
+		Actor: actor, Action: "fleet.legal_hold.released", Target: engagementID.String(), At: at,
+		Metadata: map[string]string{"engagement": engagementID.String()},
+	}); err != nil {
+		return fmt.Errorf("audit legal-hold release: %w", err)
+	}
+	return nil
+}
+
+// IsHeld is the retention guard: reports whether the engagement is under an active hold.
+func (s *Service) IsHeld(ctx context.Context, engagementID shared.ID) (bool, error) {
+	return s.store.IsHeld(ctx, engagementID)
+}
+
+// ListActive returns the tenant's active holds.
+func (s *Service) ListActive(ctx context.Context) ([]legalhold.Hold, error) {
+	return s.store.ListActive(ctx)
+}

--- a/internal/usecase/fleet/legalholduc/service_test.go
+++ b/internal/usecase/fleet/legalholduc/service_test.go
@@ -1,0 +1,87 @@
+package legalholduc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeAudit struct{ actions []string }
+
+func (f *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	f.actions = append(f.actions, e.Action)
+	return nil
+}
+
+func ctxT() context.Context { return shared.WithTenant(context.Background(), "tenant-a") }
+
+func newSvc(t *testing.T) (*Service, *fakeAudit) {
+	t.Helper()
+	audit := &fakeAudit{}
+	svc, err := NewService(memory.NewLegalHoldStore(), audit, func() time.Time { return time.Unix(0, 0).UTC() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc, audit
+}
+
+func TestPlaceHoldSuspendsAndReleaseLifts(t *testing.T) {
+	svc, audit := newSvc(t)
+	ctx := ctxT()
+
+	if held, _ := svc.IsHeld(ctx, "eng-1"); held {
+		t.Fatal("engagement must not be held initially")
+	}
+	if _, err := svc.Place(ctx, "operator", "eng-1", "litigation JIRA-123"); err != nil {
+		t.Fatal(err)
+	}
+	if held, _ := svc.IsHeld(ctx, "eng-1"); !held {
+		t.Fatal("engagement must be held after Place")
+	}
+	// Idempotent re-place.
+	if _, err := svc.Place(ctx, "operator", "eng-1", "again"); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Release(ctx, "operator", "eng-1"); err != nil {
+		t.Fatal(err)
+	}
+	if held, _ := svc.IsHeld(ctx, "eng-1"); held {
+		t.Fatal("engagement must not be held after Release")
+	}
+	// Placement + release both audited.
+	var placed, released int
+	for _, a := range audit.actions {
+		if a == "fleet.legal_hold.placed" {
+			placed++
+		}
+		if a == "fleet.legal_hold.released" {
+			released++
+		}
+	}
+	if placed < 1 || released < 1 {
+		t.Fatalf("place + release must be audited: %v", audit.actions)
+	}
+}
+
+func TestPlaceRequiresReason(t *testing.T) {
+	svc, _ := newSvc(t)
+	if _, err := svc.Place(ctxT(), "operator", "eng-1", ""); err == nil {
+		t.Fatal("a legal hold without a reason must be rejected")
+	}
+}
+
+func TestActiveHoldTenantScoped(t *testing.T) {
+	svc, _ := newSvc(t)
+	if _, err := svc.Place(ctxT(), "operator", "eng-1", "hold"); err != nil {
+		t.Fatal(err)
+	}
+	// A different tenant does not see the hold.
+	other := shared.WithTenant(context.Background(), "tenant-b")
+	if held, _ := svc.IsHeld(other, "eng-1"); held {
+		t.Fatal("a hold must be tenant-scoped")
+	}
+}

--- a/internal/usecase/ports/legal_hold.go
+++ b/internal/usecase/ports/legal_hold.go
@@ -1,0 +1,24 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/legalhold"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// LegalHoldStore persists legal holds (#635). All methods are tenant-scoped from ctx. Place is idempotent
+// per (tenant, engagement) active hold; Release closes the active hold; IsHeld is the hot-path guard the
+// retention deletion consults before expiring anything.
+type LegalHoldStore interface {
+	// Place records an active hold on the engagement. Placing when one is already active returns the
+	// existing hold (idempotent), so a re-place is safe.
+	Place(ctx context.Context, h legalhold.Hold) (legalhold.Hold, error)
+	// Release closes the active hold on the engagement (no-op if none active). releasedBy + at attribute it.
+	Release(ctx context.Context, engagementID shared.ID, releasedBy string, at time.Time) error
+	// IsHeld reports whether the engagement currently has an ACTIVE hold (tenant-scoped).
+	IsHeld(ctx context.Context, engagementID shared.ID) (bool, error)
+	// ListActive returns the tenant's currently-active holds.
+	ListActive(ctx context.Context) ([]legalhold.Hold, error)
+}

--- a/migrations/0127_legal_holds.sql
+++ b/migrations/0127_legal_holds.sql
@@ -1,0 +1,30 @@
+-- +goose Up
+-- #635 privacy & data governance: legal holds. An ACTIVE hold on an engagement suspends retention expiry
+-- for that engagement's data (the retention deletion consults IsHeld and refuses while a hold is active).
+-- Append-only history per (tenant, engagement): a released hold is kept for audit, so at most one row per
+-- engagement is active (released_at IS NULL) — enforced by a partial unique index.
+
+CREATE TABLE legal_holds (
+    tenant_id     TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+    id            BIGSERIAL,
+    engagement_id TEXT NOT NULL,
+    reason        TEXT NOT NULL,
+    placed_by     TEXT NOT NULL,
+    placed_at     TIMESTAMPTZ NOT NULL,
+    released_by   TEXT NOT NULL DEFAULT '',
+    released_at   TIMESTAMPTZ NULL,
+    PRIMARY KEY (tenant_id, id),
+    FOREIGN KEY (tenant_id, engagement_id) REFERENCES engagements(tenant_id, id) ON DELETE RESTRICT,
+    CONSTRAINT legal_holds_reason_not_blank CHECK (length(btrim(reason)) > 0),
+    CONSTRAINT legal_holds_placed_by_not_blank CHECK (length(btrim(placed_by)) > 0)
+);
+
+-- At most one ACTIVE hold per engagement (release before re-placing a distinct one).
+CREATE UNIQUE INDEX legal_holds_one_active_per_engagement
+    ON legal_holds (tenant_id, engagement_id)
+    WHERE released_at IS NULL;
+
+CALL synapse_enable_tenant_rls('legal_holds');
+
+-- +goose Down
+DROP TABLE IF EXISTS legal_holds;


### PR DESCRIPTION
feat(fleet): legal hold — suspend retention expiry for held data (#594 #635)

First governance feature of #635: a LEGAL HOLD on an engagement's data suspends
retention expiry, so data a legal/regulatory obligation requires kept survives its
retention window until the hold is released. Foundation (retention + field-RBAC +
source-side redaction) was already in place; this adds the keystone hold guard.

- domain/legalhold: Hold record (tenant, engagement, reason, placed/released
  attribution) + Validate (reason + operator mandatory); Active() = not released.
- ports.LegalHoldStore + memory + postgres (migration 0127, RLS + partial unique
  index enforcing at most one active hold per engagement) impls.
- usecase/fleet/legalholduc: Place/Release (audited: fleet.legal_hold.placed/released)
  + IsHeld guard + ListActive.
- detectledger.Expire now consults an optional legal-hold checker BEFORE deleting any
  expired projection row and REFUSES (fail-closed) while a hold is active — held
  evidence is never destroyed by retention. Wired in cmd (SetLegalHoldChecker).
- HTTP: PUT/DELETE /api/v1/fleet/engagements/{id}/legal-hold (PermReview — a
  governance decision) + GET /api/v1/fleet/legal-holds (PermView); actor + tenant
  server-side.

Tests: place suspends + release lifts + both audited + tenant-scoped + reason
required; the retention guard refuses Expire under a hold and proceeds without one;
handler RBAC (consultant can't place/release, reviewer can) + server-side scoping +
routes-absent-when-unwired. build/vet/gofmt/arch clean.

Remaining #635 (a real subsystem, best split into child issues): right-to-erasure,
export, regional residency, encryption-at-rest.
