### PR TITLE
feat(response): telemetry-verified post-condition for governed response (#594 #638)

### DIFF
--- a/internal/domain/response/record.go
+++ b/internal/domain/response/record.go
@@ -27,6 +27,30 @@ func (s State) Valid() bool {
 	}
 }
 
+// Verification is the post-condition axis of a response action: did the action's intended EFFECT
+// actually take hold on the target, confirmed against telemetry? It is SEPARATE from State — a command
+// that was applied (StateApplied) is NOT the same as an effect that was verified (#638). A kill whose
+// syscall returned but whose process is still observed alive is VerificationFailed, not a success; a
+// target with no covering telemetry is VerificationUnknown, never silently a success.
+type Verification string
+
+const (
+	VerificationPending   Verification = ""          // not verified (no verifier wired, or verification not run)
+	VerificationSucceeded Verification = "succeeded" // telemetry confirms the effect took hold
+	VerificationFailed    Verification = "failed"    // the command applied but the effect is NOT present
+	VerificationUnknown   Verification = "unknown"   // insufficient telemetry coverage to confirm or deny
+)
+
+// Valid reports whether v is a known verification outcome.
+func (v Verification) Valid() bool {
+	switch v {
+	case VerificationPending, VerificationSucceeded, VerificationFailed, VerificationUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
 // Record is the persisted state of a response action, including the approval that authorized it (sealed
 // into the evidence chain by the admission gate).
 type Record struct {
@@ -35,6 +59,7 @@ type Record struct {
 	EngagementID       shared.ID
 	Action             Action
 	State              State
+	Verification       Verification // post-condition: was the effect confirmed via telemetry? (#638)
 	ApprovedBy         string
 	ApprovalEvidenceID shared.ID
 	AppliedAt          time.Time

--- a/internal/infrastructure/persistence/postgres/response_repo.go
+++ b/internal/infrastructure/persistence/postgres/response_repo.go
@@ -50,15 +50,15 @@ func (r *ResponseRepository) Put(ctx context.Context, rec rdom.Record) error {
 	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
 		_, err := tx.Exec(ctx, `
 			INSERT INTO response_actions
-			  (tenant_id, id, engagement_id, kind, target, blast_radius, argv, reversal, state, approved_by, approval_evidence_id, applied_at, updated_at)
-			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)
+			  (tenant_id, id, engagement_id, kind, target, blast_radius, argv, reversal, state, approved_by, approval_evidence_id, applied_at, updated_at, verification)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
 			ON CONFLICT (tenant_id, id) DO UPDATE SET
 			  state = EXCLUDED.state, approved_by = EXCLUDED.approved_by,
 			  approval_evidence_id = EXCLUDED.approval_evidence_id, applied_at = EXCLUDED.applied_at,
-			  updated_at = EXCLUDED.updated_at`,
+			  updated_at = EXCLUDED.updated_at, verification = EXCLUDED.verification`,
 			rec.TenantID.String(), rec.ID.String(), rec.EngagementID.String(), string(rec.Action.Kind),
 			rec.Action.Target.String(), string(rec.Action.BlastRadius), argv, reversal, string(rec.State),
-			rec.ApprovedBy, evID, applied, rec.UpdatedAt.UTC())
+			rec.ApprovedBy, evID, applied, rec.UpdatedAt.UTC(), string(rec.Verification))
 		if err != nil {
 			return fmt.Errorf("upsert response action %s: %w", rec.ID, err)
 		}
@@ -72,7 +72,7 @@ func (r *ResponseRepository) Get(ctx context.Context, id shared.ID) (rdom.Record
 	found := false
 	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
 		row := tx.QueryRow(ctx, `
-			SELECT tenant_id, id, engagement_id, kind, target, blast_radius, argv, reversal, state, approved_by, approval_evidence_id, applied_at
+			SELECT tenant_id, id, engagement_id, kind, target, blast_radius, argv, reversal, state, approved_by, approval_evidence_id, applied_at, verification
 			FROM response_actions WHERE id = $1`, id.String())
 		var scanned rdom.Record
 		if err := scanResponse(row, &scanned); err != nil {
@@ -93,7 +93,7 @@ func (r *ResponseRepository) ListByState(ctx context.Context, state rdom.State) 
 	var out []rdom.Record
 	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
 		rows, err := tx.Query(ctx, `
-			SELECT tenant_id, id, engagement_id, kind, target, blast_radius, argv, reversal, state, approved_by, approval_evidence_id, applied_at
+			SELECT tenant_id, id, engagement_id, kind, target, blast_radius, argv, reversal, state, approved_by, approval_evidence_id, applied_at, verification
 			FROM response_actions WHERE state = $1 ORDER BY id ASC`, string(state))
 		if err != nil {
 			return err
@@ -114,11 +114,12 @@ func (r *ResponseRepository) ListByState(ctx context.Context, state rdom.State) 
 func scanResponse(row rowScanner, rec *rdom.Record) error {
 	var (
 		tenant, id, eng, kind, targetStr, radius, state, approvedBy string
+		verification                                                string
 		argv, reversal                                              []byte
 		evID                                                        *string
 		applied                                                     *time.Time
 	)
-	if err := row.Scan(&tenant, &id, &eng, &kind, &targetStr, &radius, &argv, &reversal, &state, &approvedBy, &evID, &applied); err != nil {
+	if err := row.Scan(&tenant, &id, &eng, &kind, &targetStr, &radius, &argv, &reversal, &state, &approvedBy, &evID, &applied, &verification); err != nil {
 		return err
 	}
 	var argvSlice []string
@@ -133,6 +134,7 @@ func scanResponse(row rowScanner, rec *rdom.Record) error {
 	rec.TenantID = shared.ID(tenant)
 	rec.EngagementID = shared.ID(eng)
 	rec.State = rdom.State(state)
+	rec.Verification = rdom.Verification(verification)
 	rec.ApprovedBy = approvedBy
 	if evID != nil {
 		rec.ApprovalEvidenceID = shared.ID(*evID)

--- a/internal/usecase/response/service.go
+++ b/internal/usecase/response/service.go
@@ -60,11 +60,21 @@ type ExecOutcome struct {
 	AlreadyApplied bool
 }
 
+// EffectVerifier confirms, against telemetry, whether an applied action's intended EFFECT actually took
+// hold on the target (#638). It is READ-ONLY — it observes, it never executes anything on the host — so
+// wiring it crosses no execution boundary. `CommandApplied ≠ VerifiedSucceeded`: a kill whose syscall
+// returned but whose process is still observed alive verifies as Failed; a target with no covering
+// telemetry verifies as Unknown, never silently a success. Optional (nil ⇒ verification is not run).
+type EffectVerifier interface {
+	Verify(ctx context.Context, action rdom.Action, target shared.ID) (rdom.Verification, error)
+}
+
 // Record and State are the domain types (domain/response); re-exported as aliases so callers of this
 // usecase package need not import both.
 type (
-	Record = rdom.Record
-	State  = rdom.State
+	Record       = rdom.Record
+	State        = rdom.State
+	Verification = rdom.Verification
 )
 
 const (
@@ -73,15 +83,21 @@ const (
 	StateReverted  = rdom.StateReverted
 	StateCancelled = rdom.StateCancelled
 	StateViolation = rdom.StateViolation
+
+	VerificationPending   = rdom.VerificationPending
+	VerificationSucceeded = rdom.VerificationSucceeded
+	VerificationFailed    = rdom.VerificationFailed
+	VerificationUnknown   = rdom.VerificationUnknown
 )
 
 // Service applies response actions under the shared governance.
 type Service struct {
-	admit admitter
-	exec  Executor
-	store ports.ResponseStore
-	audit ports.AuditLogger
-	clock ports.Clock
+	admit  admitter
+	exec   Executor
+	store  ports.ResponseStore
+	audit  ports.AuditLogger
+	clock  ports.Clock
+	verify EffectVerifier // optional (#638): confirms an applied effect via telemetry; nil ⇒ not run
 }
 
 // NewService validates dependencies.
@@ -90,6 +106,43 @@ func NewService(admit admitter, exec Executor, store ports.ResponseStore, audit 
 		return nil, fmt.Errorf("%w: response service is missing a dependency", shared.ErrValidation)
 	}
 	return &Service{admit: admit, exec: exec, store: store, audit: audit, clock: clock}, nil
+}
+
+// SetEffectVerifier wires the telemetry-verified post-condition (#638). Optional and read-only: when set,
+// an applied action is verified against telemetry and the outcome is recorded on the record + audited;
+// nil leaves Verification as Pending. It never executes anything on the host.
+func (s *Service) SetEffectVerifier(v EffectVerifier) { s.verify = v }
+
+// verified runs the post-condition check on an APPLIED record (when a verifier is wired) and records the
+// outcome on the record + a distinct audit line. `CommandApplied ≠ VerifiedSucceeded`: a Failed outcome
+// means the command ran but the effect is not confirmed — a loud signal the operator must act on. A
+// verifier error is NEVER a silent success: it records Unknown. Read-only; no host side effect.
+func (s *Service) verified(ctx context.Context, rec Record, approver string) Record {
+	if s.verify == nil || rec.State != StateApplied {
+		return rec
+	}
+	v, err := s.verify.Verify(ctx, rec.Action, rec.Action.Target)
+	if err != nil {
+		rec.Verification = VerificationUnknown
+		s.recordAudit(ctx, "response.verification_unknown", approver, rec.Action, map[string]string{"reason": "verifier error"})
+		return rec
+	}
+	// A verifier that RAN must yield a definite outcome: an invalid value, or Pending ("" = "not
+	// verified"), is coerced to Unknown so a verifier that ran is never recorded as un-run and is always
+	// audited. Fail-closed — never a silent success.
+	if !v.Valid() || v == VerificationPending {
+		v = VerificationUnknown
+	}
+	rec.Verification = v
+	switch v {
+	case VerificationSucceeded:
+		s.recordAudit(ctx, "response.verified", approver, rec.Action, nil)
+	case VerificationFailed:
+		s.recordAudit(ctx, "response.verification_failed", approver, rec.Action, nil)
+	case VerificationUnknown:
+		s.recordAudit(ctx, "response.verification_unknown", approver, rec.Action, map[string]string{"reason": "insufficient coverage"})
+	}
+	return rec
 }
 
 // PlanStep is one line of a dry run: the action or reversal that WOULD run, and its argv.
@@ -167,10 +220,11 @@ func (s *Service) Apply(ctx context.Context, engagementID shared.ID, action rdom
 	}
 	if out.AlreadyApplied {
 		rec := s.record(tenantID, engagementID, action, StateApplied, approver, adm.EvidenceID())
+		s.recordAudit(ctx, "response.already_applied", approver, action, nil)
+		rec = s.verified(ctx, rec, approver) // re-verify the effect still holds on an idempotent re-issue
 		if err := s.put(ctx, rec); err != nil {
 			return Record{}, err
 		}
-		s.recordAudit(ctx, "response.already_applied", approver, action, nil)
 		return rec, nil
 	}
 	// Blast radius at EXECUTION: a broader-than-declared radius OR an effect touching more than the single
@@ -185,10 +239,13 @@ func (s *Service) Apply(ctx context.Context, engagementID shared.ID, action rdom
 	}
 
 	rec := s.record(tenantID, engagementID, action, StateApplied, approver, adm.EvidenceID())
+	s.recordAudit(ctx, "response.applied", approver, action, map[string]string{"decided_by": adm.DecidedBy()})
+	// Telemetry-verified post-condition (#638): the command applied — now confirm the EFFECT actually
+	// took hold. CommandApplied ≠ VerifiedSucceeded; the outcome rides on the record + a distinct audit.
+	rec = s.verified(ctx, rec, approver)
 	if err := s.put(ctx, rec); err != nil {
 		return Record{}, err
 	}
-	s.recordAudit(ctx, "response.applied", approver, action, map[string]string{"decided_by": adm.DecidedBy()})
 	return rec, nil
 }
 

--- a/internal/usecase/response/service_test.go
+++ b/internal/usecase/response/service_test.go
@@ -341,3 +341,76 @@ func TestApplyRequiresTenant(t *testing.T) {
 		t.Fatalf("a missing tenant must be refused, got %v", err)
 	}
 }
+
+// ---- #638 telemetry-verified post-condition -------------------------------------------------------
+
+type fakeVerifier struct {
+	outcome rdom.Verification
+	err     error
+	calls   int
+}
+
+func (f *fakeVerifier) Verify(_ context.Context, _ rdom.Action, _ shared.ID) (rdom.Verification, error) {
+	f.calls++
+	return f.outcome, f.err
+}
+
+// TestApplyVerifiesEffectPostCondition is the #638 guarantee: CommandApplied ≠ VerifiedSucceeded. When a
+// verifier is wired, an applied action's EFFECT is confirmed against telemetry — a kill whose process is
+// still observed alive verifies as Failed (not a success), insufficient coverage is Unknown, and a
+// verifier error is never a silent success. The command still counts as applied; verification is a
+// separate axis carried on the record + a distinct audit line, and it is persisted.
+func TestApplyVerifiesEffectPostCondition(t *testing.T) {
+	cases := []struct {
+		name    string
+		outcome rdom.Verification
+		err     error
+		want    rdom.Verification
+		audit   string
+	}{
+		{"succeeded", VerificationSucceeded, nil, VerificationSucceeded, "response.verified"},
+		{"failed_effect_not_present", VerificationFailed, nil, VerificationFailed, "response.verification_failed"},
+		{"unknown_coverage", VerificationUnknown, nil, VerificationUnknown, "response.verification_unknown"},
+		{"verifier_error_is_not_success", VerificationPending, errors.New("telemetry down"), VerificationUnknown, "response.verification_unknown"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHarness(t)
+			vf := &fakeVerifier{outcome: tc.outcome, err: tc.err}
+			h.svc.SetEffectVerifier(vf)
+			rec, err := h.svc.Apply(tctx(), "eng-1", act("a1"), target(), "alice")
+			if err != nil {
+				t.Fatalf("apply: %v", err)
+			}
+			if rec.State != StateApplied {
+				t.Fatalf("the command must still be applied, got state %s", rec.State)
+			}
+			if vf.calls != 1 {
+				t.Fatalf("verifier must run exactly once, got %d", vf.calls)
+			}
+			if rec.Verification != tc.want {
+				t.Fatalf("verification = %q, want %q", rec.Verification, tc.want)
+			}
+			if !h.audit.has(tc.audit) {
+				t.Errorf("expected audit %q", tc.audit)
+			}
+			got, found, _ := h.store.Get(tctx(), "a1")
+			if !found || got.Verification != tc.want {
+				t.Fatalf("persisted verification = %q (found=%v), want %q", got.Verification, found, tc.want)
+			}
+		})
+	}
+}
+
+// TestApplyWithoutVerifierLeavesVerificationPending: with no verifier wired the behaviour is unchanged —
+// the effect is simply not verified (Pending), never a false claim of success.
+func TestApplyWithoutVerifierLeavesVerificationPending(t *testing.T) {
+	h := newHarness(t)
+	rec, err := h.svc.Apply(tctx(), "eng-1", act("a1"), target(), "alice")
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if rec.Verification != VerificationPending {
+		t.Fatalf("no verifier ⇒ verification pending, got %q", rec.Verification)
+	}
+}

--- a/migrations/0128_response_verification.sql
+++ b/migrations/0128_response_verification.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- #638 governed response: the telemetry-verified post-condition axis. A command that was APPLIED
+-- (state='applied') is NOT the same as an effect that was VERIFIED — a kill whose syscall returned but
+-- whose process is still observed alive is verification='failed', not a success. Separate column so the
+-- two axes never collapse. '' = pending/not-verified (default for existing rows).
+ALTER TABLE response_actions ADD COLUMN verification TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE response_actions DROP COLUMN verification;


### PR DESCRIPTION
feat(response): telemetry-verified post-condition for governed response (#594 #638)

#638's EDR-MVP exit bar requires a governed response whose success is proven, not
assumed: **CommandApplied ≠ VerifiedSucceeded**. A kill whose syscall returned but
whose process is still observed alive must read as VerificationFailed, not success;
a target with no covering telemetry must read as VerificationUnknown, never a silent
success. This adds that post-condition axis to the existing governed-response service
WITHOUT touching the execution boundary — the verifier is READ-ONLY (it observes
telemetry, it never runs anything on a host).

- domain/response: `Verification {pending,succeeded,failed,unknown}` as a SEPARATE
  axis on Record (a command being applied is not the same as its effect being
  verified).
- usecase/response: `EffectVerifier` port + optional `SetEffectVerifier`. After an
  action applies, when a verifier is wired, the effect is confirmed and the outcome
  rides on the record + a distinct audit line (response.verified /
  verification_failed / verification_unknown). A verifier error is NEVER a silent
  success — it records Unknown. Re-issue re-verifies (read-only). No verifier wired
  ⇒ Verification stays Pending, behaviour unchanged.
- postgres: migration 0128 adds the `verification` column; repo round-trips it
  (memory store already does, by value).

Golden rules intact: no host execution added (verifier is observe-only), the
admission gate / human-approver / argv-only / kill-switch paths are untouched, every
outcome audited. The concrete telemetry-backed verifier + the full saga states
(fingerprint / reversibility class) remain follow-up slices; the real host executor
stays deliberately unwired (that crosses the execution boundary and needs durable
authorization).

Tests: succeeded/failed/unknown/verifier-error each set the right Verification +
audit + persist; no-verifier leaves Pending; command still applied in all cases.
build/vet/gofmt clean.
