### PR TITLE
feat(web): engagement Runtime (detections + correlate) & Data-governance tabs

### DIFF
--- a/web/src/lib/api.governance.test.ts
+++ b/web/src/lib/api.governance.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { api } from './api'
+
+// Privacy & data governance (#635). legalhold.Hold is untagged PascalCase; the export bundle mixes a
+// snake_case view with PascalCase holds. These pin both mappings + the request shapes.
+describe('governance API (#635)', () => {
+  let fetchSpy: any
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+
+  function respond(body: unknown, status = 200) {
+    fetchSpy.mockResolvedValueOnce({ ok: status < 400, status, json: async () => body } as unknown as Response)
+  }
+
+  it('maps the PascalCase legal-hold list', async () => {
+    respond({
+      holds: [
+        {
+          TenantID: 'default',
+          EngagementID: 'eng-1',
+          Reason: 'litigation',
+          PlacedBy: 'operator',
+          PlacedAt: '2026-08-30T00:00:00Z',
+          ReleasedBy: '',
+          ReleasedAt: '0001-01-01T00:00:00Z',
+        },
+      ],
+    })
+    const holds = await api.listLegalHolds()
+    expect(fetchSpy).toHaveBeenCalledWith('/api/v1/fleet/legal-holds', expect.any(Object))
+    expect(holds[0]).toEqual({
+      tenantId: 'default',
+      engagementId: 'eng-1',
+      reason: 'litigation',
+      placedBy: 'operator',
+      placedAt: '2026-08-30T00:00:00Z',
+      releasedBy: '',
+      releasedAt: '0001-01-01T00:00:00Z',
+    })
+  })
+
+  it('places a hold with a reason body (PUT)', async () => {
+    respond({ TenantID: 'default', EngagementID: 'eng-1', Reason: 'r', PlacedBy: 'op' })
+    await api.placeLegalHold('eng-1', 'r')
+    expect(fetchSpy.mock.calls[0][0]).toBe('/api/v1/fleet/engagements/eng-1/legal-hold')
+    expect((fetchSpy.mock.calls[0][1] as RequestInit).method).toBe('PUT')
+    expect(JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string)).toEqual({ reason: 'r' })
+  })
+
+  it('maps the export bundle (snake_case view + PascalCase holds)', async () => {
+    respond({
+      engagement_id: 'eng-1',
+      generated_at: '2026-08-30T00:00:00Z',
+      detection_count: 5,
+      legal_holds: [{ EngagementID: 'eng-1', Reason: 'hold' }],
+    })
+    const b = await api.privacyExport('eng-1')
+    expect(b.engagementId).toBe('eng-1')
+    expect(b.detectionCount).toBe(5)
+    expect(b.legalHolds[0].reason).toBe('hold')
+  })
+
+  it('purges detection data with a reason body (DELETE) and reads the purged count', async () => {
+    respond({ purged: 3 })
+    const res = await api.purgeEngagementDetectionData('eng-1', 'erasure')
+    expect(fetchSpy.mock.calls[0][0]).toBe('/api/v1/fleet/engagements/eng-1/detection-data')
+    expect((fetchSpy.mock.calls[0][1] as RequestInit).method).toBe('DELETE')
+    expect(JSON.parse((fetchSpy.mock.calls[0][1] as RequestInit).body as string)).toEqual({ reason: 'erasure' })
+    expect(res.purged).toBe(3)
+  })
+})

--- a/web/src/lib/api.incidents.test.ts
+++ b/web/src/lib/api.incidents.test.ts
@@ -96,6 +96,56 @@ describe('incidents API mapping', () => {
     expect(JSON.parse((fetchSpy.mock.calls[3][1] as RequestInit).body as string)).toEqual({ owner: 'analyst-2' })
   })
 
