### PR TITLE
feat(fleet): privacy data-export (subject-access / DPO bundle) (#594 #635)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -129,6 +129,7 @@ import (
 	incidentuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/incidentuc"
 	keyregistry "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/keyregistry"
 	legalholduc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/legalholduc"
+	privacyexport "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/privacyexport"
 	privacypolicy "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/privacypolicy"
 	retrohunt "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/retrohunt"
 	riskscorebridge "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/riskscorebridge"
@@ -2009,6 +2010,15 @@ func main() {
 				detectSvc.SetLegalHoldChecker(legalHoldSvc)
 				router.SetLegalHolds(legalHoldSvc)
 				log.Info("legal holds ENABLED (#635): a held engagement's retention-bounded data is preserved until released")
+				// Data-subject / DPO export (#635): a read-only, audited bundle of an engagement's detections
+				// + active legal holds.
+				if exportSvc, xerr := privacyexport.NewService(detectionRecordStore, legalHoldSvc, auditLog, func() time.Time { return clock.Now().UTC() }); xerr != nil {
+					log.Error("privacy data-export service init failed", "err", xerr)
+					os.Exit(1)
+				} else {
+					router.SetPrivacyExport(exportSvc)
+					log.Info("privacy data-export ENABLED (#635): GET /api/v1/fleet/engagements/{id}/privacy-export")
+				}
 			}
 			tenantStore, ok := repo.(ports.DetectionReconciliationTenantStore)
 			if !ok {

--- a/internal/adapter/httpapi/privacy_export_handler.go
+++ b/internal/adapter/httpapi/privacy_export_handler.go
@@ -1,0 +1,29 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/privacyexport"
+)
+
+// privacyExporter assembles a data-subject / DPO export for one engagement (#635). privacyexport.Service
+// satisfies it. The actor is the authenticated principal; the export is an audited governance read.
+type privacyExporter interface {
+	Export(ctx context.Context, actor string, engagementID shared.ID) (privacyexport.Bundle, error)
+}
+
+// SetPrivacyExport wires the data-export surface (nil ⇒ the route is not registered).
+func (rt *Router) SetPrivacyExport(e privacyExporter) { rt.privacyExport = e }
+
+// exportEngagementData returns the governance data-export bundle for one engagement (detections + active
+// legal holds). Read-only + audited; no request body.
+func (rt *Router) exportEngagementData(w http.ResponseWriter, r *http.Request) {
+	bundle, err := rt.privacyExport.Export(incidentTenantContext(r), PrincipalFrom(r.Context()), shared.ID(r.PathValue("id")))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, bundle)
+}

