### PR TITLE
fix(web): sidebar Sign out button + dashboard legend overflow on narrow cards

### DIFF
--- a/web/src/App.rules.test.tsx
+++ b/web/src/App.rules.test.tsx
@@ -28,6 +28,7 @@ vi.mock('./lib/api', () => ({
 vi.mock('./auth/AuthContext', () => ({
   AuthProvider: ({ children }: any) => children,
   useAuth: () => ({ phase: 'ready', logout: vi.fn() }),
+  useOptionalAuth: () => ({ phase: 'ready', logout: vi.fn() }),
 }))
 
 describe('App Routing - Rules', () => {

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -34,6 +34,12 @@ export function useAuth(): AuthState {
   return v
 }
 
+// Non-throwing accessor for layout chrome (e.g. the sidebar) that renders inside AuthProvider in the
+// app but may be mounted in isolation by unit tests. Returns null when there is no provider.
+export function useOptionalAuth(): AuthState | null {
+  return useContext(Ctx)
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [phase, setPhase] = useState<Phase>('connecting')
   const [aup, setAup] = useState<AupStatus | null>(null)

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Cube01,
+  LogOut01,
   Plus,
   Server01,
   Settings01,
@@ -19,6 +20,7 @@ import {
 import { useEffect, useRef, useState, type ComponentType } from 'react'
 import { Link, NavLink, useLocation } from 'react-router-dom'
 import logo from '../../assets/logo.png'
+import { useOptionalAuth } from '../../auth/AuthContext'
 import { cn } from '../ui'
 
 type IconComponent = ComponentType<{ className?: string; 'aria-hidden'?: boolean | 'true' | 'false' }>
@@ -92,6 +94,17 @@ function storageSet(key: string, value: string) {
 }
 
 function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; onNavigate?: () => void }) {
+  const auth = useOptionalAuth()
+  const [signingOut, setSigningOut] = useState(false)
+  async function onSignOut() {
+    if (!auth) return
+    setSigningOut(true)
+    try {
+      await auth.logout()
+    } finally {
+      setSigningOut(false)
+    }
+  }
   const location = useLocation()
   const [expandedItems, setExpandedItems] = useState<Record<string, boolean>>(() => ({
     '/code-quality': storageGet('synapse-nav-expanded-/code-quality') !== 'false',
@@ -266,6 +279,22 @@ function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; on
 
       <div className="shrink-0 border-t border-secondary p-3">
         <div className="space-y-0.5">{renderItems([SETTINGS])}</div>
+        {auth && (
+        <button
+          type="button"
+          onClick={onSignOut}
+          disabled={signingOut}
+          title={collapsed ? 'Sign out' : undefined}
+          aria-label={collapsed ? 'Sign out' : undefined}
+          className={cn(
+            'group mt-0.5 flex w-full items-center rounded-lg py-2 text-sm font-medium text-secondary transition-colors hover:bg-primary_hover hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand disabled:cursor-not-allowed disabled:opacity-60',
+            collapsed ? 'justify-center px-0' : 'gap-3 px-3',
+          )}
+        >
+          <LogOut01 className="size-5 shrink-0 text-tertiary group-hover:text-primary" aria-hidden="true" />
+          <span className={cn('truncate', collapsed ? 'sr-only' : 'inline')}>{signingOut ? 'Signing out…' : 'Sign out'}</span>
+        </button>
+        )}
       </div>
     </>
   )

--- a/web/src/components/synapse/DashboardCharts.tsx
+++ b/web/src/components/synapse/DashboardCharts.tsx
@@ -46,8 +46,12 @@ export function RadarChart({
   const polygonPath = dataPoints.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x},${p.y}`).join(' ') + ' Z'
 
   return (
-    <div className="flex w-full flex-col items-center justify-around gap-4 sm:flex-row sm:gap-6">
-      <figure className="relative shrink-0 size-52 sm:size-56" aria-label={`${title}: ${total} total`}>
+    // @container so the figure+legend go side-by-side based on THIS card's width, not the viewport —
+    // in a 2-up dashboard grid a card can be ~400px while the viewport is >640px, which previously made
+    // the row layout overflow the card (the percent column spilled past the edge). Below @md it stacks.
+    <div className="@container w-full">
+      <div className="flex flex-col items-center justify-center gap-4 @md:flex-row @md:justify-around @md:gap-6">
+      <figure className="relative shrink-0 size-52 @md:size-56" aria-label={`${title}: ${total} total`}>
         <svg viewBox={`0 0 ${size} ${size}`} role="img" className="size-full select-none overflow-visible">
           <title>{title}</title>
           <defs>
@@ -150,12 +154,12 @@ export function RadarChart({
       </figure>
 
       {/* Legend list matching Untitled UI */}
-      <ul className="w-full sm:w-auto sm:min-w-[190px] sm:max-w-[220px] space-y-2">
+      <ul className="w-full min-w-0 space-y-2 @md:w-auto @md:min-w-[190px] @md:max-w-[240px]">
         {data.map((item) => (
           <li
             key={item.key}
             className={cn(
-              'grid grid-cols-[minmax(0,1fr)_2.5rem_2.5rem] items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors cursor-pointer',
+              'grid grid-cols-[minmax(0,1fr)_2.25rem_2.5rem] items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors cursor-pointer',
               hoverKey === item.key ? 'bg-secondary' : 'hover:bg-secondary',
             )}
             onMouseEnter={() => setHoverKey(item.key)}
@@ -171,6 +175,7 @@ export function RadarChart({
         ))}
         {total === 0 && <li className="text-xs text-tertiary">No posture data available.</li>}
       </ul>
+      </div>
     </div>
   )
 }
@@ -180,8 +185,10 @@ export function DonutChart({ title, centerLabel, data }: { title: string; center
   const CIRCUMFERENCE_INNER = 2 * Math.PI * 44
   let offset = 0
   return (
-    <div className="flex w-full flex-col items-center justify-around gap-4 sm:flex-row sm:gap-6">
-      <figure className="relative shrink-0 size-44 sm:size-48" aria-label={`${title}: ${total} total`}>
+    // @container: side-by-side only when this card is wide enough (see RadarChart), else stack.
+    <div className="@container w-full">
+      <div className="flex flex-col items-center justify-center gap-4 @md:flex-row @md:justify-around @md:gap-6">
+      <figure className="relative shrink-0 size-44 @md:size-48" aria-label={`${title}: ${total} total`}>
         <svg viewBox="0 0 120 120" role="img" className="size-full" aria-label={`${title} donut chart`}>
           <title>{title}</title>
           <circle cx="60" cy="60" r="44" fill="none" stroke="var(--color-border-secondary)" strokeWidth="12" />
@@ -217,9 +224,9 @@ export function DonutChart({ title, centerLabel, data }: { title: string; center
           </text>
         </svg>
       </figure>
-      <ul className="w-full sm:w-auto sm:min-w-[190px] sm:max-w-[220px] space-y-2">
+      <ul className="w-full min-w-0 space-y-2 @md:w-auto @md:min-w-[190px] @md:max-w-[240px]">
         {data.map((item) => (
-          <li key={item.key} className="grid grid-cols-[minmax(0,1fr)_2.5rem_2.5rem] items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors hover:bg-secondary">
+          <li key={item.key} className="grid grid-cols-[minmax(0,1fr)_2.25rem_2.5rem] items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors hover:bg-secondary">
             <span className="flex min-w-0 items-center gap-2.5 font-medium text-secondary">
               <span className="size-2.5 shrink-0 rounded-full" style={{ backgroundColor: item.color }} />
               <span className="truncate">{item.label}</span>
@@ -230,6 +237,7 @@ export function DonutChart({ title, centerLabel, data }: { title: string; center
         ))}
         {total === 0 && <li className="text-xs text-tertiary">No data available.</li>}
       </ul>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
fix(web): add sidebar Sign out button + fix dashboard legend overflow on narrow cards

Two UX/CSS fixes from testing on a 14" MacBook Pro.

1. No way to sign out: the app shell had no logout control (logout lived only on the
   pre-login Connect screen). Added a "Sign out" button to the sidebar footer (under
   Settings), collapsible-aware, wired to AuthContext.logout. Introduced a
   non-throwing useOptionalAuth() so the sidebar still renders in isolation (unit
   tests mount it without AuthProvider); the button only shows when auth is present.

2. Dashboard legend overflow at ~14": the Asset-Posture (radar) and Risk-Mix (donut)
   cards laid the chart + legend side-by-side based on the VIEWPORT (sm:flex-row), but
   in the 2-up dashboard grid each card is ~400px while the viewport is >640px — so the
   legend's percent column spilled past the card's right edge. Switched to Tailwind v4
   container queries: the figure+legend now go side-by-side only when THIS card is wide
   enough (@md ≥28rem), and stack below that. Also let the legend shrink (min-w-0) and
   widened its cap so nothing clips.

typecheck + 375 tests + build all green; container-query CSS verified in the bundle.
