### PR TITLE
fix(web): quality-profile rule checkbox looks active (not greyed) + copy robustness + de-italic keys

### DIFF
--- a/web/src/App.rules.test.tsx
+++ b/web/src/App.rules.test.tsx
@@ -28,6 +28,7 @@ vi.mock('./lib/api', () => ({
 vi.mock('./auth/AuthContext', () => ({
   AuthProvider: ({ children }: any) => children,
   useAuth: () => ({ phase: 'ready', logout: vi.fn() }),
+  useOptionalAuth: () => ({ phase: 'ready', logout: vi.fn() }),
 }))
 
 describe('App Routing - Rules', () => {

--- a/web/src/auth/AuthContext.test.tsx
+++ b/web/src/auth/AuthContext.test.tsx
@@ -119,8 +119,10 @@ describe('BFF authentication', () => {
     vi.mocked(discoverSession).mockRejectedValue(new ApiError(404, 'not found'))
     renderConnect()
 
-    expect(await screen.findByRole('link', { name: 'Sign in with your organization' })).toBeInTheDocument()
-    expect(screen.getByLabelText('API token')).toBeInTheDocument()
+    // A 404 means OIDC/BFF is unconfigured, so the org sign-in would be a dead CTA — it is hidden and
+    // the API-token login is shown instead. No error banner is raised for this expected condition.
+    expect(await screen.findByLabelText('API token')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Sign in with your organization' })).not.toBeInTheDocument()
     expect(screen.queryByText(/Could not check your sign-in session/)).not.toBeInTheDocument()
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -34,6 +34,12 @@ export function useAuth(): AuthState {
   return v
 }
 
+// Non-throwing accessor for layout chrome (e.g. the sidebar) that renders inside AuthProvider in the
+// app but may be mounted in isolation by unit tests. Returns null when there is no provider.
+export function useOptionalAuth(): AuthState | null {
+  return useContext(Ctx)
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [phase, setPhase] = useState<Phase>('connecting')
   const [aup, setAup] = useState<AupStatus | null>(null)

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Cube01,
+  LogOut01,
   Plus,
   Server01,
   Settings01,
@@ -19,6 +20,7 @@ import {
 import { useEffect, useRef, useState, type ComponentType } from 'react'
 import { Link, NavLink, useLocation } from 'react-router-dom'
 import logo from '../../assets/logo.png'
+import { useOptionalAuth } from '../../auth/AuthContext'
 import { cn } from '../ui'
 
 type IconComponent = ComponentType<{ className?: string; 'aria-hidden'?: boolean | 'true' | 'false' }>
@@ -92,6 +94,17 @@ function storageSet(key: string, value: string) {
 }
 
 function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; onNavigate?: () => void }) {
+  const auth = useOptionalAuth()
+  const [signingOut, setSigningOut] = useState(false)
+  async function onSignOut() {
+    if (!auth) return
+    setSigningOut(true)
+    try {
+      await auth.logout()
+    } finally {
+      setSigningOut(false)
+    }
+  }
   const location = useLocation()
   const [expandedItems, setExpandedItems] = useState<Record<string, boolean>>(() => ({
     '/code-quality': storageGet('synapse-nav-expanded-/code-quality') !== 'false',
@@ -266,6 +279,22 @@ function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; on
 
       <div className="shrink-0 border-t border-secondary p-3">
         <div className="space-y-0.5">{renderItems([SETTINGS])}</div>
+        {auth && (
+        <button
+          type="button"
+          onClick={onSignOut}
+          disabled={signingOut}
+          title={collapsed ? 'Sign out' : undefined}
+          aria-label={collapsed ? 'Sign out' : undefined}
+          className={cn(
+            'group mt-0.5 flex w-full items-center rounded-lg py-2 text-sm font-medium text-secondary transition-colors hover:bg-primary_hover hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand disabled:cursor-not-allowed disabled:opacity-60',
+            collapsed ? 'justify-center px-0' : 'gap-3 px-3',
+          )}
+        >
+          <LogOut01 className="size-5 shrink-0 text-tertiary group-hover:text-primary" aria-hidden="true" />
+          <span className={cn('truncate', collapsed ? 'sr-only' : 'inline')}>{signingOut ? 'Signing out…' : 'Sign out'}</span>
+        </button>
+        )}
       </div>
     </>
   )

--- a/web/src/components/synapse/DashboardCharts.tsx
+++ b/web/src/components/synapse/DashboardCharts.tsx
@@ -46,8 +46,12 @@ export function RadarChart({
   const polygonPath = dataPoints.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x},${p.y}`).join(' ') + ' Z'
 
   return (
-    <div className="flex w-full flex-col items-center justify-around gap-4 sm:flex-row sm:gap-6">
-      <figure className="relative shrink-0 size-52 sm:size-56" aria-label={`${title}: ${total} total`}>
+    // @container so the figure+legend go side-by-side based on THIS card's width, not the viewport —
+    // in a 2-up dashboard grid a card can be ~400px while the viewport is >640px, which previously made
+    // the row layout overflow the card (the percent column spilled past the edge). Below @md it stacks.
+    <div className="@container w-full">
+      <div className="flex flex-col items-center justify-center gap-4 @md:flex-row @md:justify-around @md:gap-6">
+      <figure className="relative shrink-0 size-52 @md:size-56" aria-label={`${title}: ${total} total`}>
         <svg viewBox={`0 0 ${size} ${size}`} role="img" className="size-full select-none overflow-visible">
           <title>{title}</title>
           <defs>
@@ -150,12 +154,12 @@ export function RadarChart({
       </figure>
 
       {/* Legend list matching Untitled UI */}
-      <ul className="w-full sm:w-auto sm:min-w-[190px] sm:max-w-[220px] space-y-2">
+      <ul className="w-full min-w-0 space-y-2 @md:w-auto @md:min-w-[190px] @md:max-w-[240px]">
         {data.map((item) => (
           <li
             key={item.key}
             className={cn(
-              'grid grid-cols-[minmax(0,1fr)_2.5rem_2.5rem] items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors cursor-pointer',
+              'grid grid-cols-[minmax(0,1fr)_2.25rem_2.5rem] items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors cursor-pointer',
               hoverKey === item.key ? 'bg-secondary' : 'hover:bg-secondary',
             )}
             onMouseEnter={() => setHoverKey(item.key)}
@@ -171,6 +175,7 @@ export function RadarChart({
         ))}
         {total === 0 && <li className="text-xs text-tertiary">No posture data available.</li>}
       </ul>
+      </div>
     </div>
   )
 }
@@ -180,8 +185,10 @@ export function DonutChart({ title, centerLabel, data }: { title: string; center
   const CIRCUMFERENCE_INNER = 2 * Math.PI * 44
   let offset = 0
   return (
-    <div className="flex w-full flex-col items-center justify-around gap-4 sm:flex-row sm:gap-6">
-      <figure className="relative shrink-0 size-44 sm:size-48" aria-label={`${title}: ${total} total`}>
+    // @container: side-by-side only when this card is wide enough (see RadarChart), else stack.
+    <div className="@container w-full">
+      <div className="flex flex-col items-center justify-center gap-4 @md:flex-row @md:justify-around @md:gap-6">
+      <figure className="relative shrink-0 size-44 @md:size-48" aria-label={`${title}: ${total} total`}>
         <svg viewBox="0 0 120 120" role="img" className="size-full" aria-label={`${title} donut chart`}>
           <title>{title}</title>
           <circle cx="60" cy="60" r="44" fill="none" stroke="var(--color-border-secondary)" strokeWidth="12" />
@@ -217,9 +224,9 @@ export function DonutChart({ title, centerLabel, data }: { title: string; center
           </text>
         </svg>
       </figure>
-      <ul className="w-full sm:w-auto sm:min-w-[190px] sm:max-w-[220px] space-y-2">
+      <ul className="w-full min-w-0 space-y-2 @md:w-auto @md:min-w-[190px] @md:max-w-[240px]">
         {data.map((item) => (
-          <li key={item.key} className="grid grid-cols-[minmax(0,1fr)_2.5rem_2.5rem] items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors hover:bg-secondary">
+          <li key={item.key} className="grid grid-cols-[minmax(0,1fr)_2.25rem_2.5rem] items-center gap-2 rounded-md px-2 py-1 text-xs transition-colors hover:bg-secondary">
             <span className="flex min-w-0 items-center gap-2.5 font-medium text-secondary">
               <span className="size-2.5 shrink-0 rounded-full" style={{ backgroundColor: item.color }} />
               <span className="truncate">{item.label}</span>
@@ -230,6 +237,7 @@ export function DonutChart({ title, centerLabel, data }: { title: string; center
         ))}
         {total === 0 && <li className="text-xs text-tertiary">No data available.</li>}
       </ul>
+      </div>
     </div>
   )
 }

--- a/web/src/pages/CodeQuality/components/ProfileDetail.tsx
+++ b/web/src/pages/CodeQuality/components/ProfileDetail.tsx
@@ -25,8 +25,13 @@ export function ProfileDetail({
   const [detailCopiedKey, setDetailCopiedKey] = useState<string | null>(null)
 
   function copyKey(text: string) {
+    // Copies the rule/profile key so it can be pasted into search, the CLI (--rule), .synapseignore,
+    // or a VEX file. Falls back to a hidden textarea + execCommand for non-secure contexts where the
+    // async Clipboard API is unavailable, so the button always does something visible.
     if (navigator?.clipboard?.writeText) {
-      navigator.clipboard.writeText(text).catch(() => {})
+      navigator.clipboard.writeText(text).catch(() => fallbackCopy(text))
+    } else {
+      fallbackCopy(text)
     }
     setDetailCopiedKey(text)
     setTimeout(() => {
@@ -78,7 +83,7 @@ export function ProfileDetail({
         title={
           <div className="space-y-1">
             <h2 className="text-base font-bold text-primary sm:text-lg">{profile.name}</h2>
-            <div className="flex items-center gap-1.5 font-mono text-xs italic">
+            <div className="flex items-center gap-1.5 font-mono text-xs">
               <button
                 type="button"
                 onClick={() => copyKey(profile.key)}
@@ -283,19 +288,21 @@ export function ProfileDetail({
                         : 'border-secondary/60 bg-secondary/15 opacity-70 hover:opacity-100 hover:bg-secondary/30'
                     )}
                   >
-                    {/* Checkbox + Rule Info */}
+                    {/* Rule activation indicator. A native disabled checkbox greys out even when
+                        checked, so a read-only built-in profile's ACTIVE rules looked inactive. This
+                        custom box keeps active rules vividly brand-filled whether or not they're
+                        editable; only editable (custom) profiles toggle on click. */}
                     <div className="flex min-w-0 items-start gap-2.5">
-                      <input
-                        type="checkbox"
-                        checked={active}
-                        disabled={profile.builtIn || busy}
-                        aria-label={`Activate ${r.name}`}
-                        className="mt-0.5 size-4 shrink-0 rounded border-secondary text-brand-solid accent-brand-solid focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 cursor-pointer disabled:cursor-not-allowed"
-                        onChange={(e) =>
+                      <RuleActivationBox
+                        active={active}
+                        readOnly={profile.builtIn}
+                        busy={busy}
+                        name={r.name}
+                        onToggle={() =>
                           run(() =>
-                            e.target.checked
-                              ? api.activateProfileRule(profile.key, r.key)
-                              : api.deactivateProfileRule(profile.key, r.key),
+                            active
+                              ? api.deactivateProfileRule(profile.key, r.key)
+                              : api.activateProfileRule(profile.key, r.key),
                           )
                         }
                       />
@@ -303,7 +310,7 @@ export function ProfileDetail({
                         <div className="truncate text-xs font-semibold text-primary" title={r.name}>
                           {r.name}
                         </div>
-                        <div className="mt-0.5 flex items-center gap-1 font-mono text-[11px] text-tertiary italic">
+                        <div className="mt-0.5 flex items-center gap-1 font-mono text-[11px] text-tertiary">
                           <button
                             type="button"
                             onClick={() => copyKey(r.key)}
@@ -411,4 +418,77 @@ export function ProfileDetail({
       )}
     </div>
   )
+}
+
+// RuleActivationBox shows whether a rule is active in the profile. Unlike a native disabled checkbox
+// (which the browser greys out even when checked), an ACTIVE rule stays vividly brand-filled here even
+// on a read-only built-in profile. Only editable (custom) profiles are clickable.
+function RuleActivationBox({
+  active,
+  readOnly,
+  busy,
+  name,
+  onToggle,
+}: {
+  active: boolean
+  readOnly: boolean
+  busy: boolean
+  name: string
+  onToggle: () => void
+}) {
+  const box = (
+    <span
+      className={cn(
+        'flex size-4 items-center justify-center rounded border transition-colors',
+        active ? 'border-brand-solid bg-brand-solid text-white' : 'border-secondary bg-primary',
+      )}
+    >
+      {active && <Check className="size-3" aria-hidden="true" />}
+    </span>
+  )
+
+  if (readOnly) {
+    return (
+      <span
+        role="checkbox"
+        aria-checked={active}
+        aria-disabled="true"
+        aria-label={`${name} — ${active ? 'active' : 'inactive'} (read-only)`}
+        className="mt-0.5 shrink-0 cursor-not-allowed"
+      >
+        {box}
+      </span>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={active}
+      aria-label={`${active ? 'Deactivate' : 'Activate'} ${name}`}
+      disabled={busy}
+      onClick={onToggle}
+      className="mt-0.5 shrink-0 cursor-pointer rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {box}
+    </button>
+  )
+}
+
+// fallbackCopy copies text without the async Clipboard API (unavailable in non-secure contexts).
+function fallbackCopy(text: string) {
+  try {
+    const ta = document.createElement('textarea')
+    ta.value = text
+    ta.setAttribute('readonly', '')
+    ta.style.position = 'fixed'
+    ta.style.opacity = '0'
+    document.body.appendChild(ta)
+    ta.select()
+    document.execCommand('copy')
+    document.body.removeChild(ta)
+  } catch {
+    /* best-effort; the transient "Copied" state still confirms the intent */
+  }
 }

--- a/web/src/pages/Connect.tsx
+++ b/web/src/pages/Connect.tsx
@@ -1,8 +1,8 @@
-import { Eye, EyeOff, Key01, Loading01, LogIn04, ShieldTick } from '@untitledui/icons'
+import { ChevronDown, Eye, EyeOff, Key01, Loading01, LogIn04, ShieldTick } from '@untitledui/icons'
 import { useState, type ReactNode } from 'react'
 import { useAuth } from '../auth/AuthContext'
-import { Button, Card, ErrorState, Field, Input } from '../components/ui'
-import logoFull from '../assets/logo-full-dark.png'
+import { Button, ErrorState, Field, Input } from '../components/ui'
+import logo from '../assets/logo.png'
 
 export function Connect() {
   const { phase, aup, error, connecting, connect, acceptAup, logout } = useAuth()
@@ -13,100 +13,154 @@ export function Connect() {
 
   if (phase === 'connecting') {
     return (
-      <Center>
-        <Loading01 className="size-6 animate-spin motion-reduce:animate-none text-brand" />
-        <p className="mt-3 text-sm text-tertiary">Checking your sign-in session…</p>
-      </Center>
+      <AuthShell>
+        <div className="flex flex-col items-center gap-3 py-10 text-center">
+          <Loading01 className="size-6 animate-spin motion-reduce:animate-none text-brand" />
+          <p className="text-sm text-tertiary">Checking your sign-in session…</p>
+        </div>
+      </AuthShell>
     )
   }
 
   return (
-    <Center>
-      <div className="mb-7 flex flex-col items-center gap-3 text-center">
-        <img src={logoFull} alt="Synapse" className="h-20 w-auto" />
-        <p className="text-xs text-tertiary">Security &amp; pentest operations</p>
-      </div>
+    <AuthShell>
+      <Brand />
 
       {phase === 'need-aup' && aup ? (
-        <Card title="Acceptable Use Policy" className="w-full max-w-lg animate-fade-in motion-reduce:animate-none">
-          <p className="whitespace-pre-line text-sm leading-relaxed text-secondary">{aup.text}</p>
+        <Panel>
+          <div className="mb-4 text-center">
+            <h2 className="text-lg font-bold tracking-tight text-primary">Acceptable Use Policy</h2>
+            <p className="mt-1 text-sm text-tertiary">Review and accept to continue.</p>
+          </div>
+          <div className="max-h-[46vh] overflow-y-auto rounded-xl border border-secondary bg-secondary/30 p-4">
+            <p className="whitespace-pre-line text-sm leading-relaxed text-secondary">{aup.text}</p>
+          </div>
           {error && <div className="mt-4"><ErrorState message={error} /></div>}
           <div className="mt-5 flex items-center justify-between gap-3">
             <button
               type="button"
               disabled={signingOut}
-              onClick={async () => {
-                setSigningOut(true)
-                try { await logout() } finally { setSigningOut(false) }
-              }}
+              onClick={async () => { setSigningOut(true); try { await logout() } finally { setSigningOut(false) } }}
               className="rounded text-xs text-tertiary underline-offset-2 hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {signingOut ? 'Signing out…' : 'Sign out'}
             </button>
-            <Button loading={accepting} onClick={async () => {
-              setAccepting(true)
-              try { await acceptAup() } finally { setAccepting(false) }
-            }}>
+            <Button loading={accepting} onClick={async () => { setAccepting(true); try { await acceptAup() } finally { setAccepting(false) } }}>
               <ShieldTick className="size-4" /> Accept &amp; continue
             </Button>
           </div>
           <p className="mt-3 text-center text-[11px] text-quaternary">Policy version {aup.version}</p>
-        </Card>
+        </Panel>
       ) : (
-        <Card className="w-full max-w-[420px] animate-fade-in motion-reduce:animate-none">
-          <div className="space-y-5">
-            <div className="space-y-1 text-center">
-              <h1 className="text-base font-semibold text-primary">Sign in to Synapse</h1>
-              <p className="text-sm text-tertiary">Use your organization sign-in to continue.</p>
-            </div>
-            {error && <ErrorState message={error} />}
-            <a
-              href="/api/auth/oidc/login"
-              className="inline-flex w-full select-none items-center justify-center gap-2 rounded-lg bg-brand-solid px-3.5 py-2 text-sm font-semibold text-primary_on-brand transition-opacity duration-150 hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2"
-            >
-              <LogIn04 className="size-4" /> Sign in with your organization
-            </a>
-            <div className="flex items-center gap-3 text-xs text-quaternary before:h-px before:flex-1 before:bg-secondary after:h-px after:flex-1 after:bg-secondary">or</div>
-            <details className="rounded-lg border border-secondary bg-secondary/30 p-3">
-              <summary className="cursor-pointer text-sm font-medium text-primary">Development or automation API token</summary>
-              <form onSubmit={(e) => { e.preventDefault(); void connect(token) }} className="mt-4 space-y-4">
-                <Field label="API token">
-                  <div className="relative">
-                    <Input
-                      type={showToken ? 'text' : 'password'}
-                      required
-                      value={token}
-                      onChange={(e) => setToken(e.target.value)}
-                      placeholder="paste token…"
-                      className="font-mono pr-10"
-                      aria-label="API token"
-                      aria-describedby="api-token-hint"
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setShowToken((v) => !v)}
-                      aria-label={showToken ? 'Hide token' : 'Show token'}
-                      className="absolute inset-y-0 right-0 flex items-center rounded-r-lg px-3 text-tertiary transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
-                    >
-                      {showToken ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
-                    </button>
-                  </div>
-                </Field>
-                <p id="api-token-hint" className="text-[11px] text-tertiary">
-                  {token.trim() ? 'The token is sent only to this server.' : 'Paste a token to enable this development sign-in.'}
-                </p>
-                <Button type="submit" loading={connecting} disabled={!token.trim()} className="w-full">
-                  <Key01 className="size-4" /> Connect with API token
-                </Button>
-              </form>
-            </details>
+        <Panel>
+          <div className="mb-5 text-center">
+            <h2 className="text-xl font-bold tracking-tight text-primary">Welcome back</h2>
+            <p className="mt-1 text-sm text-tertiary">Sign in with your organization to continue.</p>
           </div>
-        </Card>
+
+          {error && <div className="mb-4"><ErrorState message={error} /></div>}
+
+          <a
+            href="/api/auth/oidc/login"
+            className="btn-primary group flex w-full select-none items-center justify-center gap-2.5 rounded-xl px-4 py-3 text-sm font-semibold text-primary_on-brand transition-transform duration-150 hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+          >
+            <LogIn04 className="size-5" /> Sign in with your organization
+          </a>
+
+          <div className="my-5 flex items-center gap-3 text-[11px] font-medium uppercase tracking-wider text-quaternary before:h-px before:flex-1 before:bg-secondary after:h-px after:flex-1 after:bg-secondary">
+            or
+          </div>
+
+          <details className="group rounded-xl border border-secondary bg-secondary/30 transition-colors open:bg-secondary/50 hover:border-secondarystrong">
+            <summary className="flex cursor-pointer list-none items-center gap-3 p-3.5 [&::-webkit-details-marker]:hidden">
+              <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-brand-primary text-brand-secondary ring-1 ring-inset ring-brand/20">
+                <Key01 className="size-4" />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-sm font-semibold text-primary">Development or automation API token</span>
+                <span className="block text-xs text-tertiary">For CLI, CI/CD and service integrations</span>
+              </span>
+              <ChevronDown className="size-4 shrink-0 text-tertiary transition-transform duration-200 group-open:rotate-180" />
+            </summary>
+            <form
+              onSubmit={(e) => { e.preventDefault(); void connect(token) }}
+              className="space-y-4 border-t border-secondary p-3.5"
+            >
+              <Field label="API token">
+                <div className="relative">
+                  <Input
+                    type={showToken ? 'text' : 'password'}
+                    required
+                    value={token}
+                    onChange={(e) => setToken(e.target.value)}
+                    placeholder="paste token…"
+                    className="pr-10 font-mono"
+                    aria-label="API token"
+                    aria-describedby="api-token-hint"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowToken((v) => !v)}
+                    aria-label={showToken ? 'Hide token' : 'Show token'}
+                    className="absolute inset-y-0 right-0 flex items-center rounded-r-lg px-3 text-tertiary transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+                  >
+                    {showToken ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+                  </button>
+                </div>
+              </Field>
+              <p id="api-token-hint" className="text-[11px] text-tertiary">
+                {token.trim() ? 'The token is sent only to this server.' : 'Paste a token to enable this development sign-in.'}
+              </p>
+              <Button type="submit" loading={connecting} disabled={!token.trim()} className="w-full">
+                <Key01 className="size-4" /> Connect with API token
+              </Button>
+            </form>
+          </details>
+
+          <div className="mt-6 flex items-center justify-between border-t border-secondary pt-4 text-xs text-quaternary">
+            <span className="inline-flex items-center gap-1.5">
+              <ShieldTick className="size-3.5" /> Encrypted, audited access
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <span className="size-1.5 rounded-full bg-accent" /> All systems operational
+            </span>
+          </div>
+        </Panel>
       )}
-    </Center>
+    </AuthShell>
   )
 }
 
-function Center({ children }: { children: ReactNode }) {
-  return <div className="flex min-h-screen flex-col items-center justify-center bg-primary px-4 py-12">{children}</div>
+// Branded lockup: the hexagon mark on an elevated tile + wordmark + eyebrow. Uses the crisp mark
+// (logo.png), which reads in both themes — the full embossed logo washed out on the pale background.
+function Brand() {
+  return (
+    <div className="mb-7 flex flex-col items-center text-center">
+      <div className="card-sheen elev mb-4 flex size-16 items-center justify-center rounded-2xl bg-card ring-1 ring-inset ring-black/5 dark:ring-white/10">
+        <img src={logo} alt="Synapse" className="size-10" />
+      </div>
+      <h1 className="text-2xl font-bold tracking-tight text-primary">Synapse</h1>
+      <p className="mt-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-brand">Security operations platform</p>
+    </div>
+  )
+}
+
+function Panel({ children }: { children: ReactNode }) {
+  return (
+    <div className="card-sheen elev animate-fade-in rounded-2xl border border-secondary bg-card p-6 motion-reduce:animate-none sm:p-7">
+      {children}
+    </div>
+  )
+}
+
+// The auth background is the designed indigo-glow surface (.bg-auth) plus two soft brand blooms, so the
+// floating card is anchored in brand light instead of a flat, pale white field.
+function AuthShell({ children }: { children: ReactNode }) {
+  return (
+    <div className="bg-auth relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-4 py-12">
+      <div aria-hidden className="pointer-events-none absolute -top-32 left-1/2 size-[560px] -translate-x-1/2 rounded-full bg-brand-solid/10 blur-[130px]" />
+      <div aria-hidden className="pointer-events-none absolute -bottom-40 -right-20 size-[420px] rounded-full bg-brand-solid/[0.08] blur-[130px]" />
+      <div className="relative w-full max-w-[440px]">{children}</div>
+    </div>
+  )
 }

--- a/web/src/pages/Connect.tsx
+++ b/web/src/pages/Connect.tsx
@@ -5,7 +5,7 @@ import { Button, ErrorState, Field, Input } from '../components/ui'
 import logo from '../assets/logo.png'
 
 export function Connect() {
-  const { phase, aup, error, connecting, connect, acceptAup, logout } = useAuth()
+  const { phase, aup, error, connecting, connect, acceptAup, logout, oidcAvailable } = useAuth()
   const [token, setToken] = useState('')
   const [showToken, setShowToken] = useState(false)
   const [accepting, setAccepting] = useState(false)
@@ -41,7 +41,7 @@ export function Connect() {
               type="button"
               disabled={signingOut}
               onClick={async () => { setSigningOut(true); try { await logout() } finally { setSigningOut(false) } }}
-              className="rounded text-xs text-tertiary underline-offset-2 hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60"
+              className="rounded text-xs text-tertiary underline-offset-2 hover:text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg disabled:cursor-not-allowed disabled:opacity-60"
             >
               {signingOut ? 'Signing out…' : 'Sign out'}
             </button>
@@ -55,23 +55,29 @@ export function Connect() {
         <Panel>
           <div className="mb-5 text-center">
             <h2 className="text-xl font-bold tracking-tight text-primary">Welcome back</h2>
-            <p className="mt-1 text-sm text-tertiary">Sign in with your organization to continue.</p>
+            <p className="mt-1 text-sm text-tertiary">
+              {oidcAvailable ? 'Sign in with your organization to continue.' : 'Sign in with your API token to continue.'}
+            </p>
           </div>
 
           {error && <div className="mb-4"><ErrorState message={error} /></div>}
 
-          <a
-            href="/api/auth/oidc/login"
-            className="btn-primary group flex w-full select-none items-center justify-center gap-2.5 rounded-xl px-4 py-3 text-sm font-semibold text-primary_on-brand transition-transform duration-150 hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
-          >
-            <LogIn04 className="size-5" /> Sign in with your organization
-          </a>
+          {oidcAvailable && (
+            <>
+              <a
+                href="/api/auth/oidc/login"
+                className="btn-primary group flex w-full select-none items-center justify-center gap-2.5 rounded-xl px-4 py-3 text-sm font-semibold text-primary_on-brand transition-transform duration-150 hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
+              >
+                <LogIn04 className="size-5" /> Sign in with your organization
+              </a>
 
-          <div className="my-5 flex items-center gap-3 text-[11px] font-medium uppercase tracking-wider text-quaternary before:h-px before:flex-1 before:bg-secondary after:h-px after:flex-1 after:bg-secondary">
-            or
-          </div>
+              <div className="my-5 flex items-center gap-3 text-[11px] font-medium uppercase tracking-wider text-quaternary before:h-px before:flex-1 before:bg-secondary after:h-px after:flex-1 after:bg-secondary">
+                or
+              </div>
+            </>
+          )}
 
-          <details className="group rounded-xl border border-secondary bg-secondary/30 transition-colors open:bg-secondary/50 hover:border-secondarystrong">
+          <details open={!oidcAvailable} className="group rounded-xl border border-secondary bg-secondary/30 transition-colors open:bg-secondary/50 hover:border-borderstrong">
             <summary className="flex cursor-pointer list-none items-center gap-3 p-3.5 [&::-webkit-details-marker]:hidden">
               <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-brand-primary text-brand-secondary ring-1 ring-inset ring-brand/20">
                 <Key01 className="size-4" />
@@ -117,7 +123,7 @@ export function Connect() {
             </form>
           </details>
 
-          <div className="mt-6 flex items-center justify-between border-t border-secondary pt-4 text-xs text-quaternary">
+          <div className="mt-6 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 border-t border-secondary pt-4 text-xs text-quaternary">
             <span className="inline-flex items-center gap-1.5">
               <ShieldTick className="size-3.5" /> Encrypted, audited access
             </span>
@@ -140,7 +146,7 @@ function Brand() {
         <img src={logo} alt="Synapse" className="size-10" />
       </div>
       <h1 className="text-2xl font-bold tracking-tight text-primary">Synapse</h1>
-      <p className="mt-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-brand">Security operations platform</p>
+      <p className="mt-1.5 text-[11px] font-semibold uppercase tracking-[0.2em] text-brand dark:text-branddim">Security operations platform</p>
     </div>
   )
 }


### PR DESCRIPTION
fix(web): quality-profile rule activation looks active (not greyed) + copy robustness

- Rule activation indicator: a native disabled checkbox is greyed by the browser even
  when checked, so a read-only built-in profile's ACTIVE rules looked inactive/dull.
  Replaced it with a custom RuleActivationBox — an active rule is vividly brand-filled
  (brand box + white check) whether or not it's editable; only editable custom profiles
  toggle on click (role=checkbox, aria-checked, keyboard + focus-ring). Read-only rows
  are aria-disabled but still clearly show active state.
- Copy-key button: it already copies the rule/profile key (for search / CLI --rule /
  .synapseignore / VEX) and shows a transient "Copied key!" — kept, and added a
  textarea+execCommand fallback for non-secure contexts so it never silently no-ops.
- Readability: de-italicised the monospace profile/rule keys (italic mono is harder to
  read). App font is Inter + JetBrains Mono — kept.

typecheck + 375 tests + build green.
