### PR TITLE
fix(fleet): host inventory establishes the agent→telemetry asset binding (+ code-quality UI legibility)

### DIFF
--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -308,7 +308,8 @@ func main() {
 		ports.TelemetryReferenceResolver
 		ports.TelemetryBatchAccountingReader
 		ports.CoverageGapReader
-	} // A3 telemetry transport sequencing state and #610 causal-reference resolver
+		ports.TelemetryAssetBindingStore
+	} // A3 telemetry transport sequencing state, #610 causal-reference resolver, agent→asset binding
 	var sensorStateStore interface {
 		ports.SensorStateAuditStore
 		ports.CoverageSensorStateReader
@@ -1924,6 +1925,12 @@ func main() {
 			if hierr != nil {
 				log.Error("host inventory ingest init failed", "err", hierr)
 				os.Exit(1)
+			}
+			// A3 binding: a host-inventory sync establishes the reporting agent's canonical telemetry
+			// asset binding, without which telemetry ingest (and therefore the detection pipeline)
+			// cannot resolve the agent's asset. The transport store owns that binding.
+			if telemetryTransportStore != nil {
+				hiSvc.SetTelemetryBinder(telemetryTransportStore)
 			}
 			router.SetFleetHostInventory(hiSvc)
 			log.Info("fleet host inventory ingest ENABLED (VM agents persist host inventories into the asset model)")

--- a/internal/usecase/fleet/hostinventory/service.go
+++ b/internal/usecase/fleet/hostinventory/service.go
@@ -36,10 +36,17 @@ var _ AssetWriter = (*assetuc.Service)(nil)
 
 // Service maps and persists a host inventory.
 type Service struct {
-	assets AssetWriter
-	audit  ports.AuditLogger
-	clock  ports.Clock
+	assets   AssetWriter
+	audit    ports.AuditLogger
+	clock    ports.Clock
+	bindings ports.TelemetryAssetBindingStore // optional; nil ⇒ no telemetry asset binding is established
 }
+
+// SetTelemetryBinder wires the server-authoritative agent→host telemetry binding store. When set, a
+// successful host-inventory sync establishes (or refreshes) the reporting agent's canonical telemetry
+// asset binding — the A3 mapping that telemetry ingest requires (see the Sync doc comment). Kept an
+// optional setter (nil ⇒ no binding) so telemetry-less compositions are unchanged.
+func (s *Service) SetTelemetryBinder(b ports.TelemetryAssetBindingStore) { s.bindings = b }
 
 // NewService validates its dependencies and constructs the service.
 func NewService(assets AssetWriter, audit ports.AuditLogger, clock ports.Clock) (*Service, error) {
@@ -118,6 +125,35 @@ func (s *Service) Sync(ctx context.Context, actor string, in SyncInput) (*SyncRe
 			At: now,
 		}); err != nil {
 			return nil, fmt.Errorf("host inventory: audit coverage gap: %w", err)
+		}
+	}
+
+	// Establish the canonical telemetry binding this host inventory authorizes: the authenticated
+	// reporting agent (actor) owns the host asset it just reconciled. Without this, telemetry ingest
+	// cannot resolve the agent's asset and refuses every batch. guardAssetBinding above already proved
+	// the reporting agent is not stealing another agent's host, so a cross-agent conflict here is a real
+	// race and is surfaced, never swallowed.
+	if s.bindings != nil {
+		if err := s.bindings.BindTelemetryAsset(ctx, ports.TelemetryAssetBinding{
+			TenantID: in.TenantID, AgentID: shared.ID(actor), AssetID: a.ID, UpdatedAt: now,
+		}); err != nil {
+			return nil, fmt.Errorf("host inventory: establish telemetry asset binding: %w", err)
+		}
+		// Audit the establishment/refresh of this server-authoritative binding, mirroring how blocked
+		// takeovers and coverage gaps are audited — the binding is a first-class trust action, so its
+		// creation must be as attributable as its rejection.
+		if err := s.audit.Record(ctx, ports.AuditEntry{
+			Actor:  actor,
+			Action: "host_inventory.telemetry_binding_established",
+			Target: a.ID.String(),
+			Metadata: map[string]string{
+				"tenant_id": in.TenantID.String(),
+				"asset_id":  a.ID.String(),
+				"agent_id":  actor,
+			},
+			At: now,
+		}); err != nil {
+			return nil, fmt.Errorf("host inventory: audit telemetry binding: %w", err)
 		}
 	}
 

--- a/internal/usecase/fleet/hostinventory/service_test.go
+++ b/internal/usecase/fleet/hostinventory/service_test.go
@@ -262,3 +262,77 @@ func TestNewServiceValidatesDeps(t *testing.T) {
 		t.Error("nil clock must be rejected")
 	}
 }