+  it('maps PascalCase agent detection records + correlate result', async () => {
+    respond({
+      detections: [
+        {
+          ID: 'det-1',
+          AssetID: 'asset-1',
+          AgentID: 'agent-1',
+          RecordedAt: '2026-08-30T00:00:00Z',
+          Detection: {
+            RuleID: 'det.suspicious_dns_beacon',
+            RuleVersion: 2,
+            Class: 'network',
+            Severity: 'high',
+            Evidence: [{}, {}, {}],
+            Truncated: true,
+            ObservedCount: 12,
+            Observed: '2026-08-29T23:59:00Z',
+          },
+        },
+      ],
+      field_scope: 'full',
+    })
+
+    const res = await api.listEngagementDetections('eng-1')
+    expect(fetchSpy).toHaveBeenCalledWith('/api/v1/engagements/eng-1/detections', expect.any(Object))
+    expect(res.fieldScope).toBe('full')
+    expect(res.detections[0]).toEqual({
+      id: 'det-1',
+      assetId: 'asset-1',
+      agentId: 'agent-1',
+      recordedAt: '2026-08-30T00:00:00Z',
+      ruleId: 'det.suspicious_dns_beacon',
+      ruleVersion: 2,
+      class: 'network',
+      severity: 'high',
+      evidenceCount: 3,
+      truncated: true,
+      observedCount: 12,
+      observed: '2026-08-29T23:59:00Z',
+    })
+
+    respond({ created: [{ ID: 'inc-1', Title: 'x' }], reassessed: 2, reassess_failed: 1 })
+    const c = await api.correlateEngagement('eng-1')
+    expect(fetchSpy.mock.calls[1][0]).toBe('/api/v1/fleet/engagements/eng-1/correlate')
+    expect(c.created).toHaveLength(1)
+    expect(c.created[0].id).toBe('inc-1')
+    expect(c.reassessed).toBe(2)
+    expect(c.reassessFailed).toBe(1)
+  })
+
   it('maps the PascalCase State Timeline entries', async () => {
     respond({
       entries: [

--- a/web/src/lib/api/governance.ts
+++ b/web/src/lib/api/governance.ts
@@ -1,0 +1,60 @@
+import type { LegalHold, PrivacyExportBundle } from '../types'
+import { req } from './client'
+
+// Privacy & data governance (#635). legalhold.Hold and the export bundle's holds are untagged
+// PascalCase; the export bundle's own fields are snake_case (a view struct). Mapped in one place.
+
+function mapLegalHold(raw: any): LegalHold {
+  return {
+    tenantId: raw?.TenantID ?? '',
+    engagementId: raw?.EngagementID ?? '',
+    reason: raw?.Reason ?? '',
+    placedBy: raw?.PlacedBy ?? '',
+    placedAt: raw?.PlacedAt ?? '',
+    releasedBy: raw?.ReleasedBy ?? '',
+    releasedAt: raw?.ReleasedAt ?? '',
+  }
+}
+
+export const governanceApi = {
+  // Fleet-wide list of ACTIVE legal holds.
+  listLegalHolds: async (): Promise<LegalHold[]> => {
+    const res = await req('/fleet/legal-holds')
+    return Array.isArray(res?.holds) ? res.holds.map(mapLegalHold) : []
+  },
+
+  // Place a hold on one engagement's data (PermReview). Idempotent server-side.
+  placeLegalHold: async (engagementId: string, reason: string): Promise<LegalHold> =>
+    mapLegalHold(
+      await req(`/fleet/engagements/${encodeURIComponent(engagementId)}/legal-hold`, {
+        method: 'PUT',
+        body: JSON.stringify({ reason }),
+      }),
+    ),
+
+  // Release the active hold on an engagement (PermReview). Returns 204.
+  releaseLegalHold: async (engagementId: string): Promise<void> => {
+    await req(`/fleet/engagements/${encodeURIComponent(engagementId)}/legal-hold`, { method: 'DELETE' })
+  },
+
+  // Subject-access / DPO export for one engagement (read-only, audited).
+  privacyExport: async (engagementId: string): Promise<PrivacyExportBundle> => {
+    const res = await req(`/fleet/engagements/${encodeURIComponent(engagementId)}/privacy-export`)
+    return {
+      engagementId: res?.engagement_id ?? engagementId,
+      generatedAt: res?.generated_at ?? '',
+      detectionCount: res?.detection_count ?? 0,
+      legalHolds: Array.isArray(res?.legal_holds) ? res.legal_holds.map(mapLegalHold) : [],
+    }
+  },
+
+  // On-demand deletion / right-to-erasure of an engagement's detection projection (PermReview,
+  // legal-hold-checked, audited). DESTRUCTIVE — the caller must confirm and supply a reason.
+  purgeEngagementDetectionData: async (engagementId: string, reason: string): Promise<{ purged: number }> => {
+    const res = await req(`/fleet/engagements/${encodeURIComponent(engagementId)}/detection-data`, {
+      method: 'DELETE',
+      body: JSON.stringify({ reason }),
+    })
+    return { purged: res?.purged ?? 0 }
+  },
+}

--- a/web/src/lib/api/incidents.ts
+++ b/web/src/lib/api/incidents.ts
@@ -1,4 +1,6 @@
 import type {
+  AgentDetectionRecord,
+  CorrelateResult,
   Incident,
   IncidentComment,
   IncidentDisposition,
@@ -166,4 +168,46 @@ export const incidentsApi = {
     const res = await req(`/fleet/assets/${encodeURIComponent(assetId)}/timeline${qs ? `?${qs}` : ''}`)
     return Array.isArray(res?.entries) ? res.entries.map(mapTimelineEntry) : []
   },
+
+  // Agent security detections for an engagement (GET /engagements/{id}/detections). detection.Record is
+  // untagged PascalCase (its evidence events are field-RBAC redacted server-side); field_scope reports
+  // how much the caller's role is allowed to see. Answers "does agent security detection show in the UI".
+  listEngagementDetections: async (engagementId: string): Promise<{ detections: AgentDetectionRecord[]; fieldScope: string }> => {
+    const res = await req(`/engagements/${encodeURIComponent(engagementId)}/detections`)
+    return {
+      detections: Array.isArray(res?.detections) ? res.detections.map(mapDetectionRecord) : [],
+      fieldScope: res?.field_scope ?? '',
+    }
+  },
+
+  // Correlate an engagement's sealed detections into incidents (POST /fleet/engagements/{id}/correlate).
+  correlateEngagement: async (engagementId: string): Promise<CorrelateResult> => {
+    const res = await req(`/fleet/engagements/${encodeURIComponent(engagementId)}/correlate`, {
+      method: 'POST',
+      body: JSON.stringify({}),
+    })
+    return {
+      created: Array.isArray(res?.created) ? res.created.map(mapIncident) : [],
+      reassessed: res?.reassessed ?? 0,
+      reassessFailed: res?.reassess_failed ?? 0,
+    }
+  },
+}
+
+function mapDetectionRecord(raw: any): AgentDetectionRecord {
+  const d = raw?.Detection ?? {}
+  return {
+    id: raw?.ID ?? '',
+    assetId: raw?.AssetID ?? '',
+    agentId: raw?.AgentID ?? '',
+    recordedAt: raw?.RecordedAt ?? '',
+    ruleId: d?.RuleID ?? '',
+    ruleVersion: d?.RuleVersion ?? 0,
+    class: (d?.Class ?? '') as AgentDetectionRecord['class'],
+    severity: (d?.Severity ?? 'unknown') as Severity,
+    evidenceCount: Array.isArray(d?.Evidence) ? d.Evidence.length : 0,
+    truncated: Boolean(d?.Truncated),
+    observedCount: d?.ObservedCount ?? 0,
+    observed: d?.Observed ?? '',
+  }
 }

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -18,6 +18,7 @@ import { codeQualityApi } from './code-quality'
 import { rulesApi } from './rules'
 import { fleetApi } from './fleet'
 import { incidentsApi } from './incidents'
+import { governanceApi } from './governance'
 import { assetsApi } from './assets'
 import { vulnerabilityApi } from './vulnerability'
 import { aiTriageApi } from './ai-triage'
@@ -47,6 +48,7 @@ export const api = {
   ...rulesApi,
   ...fleetApi,
   ...incidentsApi,
+  ...governanceApi,
   ...assetsApi,
   ...vulnerabilityApi,
   ...aiTriageApi,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1591,6 +1591,53 @@ export interface TimelineEntry {
   summary: string
 }
 
+// One agent security detection record (#594 B/C). detection.Record + its Detection are untagged
+// PascalCase; evidence event details are field-RBAC redacted server-side, so the UI shows the summary.
+export type AgentDetectionClass = 'process' | 'network' | 'file' | 'privilege' | ''
+
+export interface AgentDetectionRecord {
+  id: string
+  assetId: string
+  agentId: string
+  recordedAt: string
+  ruleId: string
+  ruleVersion: number
+  class: AgentDetectionClass
+  severity: Severity
+  evidenceCount: number
+  truncated: boolean
+  observedCount: number
+  observed: string
+}
+
+export interface CorrelateResult {
+  created: Incident[]
+  reassessed: number
+  reassessFailed: number
+}
+
+// ---- Privacy & data governance (#635): legal hold · data export · right-to-erasure ----
+
+// A legal hold pins an engagement's data against retention expiry / deletion. legalhold.Hold is untagged
+// PascalCase; ReleasedAt zero (year <= 1) ⇒ still active.
+export interface LegalHold {
+  tenantId: string
+  engagementId: string
+  reason: string
+  placedBy: string
+  placedAt: string
+  releasedBy: string
+  releasedAt: string
+}
+
+// The subject-access / DPO export bundle for one engagement (read-only, audited).
+export interface PrivacyExportBundle {
+  engagementId: string
+  generatedAt: string
+  detectionCount: number
+  legalHolds: LegalHold[]
+}
+
 export interface DashboardTrendPoint {
   date: string
   counts: Record<string, number>

--- a/web/src/pages/EngagementDetail/DataGovernanceTab.tsx
+++ b/web/src/pages/EngagementDetail/DataGovernanceTab.tsx
@@ -33,7 +33,10 @@ export function DataGovernanceTab({ engagementId }: { engagementId: string }) {
 }
 
 function LegalHoldCard({ engagementId, canReview }: { engagementId: string; canReview: boolean }) {
-  const { data, loading, refetch } = useFetch<LegalHold[]>(() => api.listLegalHolds().catch(() => []), { deps: [engagementId] })
+  // Do NOT swallow the fetch error: on a legal-hold/retention safety control, a failed load must not
+  // render the reassuring "no hold" branch (an operator could then wrongly proceed to delete). Surface
+  // the error explicitly so the hold status is never a silent false-negative.
+  const { data, loading, error, refetch } = useFetch<LegalHold[]>(() => api.listLegalHolds(), { deps: [engagementId] })
   const [reason, setReason] = useState('')
 
   const hold = (data ?? []).find((h) => h.engagementId === engagementId && isActive(h)) ?? null
@@ -49,6 +52,11 @@ function LegalHoldCard({ engagementId, canReview }: { engagementId: string; canR
 
       {loading && !data ? (
         <p className="text-sm text-tertiary">Loading…</p>
+      ) : error && !data ? (
+        <div className="space-y-3">
+          <ErrorState message={`Could not load legal-hold status: ${error}. Hold status is unknown — do not proceed to deletion until this resolves.`} />
+          <Button variant="secondary" onClick={refetch}>Retry</Button>
+        </div>
       ) : hold ? (
         <div className="space-y-3">
           <div className="flex items-center gap-2">
@@ -157,7 +165,8 @@ function DataDeletionCard({ engagementId, canReview }: { engagementId: string; c
             <p className="text-sm text-accent">Deleted {purged} detection record{purged === 1 ? '' : 's'}.</p>
           )}
           <Field label="Reason (required, audited)">
-            <Input value={reason} onChange={(e) => setReason(e.target.value)} placeholder="e.g. subject erasure request #456" disabled={purge.loading} />
+            {/* Locked once confirming so the reason can't be cleared between confirm and fire. */}
+            <Input value={reason} onChange={(e) => setReason(e.target.value)} placeholder="e.g. subject erasure request #456" disabled={purge.loading || confirming} />
           </Field>
           {!confirming ? (
             <Button variant="danger" disabled={!reason.trim()} onClick={() => setConfirming(true)}>
@@ -168,7 +177,8 @@ function DataDeletionCard({ engagementId, canReview }: { engagementId: string; c
               <span className="text-sm font-medium text-critical">Permanently delete this engagement’s detection projection?</span>
               <div className="ml-auto flex gap-2">
                 <Button variant="secondary" onClick={() => setConfirming(false)} disabled={purge.loading}>Cancel</Button>
-                <Button variant="danger" loading={purge.loading} onClick={() => purge.mutate(reason.trim())}>Confirm delete</Button>
+                {/* Re-validate the required reason at fire time, not just at step 1. */}
+                <Button variant="danger" loading={purge.loading} disabled={!reason.trim()} onClick={() => purge.mutate(reason.trim())}>Confirm delete</Button>
               </div>
             </div>
           )}

--- a/web/src/pages/EngagementDetail/DataGovernanceTab.tsx
+++ b/web/src/pages/EngagementDetail/DataGovernanceTab.tsx
@@ -1,0 +1,181 @@
+import { useState } from 'react'
+import { Download01, Lock01, Trash01 } from '@untitledui/icons'
+import { api } from '../../lib/api'
+import type { CurrentUser, LegalHold, PrivacyExportBundle } from '../../lib/types'
+import { Button, Card, ErrorState, Field, Input, Pill, cn } from '../../components/ui'
+import { useFetch, useMutation } from '../../hooks'
+
+const REVIEW_ROLES = ['admin', 'reviewer']
+
+function fmtTime(iso: string): string {
+  if (!iso) return '—'
+  const t = new Date(iso)
+  if (Number.isNaN(t.getTime()) || t.getUTCFullYear() <= 1) return '—'
+  return t.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+function isActive(h: LegalHold): boolean {
+  const t = new Date(h.releasedAt)
+  return !h.releasedAt || Number.isNaN(t.getTime()) || t.getUTCFullYear() <= 1
+}
+
+export function DataGovernanceTab({ engagementId }: { engagementId: string }) {
+  const { data: me } = useFetch<CurrentUser | null>(() => api.me().catch(() => null), { deps: [] })
+  const canReview = REVIEW_ROLES.includes(me?.role ?? '')
+
+  return (
+    <div className="max-w-3xl space-y-5">
+      <LegalHoldCard engagementId={engagementId} canReview={canReview} />
+      <DataExportCard engagementId={engagementId} />
+      <DataDeletionCard engagementId={engagementId} canReview={canReview} />
+    </div>
+  )
+}
+
+function LegalHoldCard({ engagementId, canReview }: { engagementId: string; canReview: boolean }) {
+  const { data, loading, refetch } = useFetch<LegalHold[]>(() => api.listLegalHolds().catch(() => []), { deps: [engagementId] })
+  const [reason, setReason] = useState('')
+
+  const hold = (data ?? []).find((h) => h.engagementId === engagementId && isActive(h)) ?? null
+
+  const place = useMutation((r: string) => api.placeLegalHold(engagementId, r), { onSuccess: () => { setReason(''); refetch() } })
+  const release = useMutation(() => api.releaseLegalHold(engagementId), { onSuccess: () => refetch() })
+
+  return (
+    <Card title="Legal hold">
+      <p className="mb-3 text-sm text-tertiary">
+        An active hold preserves this engagement’s detection data against retention expiry and on-demand deletion.
+      </p>
+
+      {loading && !data ? (
+        <p className="text-sm text-tertiary">Loading…</p>
+      ) : hold ? (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <span className="inline-flex items-center gap-1.5 rounded-md bg-high/10 px-2 py-0.5 text-xs font-semibold text-high ring-1 ring-inset ring-high/30">
+              <Lock01 className="size-3.5" /> Active hold
+            </span>
+            <span className="text-xs text-tertiary">placed by {hold.placedBy || 'unknown'} · {fmtTime(hold.placedAt)}</span>
+          </div>
+          <p className="text-sm text-primary"><span className="text-tertiary">Reason:</span> {hold.reason}</p>
+          {(place.error || release.error) && <ErrorState message={place.error || release.error || ''} />}
+          {canReview ? (
+            <Button variant="secondary" loading={release.loading} onClick={() => release.mutate(undefined)}>Release hold</Button>
+          ) : (
+            <p className="text-xs text-tertiary">Review permission is required to release the hold.</p>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <p className="text-sm text-secondary">No active hold.</p>
+          {(place.error || release.error) && <ErrorState message={place.error || release.error || ''} />}
+          {canReview ? (
+            <Field label="Place a hold">
+              <div className="flex gap-2">
+                <Input value={reason} onChange={(e) => setReason(e.target.value)} placeholder="reason (e.g. litigation matter #123)" disabled={place.loading} />
+                <Button variant="secondary" disabled={!reason.trim() || place.loading} loading={place.loading} onClick={() => place.mutate(reason.trim())}>
+                  Place hold
+                </Button>
+              </div>
+            </Field>
+          ) : (
+            <p className="text-xs text-tertiary">Review permission is required to place a hold.</p>
+          )}
+        </div>
+      )}
+    </Card>
+  )
+}
+
+function DataExportCard({ engagementId }: { engagementId: string }) {
+  const [bundle, setBundle] = useState<PrivacyExportBundle | null>(null)
+  const gen = useMutation(() => api.privacyExport(engagementId), { onSuccess: (b) => setBundle(b) })
+
+  function download() {
+    if (!bundle) return
+    const blob = new Blob([JSON.stringify(bundle, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `privacy-export-${engagementId}.json`
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <Card
+      title="Data export"
+      actions={
+        <Button variant="secondary" className="px-2.5 py-1 text-xs" loading={gen.loading} onClick={() => gen.mutate(undefined)}>
+          Generate export
+        </Button>
+      }
+    >
+      <p className="mb-3 text-sm text-tertiary">
+        A read-only, audited subject-access / DPO bundle: the governance data the control plane holds for this engagement.
+      </p>
+      {gen.error && <ErrorState message={gen.error} />}
+      {bundle && (
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2 text-sm">
+            <Pill>{bundle.detectionCount} detections</Pill>
+            <Pill>{bundle.legalHolds.length} legal hold{bundle.legalHolds.length === 1 ? '' : 's'}</Pill>
+            <span className="text-xs text-tertiary">generated {fmtTime(bundle.generatedAt)}</span>
+            <Button variant="secondary" className="ml-auto px-2.5 py-1 text-xs" onClick={download}>
+              <Download01 className="size-4" /> Download JSON
+            </Button>
+          </div>
+        </div>
+      )}
+    </Card>
+  )
+}
+
+function DataDeletionCard({ engagementId, canReview }: { engagementId: string; canReview: boolean }) {
+  const [reason, setReason] = useState('')
+  const [confirming, setConfirming] = useState(false)
+  const [purged, setPurged] = useState<number | null>(null)
+
+  const purge = useMutation((r: string) => api.purgeEngagementDetectionData(engagementId, r), {
+    onSuccess: (res) => { setPurged(res.purged); setReason(''); setConfirming(false) },
+  })
+
+  return (
+    <Card title="Danger zone — delete detection data" className="border-critical/30">
+      <p className="mb-3 text-sm text-tertiary">
+        Permanently deletes this engagement’s detection projection (right-to-erasure). It is refused while a legal
+        hold is active, audited with the reason, and it never touches the immutable evidence chain — only the
+        queryable projection. This cannot be undone.
+      </p>
+
+      {!canReview ? (
+        <p className="text-sm text-tertiary">Review permission is required to delete detection data.</p>
+      ) : (
+        <div className="space-y-3">
+          {purge.error && <ErrorState message={purge.error} />}
+          {purged !== null && (
+            <p className="text-sm text-accent">Deleted {purged} detection record{purged === 1 ? '' : 's'}.</p>
+          )}
+          <Field label="Reason (required, audited)">
+            <Input value={reason} onChange={(e) => setReason(e.target.value)} placeholder="e.g. subject erasure request #456" disabled={purge.loading} />
+          </Field>
+          {!confirming ? (
+            <Button variant="danger" disabled={!reason.trim()} onClick={() => setConfirming(true)}>
+              <Trash01 className="size-4" /> Delete detection data
+            </Button>
+          ) : (
+            <div className={cn('flex flex-wrap items-center gap-2 rounded-lg border border-critical/40 bg-critical/5 p-3')}>
+              <span className="text-sm font-medium text-critical">Permanently delete this engagement’s detection projection?</span>
+              <div className="ml-auto flex gap-2">
+                <Button variant="secondary" onClick={() => setConfirming(false)} disabled={purge.loading}>Cancel</Button>
+                <Button variant="danger" loading={purge.loading} onClick={() => purge.mutate(reason.trim())}>Confirm delete</Button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </Card>
+  )
+}
+
+export default DataGovernanceTab

--- a/web/src/pages/EngagementDetail/DetectionsTab.tsx
+++ b/web/src/pages/EngagementDetail/DetectionsTab.tsx
@@ -1,0 +1,145 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { AlertTriangle, GitBranch01, RefreshCw01 } from '@untitledui/icons'
+import { api } from '../../lib/api'
+import type { AgentDetectionClass, AgentDetectionRecord, CorrelateResult, CurrentUser } from '../../lib/types'
+import { Button, Card, EmptyState, ErrorState, Pill, SevBadge, Spinner, cn } from '../../components/ui'
+import { VirtualTable, type Column } from '../../components/synapse/VirtualTable'
+import { useFetch, useMutation } from '../../hooks'
+
+const OPERATE_ROLES = ['admin', 'consultant', 'member']
+
+const CLASS_STYLE: Record<Exclude<AgentDetectionClass, ''>, string> = {
+  process: 'bg-info/10 text-info ring-info/30',
+  network: 'bg-medium/10 text-medium ring-medium/30',
+  file: 'bg-accent/10 text-accent ring-accent/30',
+  privilege: 'bg-critical/10 text-critical ring-critical/30',
+}
+
+function ClassBadge({ cls }: { cls: AgentDetectionClass }) {
+  if (!cls) return <span className="text-quaternary">—</span>
+  return (
+    <span className={cn('inline-flex items-center rounded-md px-2 py-0.5 text-xs font-semibold ring-1 ring-inset', CLASS_STYLE[cls])}>
+      {cls}
+    </span>
+  )
+}
+
+function fmtTime(iso: string): string {
+  if (!iso) return '—'
+  const t = new Date(iso)
+  if (Number.isNaN(t.getTime()) || t.getUTCFullYear() <= 1) return '—'
+  return t.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+const COLUMNS: Column<AgentDetectionRecord>[] = [
+  {
+    header: 'Rule',
+    className: 'flex-1 min-w-0',
+    cell: (d) => (
+      <div className="min-w-0">
+        <div className="truncate font-mono text-[12px] text-primary" title={d.ruleId}>{d.ruleId || d.id}</div>
+        <div className="truncate font-mono text-[10px] text-quaternary">v{d.ruleVersion} · {d.id}</div>
+      </div>
+    ),
+  },
+  { header: 'Class', className: 'w-28', cell: (d) => <ClassBadge cls={d.class} /> },
+  { header: 'Severity', className: 'w-28', cell: (d) => <SevBadge sev={d.severity} /> },
+  {
+    header: 'Agent',
+    className: 'w-36',
+    cell: (d) => <span className="font-mono text-[12px] text-tertiary" title={d.agentId}>{d.agentId || '—'}</span>,
+  },
+  {
+    header: 'Evidence',
+    className: 'w-28 tabular-nums',
+    cell: (d) => (
+      <span className="text-tertiary" title={d.truncated ? `window truncated; ${d.observedCount} observed` : undefined}>
+        {d.evidenceCount}
+        {d.truncated && <span className="ml-1 text-medium" title="evidence window truncated">⋯</span>}
+      </span>
+    ),
+  },
+  {
+    header: 'Observed',
+    className: 'w-44 tabular-nums',
+    cell: (d) => <span className="text-tertiary" title={d.observed}>{fmtTime(d.observed)}</span>,
+  },
+]
+
+export function DetectionsTab({ engagementId }: { engagementId: string }) {
+  const { data: me } = useFetch<CurrentUser | null>(() => api.me().catch(() => null), { deps: [] })
+  const canOperate = OPERATE_ROLES.includes(me?.role ?? '')
+
+  const { data, loading, error, refetch } = useFetch(() => api.listEngagementDetections(engagementId), { deps: [engagementId] })
+  const [result, setResult] = useState<CorrelateResult | null>(null)
+
+  const correlate = useMutation(() => api.correlateEngagement(engagementId), {
+    onSuccess: (r) => { setResult(r); refetch() },
+  })
+
+  const detections = data?.detections ?? null
+  const scope = data?.fieldScope ?? ''
+
+  return (
+    <div className="space-y-5">
+      <Card
+        title={`Agent security detections${detections ? ` (${detections.length})` : ''}`}
+        actions={
+          canOperate ? (
+            <Button variant="secondary" className="px-2.5 py-1 text-xs" loading={correlate.loading} onClick={() => correlate.mutate(undefined)}>
+              <GitBranch01 className="size-4" /> Correlate → incidents
+            </Button>
+          ) : undefined
+        }
+        bodyClass="p-0"
+      >
+        {scope && scope !== 'full' && (
+          <div className="border-b border-secondary px-4 py-2 text-xs text-tertiary">
+            Field scope: <span className="font-mono text-secondary">{scope}</span> — some evidence fields are redacted for your role.
+          </div>
+        )}
+        {correlate.error && <div className="px-4 pt-3"><ErrorState message={correlate.error} /></div>}
+        {result && (
+          <div className="flex flex-wrap items-center gap-2 border-b border-secondary bg-secondary/30 px-4 py-2 text-sm">
+            <Pill>{result.created.length} incident{result.created.length === 1 ? '' : 's'} created</Pill>
+            <span className="text-xs text-tertiary">· {result.reassessed} reassessed{result.reassessFailed ? ` · ${result.reassessFailed} failed` : ''}</span>
+            <Link to="/fleet/incidents" className="ml-auto text-xs font-semibold text-brand-solid hover:underline">View incidents →</Link>
+          </div>
+        )}
+
+        {loading && !detections ? (
+          <div className="px-4 py-6"><Spinner label="Loading detections…" /></div>
+        ) : error ? (
+          <div className="p-4 space-y-3">
+            <ErrorState message={error} />
+            <Button variant="secondary" onClick={refetch}>Retry</Button>
+          </div>
+        ) : detections && detections.length > 0 ? (
+          <VirtualTable
+            items={detections}
+            columns={COLUMNS}
+            rowKey={(d) => d.id}
+            maxHeightClass="max-h-[60vh]"
+            tableMinWidthClass="min-w-[60rem]"
+          />
+        ) : (
+          <div className="p-6">
+            <EmptyState
+              icon={AlertTriangle}
+              title="No detections"
+              hint="Agent security detections for this engagement appear here once an enrolled agent ships a signed detection batch. Correlate folds them into incidents."
+            />
+          </div>
+        )}
+      </Card>
+
+      <p className="flex items-center gap-1.5 text-xs text-quaternary">
+        <RefreshCw01 className="size-3.5" />
+        Correlation is operator-triggered over a stable window (it never auto-runs, to avoid duplicate incidents). Requires operate permission.
+      </p>
+    </div>
+  )
+}
+
+export default DetectionsTab

--- a/web/src/pages/EngagementDetail/index.tsx
+++ b/web/src/pages/EngagementDetail/index.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, lazy, Suspense, type FC } from 'react'
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 import {
+  Activity,
   ArrowLeft,
   ChevronRight,
   LayoutGrid01,
@@ -34,6 +35,8 @@ import { packageLocationMap, countVulnerabilityFindings, VulnsTab } from './Vuln
 import { LicensesTab } from './LicensesTab'
 import { ComponentsTab } from './ComponentsTab'
 import { ReconTab } from './ReconTab'
+import { DetectionsTab } from './DetectionsTab'
+import { DataGovernanceTab } from './DataGovernanceTab'
 import { EvidenceTab } from './EvidenceTab'
 import { SettingsTab } from './SettingsTab'
 import { JudgmentReviewTab } from './ReviewsTab'
@@ -53,8 +56,10 @@ export type Tab =
   | 'threats'
   | 'recon'
   | 'agent'
+  | 'detections'
   | 'reviews'
   | 'evidence'
+  | 'data-governance'
   | 'settings'
 
 export interface SubTabDefinition {
@@ -107,6 +112,12 @@ export const TAB_GROUPS: TabGroupDefinition[] = [
     ],
   },
   {
+    id: 'runtime',
+    label: 'Runtime',
+    icon: Activity,
+    sub: [{ id: 'detections', label: 'Detections' }],
+  },
+  {
     id: 'governance',
     label: 'Governance',
     icon: ShieldTick,
@@ -114,6 +125,7 @@ export const TAB_GROUPS: TabGroupDefinition[] = [
       { id: 'evidence', label: 'Evidence' },
       { id: 'reviews', label: 'Awaiting Review' },
       { id: 'quality', label: 'Code Quality' },
+      { id: 'data-governance', label: 'Data governance' },
     ],
   },
   {
@@ -460,6 +472,8 @@ export function EngagementDetail() {
         {tab === 'quality' && <CodeQualityTab engagementId={id} />}
         {tab === 'recon' && <ReconTab eng={eng} onGoTab={setTab} />}
         {tab === 'agent' && <AgentTab engagementId={id} />}
+        {tab === 'detections' && <DetectionsTab key={id} engagementId={id} />}
+        {tab === 'data-governance' && <DataGovernanceTab key={id} engagementId={id} />}
         {tab === 'reviews' && <JudgmentReviewTab key={id} engagementId={id} />}
         {tab === 'evidence' && <EvidenceTab key={id} engagementId={id} />}
         {tab === 'settings' && <SettingsTab eng={eng} onUpdated={setEng} />}


### PR DESCRIPTION
feat(web): engagement Runtime (detections + correlate) & Data-governance tabs

Surfaces three things that the backend exposed but the UI never showed, verified
live against a running server (in-memory, full fleet/EDR/privacy env enabled).

Runtime → Detections tab (EngagementDetail):
- Agent security detections list (GET /engagements/{id}/detections): rule, class
  (process/network/file/privilege), severity, agent, evidence count + truncation,
  observed time. detection.Record is untagged PascalCase; evidence is field-RBAC
  redacted server-side and the field_scope is shown when not "full".
- Correlate → incidents (POST /fleet/engagements/{id}/correlate, operator-gated):
  folds the engagement's sealed detections into incidents, shows created/reassessed
  counts and links to the Incidents view. Note that correlation is operator-
  triggered (never auto-run) to avoid duplicate incidents.

Governance → Data governance tab (EngagementDetail):
- Legal hold: place (reason) / release / active-hold status (#635, PermReview).
- Data export: generate the read-only DPO/subject-access bundle + download JSON.
- Danger zone: delete detection data / right-to-erasure — reason required, a
  two-step inline confirmation, PermReview. Refused server-side while a hold is
  active (verified: returns 403); never touches the evidence chain.

Also: incidents.ts gains listEngagementDetections + correlateEngagement; new
governance.ts client; types for AgentDetectionRecord/CorrelateResult/LegalHold/
PrivacyExportBundle; two new EngagementDetail tabs (Runtime group + Data governance
under the existing Governance group).

Live-verified: detections/correlate/legal-hold(place→list→release)/export/delete all
respond correctly; delete-under-hold is 403; mappers match the live JSON exactly.
typecheck + 375 tests (new detection/correlate/governance mapping tests) + build all
green.
