### PR TITLE
feat(web): EDR incidents analyst surface + fix judgment proposed_by mapping

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25,6 +25,8 @@ const CodeQualityProject = lazy(() => import('./pages/CodeQuality/CodeQualityPro
 const QualityGates = lazy(() => import('./pages/CodeQuality/QualityGates').then(m => ({ default: m.QualityGates })))
 const QualityProfiles = lazy(() => import('./pages/CodeQuality/QualityProfiles').then(m => ({ default: m.QualityProfiles })))
 const FleetCoverage = lazy(() => import('./pages/Fleet/FleetCoverage').then(m => ({ default: m.FleetCoverage })))
+const Incidents = lazy(() => import('./pages/Fleet/Incidents').then(m => ({ default: m.Incidents })))
+const IncidentDetail = lazy(() => import('./pages/Fleet/IncidentDetail').then(m => ({ default: m.IncidentDetail })))
 const Rules = lazy(() => import('./pages/Rules/index'))
 const RuleDetail = lazy(() => import('./pages/Rules/RuleDetail'))
 const Audit = lazy(() => import('./pages/Settings/Audit').then(m => ({ default: m.Audit })))
@@ -86,6 +88,8 @@ function Gate() {
         </Route>
         <Route path="fleet" element={<FleetCoverage />} />
         <Route path="fleet/agents" element={<Navigate to="/fleet" replace />} />
+        <Route path="fleet/incidents" element={<Incidents />} />
+        <Route path="fleet/incidents/:id" element={<IncidentDetail />} />
         <Route path="rules" element={<Rules />} />
         <Route path="rules/:key" element={<RuleDetail />} />
         <Route path="settings" element={<Settings />}>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 import {
   Activity,
+  AlertTriangle,
   BarChartSquare02,
   BookClosed,
   CheckDone01,
@@ -70,6 +71,7 @@ const NAV_GROUPS: Array<{
       label: 'Runtime security',
       items: [
         { icon: Server01, label: 'Fleet', to: '/fleet' },
+        { icon: AlertTriangle, label: 'Incidents', to: '/fleet/incidents' },
         { icon: Activity, label: 'Automation Observability', to: '/ai-triage/observability' },
       ],
     },

--- a/web/src/components/synapse/VirtualTable.tsx
+++ b/web/src/components/synapse/VirtualTable.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { useRef, type ReactNode } from 'react'
+import { useRef, type KeyboardEvent, type ReactNode } from 'react'
 import { cn } from '../ui'
 
 export interface Column<T> {
@@ -21,6 +21,7 @@ export function VirtualTable<T>({
   headerClassName,
   rowClassName,
   totalItems,
+  onRowClick,
 }: {
   columns: Column<T>[]
   items: T[]
@@ -31,6 +32,8 @@ export function VirtualTable<T>({
   headerClassName?: string
   rowClassName?: string | ((item: T) => string)
   totalItems?: number
+  /** When set, each row is clickable (and keyboard-activatable) and invokes this with the row item. */
+  onRowClick?: (item: T) => void
 }) {
   const parentRef = useRef<HTMLDivElement>(null)
   const v = useVirtualizer({
@@ -90,8 +93,22 @@ export function VirtualTable<T>({
                 key={rowKey(item, vi.index)}
                 role="row"
                 aria-rowindex={vi.index + 2}
+                {...(onRowClick
+                  ? {
+                      tabIndex: 0,
+                      onClick: () => onRowClick(item),
+                      onKeyDown: (e: KeyboardEvent) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          onRowClick(item)
+                        }
+                      },
+                    }
+                  : {})}
                 className={cn(
                   'absolute left-0 top-0 flex w-full items-center gap-3 border-b border-border/60 px-4 text-sm hover:bg-elevated/40',
+                  onRowClick &&
+                    'cursor-pointer focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-brand',
                   typeof rowClassName === 'function' ? rowClassName(item) : rowClassName,
                 )}
                 style={{ height: `${vi.size}px`, transform: `translateY(${vi.start}px)` }}

--- a/web/src/components/synapse/VirtualTable.tsx
+++ b/web/src/components/synapse/VirtualTable.tsx
@@ -22,6 +22,7 @@ export function VirtualTable<T>({
   rowClassName,
   totalItems,
   onRowClick,
+  rowAriaLabel,
 }: {
   columns: Column<T>[]
   items: T[]
@@ -34,6 +35,8 @@ export function VirtualTable<T>({
   totalItems?: number
   /** When set, each row is clickable (and keyboard-activatable) and invokes this with the row item. */
   onRowClick?: (item: T) => void
+  /** Accessible label for a clickable row (screen-reader cue that it activates). Used only with onRowClick. */
+  rowAriaLabel?: (item: T) => string
 }) {
   const parentRef = useRef<HTMLDivElement>(null)
   const v = useVirtualizer({
@@ -96,6 +99,7 @@ export function VirtualTable<T>({
                 {...(onRowClick
                   ? {
                       tabIndex: 0,
+                      'aria-label': rowAriaLabel?.(item),
                       onClick: () => onRowClick(item),
                       onKeyDown: (e: KeyboardEvent) => {
                         if (e.key === 'Enter' || e.key === ' ') {

--- a/web/src/lib/api.dashboard.test.ts
+++ b/web/src/lib/api.dashboard.test.ts
@@ -43,3 +43,26 @@ describe('dashboardSecurityOperations', () => {
     expect(fetchSpy).toHaveBeenCalledWith('/api/v1/dashboard/security-operations?range=90d', expect.any(Object))
   })
 })
+
+describe('judgments mapping', () => {
+  let fetchSpy: any
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  // judgment.Judgment is untagged PascalCase EXCEPT ProposedBy, which carries `json:"proposed_by"`.
+  // Reading r.ProposedBy silently blanked the attribution; this pins the snake_case read.
+  it('reads the snake_case proposed_by attribution the backend actually emits', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ judgments: [{ ID: 'j1', Capability: 'reachability', State: 'proposed', proposed_by: 'agent:planner' }] }),
+    } as unknown as Response)
+
+    const [j] = await api.judgments('eng-1')
+
+    expect(j.proposedBy).toBe('agent:planner')
+    expect(j.capability).toBe('reachability')
+  })
+})

--- a/web/src/lib/api.incidents.test.ts
+++ b/web/src/lib/api.incidents.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { api } from './api'
+
+// The incident + timeline handlers serialize the Go domain structs with NO json tags, so the wire
+// shape is PascalCase. These tests pin that mapping — a backend field rename (or a frontend regression
+// back to snake_case) would surface here instead of silently blanking the analyst view.
+describe('incidents API mapping', () => {
+  let fetchSpy: any
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  function respond(body: unknown, status = 200) {
+    fetchSpy.mockResolvedValueOnce({ ok: status < 400, status, json: async () => body } as unknown as Response)
+  }
+
+  it('maps the PascalCase incident list into the camelCase view', async () => {
+    respond({
+      incidents: [
+        {
+          ID: 'inc-1',
+          AssetID: 'asset-1',
+          Title: 'Suspicious beacon',
+          Severity: 'high',
+          State: 'open',
+          Disposition: 'unknown',
+          OwnerID: 'analyst-1',
+          DetectionIDs: ['det-1', 'det-2'],
+          Risk: {
+            AssessmentID: 'ra-1',
+            Risk: 88,
+            Confidence: 61,
+            Coverage: 43,
+            CoverageVector: { Process: 90, Network: 40, File: 0, Privilege: 0, Reasons: ['no_file_sensor'] },
+            FactorContributions: [{ Factor: 'threat', Points: 50, Detail: 'beacon' }],
+            ReasonCodes: ['beacon_confirmed'],
+            CreatedAt: '2026-08-30T00:00:00Z',
+          },
+          Comments: [{ At: '2026-08-30T01:00:00Z', Actor: 'analyst-1', Text: 'looking' }],
+          Responses: [{ ActionID: 'act-1', Verified: true }],
+          Revision: 3,
+          CreatedAt: '2026-08-30T00:00:00Z',
+          UpdatedAt: '2026-08-30T02:00:00Z',
+        },
+      ],
+      truncated: true,
+    })
+
+    const res = await api.listIncidents({ state: 'open', limit: 50 })
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/v1/fleet/incidents?state=open&limit=50', expect.any(Object))
+    expect(res.truncated).toBe(true)
+    const inc = res.incidents[0]
+    expect(inc.id).toBe('inc-1')
+    expect(inc.title).toBe('Suspicious beacon')
+    expect(inc.severity).toBe('high')
+    expect(inc.state).toBe('open')
+    expect(inc.ownerId).toBe('analyst-1')
+    expect(inc.detectionIds).toEqual(['det-1', 'det-2'])
+    // The tri-score axes are independent — a low coverage must survive the mapping, not collapse.
+    expect(inc.risk?.risk).toBe(88)
+    expect(inc.risk?.confidence).toBe(61)
+    expect(inc.risk?.coverage).toBe(43)
+    expect(inc.risk?.coverageVector.process).toBe(90)
+    expect(inc.risk?.coverageVector.reasons).toEqual(['no_file_sensor'])
+    expect(inc.risk?.factorContributions[0]).toEqual({ factor: 'threat', points: 50, detail: 'beacon' })
+    expect(inc.comments[0]).toEqual({ at: '2026-08-30T01:00:00Z', actor: 'analyst-1', text: 'looking' })
+    expect(inc.responses[0]).toEqual({ actionId: 'act-1', verified: true })
+  })
+
+  it('tolerates a null Risk (an unscored incident) without throwing', async () => {
+    respond({ incidents: [{ ID: 'inc-2', Title: 'x', Risk: null }], truncated: false })
+    const res = await api.listIncidents()
+    expect(res.incidents[0].risk).toBeNull()
+    expect(res.incidents[0].detectionIds).toEqual([])
+  })
+
+  it('posts analyst mutations with the exact request bodies the handlers expect', async () => {
+    respond({ ID: 'inc-1', State: 'triaged' })
+    await api.changeIncidentStatus('inc-1', 'triaged')
+    expect(fetchSpy.mock.calls[0][0]).toBe('/api/v1/fleet/incidents/inc-1/status')
+    expect(JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string)).toEqual({ to: 'triaged' })
+
+    respond({ ID: 'inc-1', Disposition: 'false_positive' })
+    await api.setIncidentDisposition('inc-1', 'false_positive')
+    expect(fetchSpy.mock.calls[1][0]).toBe('/api/v1/fleet/incidents/inc-1/disposition')
+    expect(JSON.parse((fetchSpy.mock.calls[1][1] as RequestInit).body as string)).toEqual({ disposition: 'false_positive' })
+
+    respond({ ID: 'inc-1' })
+    await api.commentIncident('inc-1', 'note')
+    expect(JSON.parse((fetchSpy.mock.calls[2][1] as RequestInit).body as string)).toEqual({ text: 'note' })
+
+    respond({ ID: 'inc-1' })
+    await api.assignIncidentOwner('inc-1', 'analyst-2')
+    expect(JSON.parse((fetchSpy.mock.calls[3][1] as RequestInit).body as string)).toEqual({ owner: 'analyst-2' })
+  })
+
+  it('maps the PascalCase State Timeline entries', async () => {
+    respond({
+      entries: [
+        { OccurredAt: '2026-08-30T00:00:00Z', AssetID: 'asset-1', EntityKind: 'process', EntityID: 'p1', Kind: 'process_start', EventID: 'e1', Summary: 'nginx started' },
+      ],
+    })
+
+    const entries = await api.assetTimeline('asset-1', { limit: 100 })
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/v1/fleet/assets/asset-1/timeline?limit=100', expect.any(Object))
+    expect(entries[0]).toEqual({
+      occurredAt: '2026-08-30T00:00:00Z',
+      assetId: 'asset-1',
+      entityKind: 'process',
+      entityId: 'p1',
+      kind: 'process_start',
+      eventId: 'e1',
+      summary: 'nginx started',
+    })
+  })
+})

--- a/web/src/lib/api/dashboard.ts
+++ b/web/src/lib/api/dashboard.ts
@@ -35,7 +35,9 @@ function mapJudgment(r: any): Judgment {
     subjectId: r.SubjectID ?? '',
     state: (r.State ?? 'proposed') as Judgment['state'],
     evidenceScore: r.EvidenceScore ?? 0,
-    proposedBy: r.ProposedBy ?? '',
+    // judgment.Judgment tags ProposedBy as `json:"proposed_by"` (the rest of the struct is untagged
+    // PascalCase), so read the snake_case key — reading r.ProposedBy silently blanked the attribution.
+    proposedBy: r.proposed_by ?? '',
     version: r.Version ?? 0,
     claim: r.Claim ?? {},
   }

--- a/web/src/lib/api/incidents.ts
+++ b/web/src/lib/api/incidents.ts
@@ -1,0 +1,169 @@
+import type {
+  Incident,
+  IncidentComment,
+  IncidentDisposition,
+  IncidentList,
+  IncidentResponseRef,
+  IncidentRisk,
+  IncidentState,
+  RiskCoverageVector,
+  RiskFactorContribution,
+  Severity,
+  TimelineEntry,
+} from '../types'
+import { req } from './client'
+
+// The backend serializes incident.Incident, its RiskAssessment, and endpoint.TimelineEntry with Go
+// field names (PascalCase — no json tags), so every mapper below reads PascalCase keys. Keeping the
+// mapping in one place means a backend rename surfaces here, not silently as blank cells across the UI.
+
+function mapCoverageVector(raw: any): RiskCoverageVector {
+  return {
+    process: raw?.Process ?? 0,
+    network: raw?.Network ?? 0,
+    file: raw?.File ?? 0,
+    privilege: raw?.Privilege ?? 0,
+    reasons: Array.isArray(raw?.Reasons) ? raw.Reasons : [],
+  }
+}
+
+function mapFactorContribution(raw: any): RiskFactorContribution {
+  return {
+    factor: raw?.Factor ?? '',
+    points: raw?.Points ?? 0,
+    detail: raw?.Detail ?? '',
+  }
+}
+
+function mapRisk(raw: any): IncidentRisk | null {
+  if (!raw) return null
+  return {
+    assessmentId: raw?.AssessmentID ?? '',
+    incidentRevision: raw?.IncidentRevision ?? 0,
+    scorerVersion: raw?.ScorerVersion ?? '',
+    policyVersion: raw?.PolicyVersion ?? '',
+    risk: raw?.Risk ?? 0,
+    confidence: raw?.Confidence ?? 0,
+    coverage: raw?.Coverage ?? 0,
+    coverageVector: mapCoverageVector(raw?.CoverageVector),
+    factorContributions: Array.isArray(raw?.FactorContributions)
+      ? raw.FactorContributions.map(mapFactorContribution)
+      : [],
+    reasonCodes: Array.isArray(raw?.ReasonCodes) ? raw.ReasonCodes : [],
+    createdAt: raw?.CreatedAt ?? '',
+  }
+}
+
+function mapComment(raw: any): IncidentComment {
+  return { at: raw?.At ?? '', actor: raw?.Actor ?? '', text: raw?.Text ?? '' }
+}
+
+function mapResponseRef(raw: any): IncidentResponseRef {
+  return { actionId: raw?.ActionID ?? '', verified: Boolean(raw?.Verified) }
+}
+
+function mapIncident(raw: any): Incident {
+  return {
+    id: raw?.ID ?? '',
+    assetId: raw?.AssetID ?? '',
+    title: raw?.Title ?? '',
+    severity: (raw?.Severity ?? 'unknown') as Severity,
+    state: (raw?.State ?? 'new') as IncidentState,
+    disposition: (raw?.Disposition ?? 'unknown') as IncidentDisposition,
+    ownerId: raw?.OwnerID ?? '',
+    detectionIds: Array.isArray(raw?.DetectionIDs) ? raw.DetectionIDs : [],
+    risk: mapRisk(raw?.Risk),
+    mergedInto: raw?.MergedInto ?? '',
+    comments: Array.isArray(raw?.Comments) ? raw.Comments.map(mapComment) : [],
+    responses: Array.isArray(raw?.Responses) ? raw.Responses.map(mapResponseRef) : [],
+    revision: raw?.Revision ?? 0,
+    createdAt: raw?.CreatedAt ?? '',
+    updatedAt: raw?.UpdatedAt ?? '',
+  }
+}
+
+function mapTimelineEntry(raw: any): TimelineEntry {
+  return {
+    occurredAt: raw?.OccurredAt ?? '',
+    assetId: raw?.AssetID ?? '',
+    entityKind: raw?.EntityKind ?? '',
+    entityId: raw?.EntityID ?? '',
+    kind: raw?.Kind ?? '',
+    eventId: raw?.EventID ?? '',
+    summary: raw?.Summary ?? '',
+  }
+}
+
+export interface ListIncidentsOptions {
+  asset?: string
+  state?: IncidentState
+  limit?: number
+}
+
+export const incidentsApi = {
+  listIncidents: async (opts: ListIncidentsOptions = {}): Promise<IncidentList> => {
+    const q = new URLSearchParams()
+    if (opts.asset) q.set('asset', opts.asset)
+    if (opts.state) q.set('state', opts.state)
+    if (opts.limit) q.set('limit', String(opts.limit))
+    const qs = q.toString()
+    const res = await req(`/fleet/incidents${qs ? `?${qs}` : ''}`)
+    return {
+      incidents: Array.isArray(res?.incidents) ? res.incidents.map(mapIncident) : [],
+      truncated: Boolean(res?.truncated),
+    }
+  },
+
+  getIncident: async (id: string): Promise<Incident> =>
+    mapIncident(await req(`/fleet/incidents/${encodeURIComponent(id)}`)),
+
+  assignIncidentOwner: async (id: string, owner: string): Promise<Incident> =>
+    mapIncident(
+      await req(`/fleet/incidents/${encodeURIComponent(id)}/owner`, {
+        method: 'POST',
+        body: JSON.stringify({ owner }),
+      }),
+    ),
+
+  commentIncident: async (id: string, text: string): Promise<Incident> =>
+    mapIncident(
+      await req(`/fleet/incidents/${encodeURIComponent(id)}/comments`, {
+        method: 'POST',
+        body: JSON.stringify({ text }),
+      }),
+    ),
+
+  changeIncidentStatus: async (id: string, to: IncidentState): Promise<Incident> =>
+    mapIncident(
+      await req(`/fleet/incidents/${encodeURIComponent(id)}/status`, {
+        method: 'POST',
+        body: JSON.stringify({ to }),
+      }),
+    ),
+
+  setIncidentDisposition: async (id: string, disposition: IncidentDisposition): Promise<Incident> =>
+    mapIncident(
+      await req(`/fleet/incidents/${encodeURIComponent(id)}/disposition`, {
+        method: 'POST',
+        body: JSON.stringify({ disposition }),
+      }),
+    ),
+
+  reassessIncidentRisk: async (id: string): Promise<Incident> =>
+    mapIncident(
+      await req(`/fleet/incidents/${encodeURIComponent(id)}/risk/reassess`, { method: 'POST' }),
+    ),
+
+  assetTimeline: async (
+    assetId: string,
+    opts: { from?: string; to?: string; limit?: number } = {},
+  ): Promise<TimelineEntry[]> => {
+    const q = new URLSearchParams()
+    if (opts.from) q.set('from', opts.from)
+    if (opts.to) q.set('to', opts.to)
+    if (opts.limit) q.set('limit', String(opts.limit))
+    const qs = q.toString()
+    const res = await req(`/fleet/assets/${encodeURIComponent(assetId)}/timeline${qs ? `?${qs}` : ''}`)
+    return Array.isArray(res?.entries) ? res.entries.map(mapTimelineEntry) : []
+  },
+}

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -17,6 +17,7 @@ import { agentApi } from './agent'
 import { codeQualityApi } from './code-quality'
 import { rulesApi } from './rules'
 import { fleetApi } from './fleet'
+import { incidentsApi } from './incidents'
 import { assetsApi } from './assets'
 import { vulnerabilityApi } from './vulnerability'
 import { aiTriageApi } from './ai-triage'
@@ -45,6 +46,7 @@ export const api = {
   ...codeQualityApi,
   ...rulesApi,
   ...fleetApi,
+  ...incidentsApi,
   ...assetsApi,
   ...vulnerabilityApi,
   ...aiTriageApi,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1480,6 +1480,104 @@ export interface FleetCoverageSummary {
   assetsWithoutAgent: number
 }
 
+// ---- EDR incidents · tri-score risk · State Timeline (#594 C1/C3/C5/C7, B7) ----
+// The backend serializes incident.Incident and endpoint.TimelineEntry with Go field names
+// (PascalCase, no json tags), so the api client maps those verbatim into these camelCase views.
+
+export type IncidentState =
+  | 'new'
+  | 'open'
+  | 'triaged'
+  | 'investigating'
+  | 'contained'
+  | 'remediated'
+  | 'resolved'
+  | 'closed'
+  | 'reopened'
+
+export type IncidentDisposition =
+  | 'unknown'
+  | 'true_positive'
+  | 'benign_positive'
+  | 'false_positive'
+  | 'duplicate'
+  | 'test'
+
+// Risk/Confidence/Coverage are the three independent tri-score axes (0..100). Coverage is a vector
+// across the endpoint classes; a missing class lowers Coverage, never Risk (#594 C3).
+export interface RiskCoverageVector {
+  process: number
+  network: number
+  file: number
+  privilege: number
+  reasons: string[]
+}
+
+export interface RiskFactorContribution {
+  factor: string
+  points: number
+  detail: string
+}
+
+export interface IncidentRisk {
+  assessmentId: string
+  incidentRevision: number
+  scorerVersion: string
+  policyVersion: string
+  risk: number
+  confidence: number
+  coverage: number
+  coverageVector: RiskCoverageVector
+  factorContributions: RiskFactorContribution[]
+  reasonCodes: string[]
+  createdAt: string
+}
+
+export interface IncidentComment {
+  at: string
+  actor: string
+  text: string
+}
+
+export interface IncidentResponseRef {
+  actionId: string
+  verified: boolean
+}
+
+export interface Incident {
+  id: string
+  assetId: string
+  title: string
+  severity: Severity
+  state: IncidentState
+  disposition: IncidentDisposition
+  ownerId: string
+  detectionIds: string[]
+  risk: IncidentRisk | null
+  mergedInto: string
+  comments: IncidentComment[]
+  responses: IncidentResponseRef[]
+  revision: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface IncidentList {
+  incidents: Incident[]
+  truncated: boolean
+}
+
+// State Timeline entry — the per-asset event-time projection of accepted telemetry (#594 B7).
+export interface TimelineEntry {
+  occurredAt: string
+  assetId: string
+  entityKind: string
+  entityId: string
+  kind: string
+  eventId: string
+  summary: string
+}
+
 export interface DashboardTrendPoint {
   date: string
   counts: Record<string, number>

--- a/web/src/pages/Fleet/FleetCoverage.tsx
+++ b/web/src/pages/Fleet/FleetCoverage.tsx
@@ -153,7 +153,7 @@ export function AgentsSection() {
               className={cn(
                 'rounded-md px-2 py-1 text-xs font-semibold transition-colors',
                 filter === f.value
-                  ? 'bg-brand-primary text-brand-secondary'
+                  ? 'bg-brand-solid text-primary_on-brand'
                   : 'text-tertiary hover:bg-secondary'
               )}
             >

--- a/web/src/pages/Fleet/IncidentDetail.tsx
+++ b/web/src/pages/Fleet/IncidentDetail.tsx
@@ -1,0 +1,378 @@
+import { useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { ArrowLeft, ClockRewind, RefreshCw01 } from '@untitledui/icons'
+import { api } from '../../lib/api'
+import type { CurrentUser, Incident, IncidentDisposition, IncidentState } from '../../lib/types'
+import { Button, Card, EmptyState, ErrorState, Field, Input, Pill, SevBadge, Select, Spinner, cn } from '../../components/ui'
+import { useFetch, useMutation } from '../../hooks'
+import { formatFleetTime } from './fleetShared'
+import {
+  IncidentDispositionBadge,
+  IncidentStateBadge,
+  INCIDENT_DISPOSITION_OPTIONS,
+  INCIDENT_STATE_OPTIONS,
+  ScoreBar,
+  incidentDispositionLabel,
+  incidentStateLabel,
+} from './incidentShared'
+
+// Client-side control gating mirrors the backend RBAC matrix (authoritative check stays server-side;
+// this only hides controls a role can't use). Triage = owner/status/comment; Review = disposition;
+// Operate = risk reassess.
+const TRIAGE_ROLES = ['admin', 'consultant', 'member', 'reviewer']
+const REVIEW_ROLES = ['admin', 'reviewer']
+const OPERATE_ROLES = ['admin', 'consultant', 'member']
+
+export function IncidentDetail() {
+  const { id = '' } = useParams()
+  const { data: me } = useFetch<CurrentUser | null>(() => api.me().catch(() => null), { deps: [] })
+  const { data: incident, loading, error, refetch } = useFetch<Incident>(() => api.getIncident(id), { deps: [id] })
+
+  const role = me?.role ?? ''
+  const canTriage = TRIAGE_ROLES.includes(role)
+  const canReview = REVIEW_ROLES.includes(role)
+  const canOperate = OPERATE_ROLES.includes(role)
+
+  if (loading && !incident) return <div className="p-8"><Spinner label="Loading incident…" /></div>
+  if (error && !incident)
+    return (
+      <div className="mx-auto max-w-3xl space-y-4 p-4">
+        <BackLink />
+        <ErrorState message={error} />
+        <Button variant="secondary" onClick={refetch}>Retry</Button>
+      </div>
+    )
+  if (!incident) return null
+
+  return (
+    <div className="mx-auto max-w-[1400px] animate-fade-in space-y-6 pb-12">
+      <BackLink />
+
+      <header className="space-y-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-2xl font-bold tracking-tight text-primary">{incident.title || incident.id}</h1>
+          <SevBadge sev={incident.severity} />
+          <IncidentStateBadge state={incident.state} />
+          <IncidentDispositionBadge disposition={incident.disposition} />
+        </div>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-tertiary">
+          <span className="font-mono">{incident.id}</span>
+          <span>· Asset <span className="font-mono text-secondary">{incident.assetId || '—'}</span></span>
+          <span>· Owner <span className="text-secondary">{incident.ownerId || 'unassigned'}</span></span>
+          <span>· Rev {incident.revision}</span>
+          <span>· Updated {formatFleetTime(incident.updatedAt)}</span>
+        </div>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_360px]">
+        <div className="space-y-6">
+          <RiskPanel incident={incident} canOperate={canOperate} onReassessed={refetch} />
+          <DetectionsCard incident={incident} />
+          <ResponsesCard incident={incident} />
+          <CommentsCard incident={incident} />
+          <AssetTimelineCard assetId={incident.assetId} />
+        </div>
+
+        <aside className="space-y-6">
+          <AnalystActions
+            incident={incident}
+            canTriage={canTriage}
+            canReview={canReview}
+            onChanged={refetch}
+          />
+        </aside>
+      </div>
+    </div>
+  )
+}
+
+function BackLink() {
+  return (
+    <Link to="/fleet/incidents" className="inline-flex items-center gap-1.5 text-sm text-tertiary hover:text-primary">
+      <ArrowLeft className="size-4" /> Incidents
+    </Link>
+  )
+}
+
+function RiskPanel({ incident, canOperate, onReassessed }: { incident: Incident; canOperate: boolean; onReassessed: () => void }) {
+  const { mutate, loading, error } = useMutation(() => api.reassessIncidentRisk(incident.id), { onSuccess: onReassessed })
+  const risk = incident.risk
+
+  return (
+    <Card
+      title="Tri-score risk"
+      actions={
+        canOperate ? (
+          <Button variant="secondary" className="px-2.5 py-1 text-xs" loading={loading} onClick={() => mutate(undefined)}>
+            <RefreshCw01 className="size-4" /> Reassess
+          </Button>
+        ) : undefined
+      }
+    >
+      {error && <div className="mb-3"><ErrorState message={error} /></div>}
+      {!risk ? (
+        <p className="text-sm text-tertiary">
+          Not yet scored. {canOperate ? 'Run a reassessment to gather this incident’s factors.' : 'An operator can run a reassessment.'}
+        </p>
+      ) : (
+        <div className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-3">
+            <ScoreBar label="Risk" value={risk.risk} tone="risk" hint="Escalation — from Threat/Exposure/Behavior factors only" />
+            <ScoreBar label="Confidence" value={risk.confidence} hint="Evidence strength; bounded by coverage" />
+            <ScoreBar label="Coverage" value={risk.coverage} hint="Telemetry completeness — never lowers Risk" />
+          </div>
+
+          <div>
+            <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-tertiary">Coverage by class</div>
+            <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 sm:grid-cols-4">
+              {([['Process', risk.coverageVector.process], ['Network', risk.coverageVector.network], ['File', risk.coverageVector.file], ['Privilege', risk.coverageVector.privilege]] as const).map(
+                ([label, v]) => (
+                  <div key={label} className="flex items-center justify-between rounded-md bg-secondary px-2 py-1">
+                    <span className="text-xs text-tertiary">{label}</span>
+                    <span className="font-mono text-xs font-semibold tabular-nums text-primary">{v}</span>
+                  </div>
+                ),
+              )}
+            </div>
+          </div>
+
+          {risk.factorContributions.length > 0 && (
+            <div>
+              <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-wide text-tertiary">Factor contributions</div>
+              <div className="space-y-1">
+                {risk.factorContributions.map((f, i) => (
+                  <div key={`${f.factor}:${i}`} className="flex items-center gap-2 text-xs">
+                    <span className="w-24 shrink-0 font-medium text-secondary">{f.factor}</span>
+                    <span className="font-mono tabular-nums text-primary">+{f.points}</span>
+                    <span className="truncate text-tertiary" title={f.detail}>{f.detail}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {risk.reasonCodes.length > 0 && (
+            <div className="flex flex-wrap gap-1.5">
+              {risk.reasonCodes.map((c) => (
+                <Pill key={c}>{c}</Pill>
+              ))}
+            </div>
+          )}
+
+          <div className="text-[11px] text-quaternary">
+            scorer {risk.scorerVersion || '—'} · policy {risk.policyVersion || '—'} · rev {risk.incidentRevision} · {formatFleetTime(risk.createdAt)}
+          </div>
+        </div>
+      )}
+    </Card>
+  )
+}
+
+function DetectionsCard({ incident }: { incident: Incident }) {
+  return (
+    <Card title={`Detections (${incident.detectionIds.length})`}>
+      {incident.detectionIds.length === 0 ? (
+        <p className="text-sm text-tertiary">No detections attached.</p>
+      ) : (
+        <div className="flex flex-wrap gap-1.5">
+          {incident.detectionIds.map((d) => (
+            <span key={d} className="rounded-md bg-secondary px-2 py-1 font-mono text-xs text-secondary" title={d}>{d}</span>
+          ))}
+        </div>
+      )}
+    </Card>
+  )
+}
+
+function ResponsesCard({ incident }: { incident: Incident }) {
+  if (incident.responses.length === 0) return null
+  return (
+    <Card title={`Governed responses (${incident.responses.length})`}>
+      <div className="space-y-1.5">
+        {incident.responses.map((r) => (
+          <div key={r.actionId} className="flex items-center gap-2 text-sm">
+            <span className="font-mono text-xs text-secondary">{r.actionId}</span>
+            <span
+              className={cn(
+                'inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-semibold ring-1 ring-inset',
+                r.verified ? 'bg-accent/10 text-accent ring-accent/30' : 'bg-medium/10 text-medium ring-medium/30',
+              )}
+            >
+              {r.verified ? 'Verified' : 'Applied — unverified'}
+            </span>
+          </div>
+        ))}
+      </div>
+    </Card>
+  )
+}
+
+function CommentsCard({ incident }: { incident: Incident }) {
+  return (
+    <Card title={`Comments (${incident.comments.length})`}>
+      {incident.comments.length === 0 ? (
+        <p className="text-sm text-tertiary">No comments yet.</p>
+      ) : (
+        <ul className="space-y-3">
+          {incident.comments.map((c, i) => (
+            <li key={`${c.at}:${i}`} className="text-sm">
+              <div className="flex items-center gap-2 text-xs text-tertiary">
+                <span className="font-medium text-secondary">{c.actor || 'unknown'}</span>
+                <span>{formatFleetTime(c.at)}</span>
+              </div>
+              <p className="mt-0.5 whitespace-pre-wrap text-primary">{c.text}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  )
+}
+
+function AssetTimelineCard({ assetId }: { assetId: string }) {
+  const [open, setOpen] = useState(false)
+  const { data, loading, error } = useFetch(() => api.assetTimeline(assetId, { limit: 100 }), {
+    enabled: open && !!assetId,
+    deps: [assetId, open],
+  })
+
+  return (
+    <Card
+      title="Asset State Timeline"
+      actions={
+        <Button variant="secondary" className="px-2.5 py-1 text-xs" onClick={() => setOpen((v) => !v)} disabled={!assetId}>
+          <ClockRewind className="size-4" /> {open ? 'Hide' : 'Show'}
+        </Button>
+      }
+    >
+      {!assetId ? (
+        <p className="text-sm text-tertiary">No asset associated.</p>
+      ) : !open ? (
+        <p className="text-sm text-tertiary">The event-time timeline of accepted telemetry for this asset.</p>
+      ) : loading ? (
+        <Spinner className="size-4" />
+      ) : error ? (
+        <ErrorState message={error} />
+      ) : !data || data.length === 0 ? (
+        <EmptyState icon={ClockRewind} title="No timeline entries" hint="No accepted telemetry projected for this asset yet." />
+      ) : (
+        <ol className="relative space-y-3 border-l border-secondary pl-4">
+          {data.map((e) => (
+            <li key={e.eventId} className="relative">
+              <span className="absolute -left-[21px] top-1.5 size-2 rounded-full bg-brand-solid ring-2 ring-primary" />
+              <div className="flex flex-wrap items-baseline gap-x-2 text-xs text-tertiary">
+                <span className="font-mono text-[11px] tabular-nums">{formatFleetTime(e.occurredAt)}</span>
+                <span className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[10px] uppercase text-secondary">{e.kind}</span>
+                <span className="font-mono text-[11px]">{e.entityKind}</span>
+              </div>
+              <p className="mt-0.5 text-sm text-primary">{e.summary}</p>
+            </li>
+          ))}
+        </ol>
+      )}
+    </Card>
+  )
+}
+
+function AnalystActions({
+  incident,
+  canTriage,
+  canReview,
+  onChanged,
+}: {
+  incident: Incident
+  canTriage: boolean
+  canReview: boolean
+  onChanged: () => void
+}) {
+  const [comment, setComment] = useState('')
+  const [owner, setOwner] = useState('')
+
+  const status = useMutation((to: IncidentState) => api.changeIncidentStatus(incident.id, to), { onSuccess: onChanged })
+  const disposition = useMutation((d: IncidentDisposition) => api.setIncidentDisposition(incident.id, d), { onSuccess: onChanged })
+  const assignOwner = useMutation((o: string) => api.assignIncidentOwner(incident.id, o), {
+    onSuccess: () => { setOwner(''); onChanged() },
+  })
+  const addComment = useMutation((t: string) => api.commentIncident(incident.id, t), {
+    onSuccess: () => { setComment(''); onChanged() },
+  })
+
+  const actionError = status.error || disposition.error || assignOwner.error || addComment.error
+  const busy = status.loading || disposition.loading || assignOwner.loading || addComment.loading
+
+  if (!canTriage && !canReview) {
+    return (
+      <Card title="Analyst actions">
+        <p className="text-sm text-tertiary">Triage or review permission is required to act on this incident.</p>
+      </Card>
+    )
+  }
+
+  return (
+    <Card title="Analyst actions">
+      <div className="space-y-4">
+        {actionError && <ErrorState message={actionError} />}
+
+        {canTriage && (
+          <Field label="Status">
+            <Select
+              value={incident.state}
+              onValueChange={(v) => status.mutate(v as IncidentState)}
+              options={INCIDENT_STATE_OPTIONS.map((s) => ({ value: s, label: incidentStateLabel(s) }))}
+              ariaLabel="Change incident status"
+              disabled={busy}
+            />
+          </Field>
+        )}
+
+        {canReview && (
+          <Field label="Disposition" hint="Analyst verdict — requires review permission.">
+            <Select
+              value={incident.disposition}
+              onValueChange={(v) => disposition.mutate(v as IncidentDisposition)}
+              options={INCIDENT_DISPOSITION_OPTIONS.map((d) => ({ value: d, label: incidentDispositionLabel(d) }))}
+              ariaLabel="Set incident disposition"
+              disabled={busy}
+            />
+          </Field>
+        )}
+
+        {canTriage && (
+          <>
+            <Field label="Assign owner">
+              <div className="flex gap-2">
+                <Input
+                  value={owner}
+                  onChange={(e) => setOwner(e.target.value)}
+                  placeholder={incident.ownerId || 'user id'}
+                  disabled={busy}
+                />
+                <Button variant="secondary" disabled={!owner.trim() || busy} loading={assignOwner.loading} onClick={() => assignOwner.mutate(owner.trim())}>
+                  Assign
+                </Button>
+              </div>
+            </Field>
+
+            <Field label="Add comment">
+              <textarea
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                rows={3}
+                placeholder="Investigation note…"
+                disabled={busy}
+                className="input-inset w-full rounded-lg border border-secondary bg-secondary px-3 py-2 text-sm text-primary placeholder:text-quaternary focus-visible:border-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40"
+              />
+              <div className="mt-2 flex justify-end">
+                <Button variant="secondary" disabled={!comment.trim() || busy} loading={addComment.loading} onClick={() => addComment.mutate(comment.trim())}>
+                  Comment
+                </Button>
+              </div>
+            </Field>
+          </>
+        )}
+      </div>
+    </Card>
+  )
+}
+
+export default IncidentDetail

--- a/web/src/pages/Fleet/IncidentDetail.tsx
+++ b/web/src/pages/Fleet/IncidentDetail.tsx
@@ -88,7 +88,10 @@ export function IncidentDetail() {
 
 function BackLink() {
   return (
-    <Link to="/fleet/incidents" className="inline-flex items-center gap-1.5 text-sm text-tertiary hover:text-primary">
+    <Link
+      to="/fleet/incidents"
+      className="inline-flex items-center gap-1.5 rounded-md text-sm text-tertiary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+    >
       <ArrowLeft className="size-4" /> Incidents
     </Link>
   )

--- a/web/src/pages/Fleet/Incidents.tsx
+++ b/web/src/pages/Fleet/Incidents.tsx
@@ -109,7 +109,7 @@ export function Incidents() {
                   onClick={() => setFilter(f.value)}
                   className={cn(
                     'rounded-md px-2 py-1 text-xs font-semibold transition-colors',
-                    filter === f.value ? 'bg-brand-primary text-brand-secondary' : 'text-tertiary hover:bg-secondary',
+                    filter === f.value ? 'bg-brand-solid text-primary_on-brand' : 'text-tertiary hover:bg-secondary',
                   )}
                 >
                   {f.label}
@@ -126,6 +126,7 @@ export function Incidents() {
               columns={COLUMNS}
               rowKey={(r) => r.id}
               onRowClick={(r) => navigate(`/fleet/incidents/${encodeURIComponent(r.id)}`)}
+              rowAriaLabel={(r) => `Open incident ${r.title || r.id}`}
               maxHeightClass="max-h-[70vh]"
               tableMinWidthClass="min-w-[72rem]"
             />

--- a/web/src/pages/Fleet/Incidents.tsx
+++ b/web/src/pages/Fleet/Incidents.tsx
@@ -1,0 +1,147 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { AlertTriangle } from '@untitledui/icons'
+import { api } from '../../lib/api'
+import type { Incident, IncidentState } from '../../lib/types'
+import { Button, Card, EmptyState, ErrorState, SevBadge, Spinner, cn } from '../../components/ui'
+import { VirtualTable, type Column } from '../../components/synapse/VirtualTable'
+import { useFetch } from '../../hooks'
+import { formatFleetTime } from './fleetShared'
+import { IncidentDispositionBadge, IncidentStateBadge, INCIDENT_STATE_OPTIONS, incidentStateLabel } from './incidentShared'
+
+const PAGE_LIMIT = 200
+
+type StateFilter = 'all' | IncidentState
+
+function riskCell(inc: Incident) {
+  if (!inc.risk) return <span className="text-quaternary">—</span>
+  const r = inc.risk.risk
+  const tone = r >= 75 ? 'text-critical' : r >= 50 ? 'text-high' : r >= 25 ? 'text-medium' : 'text-tertiary'
+  return (
+    <span className={cn('font-mono text-sm font-semibold tabular-nums', tone)} title={`Confidence ${inc.risk.confidence} · Coverage ${inc.risk.coverage}`}>
+      {r}
+    </span>
+  )
+}
+
+const COLUMNS: Column<Incident>[] = [
+  {
+    header: 'Title',
+    className: 'flex-1 min-w-0',
+    cell: (r) => (
+      <div className="min-w-0">
+        <div className="truncate text-primary" title={r.title}>{r.title || r.id}</div>
+        <div className="truncate font-mono text-[11px] text-quaternary" title={r.id}>{r.id}</div>
+      </div>
+    ),
+  },
+  {
+    header: 'Asset',
+    className: 'w-40',
+    cell: (r) => <span className="font-mono text-[12px] text-tertiary" title={r.assetId}>{r.assetId || '—'}</span>,
+  },
+  {
+    header: 'Severity',
+    className: 'w-28',
+    cell: (r) => <SevBadge sev={r.severity} />,
+  },
+  {
+    header: 'State',
+    className: 'w-36',
+    cell: (r) => <IncidentStateBadge state={r.state} />,
+  },
+  {
+    header: 'Disposition',
+    className: 'w-40',
+    cell: (r) => <IncidentDispositionBadge disposition={r.disposition} />,
+  },
+  {
+    header: 'Risk',
+    className: 'w-20 text-right',
+    cell: riskCell,
+  },
+  {
+    header: 'Updated',
+    className: 'w-44 tabular-nums',
+    cell: (r) => <span className="text-tertiary" title={r.updatedAt}>{formatFleetTime(r.updatedAt)}</span>,
+  },
+]
+
+const FILTERS: { value: StateFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  ...INCIDENT_STATE_OPTIONS.map((s) => ({ value: s, label: incidentStateLabel(s) })),
+]
+
+export function Incidents() {
+  const navigate = useNavigate()
+  const [filter, setFilter] = useState<StateFilter>('all')
+  const { data, loading, error, refetch } = useFetch(
+    () => api.listIncidents({ state: filter === 'all' ? undefined : filter, limit: PAGE_LIMIT }),
+    { deps: [filter] },
+  )
+
+  const rows = data?.incidents ?? null
+
+  return (
+    <div className="mx-auto max-w-[1600px] animate-fade-in space-y-6 pb-12">
+      <header>
+        <h1 className="text-2xl font-bold tracking-tight text-primary sm:text-display-xs">Incidents</h1>
+        <p className="mt-1 text-sm text-tertiary">
+          Correlated runtime detections, tri-scored (Risk · Confidence · Coverage) and dispositioned by an analyst.
+        </p>
+      </header>
+
+      {error ? (
+        <div className="space-y-3">
+          <ErrorState message={error} />
+          <Button variant="secondary" onClick={refetch}>Retry</Button>
+        </div>
+      ) : (
+        <Card
+          title={`Incidents${rows ? ` (${rows.length}${data?.truncated ? '+' : ''})` : ''}`}
+          bodyClass="p-0"
+          actions={
+            <div className="flex flex-wrap gap-1">
+              {FILTERS.map((f) => (
+                <button
+                  key={f.value}
+                  type="button"
+                  onClick={() => setFilter(f.value)}
+                  className={cn(
+                    'rounded-md px-2 py-1 text-xs font-semibold transition-colors',
+                    filter === f.value ? 'bg-brand-primary text-brand-secondary' : 'text-tertiary hover:bg-secondary',
+                  )}
+                >
+                  {f.label}
+                </button>
+              ))}
+            </div>
+          }
+        >
+          {loading && !rows ? (
+            <div className="px-4 py-6"><Spinner label="Loading incidents…" /></div>
+          ) : rows && rows.length > 0 ? (
+            <VirtualTable
+              items={rows}
+              columns={COLUMNS}
+              rowKey={(r) => r.id}
+              onRowClick={(r) => navigate(`/fleet/incidents/${encodeURIComponent(r.id)}`)}
+              maxHeightClass="max-h-[70vh]"
+              tableMinWidthClass="min-w-[72rem]"
+            />
+          ) : (
+            <div className="p-6">
+              <EmptyState
+                icon={AlertTriangle}
+                title={filter === 'all' ? 'No incidents' : `No ${incidentStateLabel(filter as IncidentState).toLowerCase()} incidents`}
+                hint="Incidents appear once runtime detections are correlated for an engagement."
+              />
+            </div>
+          )}
+        </Card>
+      )}
+    </div>
+  )
+}
+
+export default Incidents

--- a/web/src/pages/Fleet/incidentShared.tsx
+++ b/web/src/pages/Fleet/incidentShared.tsx
@@ -119,7 +119,12 @@ export function ScoreBar({
         <span className="font-mono text-sm font-semibold tabular-nums text-primary">{pct}</span>
       </div>
       <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-secondary">
-        <div className={cn('h-full rounded-full transition-all', barColor)} style={{ width: `${pct}%` }} />
+        {/* Grow via scaleX (a transform), not width, so the animation stays on the compositor and
+            honours prefers-reduced-motion like the rest of the app's bars. */}
+        <div
+          className={cn('h-full w-full origin-left rounded-full transition-transform', barColor)}
+          style={{ transform: `scaleX(${pct / 100})` }}
+        />
       </div>
     </div>
   )

--- a/web/src/pages/Fleet/incidentShared.tsx
+++ b/web/src/pages/Fleet/incidentShared.tsx
@@ -1,0 +1,126 @@
+import { cn } from '../../components/ui'
+import type { IncidentDisposition, IncidentState } from '../../lib/types'
+
+interface BadgeStyle {
+  label: string
+  soft: string
+  dot: string
+}
+
+// Incident lifecycle states. Open/new/reopened read as "needs attention" (warm), the working states
+// as info/progress, and the terminal states as muted — never green-by-default, mirroring the fleet
+// coverage rule that an unresolved estate must not look calm.
+const STATE_STYLE: Record<IncidentState, BadgeStyle> = {
+  new: { label: 'New', soft: 'bg-high/10 text-high ring-high/30', dot: 'bg-high' },
+  open: { label: 'Open', soft: 'bg-high/10 text-high ring-high/30', dot: 'bg-high' },
+  reopened: { label: 'Reopened', soft: 'bg-high/10 text-high ring-high/30', dot: 'bg-high' },
+  triaged: { label: 'Triaged', soft: 'bg-info/10 text-info ring-info/30', dot: 'bg-info' },
+  investigating: { label: 'Investigating', soft: 'bg-info/10 text-info ring-info/30', dot: 'bg-info' },
+  contained: { label: 'Contained', soft: 'bg-medium/10 text-medium ring-medium/30', dot: 'bg-medium' },
+  remediated: { label: 'Remediated', soft: 'bg-medium/10 text-medium ring-medium/30', dot: 'bg-medium' },
+  resolved: { label: 'Resolved', soft: 'bg-accent/10 text-accent ring-accent/30', dot: 'bg-accent' },
+  closed: { label: 'Closed', soft: 'bg-secondary text-tertiary ring-secondary', dot: 'bg-quaternary' },
+}
+
+// Analyst verdict. true_positive = confirmed real (critical hue); false_positive/benign/duplicate/test
+// = not a real threat (muted); unknown = undecided.
+const DISPOSITION_STYLE: Record<IncidentDisposition, BadgeStyle> = {
+  unknown: { label: 'Undecided', soft: 'bg-secondary text-tertiary ring-secondary', dot: 'bg-quaternary' },
+  true_positive: { label: 'True positive', soft: 'bg-critical/10 text-critical ring-critical/30', dot: 'bg-critical' },
+  benign_positive: { label: 'Benign', soft: 'bg-info/10 text-info ring-info/30', dot: 'bg-info' },
+  false_positive: { label: 'False positive', soft: 'bg-accent/10 text-accent ring-accent/30', dot: 'bg-accent' },
+  duplicate: { label: 'Duplicate', soft: 'bg-secondary text-tertiary ring-secondary', dot: 'bg-quaternary' },
+  test: { label: 'Test', soft: 'bg-secondary text-tertiary ring-secondary', dot: 'bg-quaternary' },
+}
+
+const FALLBACK: BadgeStyle = { label: 'Unknown', soft: 'bg-secondary text-tertiary ring-secondary', dot: 'bg-quaternary' }
+
+function Badge({ style, raw }: { style: BadgeStyle | undefined; raw: string }) {
+  const s = style ?? { ...FALLBACK, label: raw || FALLBACK.label }
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-md px-2 py-0.5 text-xs font-semibold ring-1 ring-inset',
+        s.soft,
+      )}
+    >
+      <span className={cn('size-1.5 rounded-full', s.dot)} />
+      {s.label}
+    </span>
+  )
+}
+
+export function IncidentStateBadge({ state }: { state: IncidentState }) {
+  return <Badge style={STATE_STYLE[state]} raw={state} />
+}
+
+export function IncidentDispositionBadge({ disposition }: { disposition: IncidentDisposition }) {
+  return <Badge style={DISPOSITION_STYLE[disposition]} raw={disposition} />
+}
+
+export function incidentStateLabel(state: IncidentState): string {
+  return STATE_STYLE[state]?.label ?? state
+}
+
+export function incidentDispositionLabel(d: IncidentDisposition): string {
+  return DISPOSITION_STYLE[d]?.label ?? d
+}
+
+// Selectable option lists for the analyst controls, in the order an analyst walks a case.
+export const INCIDENT_STATE_OPTIONS: IncidentState[] = [
+  'new',
+  'open',
+  'triaged',
+  'investigating',
+  'contained',
+  'remediated',
+  'resolved',
+  'closed',
+  'reopened',
+]
+
+export const INCIDENT_DISPOSITION_OPTIONS: IncidentDisposition[] = [
+  'unknown',
+  'true_positive',
+  'benign_positive',
+  'false_positive',
+  'duplicate',
+  'test',
+]
+
+// A 0..100 tri-score axis rendered as a labelled bar. Risk is the escalation axis (warm), while
+// Confidence and Coverage are neutral — a low Coverage must read as "we saw less", not "less risk".
+export function ScoreBar({
+  label,
+  value,
+  tone = 'neutral',
+  hint,
+}: {
+  label: string
+  value: number
+  tone?: 'risk' | 'neutral'
+  hint?: string
+}) {
+  const pct = Math.max(0, Math.min(100, value))
+  const barColor =
+    tone === 'risk'
+      ? pct >= 75
+        ? 'bg-critical'
+        : pct >= 50
+          ? 'bg-high'
+          : pct >= 25
+            ? 'bg-medium'
+            : 'bg-accent'
+      : 'bg-brand-solid'
+  return (
+    <div title={hint}>
+      <div className="flex items-baseline justify-between">
+        <span className="text-xs font-semibold uppercase tracking-wide text-tertiary">{label}</span>
+        <span className="font-mono text-sm font-semibold tabular-nums text-primary">{pct}</span>
+      </div>
+      <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-secondary">
+        <div className={cn('h-full rounded-full transition-all', barColor)} style={{ width: `${pct}%` }} />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
feat(web): EDR incidents analyst surface + fix judgment proposed_by mapping

Two things, from a full frontend↔backend API-mapping verification pass.

1. FIX (mapping bug): dashboard.ts mapJudgment read `r.ProposedBy`, but
   judgment.Judgment tags that one field `json:"proposed_by"` (the rest of the
   struct is untagged PascalCase). The "proposed by" attribution on every AI
   judgment rendered blank. Now reads the snake_case key; regression test added.

2. NEW UI (was missing entirely): the whole EDR incident surface the backend
   exposes under /api/v1/fleet — incidents list + detail, tri-score risk,
   analyst triage, and the per-asset State Timeline — had no api client and no
   page. Added, following the existing Fleet style (Card/VirtualTable/useFetch/
   design tokens, PascalCase→camelCase mapping centralized in one client):

   - lib/api/incidents.ts: list/get incidents, status/disposition/owner/comment
     mutations, risk reassess, and asset State Timeline. incident.Incident and
     endpoint.TimelineEntry serialize with Go field names (no json tags), so the
     mappers read PascalCase verbatim.
   - types.ts: Incident, IncidentState, IncidentDisposition, IncidentRisk (the
     three independent tri-score axes + coverage vector), TimelineEntry.
   - pages/Fleet/Incidents.tsx: virtualized, state-filtered list; row → detail.
   - pages/Fleet/IncidentDetail.tsx: tri-score panel (Risk/Confidence/Coverage —
     coverage shown as its own axis, never folded into Risk) with an operator
     Reassess; analyst actions (status/disposition/owner/comment) gated to mirror
     the backend RBAC matrix (Triage/Review/Operate); comments, governed-response
     refs, detections, and the lazy-loaded asset State Timeline.
   - incidentShared.tsx: state/disposition badges + ScoreBar (non-green-by-default,
     matching the fleet-coverage honesty rule).
   - VirtualTable: optional, backward-compatible onRowClick (keyboard-activatable).
   - App.tsx routes /fleet/incidents[/:id]; Sidebar adds Incidents under Runtime
     security.

Verified: web typecheck clean, 368 tests pass (incl. new incidents mapping +
proposed_by regression tests), production build succeeds.
