### PR TITLE
test(web): stub fleetDesiredGaps in the FleetCoverage test mock

### DIFF
--- a/web/src/pages/Fleet/FleetCoverage.test.tsx
+++ b/web/src/pages/Fleet/FleetCoverage.test.tsx
@@ -23,6 +23,7 @@ vi.mock('../../lib/api', () => {
       exportFleetCoverage: vi.fn(),
       listFleetAgents: vi.fn(),
       getFleetAgent: vi.fn(),
+      fleetDesiredGaps: vi.fn(),
     },
   }
 })
@@ -49,6 +50,7 @@ describe('FleetCoverage', () => {
     restoreViewport = installVirtualViewport()
     vi.mocked(api.fleetCoverageSummary).mockResolvedValue(emptySummary)
     vi.mocked(api.listFleetAgents).mockResolvedValue([])
+    vi.mocked(api.fleetDesiredGaps).mockResolvedValue([])
   })
   afterEach(() => restoreViewport())
 


### PR DESCRIPTION
test(web): stub fleetDesiredGaps in the FleetCoverage test mock

The desired-capability gaps section (#633) added a new api.fleetDesiredGaps call to
FleetCoverage; the component test mocks the api object explicitly, so the missing
method threw synchronously and failed 3 render tests. Add the mock fn + a default
[] resolution. Full web suite green (370).
