### PR TITLE
feat(fleet): on-demand data deletion / right-to-erasure (#594 #635)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -2010,6 +2010,13 @@ func main() {
 				detectSvc.SetLegalHoldChecker(legalHoldSvc)
 				router.SetLegalHolds(legalHoldSvc)
 				log.Info("legal holds ENABLED (#635): a held engagement's retention-bounded data is preserved until released")
+				// On-demand data deletion / right-to-erasure (#635): destructive (drops the engagement's
+				// detection projection, chain preserved), so it is OPT-IN. The Purge path is still
+				// legal-hold-checked + audited; the env flag only governs whether the HTTP surface exists.
+				if os.Getenv("SYNAPSE_DATA_DELETION_ENABLED") == "true" {
+					router.SetDataPurge(detectSvc)
+					log.Info("on-demand data deletion ENABLED (#635): DELETE /api/v1/fleet/engagements/{id}/detection-data (PermReview, legal-hold-checked)")
+				}
 				// Data-subject / DPO export (#635): a read-only, audited bundle of an engagement's detections
 				// + active legal holds.
 				if exportSvc, xerr := privacyexport.NewService(detectionRecordStore, legalHoldSvc, auditLog, func() time.Time { return clock.Now().UTC() }); xerr != nil {

--- a/internal/adapter/httpapi/data_purge_handler.go
+++ b/internal/adapter/httpapi/data_purge_handler.go
@@ -1,0 +1,41 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// dataPurger performs an on-demand governed deletion of an engagement's detection projection (#635,
+// right-to-erasure). detectledger.Service satisfies it via Purge. The delete is legal-hold-checked,
+// audited with the actor+reason, and never touches the permanent evidence chain — only the queryable
+// projection. Actor + tenant are server-side; the caller supplies only a reason.
+type dataPurger interface {
+	Purge(ctx context.Context, engagementID shared.ID, actor, reason string) (int, error)
+}
+
+// SetDataPurge wires the on-demand data-deletion surface (nil ⇒ the route is not registered).
+func (rt *Router) SetDataPurge(p dataPurger) { rt.dataPurge = p }
+
+type purgeDataRequest struct {
+	Reason string `json:"reason"`
+}
+
+// purgeEngagementData deletes ALL of an engagement's detection projection rows on demand. Destructive
+// and irreversible for the projection (the chain is preserved), so it demands an explicit reason for
+// accountability; a held engagement refuses (fail-closed in the usecase).
+func (rt *Router) purgeEngagementData(w http.ResponseWriter, r *http.Request) {
+	var req purgeDataRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, legalHoldBodyLimit)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
+		return
+	}
+	purged, err := rt.dataPurge.Purge(incidentTenantContext(r), shared.ID(r.PathValue("id")), PrincipalFrom(r.Context()), req.Reason)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"purged": purged})
+}