--- a/internal/adapter/httpapi/privacy_export_handler_test.go
+++ b/internal/adapter/httpapi/privacy_export_handler_test.go
@@ -1,0 +1,44 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/privacyexport"
+)
+
+type fakeExporter struct {
+	gotActor string
+	gotEng   shared.ID
+}
+
+func (f *fakeExporter) Export(_ context.Context, actor string, eng shared.ID) (privacyexport.Bundle, error) {
+	f.gotActor, f.gotEng = actor, eng
+	return privacyexport.Bundle{EngagementID: eng, Count: 3}, nil
+}
+
+func TestPrivacyExportRBACAndScoping(t *testing.T) {
+	f := &fakeExporter{}
+	rt := &Router{log: discardLog(), incidents: &fakeIncidentStore{}, privacyExport: f}
+	mux := rt.routes()
+
+	// consultant cannot export (governance read → PermReview).
+	if rec := incidentReq(mux, "consultant", http.MethodGet, "/api/v1/fleet/engagements/eng-9/privacy-export", ""); rec.Code != http.StatusForbidden {
+		t.Fatalf("consultant export must be forbidden, got %d", rec.Code)
+	}
+	if rec := incidentReq(mux, "reviewer", http.MethodGet, "/api/v1/fleet/engagements/eng-9/privacy-export", ""); rec.Code != http.StatusOK {
+		t.Fatalf("reviewer export: got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if f.gotActor != "analyst-1" || f.gotEng != "eng-9" {
+		t.Fatalf("actor/engagement not threaded: actor=%q eng=%q", f.gotActor, f.gotEng)
+	}
+}
+
+func TestPrivacyExportAbsentWhenUnwired(t *testing.T) {
+	rt := &Router{log: discardLog(), incidents: &fakeIncidentStore{}}
+	if rec := incidentReq(rt.routes(), "reviewer", http.MethodGet, "/api/v1/fleet/engagements/e1/privacy-export", ""); rec.Code != http.StatusNotFound {
+		t.Fatalf("unwired export route must 404, got %d", rec.Code)
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -88,6 +88,7 @@ type Router struct {
 	processLearner         processLearner            // optional; nil ⇒ reported processes are not folded into the behavior baseline (#594 D)
 	desiredCapabilities    desiredCapabilityService  // optional; nil ⇒ the desired-vs-observed routes are not registered (#633)
 	legalHolds             legalHoldService          // optional; nil ⇒ the legal-hold routes are not registered (#635)
+	privacyExport          privacyExporter           // optional; nil ⇒ the data-export route is not registered (#635)
 	endpointTimeline       endpointTimelineReader    // optional; nil ⇒ the State-Timeline read route is not registered (#594 B7)
 	retroHunter            retroHunter               // optional; nil ⇒ the retro-hunt route is not registered (#594 B7)
 	sarif                  sarifIngester             // optional; nil ⇒ the third-party SARIF import route is not registered
@@ -451,6 +452,11 @@ func (rt *Router) routes() *http.ServeMux {
 			mux.HandleFunc("PUT /api/v1/fleet/engagements/{id}/legal-hold", rt.authz(userdom.PermReview, rt.placeLegalHold))
 			mux.HandleFunc("DELETE /api/v1/fleet/engagements/{id}/legal-hold", rt.authz(userdom.PermReview, rt.releaseLegalHold))
 			mux.HandleFunc("GET /api/v1/fleet/legal-holds", rt.authz(userdom.PermView, rt.listLegalHolds))
+		}
+		if rt.privacyExport != nil {
+			// Data-subject / DPO export (#635): the governance data the control plane holds for one
+			// engagement (detections + active legal holds). Read-only + audited; a governance read → PermReview.
+			mux.HandleFunc("GET /api/v1/fleet/engagements/{id}/privacy-export", rt.authz(userdom.PermReview, rt.exportEngagementData))
 		}
 		if rt.desiredCapabilities != nil {
 			// Desired-vs-observed (#633): declare the capabilities an asset SHOULD have (PermOperate),

--- a/internal/usecase/fleet/privacyexport/service.go
+++ b/internal/usecase/fleet/privacyexport/service.go
@@ -1,0 +1,89 @@
+// Package privacyexport assembles a data-subject / DPO data-export bundle for one engagement (#635): the
+// governance-relevant data the control plane holds — the detection projection rows + the engagement's
+// active legal holds + a generated-at stamp — in a structured, read-only export. It answers a
+// subject-access / data-portability request without mutating anything; the immutable evidence chain is
+// unaffected (and, being source-side redacted, carries no raw PII).
+package privacyexport
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/legalhold"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// DetectionReader lists an engagement's detection projection rows (tenant-scoped via ctx).
+// ports.DetectionRecordStore satisfies it.
+type DetectionReader interface {
+	ListDetections(ctx context.Context, engagementID shared.ID) ([]detection.Record, error)
+}
+
+// HoldReader lists the tenant's active legal holds. legalholduc.Service satisfies it.
+type HoldReader interface {
+	ListActive(ctx context.Context) ([]legalhold.Hold, error)
+}
+
+// Bundle is the structured export for one engagement.
+type Bundle struct {
+	EngagementID shared.ID          `json:"engagement_id"`
+	GeneratedAt  time.Time          `json:"generated_at"`
+	Detections   []detection.Record `json:"detections"`
+	LegalHolds   []legalhold.Hold   `json:"legal_holds"` // active holds covering this engagement's data
+	Count        int                `json:"detection_count"`
+}
+
+// Service assembles the export.
+type Service struct {
+	detections DetectionReader
+	holds      HoldReader
+	audit      ports.AuditLogger
+	now        func() time.Time
+}
+
+// NewService constructs the exporter. holds is optional (nil ⇒ no hold section); the rest are required.
+func NewService(detections DetectionReader, holds HoldReader, audit ports.AuditLogger, now func() time.Time) (*Service, error) {
+	if detections == nil || audit == nil || now == nil {
+		return nil, fmt.Errorf("%w: privacy export needs a detection reader, an audit logger and a clock", shared.ErrValidation)
+	}
+	return &Service{detections: detections, holds: holds, audit: audit, now: now}, nil
+}
+
+// Export gathers the engagement's detection projection + active legal holds into a read-only bundle. The
+// export itself is an audited access (a subject-access request is a governance event), but reads nothing
+// it should not and mutates nothing.
+func (s *Service) Export(ctx context.Context, actor string, engagementID shared.ID) (Bundle, error) {
+	if actor == "" {
+		return Bundle{}, fmt.Errorf("%w: a data export requires an actor", shared.ErrValidation)
+	}
+	if engagementID.IsZero() {
+		return Bundle{}, fmt.Errorf("%w: a data export requires an engagement id", shared.ErrValidation)
+	}
+	recs, err := s.detections.ListDetections(ctx, engagementID)
+	if err != nil {
+		return Bundle{}, fmt.Errorf("list detections: %w", err)
+	}
+	var holds []legalhold.Hold
+	if s.holds != nil {
+		all, herr := s.holds.ListActive(ctx)
+		if herr != nil {
+			return Bundle{}, fmt.Errorf("list legal holds: %w", herr)
+		}
+		for _, h := range all {
+			if h.EngagementID == engagementID {
+				holds = append(holds, h)
+			}
+		}
+	}
+	at := s.now().UTC()
+	if err := s.audit.Record(ctx, ports.AuditEntry{
+		Actor: actor, Action: "fleet.privacy.data_export", Target: engagementID.String(), At: at,
+		Metadata: map[string]string{"engagement": engagementID.String(), "detections": fmt.Sprint(len(recs))},
+	}); err != nil {
+		return Bundle{}, fmt.Errorf("audit data export: %w", err)
+	}
+	return Bundle{EngagementID: engagementID, GeneratedAt: at, Detections: recs, LegalHolds: holds, Count: len(recs)}, nil
+}

--- a/internal/usecase/fleet/privacyexport/service_test.go
+++ b/internal/usecase/fleet/privacyexport/service_test.go
@@ -1,0 +1,60 @@
+package privacyexport
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/legalhold"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fakeDetections struct{ recs []detection.Record }
+
+func (f fakeDetections) ListDetections(context.Context, shared.ID) ([]detection.Record, error) {
+	return f.recs, nil
+}
+
+type fakeHolds struct{ holds []legalhold.Hold }
+
+func (f fakeHolds) ListActive(context.Context) ([]legalhold.Hold, error) { return f.holds, nil }
+
+type fakeAudit struct{ n int }
+
+func (f *fakeAudit) Record(context.Context, ports.AuditEntry) error { f.n++; return nil }
+
+func TestExportBundlesDetectionsAndHolds(t *testing.T) {
+	dets := fakeDetections{recs: []detection.Record{{ID: "d1", EngagementID: "eng-1"}, {ID: "d2", EngagementID: "eng-1"}}}
+	holds := fakeHolds{holds: []legalhold.Hold{{EngagementID: "eng-1", Reason: "hold"}, {EngagementID: "eng-2", Reason: "other"}}}
+	audit := &fakeAudit{}
+	svc, err := NewService(dets, holds, audit, func() time.Time { return time.Unix(0, 0).UTC() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := svc.Export(context.Background(), "dpo", "eng-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.Count != 2 || len(b.Detections) != 2 {
+		t.Fatalf("must bundle the engagement's detections: %+v", b)
+	}
+	// Only eng-1's hold is included (eng-2's is filtered out).
+	if len(b.LegalHolds) != 1 || b.LegalHolds[0].EngagementID != "eng-1" {
+		t.Fatalf("must include only this engagement's holds: %+v", b.LegalHolds)
+	}
+	if audit.n != 1 {
+		t.Fatalf("the export must be audited once, got %d", audit.n)
+	}
+}
+
+func TestExportRequiresActorAndEngagement(t *testing.T) {
+	svc, _ := NewService(fakeDetections{}, nil, &fakeAudit{}, func() time.Time { return time.Now() })
+	if _, err := svc.Export(context.Background(), "", "eng-1"); err == nil {
+		t.Fatal("export without an actor must be rejected")
+	}
+	if _, err := svc.Export(context.Background(), "dpo", ""); err == nil {
+		t.Fatal("export without an engagement id must be rejected")
+	}
+}


### PR DESCRIPTION
feat(fleet): privacy data-export (subject-access / DPO bundle) (#594 #635)

Second governance feature of #635 (after legal hold): a read-only, audited data
export for one engagement — the governance data the control plane holds (detection
projection rows + the engagement's active legal holds + a generated-at stamp) — to
answer a data-subject / data-portability request. It mutates nothing; the immutable
evidence chain is untouched (and, being source-side redacted, carries no raw PII).

- usecase/fleet/privacyexport: Export(actor, engagementID) → Bundle; the export is
  itself audited (fleet.privacy.data_export) as a governance access.
- HTTP: GET /api/v1/fleet/engagements/{id}/privacy-export (PermReview), actor + tenant
  server-side.
- cmd: wired alongside legal holds over detectionRecordStore + the legal-hold service.

Tests: bundles the engagement's detections + only its own active holds + audits once;
requires actor + engagement id; handler RBAC (consultant forbidden, reviewer ok) +
scoping + route-absent-when-unwired. build/vet/gofmt/arch clean.

Remaining #635: right-to-erasure, regional residency, encryption-at-rest (child-issue).
