### PR TITLE
fix(web): Bug badge + copy-check + status dots colourless (undefined utility scales)

### DIFF
--- a/web/src/pages/EngagementDetail/FindingsTab.tsx
+++ b/web/src/pages/EngagementDetail/FindingsTab.tsx
@@ -160,7 +160,7 @@ export function FindingsTab({
                   value: 'all',
                   label: (
                     <span className="flex items-center gap-2">
-                      <span className="size-2 rounded-full bg-utility-gray-400" />
+                      <span className="size-2 rounded-full bg-utility-neutral-400" />
                       <span>All Severities</span>
                     </span>
                   ),
@@ -169,7 +169,7 @@ export function FindingsTab({
                   value: s,
                   label: (
                     <span className="flex items-center gap-2">
-                      <span className={cn('size-2 rounded-full', STATUS_DOT[s] ?? 'bg-utility-gray-400')} />
+                      <span className={cn('size-2 rounded-full', STATUS_DOT[s] ?? 'bg-utility-neutral-400')} />
                       <span className="capitalize">{s}</span>
                     </span>
                   ),

--- a/web/src/pages/EngagementDetail/components/FindingStatus.tsx
+++ b/web/src/pages/EngagementDetail/components/FindingStatus.tsx
@@ -8,10 +8,10 @@ import type { Finding } from '../../../lib/types'
 export const FINDING_STATUSES = ['open', 'triage', 'confirmed', 'false_positive', 'remediated']
 
 export const STATUS_DOT: Record<string, string> = {
-  open: 'bg-utility-gray-400',
+  open: 'bg-utility-neutral-400',
   triage: 'bg-utility-orange-500',
   confirmed: 'bg-utility-red-500',
-  false_positive: 'bg-utility-gray-300',
+  false_positive: 'bg-utility-neutral-300',
   remediated: 'bg-utility-green-500',
 }
 
@@ -26,7 +26,7 @@ export const STATUS_TEXT: Record<string, string> = {
 export function StatusLabel({ status }: { status: string }) {
   return (
     <span className={cn('flex items-center gap-2 font-medium', STATUS_TEXT[status] ?? 'text-tertiary')}>
-      <span className={cn('size-2 shrink-0 rounded-full', STATUS_DOT[status] ?? 'bg-utility-gray-400')} />
+      <span className={cn('size-2 shrink-0 rounded-full', STATUS_DOT[status] ?? 'bg-utility-neutral-400')} />
       {statusLabel(status)}
     </span>
   )

--- a/web/src/pages/EngagementDetail/components/NewFindingModal.tsx
+++ b/web/src/pages/EngagementDetail/components/NewFindingModal.tsx
@@ -176,7 +176,7 @@ export function NewFindingModal({ engagementId, onCreated, onCancel }: { engagem
                   value: s,
                   label: (
                     <span className="flex items-center gap-2">
-                      <span className={cn('size-2 rounded-full', STATUS_DOT[s] ?? 'bg-utility-gray-400')} />
+                      <span className={cn('size-2 rounded-full', STATUS_DOT[s] ?? 'bg-utility-neutral-400')} />
                       <span className="capitalize">{s}</span>
                     </span>
                   ),

--- a/web/src/pages/EngagementDetail/components/OverviewComposition.tsx
+++ b/web/src/pages/EngagementDetail/components/OverviewComposition.tsx
@@ -11,7 +11,7 @@ const LANG_COLORS = [
   'bg-utility-orange-600',
   'bg-utility-pink-600',
   'bg-brand-solid',
-  'bg-utility-gray-600',
+  'bg-utility-neutral-600',
 ]
 
 export function CardEmpty({ icon: Icon, text }: { icon: ComponentType<{ className?: string }>; text: string }) {

--- a/web/src/pages/EngagementDetail/components/OverviewRisk.tsx
+++ b/web/src/pages/EngagementDetail/components/OverviewRisk.tsx
@@ -176,7 +176,7 @@ export function FindingsActivityGauge({
             ? 'bg-utility-yellow-600'
             : sev === 'low'
               ? 'bg-utility-blue-600'
-              : 'bg-utility-gray-600',
+              : 'bg-utility-neutral-600',
     colorHex:
       sev === 'critical'
         ? '#D92D20'
@@ -216,7 +216,7 @@ export function FindingsActivityGauge({
                   fill="none"
                   stroke="#F2F4F7"
                   strokeWidth={RING_STROKE_WIDTH}
-                  className="stroke-utility-gray-100"
+                  className="stroke-utility-neutral-100"
                 />
                 {/* Value arc */}
                 {count > 0 && (

--- a/web/src/pages/Rules/index.tsx
+++ b/web/src/pages/Rules/index.tsx
@@ -47,7 +47,7 @@ function CopyButton({ text, ariaLabel = 'Copy' }: { text: string; ariaLabel?: st
       title={copied ? 'Copied to clipboard!' : ariaLabel}
       className="rounded p-1 text-tertiary transition-colors hover:bg-secondary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
     >
-      {copied ? <Check className="size-3.5 text-utility-success-600 dark:text-utility-success-400" /> : <Copy01 className="size-3.5" />}
+      {copied ? <Check className="size-3.5 text-utility-green-600 dark:text-utility-green-400" /> : <Copy01 className="size-3.5" />}
     </button>
   )
 }
@@ -67,7 +67,9 @@ function RuleTypeBadge({ type }: { type: string }) {
     colorClass = 'border-utility-blue-200 bg-utility-blue-50 text-utility-blue-700 dark:border-utility-blue-800 dark:bg-utility-blue-950/40 dark:text-utility-blue-300'
     Icon = FileCode01
   } else if (type === 'bug') {
-    colorClass = 'border-utility-error-200 bg-utility-error-50 text-utility-error-700 dark:border-utility-error-800 dark:bg-utility-error-950/40 dark:text-utility-error-300'
+    // NOTE: the theme has no `utility-error` scale (valid red = `utility-red`), so the old
+    // utility-error-* classes emitted NO CSS and the Bug badge rendered colourless. Use utility-red.
+    colorClass = 'border-utility-red-200 bg-utility-red-50 text-utility-red-700 dark:border-utility-red-800 dark:bg-utility-red-950/40 dark:text-utility-red-300'
     Icon = AlertTriangle
   }
 


### PR DESCRIPTION
fix(web): Bug/type badges + copy-check + status dots were colourless — undefined utility scales

The Bug rule-type badge used `utility-error-*`, but the theme has no `utility-error`
colour scale (valid red is `utility-red`), so those classes emitted NO CSS and the Bug
badge rendered colourless. Same root cause in two more places:
- the Rules copy-confirmation check used `utility-success-*` (undefined) → not green;
- finding status dots used `utility-gray-*` (undefined) → invisible.

Fixes: utility-error → utility-red (Bug badge), utility-success → utility-green
(copy check), utility-gray → utility-neutral (status dots). Verified: no undefined
utility-<scale> remains in src (only theme-defined scales: amber/blue/brand/emerald/
fuchsia/green/indigo/neutral/orange/pink/purple/red/sky/slate/yellow), and the
utility-red/green/neutral classes now appear in the built CSS. typecheck + 375 tests
+ build green.