+
+// fakeBinder records the agent→asset telemetry binding a sync establishes. errOn, when non-nil, makes
+// BindTelemetryAsset fail so the sync's hard-fail-on-binding-error path can be exercised.
+type fakeBinder struct {
+	last  ports.TelemetryAssetBinding
+	calls int
+	errOn error
+}
+
+func (f *fakeBinder) BindTelemetryAsset(_ context.Context, b ports.TelemetryAssetBinding) error {
+	f.calls++
+	if f.errOn != nil {
+		return f.errOn
+	}
+	f.last = b
+	return nil
+}
+
+func (f *fakeBinder) ResolveTelemetryAsset(_ context.Context, _ shared.ID) (shared.ID, error) {
+	if f.last.AssetID.IsZero() {
+		return "", shared.ErrNotFound
+	}
+	return f.last.AssetID, nil
+}
+
+// A wired binder is what makes telemetry ingest able to resolve the agent's asset; without this the whole
+// EDR detection pipeline is unreachable. A successful sync must establish it from the server-authoritative
+// actor + reconciled asset id.
+func TestSyncEstablishesTelemetryBindingWhenBinderSet(t *testing.T) {
+	w, a := newFakeWriter(), &fakeAudit{}
+	s := newService(t, w, a)
+	binder := &fakeBinder{}
+	s.SetTelemetryBinder(binder)
+
+	res, err := s.Sync(context.Background(), "agent-1", SyncInput{TenantID: "tenant-1", Inventory: completeHost()})
+	if err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+	if binder.calls != 1 {
+		t.Fatalf("expected exactly one bind call, got %d", binder.calls)
+	}
+	if binder.last.AgentID != "agent-1" || binder.last.AssetID != res.AssetID || binder.last.TenantID != "tenant-1" {
+		t.Fatalf("binding must map the authenticated agent to the reconciled asset in-tenant: %+v (asset=%s)", binder.last, res.AssetID)
+	}
+	if binder.last.UpdatedAt.IsZero() {
+		t.Fatal("binding must carry a server-stamped update time")
+	}
+	// The binding is a first-class trust action and must be auditable.
+	e, ok := a.entry("host_inventory.telemetry_binding_established")
+	if !ok {
+		t.Fatal("establishing a telemetry binding must be audited")
+	}
+	if e.Actor != "agent-1" || e.Metadata["asset_id"] != res.AssetID.String() {
+		t.Fatalf("binding audit must attribute the actor + asset: %+v", e)
+	}
+}
+
+// The binder is optional: a telemetry-less composition (nil binder) must sync unchanged.
+func TestSyncWithoutBinderIsUnchanged(t *testing.T) {
+	s := newService(t, newFakeWriter(), &fakeAudit{})
+	if _, err := s.Sync(context.Background(), "agent-1", SyncInput{TenantID: "tenant-1", Inventory: completeHost()}); err != nil {
+		t.Fatalf("sync without a binder must succeed: %v", err)
+	}
+}
+
+// A binding failure (e.g. the asset is already bound to a different agent) must hard-fail the sync, never
+// be swallowed — a host whose telemetry cannot be attributed must not report success.
+func TestSyncFailsWhenBindingConflicts(t *testing.T) {
+	s := newService(t, newFakeWriter(), &fakeAudit{})
+	s.SetTelemetryBinder(&fakeBinder{errOn: shared.ErrConflict})
+	if _, err := s.Sync(context.Background(), "agent-1", SyncInput{TenantID: "tenant-1", Inventory: completeHost()}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("a binding conflict must fail the sync, got %v", err)
+	}
+}

