### PR TITLE
feat(response): end-to-end governed-response loop via simulation executor (#594 #638)

### DIFF
--- a/internal/domain/response/action.go
+++ b/internal/domain/response/action.go
@@ -12,6 +12,7 @@ package response
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -59,6 +60,30 @@ type Action struct {
 	BlastRadius offensivepolicy.Radius
 	Argv        []string // argv-only; no shell
 	Reversal    ReversalSpec
+}
+
+// NewAction builds a complete, valid action for a kind + target from the catalogue: the argv-only
+// command, the catalogued blast radius, and the mandatory reversal. It is the single constructor callers
+// (the HTTP surface, the agent proposer) use so an action can never be assembled with a bogus argv or a
+// mismatched reversal — Validate is run before returning. The argv verb is derived from the kind
+// (isolate_host → "isolate-host"), matching the agent-response CLI contract.
+func NewAction(id shared.ID, kind Kind, target shared.ID) (Action, error) {
+	spec, ok := SpecFor(kind)
+	if !ok {
+		return Action{}, fmt.Errorf("%w: unknown response kind %q", shared.ErrValidation, kind)
+	}
+	a := Action{
+		ID:          id,
+		Kind:        kind,
+		Target:      target,
+		BlastRadius: spec.Radius,
+		Argv:        []string{"synapse-agent-response", strings.ReplaceAll(string(kind), "_", "-"), target.String()},
+		Reversal:    spec.Reversal,
+	}
+	if err := a.Validate(); err != nil {
+		return Action{}, err
+	}
+	return a, nil
 }
 
 // Validate fails CLOSED: a missing reversal, empty argv, a shell metacharacter, an unknown kind, or an

--- a/internal/usecase/response/e2e_test.go
+++ b/internal/usecase/response/e2e_test.go
@@ -1,0 +1,143 @@
+package response
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	rdom "github.com/KKloudTarus/synapse-ce/internal/domain/response"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/approval"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/execution"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/safety"
+)
+
+// fakeEngRepo returns one in-scope, authorized engagement for every id — enough to drive the REAL
+// admission gate (guard + approval + evidence) in this end-to-end test.
+type fakeEngRepo struct{ eng *engagement.Engagement }
+
+func (f *fakeEngRepo) Create(context.Context, *engagement.Engagement) error { return nil }
+func (f *fakeEngRepo) Update(context.Context, *engagement.Engagement) error { return nil }
+func (f *fakeEngRepo) Delete(context.Context, shared.ID) error              { return nil }
+func (f *fakeEngRepo) GetByID(context.Context, shared.ID) (*engagement.Engagement, error) {
+	return f.eng, nil
+}
+func (f *fakeEngRepo) GetByIDInTenant(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error) {
+	return f.eng, nil
+}
+func (*fakeEngRepo) GetByProjectID(context.Context, shared.ID, shared.ID) (*engagement.Engagement, error) {
+	return nil, shared.ErrNotFound
+}
+func (*fakeEngRepo) ProjectContexts(context.Context, shared.ID, []shared.ID) (map[shared.ID]*engagement.Engagement, error) {
+	return map[shared.ID]*engagement.Engagement{}, nil
+}
+func (*fakeEngRepo) List(context.Context, shared.ID) ([]*engagement.Engagement, error) {
+	return nil, nil
+}
+
+// stillAliveVerifier simulates a telemetry check that finds the target's process STILL RUNNING after the
+// stop command applied — the canonical #638 case where CommandApplied ≠ VerifiedSucceeded.
+type stillAliveVerifier struct{ calls int }
+
+func (v *stillAliveVerifier) Verify(context.Context, rdom.Action, shared.ID) (rdom.Verification, error) {
+	v.calls++
+	return rdom.VerificationFailed, nil
+}
+
+type e2eIDs struct{ n int }
+
+func (g *e2eIDs) NewID() shared.ID { g.n++; return shared.ID("ev-" + string(rune('0'+g.n))) }
+
+func e2eEngagement(now time.Time) *engagement.Engagement {
+	e, _ := engagement.New(shared.ID("eng-1"), shared.ID("t1"), "Acme", "Acme", now)
+	from, to := now.Add(-time.Hour), now.Add(time.Hour)
+	_ = e.SetAuthorizationWindow(&from, &to, "UTC", now)
+	e.Scope = engagement.Scope{InScope: []engagement.Target{{Kind: engagement.TargetDomain, Value: "app.acme.io"}}}
+	return e
+}
+
+// TestGovernedResponseEndToEnd drives the FULL governed-response loop through the REAL admission gate and
+// a SIMULATION executor (no host is ever touched): propose → manual approval suspends it → a human
+// approves → admit → simulated execute → telemetry-verified post-condition. It proves the golden-rule
+// path end-to-end — nothing executes without a HUMAN approval and an in-scope target — and it proves the
+// #638 invariant: the command records as APPLIED while the effect verifies as FAILED (the process is
+// still alive), so CommandApplied is never silently read as success. No real host executor exists; the
+// simulation executor stands in so the whole loop is exercisable safely.
+func TestGovernedResponseEndToEnd(t *testing.T) {
+	now := time.Unix(1_000_000, 0).UTC()
+	clock := fixedClock{t: now}
+	audit := &fakeAudit{}
+	ctx := tctx()
+
+	guard, err := execution.NewGuard(&fakeEngRepo{eng: e2eEngagement(now)}, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	appr, err := approval.NewService(memory.NewApprovalStore(), audit, clock, agent.ModeManual, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev, err := evidence.NewService(memory.NewEvidenceStore(), nil, audit, clock, &e2eIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	gate, err := safety.NewGate(guard, appr, ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc, err := NewService(gate, SimulationExecutor{}, memory.NewResponseStore(), audit, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier := &stillAliveVerifier{}
+	svc.SetEffectVerifier(verifier)
+
+	action, err := rdom.NewAction("resp-1", rdom.KindStopProcess, "app.acme.io")
+	if err != nil {
+		t.Fatalf("build action: %v", err)
+	}
+	target := engagement.Target{Kind: engagement.TargetDomain, Value: "app.acme.io"}
+
+	// 1) Manual mode: the FIRST apply suspends — nothing executes without a human decision.
+	if _, err := svc.Apply(ctx, "eng-1", action, target, "alice"); !errors.Is(err, safety.ErrPendingApproval) {
+		t.Fatalf("unapproved apply must suspend with ErrPendingApproval, got %v", err)
+	}
+	if verifier.calls != 0 {
+		t.Fatal("nothing may be verified before the action is admitted+executed")
+	}
+
+	// 2) A HUMAN approves (a machine never could — enforced elsewhere; here bob is the human approver).
+	if _, err := appr.Decide(ctx, "bob", action.ID, true, "confirmed malicious process"); err != nil {
+		t.Fatalf("human approve: %v", err)
+	}
+
+	// 3) Re-apply: admitted → simulated execute → verified. The command APPLIED; the effect FAILED
+	//    verification (process still alive) — the #638 invariant, end-to-end.
+	rec, err := svc.Apply(ctx, "eng-1", action, target, "alice")
+	if err != nil {
+		t.Fatalf("approved apply must proceed: %v", err)
+	}
+	if rec.State != StateApplied {
+		t.Fatalf("the command must record applied, got %s", rec.State)
+	}
+	if rec.Verification != VerificationFailed {
+		t.Fatalf("CommandApplied != VerifiedSucceeded: want verification failed, got %q", rec.Verification)
+	}
+	if verifier.calls != 1 {
+		t.Fatalf("the post-condition must be verified exactly once, got %d", verifier.calls)
+	}
+	if !audit.has("response.applied") || !audit.has("response.verification_failed") {
+		t.Error("the applied action + its failed verification must both be audited")
+	}
+
+	// 4) Out-of-scope target is refused by the gate FIRST — no approval can widen scope.
+	oos, _ := rdom.NewAction("resp-2", rdom.KindStopProcess, "evil.example.com")
+	if _, err := svc.Apply(ctx, "eng-1", oos, engagement.Target{Kind: engagement.TargetDomain, Value: "evil.example.com"}, "alice"); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("out-of-scope response must be forbidden, got %v", err)
+	}
+}

--- a/internal/usecase/response/simulation.go
+++ b/internal/usecase/response/simulation.go
@@ -1,0 +1,23 @@
+package response
+
+import "context"
+
+// SimulationExecutor is an Executor that EXECUTES NOTHING on any host. It exists so the full governed
+// response loop — admission gate → human approval → execute → telemetry-verified post-condition (#638) —
+// can be wired and exercised end-to-end WITHOUT crossing the execution-safety boundary. It reports a
+// benign, single-target, in-radius outcome so a simulated action records as cleanly applied; it never
+// signals AlreadyApplied, so idempotency is exercised by the ledger, not faked here.
+//
+// A REAL host executor is DELIBERATELY not provided. Running argv on a live endpoint is a hard-to-reverse
+// outward action (Golden Rule 1/4): it must go through the same argv-only sandbox as every other tool,
+// and wiring it requires a distinct execution-safety review plus explicit operator authorization. Until
+// then the simulation executor keeps the governed loop honest and testable without ever touching a host.
+type SimulationExecutor struct{}
+
+var _ Executor = SimulationExecutor{}
+
+// Execute performs no host action. It echoes the declared radius as the observed radius (so the
+// blast-radius guard sees no violation) and reports a single affected entity (the one declared target).
+func (SimulationExecutor) Execute(_ context.Context, req ExecRequest) (ExecOutcome, error) {
+	return ExecOutcome{ObservedRadius: req.Declared, AffectedCount: 1, AlreadyApplied: false}, nil
+}


### PR DESCRIPTION
feat(response): end-to-end governed-response loop via simulation executor (#594 #638)

Makes #638's governed-response loop exercisable END-TO-END without crossing the
execution-safety boundary. The response service was fully built (#425) but had no
executor implementation and was driven only through a fake admitter — the real-gate
path had never been exercised. This adds:

- domain/response.NewAction(id, kind, target): the single constructor that builds a
  complete, valid action (argv-only command + catalogued blast radius + mandatory
  reversal) from a kind + target, so an action can never be assembled with a bogus
  argv or a mismatched reversal.
- usecase/response.SimulationExecutor: an Executor that EXECUTES NOTHING on any host.
  It lets the whole loop (admission gate -> human approval -> execute -> verified
  post-condition) run and be tested safely. A REAL host executor is deliberately NOT
  provided: running argv on a live endpoint is a hard-to-reverse outward action
  (Golden Rule 1/4) that needs a distinct execution-safety review + explicit operator
  authorization before it may be wired.
- an e2e test that drives the loop through the REAL admission gate (guard + approval
  + evidence) + the simulation executor + the #638 verifier: an unapproved apply
  suspends (ErrPendingApproval, nothing executes); a HUMAN approves; the re-apply is
  admitted, simulated, and the effect is verified — proving the #638 invariant
  end-to-end: the command records APPLIED while the effect verifies FAILED (the
  process is still alive), so CommandApplied is never silently a success; an
  out-of-scope target is refused first.

Golden rules intact: no host execution added (the executor is a no-op stand-in), the
admission gate / human-approver / argv-only / kill-switch paths are unchanged, every
step audited. build/vet/gofmt + the usecase-does-not-import-infrastructure arch
tripwire all clean.