--- a/internal/adapter/httpapi/data_purge_handler_test.go
+++ b/internal/adapter/httpapi/data_purge_handler_test.go
@@ -1,0 +1,45 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type fakePurger struct {
+	gotActor  string
+	gotEng    shared.ID
+	gotReason string
+}
+
+func (f *fakePurger) Purge(_ context.Context, eng shared.ID, actor, reason string) (int, error) {
+	f.gotActor, f.gotEng, f.gotReason = actor, eng, reason
+	return 2, nil
+}
+
+func TestDataPurgeRBACAndScoping(t *testing.T) {
+	f := &fakePurger{}
+	rt := &Router{log: discardLog(), incidents: &fakeIncidentStore{}, dataPurge: f}
+	mux := rt.routes()
+
+	// consultant cannot purge (destructive governance decision → PermReview).
+	if rec := incidentReq(mux, "consultant", http.MethodDelete, "/api/v1/fleet/engagements/eng-9/detection-data", `{"reason":"erasure"}`); rec.Code != http.StatusForbidden {
+		t.Fatalf("consultant purge must be forbidden, got %d", rec.Code)
+	}
+	rec := incidentReq(mux, "reviewer", http.MethodDelete, "/api/v1/fleet/engagements/eng-9/detection-data", `{"reason":"subject erasure"}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("reviewer purge: got %d (%s)", rec.Code, rec.Body.String())
+	}
+	if f.gotActor != "analyst-1" || f.gotEng != "eng-9" || f.gotReason != "subject erasure" {
+		t.Fatalf("actor/engagement/reason not threaded: actor=%q eng=%q reason=%q", f.gotActor, f.gotEng, f.gotReason)
+	}
+}
+
+func TestDataPurgeAbsentWhenUnwired(t *testing.T) {
+	rt := &Router{log: discardLog(), incidents: &fakeIncidentStore{}}
+	if rec := incidentReq(rt.routes(), "reviewer", http.MethodDelete, "/api/v1/fleet/engagements/e1/detection-data", `{"reason":"x"}`); rec.Code != http.StatusNotFound {
+		t.Fatalf("unwired purge route must 404, got %d", rec.Code)
+	}
+}

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -89,6 +89,7 @@ type Router struct {
 	desiredCapabilities    desiredCapabilityService  // optional; nil ⇒ the desired-vs-observed routes are not registered (#633)
 	legalHolds             legalHoldService          // optional; nil ⇒ the legal-hold routes are not registered (#635)
 	privacyExport          privacyExporter           // optional; nil ⇒ the data-export route is not registered (#635)
+	dataPurge              dataPurger                // optional; nil ⇒ the on-demand data-deletion route is not registered (#635)
 	endpointTimeline       endpointTimelineReader    // optional; nil ⇒ the State-Timeline read route is not registered (#594 B7)
 	retroHunter            retroHunter               // optional; nil ⇒ the retro-hunt route is not registered (#594 B7)
 	sarif                  sarifIngester             // optional; nil ⇒ the third-party SARIF import route is not registered
@@ -457,6 +458,12 @@ func (rt *Router) routes() *http.ServeMux {
 			// Data-subject / DPO export (#635): the governance data the control plane holds for one
 			// engagement (detections + active legal holds). Read-only + audited; a governance read → PermReview.
 			mux.HandleFunc("GET /api/v1/fleet/engagements/{id}/privacy-export", rt.authz(userdom.PermReview, rt.exportEngagementData))
+		}
+		if rt.dataPurge != nil {
+			// On-demand data deletion / right-to-erasure (#635): purge ALL of an engagement's detection
+			// projection now (legal-hold-checked, audited, chain preserved). Destructive + a governance
+			// decision → PermReview; a reason is required. Actor + tenant are server-side.
+			mux.HandleFunc("DELETE /api/v1/fleet/engagements/{id}/detection-data", rt.authz(userdom.PermReview, rt.purgeEngagementData))
 		}
 		if rt.desiredCapabilities != nil {
 			// Desired-vs-observed (#633): declare the capabilities an asset SHOULD have (PermOperate),

--- a/internal/usecase/fleet/detectledger/service.go
+++ b/internal/usecase/fleet/detectledger/service.go
@@ -721,7 +721,7 @@ func (s *Service) deleteExpiredProjections(ctx context.Context, engagementID sha
 	if err := s.audit.RecordOnce(ctx, ports.AuditEntry{
 		Actor: actor, Action: "detection.expired", Target: engagementID.String(), At: s.clock.Now().UTC(),
 		Metadata: map[string]string{
-			"idempotency_key": expiryAuditKey(engagementID, ids, actor, reason),
+			"idempotency_key": deletionAuditKey("detection.expired", engagementID, ids, actor, reason),
 			"engagement":      engagementID.String(), "reason": reason, "expired": fmt.Sprint(len(ids)),
 		},
 	}); err != nil {
@@ -740,9 +740,106 @@ func (s *Service) deleteExpiredProjections(ctx context.Context, engagementID sha
 	return deleted, nil
 }
 
-// expiryAuditKey binds the audit line to the exact expiry set so a retry of the same
-// expiry repairs a missing line, while a later expiry of different detections records its own.
-func expiryAuditKey(engagementID shared.ID, ids []shared.ID, actor, reason string) string {
+// Purge is an on-demand governed deletion of ALL of an engagement's current detection projection
+// rows (#635 data deletion / right-to-erasure). Unlike Expire it is not gated on the retention
+// window — an operator/DPO purges the engagement's queryable data on demand — but it is otherwise
+// the SAME governed removal as retention expiry: legal-hold-checked (a held engagement refuses,
+// fail-closed), audited with the actor+reason BEFORE any row is dropped, provenance-tombstoned when
+// provenance is enabled, and it never touches the permanent hash chain — only the projection is
+// removed. Raw PII never enters that chain (source-side redaction), so purging the projection is
+// the deletion this platform can honestly offer. Returns the count purged.
+func (s *Service) Purge(ctx context.Context, engagementID shared.ID, actor, reason string) (int, error) {
+	if strings.TrimSpace(actor) == "" {
+		return 0, fmt.Errorf("%w: purge must name the actor", shared.ErrValidation)
+	}
+	if strings.TrimSpace(reason) == "" {
+		return 0, fmt.Errorf("%w: purge must carry a reason", shared.ErrValidation)
+	}
+	// Legal hold (#635): a held engagement's data must NOT be deleted, even on an erasure request —
+	// preservation trumps erasure. Fail-closed: a checker error blocks the deletion.
+	if s.holds != nil {
+		held, herr := s.holds.IsHeld(ctx, engagementID)
+		if herr != nil {
+			return 0, fmt.Errorf("legal-hold check before purge: %w", herr)
+		}
+		if held {
+			return 0, fmt.Errorf("%w: engagement %s is under a legal hold; data deletion is suspended", shared.ErrForbidden, engagementID)
+		}
+	}
+
+	recs, err := s.records.ListDetections(ctx, engagementID)
+	if err != nil {
+		return 0, fmt.Errorf("list detections for purge: %w", err)
+	}
+	if len(recs) == 0 {
+		return 0, nil
+	}
+	ids := make([]shared.ID, 0, len(recs))
+	for _, r := range recs {
+		ids = append(ids, r.ID)
+	}
+
+	if s.provenance != nil {
+		tenantID, ok := shared.TenantFrom(ctx)
+		if !ok || tenantID.IsZero() {
+			return 0, fmt.Errorf("%w: provenance purge requires a tenant in context", shared.ErrValidation)
+		}
+		for _, detectionID := range ids {
+			current, found, err := s.provenance.Current(ctx, engagementID, detectionID)
+			if err != nil {
+				return 0, fmt.Errorf("read provenance before purge: %w", err)
+			}
+			if !found {
+				return 0, fmt.Errorf("%w: detection %s has no durable provenance", shared.ErrConflict, detectionID)
+			}
+			if current.Status == detectionprovenance.StatusBroken {
+				return 0, fmt.Errorf("%w: detection %s provenance is broken", shared.ErrConflict, detectionID)
+			}
+			if current.Status != detectionprovenance.StatusExpired {
+				if err := appendProvenance(ctx, s.provenance, tenantID, engagementID, detectionID,
+					detectionprovenance.Expired, detectionprovenance.StatusExpired, current.EvidenceID, reason, s.clock); err != nil {
+					return 0, err
+				}
+			}
+		}
+	}
+	return s.purgeProjections(ctx, engagementID, ids, actor, reason)
+}
+
+// purgeProjections audits the actor+reason (action detection.purged) BEFORE dropping any row, on the
+// same fail-closed contract as deleteExpiredProjections — a failed audit stops the deletion so no
+// unattributable data loss is left behind. The key is derived from the purged set, so an exact retry
+// reuses the same line instead of duplicating it.
+func (s *Service) purgeProjections(ctx context.Context, engagementID shared.ID, ids []shared.ID, actor, reason string) (int, error) {
+	if len(ids) == 0 {
+		return 0, nil
+	}
+	if err := s.audit.RecordOnce(ctx, ports.AuditEntry{
+		Actor: actor, Action: "detection.purged", Target: engagementID.String(), At: s.clock.Now().UTC(),
+		Metadata: map[string]string{
+			"idempotency_key": deletionAuditKey("detection.purged", engagementID, ids, actor, reason),
+			"engagement":      engagementID.String(), "reason": reason, "purged": fmt.Sprint(len(ids)),
+		},
+	}); err != nil {
+		return 0, fmt.Errorf("audit detection purge before deletion: %w", err)
+	}
+	deleted := 0
+	for _, detectionID := range ids {
+		removed, err := s.records.DeleteDetection(ctx, engagementID, detectionID)
+		if err != nil {
+			return deleted, fmt.Errorf("delete detection %s: %w", detectionID, err)
+		}
+		if removed {
+			deleted++
+		}
+	}
+	return deleted, nil
+}
+
+// deletionAuditKey binds the audit line to the exact deletion set (per action) so a retry of the
+// same deletion repairs a missing line, while a later deletion of different detections records its
+// own. The action prefix keeps expiry and purge lines distinct even over an identical set.
+func deletionAuditKey(action string, engagementID shared.ID, ids []shared.ID, actor, reason string) string {
 	sorted := make([]string, 0, len(ids))
 	for _, id := range ids {
 		sorted = append(sorted, id.String())
@@ -753,6 +850,9 @@ func expiryAuditKey(engagementID shared.ID, ids []shared.ID, actor, reason strin
 		_, _ = fmt.Fprintf(h, "%d:", len(value))
 		_, _ = h.Write([]byte(value))
 	}
+	// The action is NOT hashed — the returned key is prefixed with it, which already keeps expiry and
+	// purge lines distinct over an identical set. Keeping it out of the preimage leaves the expiry
+	// digest byte-identical to the pre-refactor key, so a retry straddling a binary upgrade still dedups.
 	write(engagementID.String())
 	write(strings.TrimSpace(actor))
 	write(strings.TrimSpace(reason))
@@ -760,7 +860,7 @@ func expiryAuditKey(engagementID shared.ID, ids []shared.ID, actor, reason strin
 	for _, id := range sorted {
 		write(id)
 	}
-	return "detection.expired:" + engagementID.String() + ":" + hex.EncodeToString(h.Sum(nil))
+	return action + ":" + engagementID.String() + ":" + hex.EncodeToString(h.Sum(nil))
 }
 
 // membership asserts the supplied items are EXACTLY the signed batch membership — a multiset match, so a

--- a/internal/usecase/fleet/detectledger/service_test.go
+++ b/internal/usecase/fleet/detectledger/service_test.go
@@ -1297,14 +1297,14 @@ func TestExpireV2DeletionFailureAfterTombstoneIsResumable(t *testing.T) {
 // the audit and completes the expiry, writing exactly one line for that expiry set.
 func TestExpiryAuditKeyBindsActorReasonAndSet(t *testing.T) {
 	ids := []shared.ID{"d2", "d1"}
-	base := expiryAuditKey("eng-1", ids, "operator", "retention")
-	if got := expiryAuditKey("eng-1", []shared.ID{"d1", "d2"}, "operator", "retention"); got != base {
+	base := deletionAuditKey("detection.expired", "eng-1", ids, "operator", "retention")
+	if got := deletionAuditKey("detection.expired", "eng-1", []shared.ID{"d1", "d2"}, "operator", "retention"); got != base {
 		t.Fatalf("same expiry operation in another set order changed identity: %q != %q", got, base)
 	}
-	if got := expiryAuditKey("eng-1", ids, "other-operator", "retention"); got == base {
+	if got := deletionAuditKey("detection.expired", "eng-1", ids, "other-operator", "retention"); got == base {
 		t.Fatal("expiry operation identity did not bind actor")
 	}
-	if got := expiryAuditKey("eng-1", ids, "operator", "manual cleanup"); got == base {
+	if got := deletionAuditKey("detection.expired", "eng-1", ids, "operator", "manual cleanup"); got == base {
 		t.Fatal("expiry operation identity did not bind reason")
 	}
 }
@@ -1330,7 +1330,7 @@ func TestExpireAuditFailureDeletesNoProjection(t *testing.T) {
 	if err != nil || deleted != 1 {
 		t.Fatalf("expiry retry must repair the audit and delete: deleted=%d err=%v", deleted, err)
 	}
-	key := expiryAuditKey("eng-1", []shared.ID{"d1"}, "operator", "retention")
+	key := deletionAuditKey("detection.expired", "eng-1", []shared.ID{"d1"}, "operator", "retention")
 	if got := h.audit.recordedOnce(key); got != 1 {
 		t.Fatalf("repaired expiry audit lines = %d, want exactly 1", got)
 	}
@@ -1358,5 +1358,56 @@ func TestExpireRefusedUnderLegalHold(t *testing.T) {
 	h.svc.SetLegalHoldChecker(fakeHoldChecker{held: false})
 	if _, err := h.svc.Expire(tctx(), "eng-1", "operator", "retention"); err != nil {
 		t.Fatalf("expiry without a hold must proceed: %v", err)
+	}
+}
+
+// TestPurgeDeletesOnDemandAuditedAndHoldChecked: on-demand deletion (#635, right-to-erasure) drops ALL
+// of an engagement's current detection projection now — not gated on the retention window — but only
+// when named + reasoned, never under a legal hold, and always audited before any row is dropped.
+func TestPurgeDeletesOnDemandAuditedAndHoldChecked(t *testing.T) {
+	h := newHarness(t, 0) // never-expire projection: purge deletes on demand, not via the retention window
+	items := []IngestItem{
+		{ID: "d1", Detection: mkDetection(t, "ps"), AssetID: "asset-1"},
+		{ID: "d2", Detection: mkDetection(t, "ps"), AssetID: "asset-2"},
+	}
+	if _, err := h.svc.Ingest(tctx(), "agent:1", h.signedBatch(t, 1, items), items); err != nil {
+		t.Fatal(err)
+	}
+	// Actor + reason required.
+	if _, err := h.svc.Purge(tctx(), "eng-1", " ", "erasure"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("purge must require an actor, got %v", err)
+	}
+	if _, err := h.svc.Purge(tctx(), "eng-1", "dpo", " "); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("purge must require a reason, got %v", err)
+	}
+	// A held engagement refuses deletion (preservation trumps erasure) — nothing is dropped.
+	h.svc.SetLegalHoldChecker(fakeHoldChecker{held: true})
+	if _, err := h.svc.Purge(tctx(), "eng-1", "dpo", "erasure"); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("purge under a legal hold must be forbidden, got %v", err)
+	}
+	if got, _ := h.svc.ListDetections(tctx(), "eng-1"); len(got) != 2 {
+		t.Fatalf("held engagement must keep all rows, got %d", len(got))
+	}
+	// Release the hold: on-demand purge drops ALL current rows though none are past retention.
+	h.svc.SetLegalHoldChecker(fakeHoldChecker{held: false})
+	n, err := h.svc.Purge(tctx(), "eng-1", "dpo", "subject erasure request")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("purge must drop every current row, got %d", n)
+	}
+	if got, _ := h.svc.ListDetections(tctx(), "eng-1"); len(got) != 0 {
+		t.Fatalf("projection must be empty after purge, got %d", len(got))
+	}
+	if !h.audit.has("detection.purged") {
+		t.Error("purge must be audited (actor + reason), never silent")
+	}
+	if e := h.audit.last["detection.purged"]; e.Actor != "dpo" || e.Metadata["reason"] != "subject erasure request" || e.Metadata["purged"] != "2" {
+		t.Errorf("purge audit must carry actor + reason + count, got %+v", e)
+	}
+	// Nothing left → a second purge is a no-op (not an error).
+	if n, err := h.svc.Purge(tctx(), "eng-1", "dpo", "erasure"); err != nil || n != 0 {
+		t.Fatalf("purge of an empty engagement must be a no-op, got n=%d err=%v", n, err)
 	}
 }


### PR DESCRIPTION
feat(fleet): on-demand data deletion / right-to-erasure (#594 #635)

Third governance feature of #635 (after legal hold + data-export): an on-demand,
governed deletion of ALL of an engagement's detection projection. Unlike the
retention Expire path it is not gated on the retention window — an operator/DPO
purges the engagement's queryable data now, to honour an erasure request — but it
is otherwise the SAME governed removal:

- legal-hold-checked (a held engagement refuses, fail-closed — preservation trumps
  erasure);
- audited (detection.purged) with the actor + reason BEFORE any row is dropped, on
  the same contract as expiry: a failed audit stops the deletion, never silent;
- provenance-tombstoned when provenance is enabled;
- it never touches the permanent hash chain — only the projection. Raw PII never
  enters that chain (source-side redaction), so purging the projection is the
  deletion this platform can honestly offer.

detectledger.Purge(engagementID, actor, reason) → count. Audit key factored to
deletionAuditKey(action, ...) so purge and expiry lines stay distinct over an
identical set. HTTP: DELETE /api/v1/fleet/engagements/{id}/detection-data
(PermReview — destructive governance decision; reason required; actor + tenant
server-side), OPT-IN behind SYNAPSE_DATA_DELETION_ENABLED (default off).

Tests: purge drops every current row on demand, requires actor + reason, refuses
under a legal hold (rows preserved), audits actor+reason+count, empty-engagement
no-op; handler RBAC (consultant forbidden, reviewer ok) + scoping + route-absent-
when-unwired. build/vet/gofmt clean.

Remaining #635: regional data residency, encryption-at-rest (infra-level).