--- a/web/src/components/codequality/ProjectCodeWorkspace/index.tsx
+++ b/web/src/components/codequality/ProjectCodeWorkspace/index.tsx
@@ -564,10 +564,15 @@ function SourcePane({
           {visible.map((item) => {
             const line = source.lines[item.index]
             const lineFindings = byLine[line.number] ?? []
+            const hasFinding = lineFindings.length > 0
             const isHighlightLine =
               !!selectedFinding &&
               line.number >= selectedFinding.location.startLine &&
               line.number <= selectedFinding.location.endLine
+            // A line that carries a finding but isn't the currently-selected one still needs to stand out —
+            // otherwise a vulnerable line reads identically to a clean one (only a tiny gutter marker set it
+            // apart). Tint the whole row + a red rail, the way SonarQube/GitHub flag an issue line.
+            const isUnselectedFindingLine = hasFinding && !isHighlightLine
             const isCardLine = !!selectedFinding && line.number === selectedFinding.location.endLine
 
             return (
@@ -579,9 +584,11 @@ function SourcePane({
                   'group absolute left-0 top-0 flex flex-col w-full border-b border-secondary/15 transition-colors',
                   isHighlightLine
                     ? 'bg-brand-primary/10 border-l-2 border-l-brand-solid'
-                    : 'hover:bg-secondary/40',
-                  line.change === 'addition' && !isHighlightLine && 'bg-success-primary/5',
-                  line.duplicated && !isHighlightLine && 'bg-warning-primary/5',
+                    : isUnselectedFindingLine
+                      ? 'bg-error-primary/[0.06] border-l-2 border-l-error-primary/60 hover:bg-error-primary/10'
+                      : 'hover:bg-secondary/40',
+                  line.change === 'addition' && !isHighlightLine && !isUnselectedFindingLine && 'bg-success-primary/5',
+                  line.duplicated && !isHighlightLine && !isUnselectedFindingLine && 'bg-warning-primary/5',
                 )}
                 style={{ transform: `translateY(${item.start}px)` }}
               >
@@ -593,6 +600,7 @@ function SourcePane({
                     className={cn(
                       'sticky left-0 z-10 w-12 shrink-0 select-none border-r border-secondary bg-primary px-2 text-right leading-6.5 tabular-nums text-tertiary group-hover:text-primary transition-colors',
                       isHighlightLine && 'bg-brand-primary/20 text-brand-secondary font-bold',
+                      isUnselectedFindingLine && 'bg-error-primary/10 text-error-primary font-semibold',
                       line.change === 'addition' && 'border-l-2 border-l-success-primary',
                     )}
                   >
@@ -605,6 +613,7 @@ function SourcePane({
                     className={cn(
                       'sticky left-12 z-10 flex w-7 shrink-0 items-center justify-center border-r border-secondary bg-primary',
                       isHighlightLine && 'bg-brand-primary/20',
+                      isUnselectedFindingLine && 'bg-error-primary/10',
                     )}
                   >
                     {lineFindings.length > 0 && (

--- a/web/src/components/codequality/projectOverview/OverviewMetricCard.tsx
+++ b/web/src/components/codequality/projectOverview/OverviewMetricCard.tsx
@@ -11,6 +11,7 @@ import {
   unavailableReasonText,
 } from '../../../lib/projectOverviewPresentation'
 import { Card, cn } from '../../ui'
+import { gradeTone, type Grade } from '../qualityPresentation'
 
 const icons: Record<OverviewMetricCardModel['key'], FC<SVGProps<SVGSVGElement>>> = {
   security: Shield,
@@ -51,9 +52,23 @@ export function OverviewMetricCard({
             <Icon className="size-4" aria-hidden="true" />
           </span>
         </div>
-        <div className={cn('font-mono text-4xl font-semibold tabular-nums', available ? 'text-foreground' : 'text-mutedfg')}>
-          {value ?? '—'}
-        </div>
+        {card.kind === 'rating' && available && value ? (
+          // A colour-coded grade chip (A green → E red), like SonarQube, so the rating reads at a glance
+          // instead of as flat monochrome text.
+          <div
+            className={cn(
+              'inline-flex size-14 items-center justify-center rounded-xl border font-mono text-3xl font-bold shadow-2xs',
+              gradeTone(value as Grade),
+            )}
+            aria-label={`${card.label} grade ${value}`}
+          >
+            {value}
+          </div>
+        ) : (
+          <div className={cn('font-mono text-4xl font-semibold tabular-nums', available ? 'text-foreground' : 'text-mutedfg')}>
+            {value ?? '—'}
+          </div>
+        )}
         {reason && <p className="text-sm text-mutedfg">{reason}</p>}
         {detailTarget ? (
           <Link


### PR DESCRIPTION
## What

Two fixes uncovered while seeding the EDR incident flow for a demo.

### 1. `fix(fleet)` — host inventory now establishes the agent→telemetry asset binding

`BindTelemetryAsset` had **zero production callers**. Host-inventory `Sync` documented that it establishes the canonical A3 telemetry binding, but never actually called it — so `ResolveTelemetryAsset` always returned `NotFound`, telemetry ingest `403`'d `asset_binding_missing`, detections stayed **pending** (never sealed), and the entire EDR pipeline (telemetry → durable events → sealed detections → incidents) was **unreachable through the API**.

`hostinventory.Service` gains an optional `TelemetryAssetBindingStore` (nil ⇒ unchanged). After a successful asset upsert it binds the authenticated reporting agent to the reconciled asset in-tenant and **audits** `host_inventory.telemetry_binding_established`. `main.go` supplies the telemetry transport store as the binder under `SYNAPSE_FLEET_HOST_INGEST_ENABLED`.

Safety: the existing takeover guard still blocks a cross-agent host claim **before** any write; `BindTelemetryAsset` stays fail-closed (cross-agent asset move ⇒ `ErrConflict`, cross-tenant ⇒ `ErrForbidden`). Tests cover binder-set, nil-binder, conflict-hard-fail, and the binding audit.

### 2. `fix(web)` — code-quality UI legibility

- Overview rating cards (Security/Reliability/Maintainability) now render the grade as a **colour-coded chip (A green → E red)** via the existing `gradeTone`, instead of flat monochrome text.
- Code viewer: a line carrying a finding but not currently selected read identically to a clean line. Unselected finding lines now get a **subtle red row background + red left rail + tinted gutter** (SonarQube/GitHub style) so problem lines stand out.

## Verification

- `go build` / `go vet` / `go test ./internal/usecase/fleet/hostinventory/` green.
- Web `pnpm build` + 375 web tests green.
- End-to-end on a local in-memory instance: 3 incidents (1/host, High/Risk-80, 4 sealed detections each), 12 detections queryable.
- go-arch-reviewer: PASS. security-auditor: trust boundary holds, no critical/high.

Known pre-existing follow-up (out of scope here): the Postgres `BindTelemetryAsset` unique-violation isn't normalized to `ErrConflict` (surfaces as 500 not 409); the takeover guard blocks the common case first and the write stays fail-closed.
