### PR TITLE
feat(web): surface desired-vs-observed capability gaps on the Fleet page (#633)

### DIFF
--- a/web/src/lib/api.fleet.test.ts
+++ b/web/src/lib/api.fleet.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { api } from './api'
+
+describe('fleet desired-capability gaps mapping (#633)', () => {
+  let fetchSpy: any
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  function respond(body: unknown, status = 200) {
+    fetchSpy.mockResolvedValueOnce({ ok: status < 400, status, json: async () => body } as unknown as Response)
+  }
+
+  // ReconciliationRow is snake_case-tagged; this pins the field reads.
+  it('maps the snake_case gap rows into the camelCase view', async () => {
+    respond({
+      gaps: [
+        {
+          asset_id: 'asset-1',
+          capability: 'edr.process',
+          covered: false,
+          agent_id: 'agent-2',
+          agent_health: 'stale',
+          gap_reason: 'no_agent',
+          detail: 'no agent advertises this capability',
+          last_seen: '2026-08-30T00:00:00Z',
+        },
+      ],
+    })
+
+    const gaps = await api.fleetDesiredGaps()
+
+    expect(fetchSpy).toHaveBeenCalledWith('/api/v1/fleet/desired-capabilities/gaps', expect.any(Object))
+    expect(gaps[0]).toEqual({
+      assetId: 'asset-1',
+      capability: 'edr.process',
+      covered: false,
+      agentId: 'agent-2',
+      agentHealth: 'stale',
+      gapReason: 'no_agent',
+      detail: 'no agent advertises this capability',
+      lastSeen: '2026-08-30T00:00:00Z',
+    })
+  })
+
+  it('returns an empty list when the response has no gaps array', async () => {
+    respond({})
+    await expect(api.fleetDesiredGaps()).resolves.toEqual([])
+  })
+})

--- a/web/src/lib/api/fleet.ts
+++ b/web/src/lib/api/fleet.ts
@@ -4,6 +4,7 @@ import type {
   FleetAgentRow,
   FleetCoverageRow,
   FleetCoverageSummary,
+  FleetDesiredGap,
 } from '../types'
 import { blobDownload, req } from './client'
 
@@ -68,5 +69,23 @@ export const fleetApi = {
 
   exportFleetCoverage: async (): Promise<void> => {
     await blobDownload('/api/v1/fleet/coverage/export', 'fleet-coverage.csv')
+  },
+
+  // Desired-vs-observed capability reconciliation (#633). Rows are snake_case-tagged (ReconciliationRow).
+  // The route only exists when the desired-capabilities service is wired, so callers degrade gracefully.
+  fleetDesiredGaps: async (): Promise<FleetDesiredGap[]> => {
+    const res = await req('/fleet/desired-capabilities/gaps')
+    return (Array.isArray(res?.gaps) ? res.gaps : []).map(
+      (raw: any): FleetDesiredGap => ({
+        assetId: raw?.asset_id ?? '',
+        capability: raw?.capability ?? '',
+        covered: Boolean(raw?.covered),
+        agentId: raw?.agent_id ?? '',
+        agentHealth: raw?.agent_health ?? '',
+        gapReason: raw?.gap_reason ?? '',
+        detail: raw?.detail ?? '',
+        lastSeen: raw?.last_seen ?? '',
+      }),
+    )
   },
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1480,6 +1480,19 @@ export interface FleetCoverageSummary {
   assetsWithoutAgent: number
 }
 
+// Desired-vs-observed capability reconciliation row (#633): a capability an asset SHOULD have, and
+// whether the observed agent fleet covers it. Only uncovered rows (covered=false) are gaps.
+export interface FleetDesiredGap {
+  assetId: string
+  capability: string
+  covered: boolean
+  agentId: string
+  agentHealth: string
+  gapReason: string
+  detail: string
+  lastSeen: string
+}
+
 // ---- EDR incidents · tri-score risk · State Timeline (#594 C1/C3/C5/C7, B7) ----
 // The backend serializes incident.Incident and endpoint.TimelineEntry with Go field names
 // (PascalCase, no json tags), so the api client maps those verbatim into these camelCase views.

--- a/web/src/pages/Fleet/FleetCoverage.tsx
+++ b/web/src/pages/Fleet/FleetCoverage.tsx
@@ -6,6 +6,7 @@ import type {
   FleetAgentHealth,
   FleetCoverageRow,
   FleetCoverageSummary,
+  FleetDesiredGap,
   FleetVerdict,
 } from '../../lib/types'
 import { Button, Card, EmptyState, ErrorState, Pill, Spinner, cn } from '../../components/ui'
@@ -215,6 +216,51 @@ export function AgentsSection() {
   )
 }
 
+// --- Desired-capability gaps (#633) ---
+// A supplementary, self-degrading section: the desired-capabilities service is optional, so a fetch
+// error (feature off ⇒ 404) simply yields no gaps and the section renders nothing. Only UNCOVERED
+// rows are gaps, so a fully-covered estate also shows nothing here — no false "all clear" card.
+function DesiredGapsSection() {
+  const { data } = useFetch<FleetDesiredGap[]>(() => api.fleetDesiredGaps().catch(() => []), { deps: [] })
+  const gaps = (data ?? []).filter((g) => !g.covered)
+  if (gaps.length === 0) return null
+
+  return (
+    <Card title={`Desired-capability gaps (${gaps.length})`} bodyClass="p-0">
+      <VirtualTable
+        items={gaps}
+        columns={GAP_COLUMNS}
+        rowKey={(g, i) => `${g.assetId}:${g.capability}:${i}`}
+        maxHeightClass="max-h-[50vh]"
+        tableMinWidthClass="min-w-[56rem]"
+      />
+    </Card>
+  )
+}
+
+const GAP_COLUMNS: Column<FleetDesiredGap>[] = [
+  {
+    header: 'Asset',
+    className: 'w-52',
+    cell: (g) => <span className="font-mono text-[12px] text-primary" title={g.assetId}>{g.assetId}</span>,
+  },
+  {
+    header: 'Missing capability',
+    className: 'w-48',
+    cell: (g) => <span className="font-mono text-[12px] text-tertiary">{g.capability || 'N/A'}</span>,
+  },
+  {
+    header: 'Reason',
+    className: 'w-40',
+    cell: (g) => <span className="text-tertiary">{g.gapReason || 'uncovered'}</span>,
+  },
+  {
+    header: 'Detail',
+    className: 'flex-1',
+    cell: (g) => <span className="text-tertiary">{g.detail || 'N/A'}</span>,
+  },
+]
+
 // --- Main Fleet Page ---
 export function FleetCoverage() {
   const [exporting, setExporting] = useState(false)
@@ -279,6 +325,9 @@ export function FleetCoverage() {
         <div className="space-y-6">
           {/* Agents section */}
           <AgentsSection />
+
+          {/* Desired-vs-observed capability gaps (#633) — only renders when gaps exist */}
+          <DesiredGapsSection />
 
           {/* Per-asset coverage table */}
           {rows.length === 0 ? (


### PR DESCRIPTION
feat(web): surface desired-vs-observed capability gaps on the Fleet page (#633)

The backend reconciles the capabilities an asset SHOULD have against the observed
agent fleet (GET /api/v1/fleet/desired-capabilities/gaps), but nothing showed it.

- lib/api/fleet.ts: fleetDesiredGaps() maps the snake_case ReconciliationRow rows.
- types.ts: FleetDesiredGap.
- FleetCoverage.tsx: a "Desired-capability gaps" section between the agents list and
  the per-asset coverage table. It is supplementary and self-degrading — the service
  is optional, so a fetch error (feature off ⇒ 404) yields no gaps and the section
  renders nothing; it also only lists UNCOVERED rows, so a fully-covered estate shows
  nothing rather than a false "all clear" card.

In-style (Card + VirtualTable + design tokens). typecheck + tests (new gap-mapping
test) + build all green.
