### PR TITLE
feat: add assessment cycles and immutable snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Tenant-gated Assessment Cycles and immutable Assessment Snapshots.** New Cycle, Re-test,
+  archive/reopen, Snapshot finalization, bounded history, historical projection, and integrity APIs
+  preserve legacy completion while rollout is disabled and enforce native finalized evidence only for
+  explicit tenant cohorts. The `synapse-assessment-backfill`, `synapse-assessment-integrity`, and
+  `synapse-assessment-snapshot-backfill` operators provide resumable, lease-fenced migration tooling.
+  Migrations 0131–0135 add the tenant-isolated Snapshot, retained-request, backfill, and integrity
+  stores. Rollout is controlled by `SYNAPSE_ASSESSMENT_CYCLE_API_ENABLED`,
+  `SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_ENABLED`, `SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_TENANTS`,
+  `SYNAPSE_ASSESSMENT_SNAPSHOT_ENABLED`, `SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_ENABLED`,
+  `SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_TENANTS`, `SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED`,
+  `SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS`, `SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_ENABLED`,
+  and `SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_TENANTS`.
+
 - **Python Tier-2 semantic reachability and interprocedural taint analysis.** An opt-in, source-only
   tree-sitter sidecar now emits bounded semantic facts without importing or executing target Python;
   pure Go resolution proves affected-symbol call paths and precise value flow across assignments,

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -29,6 +29,10 @@ tags:
 - name: health
 - name: aup
 - name: engagements
+- name: assessment-cycles
+  description: Tenant-scoped initial Assessment and Re-test lifecycle Cycles
+- name: assessment-snapshots
+  description: Immutable coverage snapshots finalized from trusted Scan Runs
 - name: findings
 - name: sca
 - name: export
@@ -128,7 +132,12 @@ paths:
         "403": {$ref: "#/components/responses/Forbidden"}
     post:
       tags: [engagements]
-      summary: Create an engagement
+      summary: Create an initial Assessment and Assessment Cycle
+      parameters:
+      - name: Idempotency-Key
+        in: header
+        required: true
+        schema: {type: string, minLength: 1, maxLength: 128}
       requestBody:
         required: true
         content:
@@ -155,8 +164,249 @@ paths:
         "400": {$ref: "#/components/responses/BadRequest"}
         "401": {$ref: "#/components/responses/Unauthorized"}
         "403": {$ref: "#/components/responses/Forbidden"}
-        "409": {description: Engagement already has a different uploaded source package}
+        "409": {description: Idempotency body mismatch or source-package conflict}
         "413": {description: Uploaded source package exceeds 512 MiB}
+
+  /api/v1/engagements/{assessmentId}/retests:
+    parameters:
+    - name: assessmentId
+      in: path
+      required: true
+      schema: {type: string}
+    post:
+      tags: [engagements, assessment-cycles]
+      operationId: createAssessmentRetest
+      summary: Create a non-executable Assessment Re-test draft
+      parameters:
+      - name: Idempotency-Key
+        in: header
+        required: true
+        schema: {type: string, minLength: 1, maxLength: 128}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: "#/components/schemas/CreateAssessmentRetestRequest"}
+      responses:
+        "201":
+          description: Re-test created
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/CreateAssessmentRetestResponse"}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Idempotency mismatch, completed Cycle, or concurrent conflict}
+
+  /api/v1/engagements/{assessmentId}/lifecycle:
+    parameters:
+    - name: assessmentId
+      in: path
+      required: true
+      schema: {type: string}
+    get:
+      tags: [engagements, assessment-cycles]
+      operationId: getAssessmentLifecycle
+      summary: Get the Assessment lifecycle containing an Assessment
+      responses:
+        "200":
+          description: Assessment lifecycle
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/AssessmentLifecycle"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/engagements/{assessmentId}/snapshots/finalize:
+    parameters:
+    - name: assessmentId
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
+    post:
+      tags: [assessment-snapshots]
+      operationId: finalizeAssessmentSnapshot
+      summary: Finalize an immutable Assessment Snapshot
+      parameters:
+      - name: Idempotency-Key
+        in: header
+        required: true
+        schema: {type: string, minLength: 1, maxLength: 128}
+      - name: If-Match
+        in: header
+        required: true
+        description: Current default Snapshot version; use 0 when no default Snapshot exists.
+        schema: {type: string, pattern: '^(W/)?"?[0-9]+"?$'}
+        example: '"0"'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: "#/components/schemas/FinalizeAssessmentSnapshotRequest"}
+            example:
+              selected_runs:
+              - run_id: scan-run-01
+                lane_keys: [sca, sast]
+      responses:
+        "201":
+          description: Finalized Snapshot or retained idempotent response
+          headers:
+            ETag:
+              description: Default Snapshot version accepted by the next If-Match request.
+              schema: {type: string}
+            Idempotency-Replayed:
+              description: Present and true when the retained response was replayed.
+              schema: {type: string, enum: ['true']}
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/FinalizeAssessmentSnapshotResponse"}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Idempotency body mismatch, stale default version, or concurrent conflict}
+        "413": {description: Request body exceeds 64 KiB}
+        "428": {description: If-Match is required}
+
+  /api/v1/engagements/{assessmentId}/snapshots:
+    parameters:
+    - name: assessmentId
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
+    get:
+      tags: [assessment-snapshots]
+      operationId: listAssessmentSnapshots
+      summary: List immutable Snapshots for one Assessment
+      responses:
+        "200":
+          description: Snapshot history and current default pointer
+          headers:
+            ETag:
+              description: Current default Snapshot version, or 0 when none exists.
+              schema: {type: string}
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/AssessmentSnapshotListResponse"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/assessment-snapshots/{snapshotId}:
+    parameters:
+    - name: snapshotId
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
+    get:
+      tags: [assessment-snapshots]
+      operationId: getAssessmentSnapshot
+      summary: Get one immutable tenant-scoped Assessment Snapshot
+      responses:
+        "200":
+          description: Immutable Assessment Snapshot
+          headers:
+            ETag:
+              description: SHA-256 content-hash entity tag.
+              schema: {type: string}
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/AssessmentSnapshot"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/assessment-cycles:
+    get:
+      tags: [assessment-cycles]
+      operationId: listAssessmentCycles
+      summary: List tenant-scoped Assessment Cycles
+      parameters:
+      - {name: status, in: query, schema: {type: string, enum: [open, completed, archived]}}
+      - {name: boundary_kind, in: query, schema: {type: string, enum: [standalone, asset, project, asset_project]}}
+      - {name: assessment_status, in: query, description: Selected-head Assessment status., schema: {type: string, enum: [draft, active, completed, archived]}}
+      - {name: selected_head_assessment_id, in: query, schema: {type: string, maxLength: 256}}
+      - {name: assessment_type, in: query, description: Require at least one member of this type., schema: {type: string, enum: [initial, retest]}}
+      - {name: scan_staleness, in: query, description: Fresh means a sealed native succeeded/partial selected-head scan within 24 hours., schema: {type: string, enum: [fresh, stale, missing]}}
+      - {name: q, in: query, description: Bounded literal search across Cycle name/ID, root ID, and selected-head ID., schema: {type: string, maxLength: 256}}
+      - {name: cursor, in: query, schema: {type: string, maxLength: 512}}
+      - {name: limit, in: query, schema: {type: integer, minimum: 1, maximum: 100, default: 50}}
+      responses:
+        "200":
+          description: Stable descending page ordered by updated_at and cycle_id
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/AssessmentCyclePage"}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+
+  /api/v1/assessment-cycles/{cycleId}:
+    parameters:
+    - name: cycleId
+      in: path
+      required: true
+      schema: {type: string}
+    get:
+      tags: [assessment-cycles]
+      operationId: getAssessmentCycle
+      summary: Get an Assessment Cycle and immutable member projection IDs
+      responses:
+        "200": {description: Assessment Cycle detail, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentCycleDetail"}}}}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/assessment-cycles/{cycleId}/members:
+    parameters:
+    - name: cycleId
+      in: path
+      required: true
+      schema: {type: string}
+    get:
+      tags: [assessment-cycles]
+      operationId: listAssessmentCycleMembers
+      summary: Continue the deterministic member page for one Assessment Cycle
+      parameters:
+      - {name: cursor, in: query, schema: {type: string, maxLength: 684}}
+      - {name: limit, in: query, schema: {type: integer, minimum: 1, maximum: 100, default: 25}}
+      responses:
+        "200": {description: Root-first member page, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentCycleMemberPage"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/assessment-cycles/{cycleId}/archive:
+    parameters:
+    - name: cycleId
+      in: path
+      required: true
+      schema: {type: string}
+    post:
+      tags: [assessment-cycles]
+      operationId: archiveAssessmentCycle
+      summary: Archive an Assessment Cycle with optimistic concurrency
+      parameters:
+      - name: Idempotency-Key
+        in: header
+        required: true
+        schema: {type: string, minLength: 1, maxLength: 128}
+      - name: If-Match
+        in: header
+        required: true
+        description: Current Cycle version, optionally quoted as an ETag.
+        schema: {type: string, pattern: '^(W/)?"?[1-9][0-9]*"?$'}
+      responses:
+        "200": {description: Archived Assessment Cycle, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentCycleDetail"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Idempotency body mismatch or Cycle version conflict}
+        "428": {description: If-Match is missing or invalid}
 
   /api/v1/engagements/{id}/source:
     parameters:
@@ -3931,6 +4181,288 @@ components:
         timezone: {type: string, description: IANA timezone name}
         asset_id: {type: string}
 
+    AssessmentCycleMember:
+      type: object
+      required: [assessment_id, assessment_type, retest_number, relationship_version, created_at, created_by]
+      properties:
+        assessment_id: {type: string}
+        assessment_type: {type: string, enum: [initial, retest]}
+        predecessor_assessment_id: {type: string}
+        retest_number: {type: integer, minimum: 0}
+        relationship_version: {type: integer, format: int64, minimum: 1}
+        created_at: {type: string, format: date-time}
+        created_by: {type: string}
+        archived_at: {type: [string, "null"], format: date-time}
+
+    AssessmentCycle:
+      type: object
+      required: [id, name, boundary_kind, status, root_assessment_id, selected_head_assessment_id, next_retest_number, version, created_at, updated_at, created_by, updated_by]
+      properties:
+        id: {type: string}
+        name: {type: string}
+        boundary_kind: {type: string, enum: [standalone, asset, project, asset_project]}
+        business_asset_id: {type: string}
+        project_id: {type: string}
+        status: {type: string, enum: [open, completed, archived]}
+        root_assessment_id: {type: string}
+        selected_head_assessment_id: {type: string}
+        next_retest_number: {type: integer, minimum: 1}
+        version: {type: integer, format: int64, minimum: 1}
+        created_at: {type: string, format: date-time}
+        updated_at: {type: string, format: date-time}
+        created_by: {type: string}
+        updated_by: {type: string}
+
+    AssessmentCycleDetail:
+      type: object
+      required: [cycle, members, branch_heads]
+      properties:
+        cycle: {$ref: "#/components/schemas/AssessmentCycle"}
+        members:
+          type: array
+          items: {$ref: "#/components/schemas/AssessmentCycleMember"}
+        branch_heads:
+          type: array
+          items: {$ref: "#/components/schemas/AssessmentCycleMember"}
+
+    AssessmentLifecycle:
+      allOf:
+      - $ref: "#/components/schemas/AssessmentCycleDetail"
+      - type: object
+        required: [assessment_id]
+        properties:
+          assessment_id: {type: string}
+
+    AssessmentCycleSummary:
+      allOf:
+      - $ref: "#/components/schemas/AssessmentCycle"
+      - type: object
+        required: [member_count, active_branch_count, latest_retest_number, members, scan_staleness]
+        properties:
+          member_count: {type: integer, minimum: 0}
+          active_branch_count: {type: integer, minimum: 0}
+          latest_assessment_id: {type: string}
+          latest_retest_number: {type: integer, minimum: 0}
+          members: {type: array, maxItems: 10, items: {$ref: "#/components/schemas/AssessmentCycleMember"}}
+          members_next_cursor: {type: string}
+          root_snapshot_id: {type: string}
+          current_snapshot_id: {type: string}
+          selected_head_last_scan_at: {type: string, format: date-time}
+          scan_staleness: {type: string, enum: [fresh, stale, missing]}
+
+    AssessmentCycleMemberPage:
+      type: object
+      required: [items]
+      properties:
+        items: {type: array, maxItems: 100, items: {$ref: "#/components/schemas/AssessmentCycleMember"}}
+        next_cursor: {type: string}
+
+    AssessmentCycleMigrationPending:
+      type: object
+      required: [assessment_id, name, status, boundary_kind, updated_at]
+      properties:
+        assessment_id: {type: string}
+        name: {type: string}
+        status: {type: string, enum: [draft, active, completed, archived]}
+        boundary_kind: {type: string, enum: [standalone, asset]}
+        business_asset_id: {type: string}
+        updated_at: {type: string, format: date-time}
+
+    AssessmentCyclePage:
+      type: object
+      required: [items, migration_pending, migration_pending_total]
+      properties:
+        items:
+          type: array
+          maxItems: 100
+          items: {$ref: "#/components/schemas/AssessmentCycleSummary"}
+        next_cursor: {type: string}
+        migration_pending:
+          type: array
+          maxItems: 100
+          items: {$ref: "#/components/schemas/AssessmentCycleMigrationPending"}
+        migration_pending_total: {type: integer, minimum: 0}
+
+    CreateAssessmentRetestRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        name: {type: string}
+        predecessor_assessment_id: {type: string}
+        scope_strategy: {type: string, enum: [copy, empty], default: copy}
+        profile_strategy: {type: string, enum: [none], default: none}
+        authorized_from: {type: string, format: date-time}
+        authorized_to: {type: string, format: date-time}
+        timezone: {type: string}
+        roe:
+          type: object
+          properties:
+            allowed_tool_classes:
+              type: array
+              items: {type: string}
+            blackouts:
+              type: array
+              items:
+                type: object
+                required: [from, to]
+                properties:
+                  from: {type: string, format: date-time}
+                  to: {type: string, format: date-time}
+
+    AssessmentInheritanceDiff:
+      type: object
+      required: [scope, authorization, roe, scanner_profile]
+      properties:
+        scope: {type: string, enum: [copy, empty]}
+        authorization: {type: string, enum: [explicit_only]}
+        roe: {type: string, enum: [explicit_only]}
+        scanner_profile: {type: string, enum: [none]}
+
+    CreateAssessmentRetestResponse:
+      type: object
+      required: [engagement, cycle, member, inheritance_diff, warnings]
+      properties:
+        engagement: {$ref: "#/components/schemas/Engagement"}
+        cycle: {$ref: "#/components/schemas/AssessmentCycle"}
+        member: {$ref: "#/components/schemas/AssessmentCycleMember"}
+        inheritance_diff: {$ref: "#/components/schemas/AssessmentInheritanceDiff"}
+        warnings:
+          type: array
+          items:
+            type: string
+            enum: [authorization_not_inherited, roe_not_inherited, scanner_profile_not_inherited]
+
+    FinalizeAssessmentSnapshotRun:
+      type: object
+      additionalProperties: false
+      required: [run_id]
+      properties:
+        run_id: {type: string, minLength: 1, maxLength: 256}
+        lane_keys:
+          type: array
+          maxItems: 100
+          uniqueItems: true
+          description: Omit to select every eligible lane in the run.
+          items: {type: string, minLength: 1, maxLength: 256}
+
+    FinalizeAssessmentSnapshotRequest:
+      type: object
+      additionalProperties: false
+      required: [selected_runs]
+      properties:
+        selected_runs:
+          type: array
+          minItems: 1
+          maxItems: 100
+          items: {$ref: "#/components/schemas/FinalizeAssessmentSnapshotRun"}
+
+    AssessmentSnapshotBoundary:
+      type: object
+      required: [boundary_kind]
+      properties:
+        boundary_kind: {type: string, enum: [standalone, asset, project, asset_project]}
+        business_asset_id: {type: string}
+        project_id: {type: string}
+
+    AssessmentSnapshotLaneReference:
+      type: object
+      required: [lane_key, manifest_hash]
+      properties:
+        lane_key: {type: string}
+        manifest_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+
+    AssessmentSnapshotRunReference:
+      type: object
+      required: [run_id, manifest_hash, lane_refs]
+      properties:
+        run_id: {type: string}
+        manifest_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        lane_refs:
+          type: array
+          items: {$ref: "#/components/schemas/AssessmentSnapshotLaneReference"}
+
+    AssessmentSnapshotTarget:
+      type: object
+      required: [kind, schema_version, canonical]
+      properties:
+        kind: {type: string, enum: [repository, oci, host, url, cloud_resource]}
+        schema_version: {type: integer, minimum: 1}
+        canonical: {type: string}
+        evaluated_revision: {type: string}
+
+    AssessmentSnapshotVersion:
+      type: object
+      required: [kind, name, version]
+      properties:
+        kind: {type: string, enum: [tool, scanner, profile, rule_pack, advisory_database, correlation, schema]}
+        name: {type: string}
+        version: {type: string}
+        digest: {type: string}
+
+    AssessmentSnapshotDimension:
+      type: object
+      required: [run_id, lane_key, lane_manifest_hash, producer, finding_kind, target, state, reason_code, included_scope, excluded_scope, versions]
+      properties:
+        run_id: {type: string}
+        lane_key: {type: string}
+        lane_manifest_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        producer: {type: string}
+        finding_kind: {type: string}
+        target: {$ref: "#/components/schemas/AssessmentSnapshotTarget"}
+        state: {type: string, enum: [complete, partial, unknown]}
+        reason_code:
+          type: string
+          enum: [trusted_terminal_lane, legacy_provenance, run_partial, run_failed, run_cancelled, lane_partial, lane_failed, lane_cancelled, stage_failed, stage_skipped]
+        included_scope: {type: array, items: {type: string}}
+        excluded_scope: {type: array, items: {type: string}}
+        versions:
+          type: array
+          items: {$ref: "#/components/schemas/AssessmentSnapshotVersion"}
+
+    AssessmentSnapshot:
+      type: object
+      required: [id, cycle_id, assessment_id, snapshot_number, lifecycle, provenance, boundary, run_references, dimensions, schema_version, content_hash, created_at, created_by, finalized_at, finalized_by]
+      properties:
+        id: {type: string}
+        cycle_id: {type: string}
+        assessment_id: {type: string}
+        snapshot_number: {type: integer, minimum: 1}
+        lifecycle: {type: string, enum: [finalized, superseded]}
+        provenance: {type: string, enum: [native, legacy]}
+        boundary: {$ref: "#/components/schemas/AssessmentSnapshotBoundary"}
+        run_references:
+          type: array
+          minItems: 1
+          items: {$ref: "#/components/schemas/AssessmentSnapshotRunReference"}
+        dimensions:
+          type: array
+          items: {$ref: "#/components/schemas/AssessmentSnapshotDimension"}
+        schema_version: {type: integer, const: 1}
+        content_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        created_at: {type: string, format: date-time}
+        created_by: {type: string}
+        finalized_at: {type: string, format: date-time}
+        finalized_by: {type: string}
+        superseded_at: {type: string, format: date-time}
+        superseded_by: {type: string}
+
+    FinalizeAssessmentSnapshotResponse:
+      type: object
+      required: [snapshot, default_version]
+      properties:
+        snapshot: {$ref: "#/components/schemas/AssessmentSnapshot"}
+        default_version: {type: integer, minimum: 1}
+
+    AssessmentSnapshotListResponse:
+      type: object
+      required: [items, default_version]
+      properties:
+        items:
+          type: array
+          items: {$ref: "#/components/schemas/AssessmentSnapshot"}
+        default_snapshot_id: {type: string}
+        default_version: {type: integer, minimum: 0}
+
     UploadedSourcePackage:
       type: object
       required: [filename, size, sha256, target, uploaded_by, uploaded_at]
@@ -3969,6 +4501,7 @@ components:
                   Value: {type: string}
         AuthorizedFrom: {type: [string, "null"], format: date-time}
         AuthorizedTo: {type: [string, "null"], format: date-time}
+        RequiresExplicitExecutionAuthorization: {type: boolean}
 
     CreateManualFindingRequest:
       type: object

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -136,7 +136,8 @@ paths:
       parameters:
       - name: Idempotency-Key
         in: header
-        required: true
+        required: false
+        description: Optional client key. When omitted, the server derives a stable key from the canonical create request for safe retries.
         schema: {type: string, minLength: 1, maxLength: 128}
       requestBody:
         required: true
@@ -280,6 +281,9 @@ paths:
       tags: [assessment-snapshots]
       operationId: listAssessmentSnapshots
       summary: List immutable Snapshots for one Assessment
+      parameters:
+      - {name: cursor, in: query, schema: {type: string, maxLength: 128}}
+      - {name: limit, in: query, schema: {type: integer, minimum: 1, maximum: 100, default: 50}}
       responses:
         "200":
           description: Snapshot history and current default pointer
@@ -401,6 +405,45 @@ paths:
         schema: {type: string, pattern: '^(W/)?"?[1-9][0-9]*"?$'}
       responses:
         "200": {description: Archived Assessment Cycle, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentCycleDetail"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Idempotency body mismatch or Cycle version conflict}
+        "428": {description: If-Match is missing or invalid}
+
+  /api/v1/assessment-cycles/{cycleId}/reopen:
+    parameters:
+    - name: cycleId
+      in: path
+      required: true
+      schema: {type: string}
+    post:
+      tags: [assessment-cycles]
+      operationId: reopenAssessmentCycle
+      summary: Reopen a completed Assessment Cycle with an audited reason
+      parameters:
+      - name: Idempotency-Key
+        in: header
+        required: true
+        schema: {type: string, minLength: 1, maxLength: 128}
+      - name: If-Match
+        in: header
+        required: true
+        description: Current Cycle version, optionally quoted as an ETag.
+        schema: {type: string, pattern: '^(W/)?"?[1-9][0-9]*"?$'}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [reason]
+              properties:
+                reason: {type: string, minLength: 1, maxLength: 1024}
+      responses:
+        "200": {description: Reopened Assessment Cycle, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentCycleDetail"}}}}
         "400": {$ref: "#/components/responses/BadRequest"}
         "401": {$ref: "#/components/responses/Unauthorized"}
         "403": {$ref: "#/components/responses/Forbidden"}
@@ -4459,7 +4502,9 @@ components:
       properties:
         items:
           type: array
+          maxItems: 100
           items: {$ref: "#/components/schemas/AssessmentSnapshot"}
+        next_cursor: {type: string}
         default_snapshot_id: {type: string}
         default_version: {type: integer, minimum: 0}
 

--- a/api/openapi_test.go
+++ b/api/openapi_test.go
@@ -307,3 +307,79 @@ func TestAttackPathOpenAPIContract(t *testing.T) {
 		}
 	}
 }
+
+func TestAssessmentCycleOpenAPIContract(t *testing.T) {
+	b, err := os.ReadFile("openapi.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	paths, _ := doc["paths"].(map[string]any)
+	for path, methods := range map[string]map[string]string{
+		"/api/v1/engagements/{assessmentId}/retests":   {"post": "createAssessmentRetest"},
+		"/api/v1/engagements/{assessmentId}/lifecycle": {"get": "getAssessmentLifecycle"},
+		"/api/v1/assessment-cycles":                    {"get": "listAssessmentCycles"},
+		"/api/v1/assessment-cycles/{cycleId}":          {"get": "getAssessmentCycle"},
+		"/api/v1/assessment-cycles/{cycleId}/members":  {"get": "listAssessmentCycleMembers"},
+		"/api/v1/assessment-cycles/{cycleId}/archive":  {"post": "archiveAssessmentCycle"},
+	} {
+		route, ok := paths[path].(map[string]any)
+		if !ok {
+			t.Errorf("assessment cycle path %s missing", path)
+			continue
+		}
+		for method, operationID := range methods {
+			operation, ok := route[method].(map[string]any)
+			if !ok || operation["operationId"] != operationID {
+				t.Errorf("%s %s operationId=%v, want %s", method, path, operation["operationId"], operationID)
+			}
+		}
+	}
+}
+
+func TestAssessmentSnapshotOpenAPIContract(t *testing.T) {
+	b, err := os.ReadFile("openapi.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	paths, _ := doc["paths"].(map[string]any)
+	for path, methods := range map[string]map[string]string{
+		"/api/v1/engagements/{assessmentId}/snapshots/finalize": {"post": "finalizeAssessmentSnapshot"},
+		"/api/v1/engagements/{assessmentId}/snapshots":          {"get": "listAssessmentSnapshots"},
+		"/api/v1/assessment-snapshots/{snapshotId}":             {"get": "getAssessmentSnapshot"},
+	} {
+		route, ok := paths[path].(map[string]any)
+		if !ok {
+			t.Errorf("assessment snapshot path %s missing", path)
+			continue
+		}
+		for method, operationID := range methods {
+			operation, ok := route[method].(map[string]any)
+			if !ok || operation["operationId"] != operationID {
+				t.Errorf("%s %s operationId=%v, want %s", method, path, operation["operationId"], operationID)
+			}
+		}
+	}
+
+	components, _ := doc["components"].(map[string]any)
+	schemas, _ := components["schemas"].(map[string]any)
+	snapshot, _ := schemas["AssessmentSnapshot"].(map[string]any)
+	snapshotProperties, _ := snapshot["properties"].(map[string]any)
+	for _, forbidden := range []string{"tenant_id", "request_key", "request_hash", "evidence", "credentials"} {
+		if _, ok := snapshotProperties[forbidden]; ok {
+			t.Errorf("AssessmentSnapshot response exposes forbidden property %q", forbidden)
+		}
+	}
+	request, _ := schemas["FinalizeAssessmentSnapshotRequest"].(map[string]any)
+	requestProperties, _ := request["properties"].(map[string]any)
+	if len(requestProperties) != 1 || requestProperties["selected_runs"] == nil {
+		t.Errorf("FinalizeAssessmentSnapshotRequest must contain only server-resolved run/lane selections: %v", requestProperties)
+	}
+}

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -91,6 +91,8 @@ import (
 	aitriagereviewuc "github.com/KKloudTarus/synapse-ce/internal/usecase/aitriagereviewuc"
 	analysisuc "github.com/KKloudTarus/synapse-ce/internal/usecase/analysis"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/approval"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
 	attackpathuc "github.com/KKloudTarus/synapse-ce/internal/usecase/attackpath"
 	audituc "github.com/KKloudTarus/synapse-ce/internal/usecase/audit"
@@ -279,6 +281,10 @@ func main() {
 		log.Error("network execution posture invalid", "err", err)
 		os.Exit(1)
 	}
+	if err := cfg.ValidateAssessmentLifecycleRollout(); err != nil {
+		log.Error("assessment lifecycle rollout invalid", "err", err)
+		os.Exit(1)
+	}
 
 	// Fail closed: no anonymous access. The token is never logged.
 	if cfg.APIToken == "" {
@@ -348,6 +354,7 @@ func main() {
 	var promotionStore ports.PendingPromotionAuditStore
 	var scanJobStore ports.ScanJobStore
 	var scanRunStore ports.ScanRunStore
+	var assessmentSnapshotStore ports.AssessmentSnapshotRepository
 	var projectAnalysisStore ports.ProjectAnalysisStore
 	var qualityGateStore ports.QualityGateStore
 	var qualityProfileStore ports.QualityProfileStore
@@ -375,6 +382,12 @@ func main() {
 	var vulnerabilityActions ports.VulnerabilityActionStore
 	var vulnerabilityReconcileRuns ports.VulnerabilityReconcileRunStore
 	var vulnerabilityTransactions ports.TenantTransactionRunner
+	var assessmentCycleStore interface {
+		ports.AssessmentCycleRepository
+		ports.AssessmentCycleListRepository
+	}
+	var assessmentCycleRequests ports.AssessmentCycleRequestStore
+	var assessmentCycleTransactions ports.TenantTransactionRunner
 	var slaStore ports.SLAStore
 	var vulnerabilityWorker *worker.Worker
 	var reconRunLock ports.RunLocker              // recon run lease (Postgres only); row-lease, no pinned conn
@@ -487,6 +500,10 @@ func main() {
 		}
 		scanJobStore = postgres.NewScanJobStore(pool)
 		scanRunStore = postgres.NewScanRunStore(pool)
+		assessmentSnapshotStore = postgres.NewAssessmentSnapshotRepository(pool)
+		assessmentCycleStore = postgres.NewAssessmentCycleRepository(pool)
+		assessmentCycleRequests = postgres.NewAssessmentCycleRequestRepository(pool)
+		assessmentCycleTransactions = postgres.NewTenantTransactionRunner(pool)
 		projectAnalysisStore = postgres.NewProjectAnalysisStore(pool)
 		qualityGateStore = postgres.NewQualityGateStore(pool)
 		qualityProfileStore = postgres.NewQualityProfileStore(pool)
@@ -627,6 +644,10 @@ func main() {
 		}
 		scanJobStore = memory.NewScanJobStore()
 		scanRunStore = memory.NewScanRunStore()
+		assessmentSnapshotStore = memory.NewAssessmentSnapshotRepository()
+		assessmentCycleStore = memory.NewAssessmentCycleRepository()
+		assessmentCycleRequests = memory.NewAssessmentCycleRequestRepository()
+		assessmentCycleTransactions = memory.NewTenantTransactionRunner()
 		projectAnalysisStore = memory.NewProjectAnalysisStore()
 		qualityGateStore = memory.NewQualityGateStore()
 		qualityProfileStore = memory.NewQualityProfileStore()
@@ -672,6 +693,9 @@ func main() {
 
 	// Use cases.
 	engService := enguc.NewService(repo, clock, ids, auditLog)
+	if cfg.AssessmentSnapshotEnabled {
+		engService.SetCompletionSnapshotReader(assessmentSnapshotStore)
+	}
 	projectService := projectuc.NewService(projectRepo, repo, clock, ids, auditLog, !cfg.IsProduction())
 	projectService.SetArchiveStore(file.NewProjectArchiveStore(cfg.ProjectUploadDir, cfg.MaxWorkspaceBytes))
 	projectService.SetAnalysisStore(projectAnalysisStore)
@@ -1188,6 +1212,16 @@ func main() {
 		}
 	}
 	router.SetObservability(cfg.AccessLogEnabled, httpObserver)
+	router.SetAssessmentLifecycleRollout(cfg.AssessmentLifecycleReadForTenant, cfg.AssessmentLifecycleUIForTenant)
+	var snapshotService *snapshotuc.Service
+	if cfg.AssessmentSnapshotEnabled {
+		snapshotService, err = snapshotuc.NewService(assessmentSnapshotStore, assessmentCycleStore, repo, scanRunStore, assessmentCycleTransactions, ids, clock, auditLog)
+		if err != nil {
+			log.Error("assessment snapshot service init failed", "err", err)
+			os.Exit(1)
+		}
+		snapshotService.SetScanJobStore(scanJobStore)
+	}
 	vulnerabilityRollout, err := vulnerabilityrollout.New(vulnerabilityrollout.Config{
 		ProviderSync: cfg.VulnerabilityProviderSyncEnabled, OccurrenceWrites: cfg.VulnerabilityOccurrenceWritesEnabled,
 		FindingProjection: cfg.VulnerabilityFindingProjectionEnabled, Actions: cfg.VulnerabilityActionsEnabled,
@@ -1364,6 +1398,24 @@ func main() {
 		os.Exit(1)
 	}
 	router.SetBusinessAssets(businessAssetService)
+	if cfg.AssessmentCycleAPIEnabled || cfg.AssessmentCycleDualWriteEnabled {
+		cycleService, cycleErr := cycleuc.NewService(assessmentCycleStore, repo, businessAssetStore, projectRepo, assessmentCycleTransactions, ids, clock, auditLog)
+		if cycleErr != nil {
+			log.Error("assessment cycle service init failed", "err", cycleErr)
+			os.Exit(1)
+		}
+		cycleAPI, cycleErr := cycleuc.NewAPIService(cycleService, assessmentCycleStore, assessmentCycleRequests, engService, assessmentCycleTransactions, clock, auditLog)
+		if cycleErr != nil {
+			log.Error("assessment cycle API init failed", "err", cycleErr)
+			os.Exit(1)
+		}
+		router.SetAssessmentCycles(cycleAPI, cfg.AssessmentCycleAPIEnabled, cfg.AssessmentCycleDualWriteForTenant)
+		log.Info("assessment cycle services configured", "api_enabled", cfg.AssessmentCycleAPIEnabled, "dual_write_enabled", cfg.AssessmentCycleDualWriteEnabled, "dual_write_tenant_count", len(cfg.AssessmentCycleDualWriteTenants))
+	}
+	if snapshotService != nil {
+		router.SetAssessmentSnapshots(snapshotService)
+		log.Info("assessment snapshot API configured")
+	}
 	router.SetExploitation(exploitationService) // evidence-gated finding verify endpoint
 	// Read-only code-quality dashboard. Server-side analysis is PURE-GO and memory-safe only (pattern
 	// rules + duplication + Go-parser inventory); tree-sitter complexity is intentionally NOT wired here

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -693,9 +693,7 @@ func main() {
 
 	// Use cases.
 	engService := enguc.NewService(repo, clock, ids, auditLog)
-	if cfg.AssessmentSnapshotEnabled {
-		engService.SetCompletionSnapshotReader(assessmentSnapshotStore)
-	}
+	engService.SetCompletionSnapshotPolicy(assessmentSnapshotStore, cfg.AssessmentSnapshotCompletionForTenant)
 	projectService := projectuc.NewService(projectRepo, repo, clock, ids, auditLog, !cfg.IsProduction())
 	projectService.SetArchiveStore(file.NewProjectArchiveStore(cfg.ProjectUploadDir, cfg.MaxWorkspaceBytes))
 	projectService.SetAnalysisStore(projectAnalysisStore)
@@ -1397,6 +1395,7 @@ func main() {
 		log.Error("business asset service init failed", "err", err)
 		os.Exit(1)
 	}
+	businessAssetService.SetAssessmentCycleReader(assessmentCycleStore)
 	router.SetBusinessAssets(businessAssetService)
 	if cfg.AssessmentCycleAPIEnabled || cfg.AssessmentCycleDualWriteEnabled {
 		cycleService, cycleErr := cycleuc.NewService(assessmentCycleStore, repo, businessAssetStore, projectRepo, assessmentCycleTransactions, ids, clock, auditLog)

--- a/cmd/synapse-assessment-backfill/main.go
+++ b/cmd/synapse-assessment-backfill/main.go
@@ -1,0 +1,159 @@
+// Command synapse-assessment-backfill runs the resumable historical singleton-Cycle backfill.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/postgres"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/config"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/logging"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+)
+
+type backfillOptions struct {
+	tenants       []shared.ID
+	actor         string
+	dryRun        bool
+	batchSize     int
+	resumeAfter   shared.ID
+	timeout       time.Duration
+	leaseDuration time.Duration
+}
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string) error {
+	options, err := parseBackfillOptions(args, os.Stderr)
+	if err != nil {
+		return err
+	}
+	cfg := config.Load()
+	log := logging.New(cfg.LogLevel)
+	if cfg.DBDSN == "" {
+		return errors.New("synapse-assessment-backfill requires SYNAPSE_DB_DSN")
+	}
+	signalCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	ctx, cancel := context.WithTimeout(signalCtx, options.timeout)
+	defer cancel()
+	pool, err := postgres.Connect(ctx, cfg.DBDSN)
+	if err != nil {
+		return err
+	}
+	defer pool.Close()
+
+	clock, ids := idgen.SystemClock{}, idgen.RandomID{}
+	engagements := postgres.NewEngagementRepository(pool)
+	cycles := postgres.NewAssessmentCycleRepository(pool)
+	transactions := postgres.NewTenantTransactionRunner(pool)
+	audit := postgres.NewAuditLog(pool)
+	cycleService, err := cycleuc.NewService(cycles, engagements, nil, nil, transactions, ids, clock, audit)
+	if err != nil {
+		return err
+	}
+	runner, err := cycleuc.NewBackfillRunner(cycleService, engagements, postgres.NewAssessmentCycleBackfillRepository(pool), ids, clock, audit, nil)
+	if err != nil {
+		return err
+	}
+	hostname, _ := os.Hostname()
+	if len(hostname) > 160 {
+		hostname = hostname[:160]
+	}
+	ctx, cancelRuns := context.WithCancel(ctx)
+	defer cancelRuns()
+	errorsCh := make(chan error, len(options.tenants))
+	var wait sync.WaitGroup
+	for index, tenantID := range options.tenants {
+		wait.Add(1)
+		go func(index int, tenantID shared.ID) {
+			defer wait.Done()
+			leaseOwner := strings.Join([]string{hostname, strconv.Itoa(os.Getpid()), strconv.Itoa(index)}, "-")
+			log.Info("assessment cycle backfill started", "tenant_id", tenantID, "dry_run", options.dryRun, "batch_size", options.batchSize)
+			run, err := runner.Run(ctx, cycleuc.BackfillRequest{
+				TenantID: tenantID, Actor: options.actor, LeaseOwner: leaseOwner, DryRun: options.dryRun,
+				BatchSize: options.batchSize, ResumeAfter: options.resumeAfter, LeaseDuration: options.leaseDuration,
+			})
+			if err == nil && run.FailedCount > 0 {
+				err = fmt.Errorf("tenant %s backfill completed with %d stable failure records", tenantID, run.FailedCount)
+			}
+			if err != nil {
+				errorsCh <- fmt.Errorf("tenant %s: %w", tenantID, err)
+				cancelRuns()
+				return
+			}
+			log.Info("assessment cycle backfill completed", "tenant_id", tenantID, "run_id", run.ID, "processed", run.ProcessedCount, "created", run.CreatedCount, "would_create", run.WouldCreateCount, "skipped", run.SkippedCount, "failed", run.FailedCount, "checkpoint", run.CheckpointAssessment)
+		}(index, tenantID)
+	}
+	wait.Wait()
+	close(errorsCh)
+	var combined error
+	for err := range errorsCh {
+		combined = errors.Join(combined, err)
+	}
+	return combined
+}
+
+func parseBackfillOptions(args []string, output io.Writer) (backfillOptions, error) {
+	flags := flag.NewFlagSet("synapse-assessment-backfill", flag.ContinueOnError)
+	flags.SetOutput(output)
+	tenantsValue := flags.String("tenants", "", "comma-separated tenant IDs; maximum four")
+	actor := flags.String("actor", "assessment-cycle-backfill", "audit actor")
+	dryRun := flags.Bool("dry-run", false, "plan without creating Cycles")
+	batchSize := flags.Int("batch-size", cycleuc.DefaultAssessmentCycleBackfillBatch, "rows per committed batch")
+	resumeAfter := flags.String("resume-after", "", "initial Assessment ID checkpoint; single tenant only")
+	timeout := flags.Duration("timeout", 30*time.Minute, "overall command timeout")
+	leaseDuration := flags.Duration("lease-duration", 10*time.Minute, "per-tenant job lease")
+	if err := flags.Parse(args); err != nil {
+		return backfillOptions{}, err
+	}
+	if flags.NArg() != 0 {
+		return backfillOptions{}, fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	seen := map[shared.ID]bool{}
+	tenants := make([]shared.ID, 0, 4)
+	for _, value := range strings.Split(*tenantsValue, ",") {
+		tenantID := shared.ID(strings.TrimSpace(value))
+		if tenantID.IsZero() || seen[tenantID] {
+			continue
+		}
+		seen[tenantID] = true
+		tenants = append(tenants, tenantID)
+	}
+	if len(tenants) == 0 || len(tenants) > 4 {
+		return backfillOptions{}, errors.New("--tenants requires between one and four unique tenant IDs")
+	}
+	if *batchSize < 1 || *batchSize > cycleuc.MaxAssessmentCycleBackfillBatch {
+		return backfillOptions{}, fmt.Errorf("--batch-size must be between 1 and %d", cycleuc.MaxAssessmentCycleBackfillBatch)
+	}
+	if strings.TrimSpace(*actor) == "" || len(strings.TrimSpace(*actor)) > 256 {
+		return backfillOptions{}, errors.New("--actor must contain between 1 and 256 characters")
+	}
+	if *timeout <= 0 || *leaseDuration <= 0 {
+		return backfillOptions{}, errors.New("--timeout and --lease-duration must be positive")
+	}
+	if strings.TrimSpace(*resumeAfter) != "" && len(tenants) != 1 {
+		return backfillOptions{}, errors.New("--resume-after requires exactly one tenant")
+	}
+	return backfillOptions{
+		tenants: tenants, actor: strings.TrimSpace(*actor), dryRun: *dryRun, batchSize: *batchSize,
+		resumeAfter: shared.ID(strings.TrimSpace(*resumeAfter)), timeout: *timeout, leaseDuration: *leaseDuration,
+	}, nil
+}

--- a/cmd/synapse-assessment-backfill/main_test.go
+++ b/cmd/synapse-assessment-backfill/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"io"
+	"testing"
+	"time"
+)
+
+func TestParseBackfillOptions(t *testing.T) {
+	options, err := parseBackfillOptions([]string{"--tenants", "tenant-a,tenant-b,tenant-a", "--dry-run", "--batch-size", "2000", "--timeout", "1h"}, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(options.tenants) != 2 || !options.dryRun || options.batchSize != 2000 || options.timeout != time.Hour {
+		t.Fatalf("options = %+v", options)
+	}
+	for _, args := range [][]string{
+		{},
+		{"--tenants", "a,b,c,d,e"},
+		{"--tenants", "a", "--batch-size", "2001"},
+		{"--tenants", "a,b", "--resume-after", "assessment-1"},
+	} {
+		if _, err := parseBackfillOptions(args, io.Discard); err == nil {
+			t.Fatalf("expected invalid options for %v", args)
+		}
+	}
+}

--- a/cmd/synapse-assessment-integrity/main.go
+++ b/cmd/synapse-assessment-integrity/main.go
@@ -1,0 +1,174 @@
+// Command synapse-assessment-integrity runs the read-only Assessment Cycle integrity verifier.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/postgres"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/config"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/logging"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+)
+
+type integrityOptions struct {
+	tenants       []shared.ID
+	actor         string
+	batchSize     int
+	timeout       time.Duration
+	leaseDuration time.Duration
+}
+
+type findingOutput struct {
+	TenantID     shared.ID       `json:"tenant_id"`
+	RunID        shared.ID       `json:"run_id"`
+	OccurrenceID string          `json:"occurrence_id"`
+	AssessmentID shared.ID       `json:"assessment_id"`
+	CycleID      shared.ID       `json:"cycle_id,omitempty"`
+	MemberID     shared.ID       `json:"member_id,omitempty"`
+	ReasonCode   string          `json:"reason_code"`
+	Severity     string          `json:"severity"`
+	RepairPlan   json.RawMessage `json:"repair_plan"`
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, output io.Writer) error {
+	options, err := parseIntegrityOptions(args, os.Stderr)
+	if err != nil {
+		return err
+	}
+	cfg := config.Load()
+	log := logging.New(cfg.LogLevel)
+	if cfg.DBDSN == "" {
+		return errors.New("synapse-assessment-integrity requires SYNAPSE_DB_DSN")
+	}
+	signalCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	ctx, cancel := context.WithTimeout(signalCtx, options.timeout)
+	defer cancel()
+	pool, err := postgres.Connect(ctx, cfg.DBDSN)
+	if err != nil {
+		return err
+	}
+	defer pool.Close()
+
+	clock, ids := idgen.SystemClock{}, idgen.RandomID{}
+	repository := postgres.NewAssessmentCycleIntegrityRepository(pool)
+	audit := postgres.NewAuditLog(pool)
+	verifier, err := cycleuc.NewIntegrityVerifier(repository, repository, ids, clock, audit, nil)
+	if err != nil {
+		return err
+	}
+	hostname, _ := os.Hostname()
+	if len(hostname) > 160 {
+		hostname = hostname[:160]
+	}
+	encoder := json.NewEncoder(output)
+	encoder.SetEscapeHTML(false)
+	var outputMu sync.Mutex
+	errorsCh := make(chan error, len(options.tenants))
+	var wait sync.WaitGroup
+	for index, tenantID := range options.tenants {
+		wait.Add(1)
+		go func(index int, tenantID shared.ID) {
+			defer wait.Done()
+			leaseOwner := strings.Join([]string{hostname, strconv.Itoa(os.Getpid()), strconv.Itoa(index)}, "-")
+			log.Info("assessment cycle integrity verification started", "tenant_id", tenantID, "batch_size", options.batchSize)
+			run, err := verifier.Run(ctx, cycleuc.IntegrityRequest{TenantID: tenantID, Actor: options.actor, LeaseOwner: leaseOwner, BatchSize: options.batchSize, LeaseDuration: options.leaseDuration})
+			if err != nil {
+				errorsCh <- fmt.Errorf("tenant %s: %w", tenantID, err)
+				return
+			}
+			findings, err := repository.ListAssessmentCycleIntegrityFindings(ctx, tenantID, run.ID)
+			if err != nil {
+				errorsCh <- fmt.Errorf("tenant %s list findings: %w", tenantID, err)
+				return
+			}
+			outputMu.Lock()
+			for _, finding := range findings {
+				if err := encoder.Encode(findingOutput{
+					TenantID: finding.TenantID, RunID: finding.RunID, OccurrenceID: finding.OccurrenceID, AssessmentID: finding.AssessmentID,
+					CycleID: finding.CycleID, MemberID: finding.MemberID, ReasonCode: finding.ReasonCode, Severity: finding.Severity, RepairPlan: finding.RepairPlan,
+				}); err != nil {
+					outputMu.Unlock()
+					errorsCh <- fmt.Errorf("tenant %s write finding output: %w", tenantID, err)
+					return
+				}
+			}
+			outputMu.Unlock()
+			log.Info("assessment cycle integrity verification completed", "tenant_id", tenantID, "run_id", run.ID, "scanned", run.ScannedCount, "clean", run.CleanCount, "findings", run.FindingCount, "checkpoint", run.CheckpointAssessment)
+			if run.FindingCount > 0 {
+				errorsCh <- fmt.Errorf("tenant %s integrity verification found %d repair plans", tenantID, run.FindingCount)
+			}
+		}(index, tenantID)
+	}
+	wait.Wait()
+	close(errorsCh)
+	var combined error
+	for err := range errorsCh {
+		combined = errors.Join(combined, err)
+	}
+	return combined
+}
+
+func parseIntegrityOptions(args []string, output io.Writer) (integrityOptions, error) {
+	flags := flag.NewFlagSet("synapse-assessment-integrity", flag.ContinueOnError)
+	flags.SetOutput(output)
+	tenantsValue := flags.String("tenants", "", "comma-separated tenant IDs; maximum four")
+	actor := flags.String("actor", "assessment-cycle-integrity", "audit actor")
+	dryRun := flags.Bool("dry-run", true, "read-only verification mode")
+	batchSize := flags.Int("batch-size", cycleuc.DefaultAssessmentCycleIntegrityBatch, "Assessments per committed checkpoint")
+	timeout := flags.Duration("timeout", 30*time.Minute, "overall command timeout")
+	leaseDuration := flags.Duration("lease-duration", 10*time.Minute, "per-tenant verifier lease")
+	if err := flags.Parse(args); err != nil {
+		return integrityOptions{}, err
+	}
+	if flags.NArg() != 0 {
+		return integrityOptions{}, fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	if !*dryRun {
+		return integrityOptions{}, errors.New("the integrity verifier is read-only; --dry-run=false is not supported")
+	}
+	seen := map[shared.ID]bool{}
+	tenants := make([]shared.ID, 0, 4)
+	for _, value := range strings.Split(*tenantsValue, ",") {
+		tenantID := shared.ID(strings.TrimSpace(value))
+		if tenantID.IsZero() || seen[tenantID] {
+			continue
+		}
+		seen[tenantID] = true
+		tenants = append(tenants, tenantID)
+	}
+	if len(tenants) == 0 || len(tenants) > 4 {
+		return integrityOptions{}, errors.New("--tenants requires between one and four unique tenant IDs")
+	}
+	if *batchSize < 1 || *batchSize > cycleuc.MaxAssessmentCycleIntegrityBatch {
+		return integrityOptions{}, fmt.Errorf("--batch-size must be between 1 and %d", cycleuc.MaxAssessmentCycleIntegrityBatch)
+	}
+	if strings.TrimSpace(*actor) == "" || len(strings.TrimSpace(*actor)) > 256 {
+		return integrityOptions{}, errors.New("--actor must contain between 1 and 256 characters")
+	}
+	if *timeout <= 0 || *leaseDuration <= 0 {
+		return integrityOptions{}, errors.New("--timeout and --lease-duration must be positive")
+	}
+	return integrityOptions{tenants: tenants, actor: strings.TrimSpace(*actor), batchSize: *batchSize, timeout: *timeout, leaseDuration: *leaseDuration}, nil
+}

--- a/cmd/synapse-assessment-integrity/main_test.go
+++ b/cmd/synapse-assessment-integrity/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"io"
+	"testing"
+	"time"
+)
+
+func TestParseIntegrityOptions(t *testing.T) {
+	options, err := parseIntegrityOptions([]string{"--tenants", "tenant-a,tenant-b,tenant-a", "--batch-size", "2000", "--timeout", "1h"}, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(options.tenants) != 2 || options.batchSize != 2000 || options.timeout != time.Hour {
+		t.Fatalf("options = %+v", options)
+	}
+	for _, args := range [][]string{
+		{},
+		{"--tenants", "a,b,c,d,e"},
+		{"--tenants", "a", "--batch-size", "2001"},
+		{"--tenants", "a", "--dry-run=false"},
+	} {
+		if _, err := parseIntegrityOptions(args, io.Discard); err == nil {
+			t.Fatalf("expected invalid options for %v", args)
+		}
+	}
+}

--- a/cmd/synapse-assessment-snapshot-backfill/main.go
+++ b/cmd/synapse-assessment-snapshot-backfill/main.go
@@ -1,0 +1,161 @@
+// Command synapse-assessment-snapshot-backfill projects historical scan evidence into immutable legacy Assessment Snapshots.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/postgres"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/config"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/logging"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+)
+
+type snapshotBackfillOptions struct {
+	tenants       []shared.ID
+	actor         string
+	dryRun        bool
+	batchSize     int
+	resumeAfter   shared.ID
+	timeout       time.Duration
+	leaseDuration time.Duration
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stderr); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, output io.Writer) error {
+	options, err := parseSnapshotBackfillOptions(args, output)
+	if err != nil {
+		return err
+	}
+	cfg := config.Load()
+	log := logging.New(cfg.LogLevel)
+	if cfg.DBDSN == "" {
+		return errors.New("synapse-assessment-snapshot-backfill requires SYNAPSE_DB_DSN")
+	}
+	signalCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	ctx, cancel := context.WithTimeout(signalCtx, options.timeout)
+	defer cancel()
+	pool, err := postgres.Connect(ctx, cfg.DBDSN)
+	if err != nil {
+		return err
+	}
+	defer pool.Close()
+
+	clock, ids := idgen.SystemClock{}, idgen.RandomID{}
+	engagements := postgres.NewEngagementRepository(pool)
+	cycles := postgres.NewAssessmentCycleRepository(pool)
+	snapshots := postgres.NewAssessmentSnapshotRepository(pool)
+	runs := postgres.NewScanRunStore(pool)
+	results := postgres.NewScanResultStore(pool)
+	audit := postgres.NewAuditLog(pool)
+	projector, err := snapshotuc.NewLegacyProjector(snapshots, cycles, postgres.NewTenantTransactionRunner(pool), ids, clock, audit)
+	if err != nil {
+		return err
+	}
+	runner, err := snapshotuc.NewBackfillRunner(projector, engagements, postgres.NewAssessmentSnapshotBackfillRepository(pool), runs, results, ids, clock, audit, nil)
+	if err != nil {
+		return err
+	}
+	hostname, _ := os.Hostname()
+	if len(hostname) > 160 {
+		hostname = hostname[:160]
+	}
+	ctx, cancelRuns := context.WithCancel(ctx)
+	defer cancelRuns()
+	errorsCh := make(chan error, len(options.tenants))
+	var wait sync.WaitGroup
+	for index, tenantID := range options.tenants {
+		wait.Add(1)
+		go func(index int, tenantID shared.ID) {
+			defer wait.Done()
+			leaseOwner := strings.Join([]string{hostname, strconv.Itoa(os.Getpid()), strconv.Itoa(index)}, "-")
+			log.Info("assessment snapshot backfill started", "tenant_id", tenantID, "dry_run", options.dryRun, "batch_size", options.batchSize)
+			run, err := runner.Run(ctx, snapshotuc.BackfillRequest{
+				TenantID: tenantID, Actor: options.actor, LeaseOwner: leaseOwner, DryRun: options.dryRun,
+				BatchSize: options.batchSize, ResumeAfter: options.resumeAfter, LeaseDuration: options.leaseDuration,
+			})
+			if err == nil && run.FailedCount > 0 {
+				err = fmt.Errorf("tenant %s snapshot backfill completed with %d stable failure records", tenantID, run.FailedCount)
+			}
+			if err != nil {
+				errorsCh <- fmt.Errorf("tenant %s: %w", tenantID, err)
+				cancelRuns()
+				return
+			}
+			log.Info("assessment snapshot backfill completed", "tenant_id", tenantID, "run_id", run.ID, "processed", run.ProcessedCount, "created", run.CreatedCount, "would_create", run.WouldCreateCount, "skipped", run.SkippedCount, "failed", run.FailedCount, "checkpoint", run.CheckpointAssessment)
+		}(index, tenantID)
+	}
+	wait.Wait()
+	close(errorsCh)
+	var combined error
+	for err := range errorsCh {
+		combined = errors.Join(combined, err)
+	}
+	return combined
+}
+
+func parseSnapshotBackfillOptions(args []string, output io.Writer) (snapshotBackfillOptions, error) {
+	flags := flag.NewFlagSet("synapse-assessment-snapshot-backfill", flag.ContinueOnError)
+	flags.SetOutput(output)
+	tenantsValue := flags.String("tenants", "", "comma-separated tenant IDs; maximum four")
+	actor := flags.String("actor", "assessment-snapshot-backfill", "audit actor")
+	dryRun := flags.Bool("dry-run", false, "plan without creating legacy Snapshots")
+	batchSize := flags.Int("batch-size", snapshotuc.DefaultAssessmentSnapshotBackfillBatch, "rows per committed batch")
+	resumeAfter := flags.String("resume-after", "", "initial Assessment ID checkpoint; single tenant only")
+	timeout := flags.Duration("timeout", 30*time.Minute, "overall command timeout")
+	leaseDuration := flags.Duration("lease-duration", 10*time.Minute, "per-tenant job lease")
+	if err := flags.Parse(args); err != nil {
+		return snapshotBackfillOptions{}, err
+	}
+	if flags.NArg() != 0 {
+		return snapshotBackfillOptions{}, fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	seen := map[shared.ID]bool{}
+	tenants := make([]shared.ID, 0, 4)
+	for _, value := range strings.Split(*tenantsValue, ",") {
+		tenantID := shared.ID(strings.TrimSpace(value))
+		if tenantID.IsZero() || seen[tenantID] {
+			continue
+		}
+		seen[tenantID] = true
+		tenants = append(tenants, tenantID)
+	}
+	if len(tenants) == 0 || len(tenants) > 4 {
+		return snapshotBackfillOptions{}, errors.New("--tenants requires between one and four unique tenant IDs")
+	}
+	if *batchSize < 1 || *batchSize > snapshotuc.MaxAssessmentSnapshotBackfillBatch {
+		return snapshotBackfillOptions{}, fmt.Errorf("--batch-size must be between 1 and %d", snapshotuc.MaxAssessmentSnapshotBackfillBatch)
+	}
+	if strings.TrimSpace(*actor) == "" || len(strings.TrimSpace(*actor)) > 256 {
+		return snapshotBackfillOptions{}, errors.New("--actor must contain between 1 and 256 characters")
+	}
+	if *timeout <= 0 || *leaseDuration <= 0 {
+		return snapshotBackfillOptions{}, errors.New("--timeout and --lease-duration must be positive")
+	}
+	if strings.TrimSpace(*resumeAfter) != "" && len(tenants) != 1 {
+		return snapshotBackfillOptions{}, errors.New("--resume-after requires exactly one tenant")
+	}
+	return snapshotBackfillOptions{
+		tenants: tenants, actor: strings.TrimSpace(*actor), dryRun: *dryRun, batchSize: *batchSize,
+		resumeAfter: shared.ID(strings.TrimSpace(*resumeAfter)), timeout: *timeout, leaseDuration: *leaseDuration,
+	}, nil
+}

--- a/cmd/synapse-assessment-snapshot-backfill/main_test.go
+++ b/cmd/synapse-assessment-snapshot-backfill/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"io"
+	"testing"
+	"time"
+)
+
+func TestParseSnapshotBackfillOptions(t *testing.T) {
+	options, err := parseSnapshotBackfillOptions([]string{"--tenants", "tenant-a,tenant-b,tenant-a", "--dry-run", "--batch-size", "2000", "--timeout", "1h"}, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(options.tenants) != 2 || !options.dryRun || options.batchSize != 2000 || options.timeout != time.Hour {
+		t.Fatalf("options=%+v", options)
+	}
+	for _, args := range [][]string{
+		{},
+		{"--tenants", "a,b,c,d,e"},
+		{"--tenants", "a", "--batch-size", "2001"},
+		{"--tenants", "a,b", "--resume-after", "assessment-1"},
+	} {
+		if _, err := parseSnapshotBackfillOptions(args, io.Discard); err == nil {
+			t.Fatalf("expected invalid options for %v", args)
+		}
+	}
+}

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -34,6 +34,7 @@ architectural boundaries that keep execution auditable.
 | Guide | What it covers |
 | --- | --- |
 | [Configuration](configuration.md) | Environment variables, defaults, dependencies, and production requirements |
+| [Assessment Cycle and Snapshot rollout](assessment-lifecycle-operations.md) | Tenant canary, resumable backfills, integrity verification, read cutover, and rollback |
 | [Deployment](deployment.md) | Containers, services, agents, Linux-only capabilities, and production checks |
 | [Backup, restore, and upgrade recovery](backup-restore-upgrade.md) | Quiesced paired backups, restore verification, active-write characterization, and safe upgrades |
 | [CLI](cli.md) | Scanning, code-quality gates, advisory maintenance, imports, and exit contracts |

--- a/docs/guide/architecture.md
+++ b/docs/guide/architecture.md
@@ -33,6 +33,8 @@ authorization window, and lifecycle gate all execution. They are independent agg
 owns the other. Both may invoke the same analysis pipeline, while future project analyses reference
 their Project instead of duplicating or forking that engine.
 
+An **Assessment Cycle** owns rooted initial Assessment/Re-test ancestry and a frozen Asset/Project boundary. Immutable **Assessment Snapshots** select only sealed, hash-verified Scan Run inputs and record explicit coverage. Lifecycle migrations and historical backfills are separate: API/worker startup never runs backfill commands, and all rollout gates default off.
+
 ## Binaries
 
 `cmd/` holds 15 composition roots. They fall into four groups.
@@ -50,6 +52,14 @@ their Project instead of duplicating or forking that engine.
 | Binary | Role |
 | --- | --- |
 | `synapse-cli` | CI-oriented scanner and code-quality gate using the same pipeline as the server. |
+
+**Assessment lifecycle operations**
+
+| Binary | Role |
+| --- | --- |
+| `synapse-assessment-backfill` | Resumable tenant-scoped historical singleton-Cycle backfill. |
+| `synapse-assessment-snapshot-backfill` | Append-only projection of historical scan evidence into legacy Snapshots with explicit unknown coverage. |
+| `synapse-assessment-integrity` | Read-only Cycle integrity verification and deterministic repair-plan output. |
 
 **Sandboxed helpers**
 

--- a/docs/guide/assessment-lifecycle-operations.md
+++ b/docs/guide/assessment-lifecycle-operations.md
@@ -1,0 +1,86 @@
+# Assessment Cycle and Snapshot rollout
+
+Assessment lifecycle rollout is additive and fail-closed. Apply migrations first, enable Cycle dual-write for a bounded tenant allowlist, backfill historical Assessments, verify integrity, and only then enable lifecycle reads and UI.
+
+The API and worker never run historical backfills during startup. Every command below requires `SYNAPSE_DB_DSN` and accepts at most four comma-separated tenant IDs per process.
+
+## 1. Backfill singleton Cycles
+
+Start with a dry run:
+
+```bash
+synapse-assessment-backfill \
+  --tenants tenant-a \
+  --dry-run \
+  --batch-size 500
+```
+
+After reviewing the projected count, run the write pass:
+
+```bash
+synapse-assessment-backfill \
+  --tenants tenant-a \
+  --batch-size 500 \
+  --timeout 2h
+```
+
+The command excludes hidden Project analysis contexts and never rewrites or deletes source rows. Each tenant has one leased active run, a frozen source snapshot, and a durable Assessment-ID checkpoint after every committed batch. An expired lease resumes the existing run without creating duplicate Cycles. `--resume-after` is available only for a single tenant.
+
+The default batch size is `500`; the maximum is `2000`. Cancellation is durable. Item records contain stable reason codes and bounded repair guidance rather than raw database/provider errors.
+
+## 2. Backfill legacy Snapshots
+
+Run this only after the Cycle backfill completes:
+
+```bash
+synapse-assessment-snapshot-backfill \
+  --tenants tenant-a \
+  --dry-run \
+  --batch-size 500
+
+synapse-assessment-snapshot-backfill \
+  --tenants tenant-a \
+  --batch-size 500 \
+  --timeout 2h
+```
+
+The command appends immutable `legacy` Snapshots without changing an Assessment's default Snapshot pointer or rewriting Scan Runs. It prefers verified sealed run manifests. When lane provenance is unavailable it does not invent coverage dimensions; projected legacy coverage remains `unknown`. A changed source creates a new append-only projection, while an unchanged rerun records `already_projected`.
+
+Native Snapshot finalization accepts only tenant-owned Scan Runs whose aggregate and lane manifest hashes recompute correctly. The API selects server-stored run/lane facts; clients cannot submit arbitrary target, version, coverage, or evidence fields.
+
+## 3. Verify integrity
+
+Run the read-only verifier after both write passes:
+
+```bash
+synapse-assessment-integrity \
+  --tenants tenant-a \
+  --dry-run \
+  --batch-size 500
+```
+
+`--dry-run=false` is rejected. The verifier checks coverage, root/member shape, frozen boundaries, selected-head eligibility, Re-test allocation, predecessor integrity, graph acyclicity, and source/checkpoint reconciliation. Findings are persisted under tenant RLS and emitted as JSON lines with stable reason/severity codes and deterministic repair plans. Any finding causes a non-zero exit and must be resolved before read cutover.
+
+## 4. Canary and cut over reads
+
+For each tenant, record the deployment revision, enabled flags, backfill run IDs, integrity run ID, approver, start/end timestamps, and rollback result.
+
+Use this order:
+
+1. Apply lifecycle migrations `0131` through `0135` after the Scan Run provenance migration from PR #779.
+2. Enable `SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_ENABLED` for an internal tenant allowlist.
+3. Confirm new initial Assessments atomically create a Cycle and root member.
+4. Run both backfills and the integrity verifier.
+5. Enable `SYNAPSE_ASSESSMENT_SNAPSHOT_ENABLED`.
+6. Enable `SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED` for the verified tenant allowlist.
+7. Enable `SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_ENABLED` only for tenants already enabled for lifecycle reads.
+
+## Rollback
+
+1. Remove the tenant from `SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_TENANTS` and deploy.
+2. Remove it from `SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS` and deploy.
+3. Disable Snapshot and dual-write gates if the incident requires write rollback.
+4. Do not delete source Assessments, Scan Runs, Cycles, members, or Snapshots.
+5. Verify `/api/v1/me` reports lifecycle read/UI as false, lifecycle routes fail closed, the sidebar is hidden, and legacy Engagement reads still work.
+
+Rollback migrations deliberately refuse to drop populated immutable lifecycle state. Preserve it for audit and repair.

--- a/docs/guide/assessment-lifecycle-operations.md
+++ b/docs/guide/assessment-lifecycle-operations.md
@@ -48,6 +48,8 @@ The command appends immutable `legacy` Snapshots without changing an Assessment'
 
 Native Snapshot finalization accepts only tenant-owned Scan Runs whose aggregate and lane manifest hashes recompute correctly. The API selects server-stored run/lane facts; clients cannot submit arbitrary target, version, coverage, or evidence fields.
 
+Creating a Re-test from a completed Cycle first requires `POST /api/v1/assessment-cycles/{cycleId}/reopen` with Review permission, `Idempotency-Key`, the current Cycle version in `If-Match`, and a non-empty audited `reason`.
+
 ## 3. Verify integrity
 
 Run the read-only verifier after both write passes:
@@ -59,7 +61,7 @@ synapse-assessment-integrity \
   --batch-size 500
 ```
 
-`--dry-run=false` is rejected. The verifier checks coverage, root/member shape, frozen boundaries, selected-head eligibility, Re-test allocation, predecessor integrity, graph acyclicity, and source/checkpoint reconciliation. Findings are persisted under tenant RLS and emitted as JSON lines with stable reason/severity codes and deterministic repair plans. Any finding causes a non-zero exit and must be resolved before read cutover.
+`--dry-run=false` is rejected. The verifier checks coverage, root/member shape, frozen boundaries, selected-head eligibility, Re-test allocation, predecessor integrity, graph acyclicity, and source/checkpoint reconciliation. A tenant-local source generation fences completion, so a concurrent Assessment, Cycle, or membership change forces the run to fail and restart instead of publishing a stale clean result. Findings are persisted under tenant RLS and emitted as JSON lines with stable reason/severity codes and deterministic repair plans. Any finding causes a non-zero exit and must be resolved before read cutover.
 
 ## 4. Canary and cut over reads
 
@@ -74,13 +76,15 @@ Use this order:
 5. Enable `SYNAPSE_ASSESSMENT_SNAPSHOT_ENABLED`.
 6. Enable `SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED` for the verified tenant allowlist.
 7. Enable `SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_ENABLED` only for tenants already enabled for lifecycle reads.
+8. After native Snapshot finalization is verified for the cohort, enable `SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_ENABLED` and add only those tenants to `SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_TENANTS`. Until this step, legacy Assessment completion remains available.
 
 ## Rollback
 
-1. Remove the tenant from `SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_TENANTS` and deploy.
-2. Remove it from `SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS` and deploy.
-3. Disable Snapshot and dual-write gates if the incident requires write rollback.
-4. Do not delete source Assessments, Scan Runs, Cycles, members, or Snapshots.
-5. Verify `/api/v1/me` reports lifecycle read/UI as false, lifecycle routes fail closed, the sidebar is hidden, and legacy Engagement reads still work.
+1. Remove the tenant from `SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_TENANTS` so legacy completion is restored.
+2. Remove the tenant from `SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_TENANTS` and deploy.
+3. Remove it from `SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS` and deploy.
+4. Disable Snapshot and dual-write gates if the incident requires write rollback.
+5. Do not delete source Assessments, Scan Runs, Cycles, members, or Snapshots.
+6. Verify `/api/v1/me` reports lifecycle read/UI as false, lifecycle routes fail closed, the sidebar is hidden, and legacy Engagement reads still work.
 
 Rollback migrations deliberately refuse to drop populated immutable lifecycle state. Preserve it for audit and repair.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -264,6 +264,14 @@ All off by default. The fleet needs PostgreSQL + `synapse-worker`; agents run on
 | `SYNAPSE_VULNERABILITY_DRY_RUN_ENABLED` | `true` | Persist reconciliation diffs and counts without occurrence, finding, action, or notification mutations. |
 | `SYNAPSE_VULNERABILITY_TENANT_ALLOWLIST` | empty | Comma-separated tenant IDs allowed to use tenant-scoped gates and dry-run; `*` enables every tenant. Empty fails closed. |
 | `SYNAPSE_SLA_ENABLED` | `false` | Enable versioned risk-based remediation deadlines, immutable assessment history, human-only lifecycle transitions, and continuous-intelligence reassessment. See [Remediation SLA governance](sla-governance.md). |
+| `SYNAPSE_ASSESSMENT_CYCLE_API_ENABLED` | `false` | Enable Cycle/Re-test/list/archive APIs and atomically create a Cycle for new initial Assessments. Retained writes require `Idempotency-Key`; archive also requires `If-Match`. |
+| `SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_ENABLED` | `false` | Enable new-initial-Assessment Cycle/root dual-write only for the configured tenant allowlist. |
+| `SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_TENANTS` | empty | Comma-separated dual-write tenant allowlist; `*` enables all tenants. Required when the dual-write gate is enabled. |
+| `SYNAPSE_ASSESSMENT_SNAPSHOT_ENABLED` | `false` | Enable immutable Snapshot finalization and reads from sealed, hash-verified Scan Runs. |
+| `SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED` | `false` | Enable lifecycle read projections after backfill and integrity verification. |
+| `SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS` | empty | Comma-separated lifecycle-read allowlist; `*` enables all tenants. Required when lifecycle reads are enabled. |
+| `SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_ENABLED` | `false` | Show the Assessment Cycles UI by default. Startup rejects this unless lifecycle reads are enabled. |
+| `SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_TENANTS` | empty | Comma-separated UI allowlist; it must be a subset of the lifecycle-read allowlist. |
 | `SYNAPSE_DAST_RATE_PER_SEC` | `5` | DAST crawler request rate. |
 | `SYNAPSE_DAST_CONCURRENCY` | `4` | DAST crawler concurrency. |
 | `SYNAPSE_DAST_MAX_DEPTH` | `8` | Maximum crawl depth. |

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -268,6 +268,8 @@ All off by default. The fleet needs PostgreSQL + `synapse-worker`; agents run on
 | `SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_ENABLED` | `false` | Enable new-initial-Assessment Cycle/root dual-write only for the configured tenant allowlist. |
 | `SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_TENANTS` | empty | Comma-separated dual-write tenant allowlist; `*` enables all tenants. Required when the dual-write gate is enabled. |
 | `SYNAPSE_ASSESSMENT_SNAPSHOT_ENABLED` | `false` | Enable immutable Snapshot finalization and reads from sealed, hash-verified Scan Runs. |
+| `SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_ENABLED` | `false` | Require a finalized default Snapshot before Assessment completion for an explicit rollout cohort. Disabled preserves legacy completion behavior. |
+| `SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_TENANTS` | empty | Comma-separated Snapshot-completion enforcement allowlist; it must be a subset of the lifecycle-read allowlist. |
 | `SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED` | `false` | Enable lifecycle read projections after backfill and integrity verification. |
 | `SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS` | empty | Comma-separated lifecycle-read allowlist; `*` enables all tenants. Required when lifecycle reads are enabled. |
 | `SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_ENABLED` | `false` | Show the Assessment Cycles UI by default. Startup rejects this unless lifecycle reads are enabled. |

--- a/docs/guide/security.md
+++ b/docs/guide/security.md
@@ -88,6 +88,8 @@ admin, consultant, reviewer, and read-only. Separation of duties means a machine
 never verify or accept its own claim. Tenant isolation is enforced at the service layer, so a
 caller cannot read another tenant's engagement even if a route wrapper is bypassed.
 
+Assessment lifecycle projections are additive and fail closed behind independent rollout gates. Cycle, member, request, backfill, integrity, and Snapshot tables use tenant ownership constraints and forced PostgreSQL RLS. Native Snapshot finalization recomputes aggregate and lane manifest hashes from server-stored Scan Runs; callers submit identifiers only and cannot forge target, coverage, version, or evidence fields. Retained writes use idempotency keys, and pointer changes use optimistic concurrency.
+
 ## Browser OIDC access
 
 Browser OIDC uses a backend-for-frontend model. The server accepts an identity only for an exact approved

--- a/internal/adapter/httpapi/assessment_cycle_handler.go
+++ b/internal/adapter/httpapi/assessment_cycle_handler.go
@@ -1,0 +1,206 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+)
+
+const assessmentCycleRequestLimit = int64(1 << 20)
+
+type createAssessmentRetestRequest struct {
+	Name                    string      `json:"name"`
+	PredecessorAssessmentID string      `json:"predecessor_assessment_id"`
+	ScopeStrategy           string      `json:"scope_strategy"`
+	ProfileStrategy         string      `json:"profile_strategy"`
+	AuthorizedFrom          string      `json:"authorized_from"`
+	AuthorizedTo            string      `json:"authorized_to"`
+	Timezone                string      `json:"timezone"`
+	RoE                     *engdom.RoE `json:"roe"`
+}
+
+func (rt *Router) createAssessmentRetest(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, assessmentCycleRequestLimit)
+	var request createAssessmentRetestRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_request"})
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_request"})
+		return
+	}
+	authorizedFrom, err := parseRFC3339Ptr(request.AuthorizedFrom)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_authorized_from"})
+		return
+	}
+	authorizedTo, err := parseRFC3339Ptr(request.AuthorizedTo)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_authorized_to"})
+		return
+	}
+	response, err := rt.assessmentCycles.CreateRetestAssessment(r.Context(), cycleuc.CreateRetestAssessmentInput{
+		Request: cycleuc.RetainedRequest{
+			TenantID: shared.ID(TenantFrom(r.Context())), Actor: PrincipalFrom(r.Context()), Route: r.URL.Path,
+			IdempotencyKey: r.Header.Get("Idempotency-Key"),
+		},
+		AssessmentID: shared.ID(r.PathValue("assessmentId")), Name: request.Name,
+		PredecessorAssessmentID: shared.ID(request.PredecessorAssessmentID), ScopeStrategy: request.ScopeStrategy,
+		ProfileStrategy: request.ProfileStrategy, AuthorizedFrom: authorizedFrom, AuthorizedTo: authorizedTo,
+		Timezone: request.Timezone, RoE: request.RoE,
+	})
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeRetainedJSON(w, response)
+}
+
+func (rt *Router) getAssessmentLifecycle(w http.ResponseWriter, r *http.Request) {
+	response, err := rt.assessmentCycles.GetLifecycle(r.Context(), shared.ID(TenantFrom(r.Context())), shared.ID(r.PathValue("assessmentId")))
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (rt *Router) getAssessmentCycle(w http.ResponseWriter, r *http.Request) {
+	response, err := rt.assessmentCycles.GetCycle(r.Context(), shared.ID(TenantFrom(r.Context())), shared.ID(r.PathValue("cycleId")))
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (rt *Router) listAssessmentCycles(w http.ResponseWriter, r *http.Request) {
+	limit := 0
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: cycleuc.CodeInvalidPageSize})
+			return
+		}
+		limit = parsed
+	}
+	response, err := rt.assessmentCycles.ListCycles(r.Context(), cycleuc.ListCyclesInput{
+		TenantID: shared.ID(TenantFrom(r.Context())), Status: cycledom.Status(r.URL.Query().Get("status")),
+		BoundaryKind: cycledom.BoundaryKind(r.URL.Query().Get("boundary_kind")), AssessmentStatus: engdom.Status(r.URL.Query().Get("assessment_status")),
+		SelectedHeadID: shared.ID(r.URL.Query().Get("selected_head_assessment_id")), AssessmentType: cycledom.AssessmentType(r.URL.Query().Get("assessment_type")),
+		ScanStaleness: r.URL.Query().Get("scan_staleness"), Search: r.URL.Query().Get("q"), Cursor: r.URL.Query().Get("cursor"), Limit: limit,
+	})
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (rt *Router) listAssessmentCycleMembers(w http.ResponseWriter, r *http.Request) {
+	limit := 0
+	if value := strings.TrimSpace(r.URL.Query().Get("limit")); value != "" {
+		parsed, err := strconv.Atoi(value)
+		if err != nil || parsed < 1 {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: cycleuc.CodeInvalidPageSize})
+			return
+		}
+		limit = parsed
+	}
+	page, err := rt.assessmentCycles.ListCycleMembers(r.Context(), cycleuc.ListCycleMembersInput{
+		TenantID: shared.ID(TenantFrom(r.Context())), CycleID: shared.ID(r.PathValue("cycleId")), Cursor: r.URL.Query().Get("cursor"), Limit: limit,
+	})
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, page)
+}
+
+func (rt *Router) archiveAssessmentCycle(w http.ResponseWriter, r *http.Request) {
+	expectedVersion, err := parseCycleIfMatch(r.Header.Get("If-Match"))
+	if err != nil {
+		writeJSON(w, http.StatusPreconditionRequired, errorBody{Error: "precondition_required"})
+		return
+	}
+	response, err := rt.assessmentCycles.ArchiveCycle(r.Context(), cycleuc.ArchiveCycleRequest{
+		Request: cycleuc.RetainedRequest{
+			TenantID: shared.ID(TenantFrom(r.Context())), Actor: PrincipalFrom(r.Context()), Route: r.URL.Path,
+			IdempotencyKey: r.Header.Get("Idempotency-Key"),
+		},
+		CycleID: shared.ID(r.PathValue("cycleId")), ExpectedVersion: expectedVersion,
+	})
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeRetainedJSON(w, response)
+}
+
+func decodeAssessmentCycleJSON(w http.ResponseWriter, r *http.Request, target any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, assessmentCycleRequestLimit)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_request"})
+		return false
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_request"})
+		return false
+	}
+	return true
+}
+
+func parseCycleIfMatch(value string) (int64, error) {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "W/") {
+		value = strings.TrimSpace(strings.TrimPrefix(value, "W/"))
+	}
+	value = strings.Trim(value, "\"")
+	version, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || version < 1 {
+		return 0, errors.New("invalid If-Match")
+	}
+	return version, nil
+}
+
+func writeRetainedJSON(w http.ResponseWriter, response cycleuc.RetainedResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	if response.Replayed {
+		w.Header().Set("Idempotency-Replayed", "true")
+	}
+	w.WriteHeader(response.StatusCode)
+	_, _ = io.Copy(w, bytes.NewReader(response.Body))
+}
+
+func writeAssessmentCycleError(w http.ResponseWriter, log *slog.Logger, err error) {
+	code := cycleuc.ErrorCode(err)
+	if code == "" {
+		writeError(w, log, err)
+		return
+	}
+	status := http.StatusBadRequest
+	switch {
+	case errors.Is(err, shared.ErrNotFound):
+		status = http.StatusNotFound
+	case errors.Is(err, shared.ErrForbidden):
+		status = http.StatusForbidden
+	case errors.Is(err, shared.ErrConflict):
+		status = http.StatusConflict
+	}
+	writeJSON(w, status, errorBody{Error: code})
+}

--- a/internal/adapter/httpapi/assessment_cycle_handler.go
+++ b/internal/adapter/httpapi/assessment_cycle_handler.go
@@ -150,6 +150,32 @@ func (rt *Router) archiveAssessmentCycle(w http.ResponseWriter, r *http.Request)
 	writeRetainedJSON(w, response)
 }
 
+func (rt *Router) reopenAssessmentCycle(w http.ResponseWriter, r *http.Request) {
+	expectedVersion, err := parseCycleIfMatch(r.Header.Get("If-Match"))
+	if err != nil {
+		writeJSON(w, http.StatusPreconditionRequired, errorBody{Error: "precondition_required"})
+		return
+	}
+	var request struct {
+		Reason string `json:"reason"`
+	}
+	if !decodeAssessmentCycleJSON(w, r, &request) {
+		return
+	}
+	response, err := rt.assessmentCycles.ReopenCycle(r.Context(), cycleuc.ReopenCycleRequest{
+		Request: cycleuc.RetainedRequest{
+			TenantID: shared.ID(TenantFrom(r.Context())), Actor: PrincipalFrom(r.Context()), Route: r.URL.Path,
+			IdempotencyKey: r.Header.Get("Idempotency-Key"),
+		},
+		CycleID: shared.ID(r.PathValue("cycleId")), ExpectedVersion: expectedVersion, Reason: request.Reason,
+	})
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeRetainedJSON(w, response)
+}
+
 func decodeAssessmentCycleJSON(w http.ResponseWriter, r *http.Request, target any) bool {
 	r.Body = http.MaxBytesReader(w, r.Body, assessmentCycleRequestLimit)
 	decoder := json.NewDecoder(r.Body)

--- a/internal/adapter/httpapi/assessment_cycle_handler_test.go
+++ b/internal/adapter/httpapi/assessment_cycle_handler_test.go
@@ -1,0 +1,247 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type assessmentCycleHTTPIDs struct{ next int }
+
+func (ids *assessmentCycleHTTPIDs) NewID() shared.ID {
+	ids.next++
+	return shared.ID("cycle-http-" + strconv.Itoa(ids.next))
+}
+
+type assessmentCycleHTTPObserver struct{ outcomes []string }
+
+func (*assessmentCycleHTTPObserver) ObserveHTTPRequest(string, string, string, time.Duration) {}
+
+func (observer *assessmentCycleHTTPObserver) ObserveAssessmentCycleDualWrite(outcome string) {
+	observer.outcomes = append(observer.outcomes, outcome)
+}
+
+func (observer *assessmentCycleHTTPObserver) count(outcome string) int {
+	count := 0
+	for _, observed := range observer.outcomes {
+		if observed == outcome {
+			count++
+		}
+	}
+	return count
+}
+
+func newAssessmentCycleHTTPRouter(t *testing.T, apiEnabled bool, dualWrite func(string) bool) (*Router, *memory.AssessmentCycleRepository, *assessmentCycleHTTPObserver) {
+	t.Helper()
+	clock := fixedClock{t: time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)}
+	ids := &assessmentCycleHTTPIDs{}
+	audit := &fakeAudit{}
+	engagements := memory.NewEngagementRepository()
+	cycles := memory.NewAssessmentCycleRepository()
+	transactions := memory.NewTenantTransactionRunner()
+	engagementService := enguc.NewService(engagements, clock, ids, audit)
+	cycleService, err := cycleuc.NewService(cycles, engagements, nil, nil, transactions, ids, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cycleAPI, err := cycleuc.NewAPIService(cycleService, cycles, memory.NewAssessmentCycleRequestRepository(), engagementService, transactions, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observer := &assessmentCycleHTTPObserver{}
+	router := &Router{log: discardLog(), eng: engagementService}
+	router.SetObservability(false, observer)
+	router.SetAssessmentCycles(cycleAPI, apiEnabled, dualWrite)
+	return router, cycles, observer
+}
+
+func TestAssessmentLifecycleReadGateIsTenantScopedAndFailClosed(t *testing.T) {
+	router, _, _ := newAssessmentCycleHTTPRouter(t, true, func(string) bool { return true })
+	router.SetAssessmentLifecycleRollout(func(tenantID string) bool { return tenantID == "tenant-canary" }, func(string) bool { return false })
+	handler := router.requireAssessmentLifecycleRead(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+
+	blocked := httptest.NewRecorder()
+	handler(blocked, cycleRequest(http.MethodGet, "/api/v1/assessment-cycles", "", userdom.RoleReadOnly, "tenant-other"))
+	if blocked.Code != http.StatusNotFound || !strings.Contains(blocked.Body.String(), "assessment_lifecycle_read_disabled") {
+		t.Fatalf("blocked lifecycle read = %d %s", blocked.Code, blocked.Body.String())
+	}
+
+	allowed := httptest.NewRecorder()
+	handler(allowed, cycleRequest(http.MethodGet, "/api/v1/assessment-cycles", "", userdom.RoleReadOnly, "tenant-canary"))
+	if allowed.Code != http.StatusNoContent {
+		t.Fatalf("allowed lifecycle read = %d", allowed.Code)
+	}
+}
+
+func TestAssessmentCycleRoutesPermissionAndIdempotency(t *testing.T) {
+	router, _, _ := newAssessmentCycleHTTPRouter(t, true, func(string) bool { return true })
+	handler := router.routes()
+
+	missingKey := cycleRequest(http.MethodPost, "/api/v1/engagements", `{"name":"Acme"}`, userdom.RoleConsultant, "tenant-1")
+	missingKeyResponse := httptest.NewRecorder()
+	handler.ServeHTTP(missingKeyResponse, missingKey)
+	if missingKeyResponse.Code != http.StatusBadRequest || !strings.Contains(missingKeyResponse.Body.String(), cycleuc.CodeIdempotencyKeyRequired) {
+		t.Fatalf("missing key response = %d %s", missingKeyResponse.Code, missingKeyResponse.Body.String())
+	}
+
+	create := cycleRequest(http.MethodPost, "/api/v1/engagements", `{"name":"Acme","in_scope":[{"kind":"domain","value":"app.example.com"}]}`, userdom.RoleConsultant, "tenant-1")
+	create.Header.Set("Idempotency-Key", "create-1")
+	created := httptest.NewRecorder()
+	handler.ServeHTTP(created, create)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create response = %d %s", created.Code, created.Body.String())
+	}
+	var engagement struct{ ID shared.ID }
+	if err := json.Unmarshal(created.Body.Bytes(), &engagement); err != nil {
+		t.Fatal(err)
+	}
+
+	replay := cycleRequest(http.MethodPost, "/api/v1/engagements", `{"name":"Acme","in_scope":[{"kind":"domain","value":"app.example.com"}]}`, userdom.RoleConsultant, "tenant-1")
+	replay.Header.Set("Idempotency-Key", "create-1")
+	replayed := httptest.NewRecorder()
+	handler.ServeHTTP(replayed, replay)
+	if replayed.Code != http.StatusCreated || replayed.Header().Get("Idempotency-Replayed") != "true" {
+		t.Fatalf("replay response = %d headers=%v", replayed.Code, replayed.Header())
+	}
+
+	lifecyclePath := "/api/v1/engagements/" + engagement.ID.String() + "/lifecycle"
+	crossTenant := cycleRequest(http.MethodGet, lifecyclePath, "", userdom.RoleReadOnly, "tenant-2")
+	crossTenantResponse := httptest.NewRecorder()
+	handler.ServeHTTP(crossTenantResponse, crossTenant)
+	if crossTenantResponse.Code != http.StatusNotFound {
+		t.Fatalf("cross-tenant lifecycle = %d %s", crossTenantResponse.Code, crossTenantResponse.Body.String())
+	}
+
+	retestPath := "/api/v1/engagements/" + engagement.ID.String() + "/retests"
+	reviewerRetest := cycleRequest(http.MethodPost, retestPath, `{}`, userdom.RoleReviewer, "tenant-1")
+	reviewerRetest.Header.Set("Idempotency-Key", "retest-denied")
+	reviewerRetestResponse := httptest.NewRecorder()
+	handler.ServeHTTP(reviewerRetestResponse, reviewerRetest)
+	if reviewerRetestResponse.Code != http.StatusForbidden {
+		t.Fatalf("reviewer retest = %d", reviewerRetestResponse.Code)
+	}
+
+	retest := cycleRequest(http.MethodPost, retestPath, `{}`, userdom.RoleConsultant, "tenant-1")
+	retest.Header.Set("Idempotency-Key", "retest-1")
+	retestResponse := httptest.NewRecorder()
+	handler.ServeHTTP(retestResponse, retest)
+	if retestResponse.Code != http.StatusCreated {
+		t.Fatalf("retest response = %d %s", retestResponse.Code, retestResponse.Body.String())
+	}
+
+	lifecycle := cycleRequest(http.MethodGet, lifecyclePath, "", userdom.RoleReadOnly, "tenant-1")
+	lifecycleResponse := httptest.NewRecorder()
+	handler.ServeHTTP(lifecycleResponse, lifecycle)
+	if lifecycleResponse.Code != http.StatusOK {
+		t.Fatalf("lifecycle response = %d %s", lifecycleResponse.Code, lifecycleResponse.Body.String())
+	}
+	var lifecycleBody cycleuc.LifecycleView
+	if err := json.Unmarshal(lifecycleResponse.Body.Bytes(), &lifecycleBody); err != nil {
+		t.Fatal(err)
+	}
+
+	archivePath := "/api/v1/assessment-cycles/" + lifecycleBody.Cycle.ID + "/archive"
+	consultantArchive := cycleRequest(http.MethodPost, archivePath, "", userdom.RoleConsultant, "tenant-1")
+	consultantArchive.Header.Set("Idempotency-Key", "archive-denied")
+	consultantArchive.Header.Set("If-Match", strconv.FormatInt(lifecycleBody.Cycle.Version, 10))
+	consultantArchiveResponse := httptest.NewRecorder()
+	handler.ServeHTTP(consultantArchiveResponse, consultantArchive)
+	if consultantArchiveResponse.Code != http.StatusForbidden {
+		t.Fatalf("consultant archive = %d", consultantArchiveResponse.Code)
+	}
+
+	archive := cycleRequest(http.MethodPost, archivePath, "", userdom.RoleReviewer, "tenant-1")
+	archive.Header.Set("Idempotency-Key", "archive-1")
+	archive.Header.Set("If-Match", `"`+strconv.FormatInt(lifecycleBody.Cycle.Version, 10)+`"`)
+	archiveResponse := httptest.NewRecorder()
+	handler.ServeHTTP(archiveResponse, archive)
+	if archiveResponse.Code != http.StatusOK {
+		t.Fatalf("archive response = %d %s", archiveResponse.Code, archiveResponse.Body.String())
+	}
+}
+
+func TestAssessmentCycleDualWriteTenantRollout(t *testing.T) {
+	router, cycles, observer := newAssessmentCycleHTTPRouter(t, false, func(tenantID string) bool { return tenantID == "tenant-a" })
+	handler := router.routes()
+	body := `{"name":"Acme","in_scope":[{"kind":"domain","value":"app.example.com"}]}`
+
+	missingKey := cycleRequest(http.MethodPost, "/api/v1/engagements", body, userdom.RoleConsultant, "tenant-a")
+	missingKeyResponse := httptest.NewRecorder()
+	handler.ServeHTTP(missingKeyResponse, missingKey)
+	if missingKeyResponse.Code != http.StatusBadRequest || observer.count("failed") != 1 {
+		t.Fatalf("tenant-a missing key = %d outcomes=%v body=%s", missingKeyResponse.Code, observer.outcomes, missingKeyResponse.Body.String())
+	}
+
+	tenantA := cycleRequest(http.MethodPost, "/api/v1/engagements", body, userdom.RoleConsultant, "tenant-a")
+	tenantA.Header.Set("Idempotency-Key", "tenant-a-create")
+	tenantAResponse := httptest.NewRecorder()
+	handler.ServeHTTP(tenantAResponse, tenantA)
+	if tenantAResponse.Code != http.StatusCreated || tenantAResponse.Header().Get("X-Synapse-Assessment-Cycle-Dual-Write") != "true" || observer.count("created") != 1 {
+		t.Fatalf("tenant-a create = %d headers=%v outcomes=%v body=%s", tenantAResponse.Code, tenantAResponse.Header(), observer.outcomes, tenantAResponse.Body.String())
+	}
+
+	replay := cycleRequest(http.MethodPost, "/api/v1/engagements", body, userdom.RoleConsultant, "tenant-a")
+	replay.Header.Set("Idempotency-Key", "tenant-a-create")
+	replayResponse := httptest.NewRecorder()
+	handler.ServeHTTP(replayResponse, replay)
+	if replayResponse.Code != http.StatusCreated || replayResponse.Header().Get("Idempotency-Replayed") != "true" || replayResponse.Body.String() != tenantAResponse.Body.String() || observer.count("replayed") != 1 {
+		t.Fatalf("tenant-a replay = %d headers=%v outcomes=%v body=%s", replayResponse.Code, replayResponse.Header(), observer.outcomes, replayResponse.Body.String())
+	}
+
+	tenantB := cycleRequest(http.MethodPost, "/api/v1/engagements", body, userdom.RoleConsultant, "tenant-b")
+	tenantBResponse := httptest.NewRecorder()
+	handler.ServeHTTP(tenantBResponse, tenantB)
+	if tenantBResponse.Code != http.StatusCreated || tenantBResponse.Header().Get("X-Synapse-Assessment-Cycle-Dual-Write") != "" || observer.count("legacy") != 1 {
+		t.Fatalf("tenant-b legacy create = %d headers=%v outcomes=%v body=%s", tenantBResponse.Code, tenantBResponse.Header(), observer.outcomes, tenantBResponse.Body.String())
+	}
+
+	for tenantID, want := range map[shared.ID]int{"tenant-a": 1, "tenant-b": 0} {
+		records, err := cycles.ListCycles(context.Background(), ports.AssessmentCycleListQuery{TenantID: tenantID, Limit: 10})
+		if err != nil || len(records) != want {
+			t.Fatalf("tenant %s cycle count = %d, want %d, err=%v", tenantID, len(records), want, err)
+		}
+	}
+}
+
+func TestAssessmentCycleDualWriteDisabledPreservesLegacyResponse(t *testing.T) {
+	configured, cycles, observer := newAssessmentCycleHTTPRouter(t, false, func(string) bool { return false })
+	legacy, _, _ := newAssessmentCycleHTTPRouter(t, false, func(string) bool { return false })
+	legacy.assessmentCycles = nil
+	legacy.assessmentCycleDualWrite = nil
+
+	body := `{"name":"Acme","in_scope":[{"kind":"domain","value":"app.example.com"}]}`
+	configuredResponse := httptest.NewRecorder()
+	configured.routes().ServeHTTP(configuredResponse, cycleRequest(http.MethodPost, "/api/v1/engagements", body, userdom.RoleConsultant, "tenant-a"))
+	legacyResponse := httptest.NewRecorder()
+	legacy.routes().ServeHTTP(legacyResponse, cycleRequest(http.MethodPost, "/api/v1/engagements", body, userdom.RoleConsultant, "tenant-a"))
+
+	if configuredResponse.Code != legacyResponse.Code || configuredResponse.Body.String() != legacyResponse.Body.String() {
+		t.Fatalf("disabled dual-write response changed: configured=(%d,%q) legacy=(%d,%q)", configuredResponse.Code, configuredResponse.Body.String(), legacyResponse.Code, legacyResponse.Body.String())
+	}
+	if configuredResponse.Header().Get("X-Synapse-Assessment-Cycle-Dual-Write") != "" || observer.count("legacy") != 1 {
+		t.Fatalf("disabled dual-write headers=%v outcomes=%v", configuredResponse.Header(), observer.outcomes)
+	}
+	records, err := cycles.ListCycles(context.Background(), ports.AssessmentCycleListQuery{TenantID: "tenant-a", Limit: 10})
+	if err != nil || len(records) != 0 {
+		t.Fatalf("disabled dual-write cycle count = %d, err=%v", len(records), err)
+	}
+}
+
+func cycleRequest(method, target, body string, role userdom.Role, tenantID string) *http.Request {
+	request := httptest.NewRequest(method, target, strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	principal := Principal{ID: "actor-1", Role: string(role), TenantID: tenantID}
+	return request.WithContext(context.WithValue(request.Context(), principalKey, principal))
+}

--- a/internal/adapter/httpapi/assessment_cycle_handler_test.go
+++ b/internal/adapter/httpapi/assessment_cycle_handler_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
@@ -64,6 +65,7 @@ func newAssessmentCycleHTTPRouter(t *testing.T, apiEnabled bool, dualWrite func(
 	router := &Router{log: discardLog(), eng: engagementService}
 	router.SetObservability(false, observer)
 	router.SetAssessmentCycles(cycleAPI, apiEnabled, dualWrite)
+	router.SetAssessmentLifecycleRollout(func(string) bool { return true }, func(string) bool { return true })
 	return router, cycles, observer
 }
 
@@ -85,14 +87,32 @@ func TestAssessmentLifecycleReadGateIsTenantScopedAndFailClosed(t *testing.T) {
 	}
 }
 
-func TestAssessmentCycleRoutesPermissionAndIdempotency(t *testing.T) {
+func TestAssessmentLifecycleWriteGateUsesTenantReadCanary(t *testing.T) {
 	router, _, _ := newAssessmentCycleHTTPRouter(t, true, func(string) bool { return true })
+	router.SetAssessmentLifecycleRollout(func(tenantID string) bool { return tenantID == "tenant-canary" }, func(string) bool { return false })
+	handler := router.requireAssessmentLifecycleWrite(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+
+	blocked := httptest.NewRecorder()
+	handler(blocked, cycleRequest(http.MethodPost, "/api/v1/engagements/a/retests", `{}`, userdom.RoleConsultant, "tenant-other"))
+	if blocked.Code != http.StatusNotFound || !strings.Contains(blocked.Body.String(), "assessment_lifecycle_write_disabled") {
+		t.Fatalf("blocked lifecycle write = %d %s", blocked.Code, blocked.Body.String())
+	}
+
+	allowed := httptest.NewRecorder()
+	handler(allowed, cycleRequest(http.MethodPost, "/api/v1/engagements/a/retests", `{}`, userdom.RoleConsultant, "tenant-canary"))
+	if allowed.Code != http.StatusNoContent {
+		t.Fatalf("allowed lifecycle write = %d", allowed.Code)
+	}
+}
+
+func TestAssessmentCycleRoutesPermissionAndIdempotency(t *testing.T) {
+	router, cycles, _ := newAssessmentCycleHTTPRouter(t, true, func(string) bool { return true })
 	handler := router.routes()
 
 	missingKey := cycleRequest(http.MethodPost, "/api/v1/engagements", `{"name":"Acme"}`, userdom.RoleConsultant, "tenant-1")
 	missingKeyResponse := httptest.NewRecorder()
 	handler.ServeHTTP(missingKeyResponse, missingKey)
-	if missingKeyResponse.Code != http.StatusBadRequest || !strings.Contains(missingKeyResponse.Body.String(), cycleuc.CodeIdempotencyKeyRequired) {
+	if missingKeyResponse.Code != http.StatusCreated || missingKeyResponse.Header().Get("X-Synapse-Assessment-Cycle-Dual-Write") != "true" {
 		t.Fatalf("missing key response = %d %s", missingKeyResponse.Code, missingKeyResponse.Body.String())
 	}
 
@@ -151,6 +171,38 @@ func TestAssessmentCycleRoutesPermissionAndIdempotency(t *testing.T) {
 	if err := json.Unmarshal(lifecycleResponse.Body.Bytes(), &lifecycleBody); err != nil {
 		t.Fatal(err)
 	}
+	storedCycle, err := cycles.GetCycle(context.Background(), "tenant-1", shared.ID(lifecycleBody.Cycle.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := storedCycle.Transition(cycledom.StatusCompleted, storedCycle.Version, "reviewer", time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.UpdateCycleCAS(context.Background(), storedCycle, lifecycleBody.Cycle.Version); err != nil {
+		t.Fatal(err)
+	}
+	reopenPath := "/api/v1/assessment-cycles/" + lifecycleBody.Cycle.ID + "/reopen"
+	missingReason := cycleRequest(http.MethodPost, reopenPath, `{}`, userdom.RoleReviewer, "tenant-1")
+	missingReason.Header.Set("Idempotency-Key", "reopen-missing-reason")
+	missingReason.Header.Set("If-Match", strconv.FormatInt(storedCycle.Version, 10))
+	missingReasonResponse := httptest.NewRecorder()
+	handler.ServeHTTP(missingReasonResponse, missingReason)
+	if missingReasonResponse.Code != http.StatusBadRequest || !strings.Contains(missingReasonResponse.Body.String(), "reopen_reason_required") {
+		t.Fatalf("missing reopen reason = %d %s", missingReasonResponse.Code, missingReasonResponse.Body.String())
+	}
+	reopen := cycleRequest(http.MethodPost, reopenPath, `{"reason":"continue remediation verification"}`, userdom.RoleReviewer, "tenant-1")
+	reopen.Header.Set("Idempotency-Key", "reopen-1")
+	reopen.Header.Set("If-Match", strconv.FormatInt(storedCycle.Version, 10))
+	reopenResponse := httptest.NewRecorder()
+	handler.ServeHTTP(reopenResponse, reopen)
+	if reopenResponse.Code != http.StatusOK {
+		t.Fatalf("reopen response = %d %s", reopenResponse.Code, reopenResponse.Body.String())
+	}
+	var reopened cycleuc.CycleDetail
+	if err := json.Unmarshal(reopenResponse.Body.Bytes(), &reopened); err != nil || reopened.Cycle.Status != cycledom.StatusOpen {
+		t.Fatalf("reopened cycle = %+v err=%v", reopened, err)
+	}
+	lifecycleBody.Cycle = reopened.Cycle
 
 	archivePath := "/api/v1/assessment-cycles/" + lifecycleBody.Cycle.ID + "/archive"
 	consultantArchive := cycleRequest(http.MethodPost, archivePath, "", userdom.RoleConsultant, "tenant-1")
@@ -180,24 +232,15 @@ func TestAssessmentCycleDualWriteTenantRollout(t *testing.T) {
 	missingKey := cycleRequest(http.MethodPost, "/api/v1/engagements", body, userdom.RoleConsultant, "tenant-a")
 	missingKeyResponse := httptest.NewRecorder()
 	handler.ServeHTTP(missingKeyResponse, missingKey)
-	if missingKeyResponse.Code != http.StatusBadRequest || observer.count("failed") != 1 {
+	if missingKeyResponse.Code != http.StatusCreated || observer.count("created") != 1 {
 		t.Fatalf("tenant-a missing key = %d outcomes=%v body=%s", missingKeyResponse.Code, observer.outcomes, missingKeyResponse.Body.String())
 	}
 
 	tenantA := cycleRequest(http.MethodPost, "/api/v1/engagements", body, userdom.RoleConsultant, "tenant-a")
-	tenantA.Header.Set("Idempotency-Key", "tenant-a-create")
 	tenantAResponse := httptest.NewRecorder()
 	handler.ServeHTTP(tenantAResponse, tenantA)
-	if tenantAResponse.Code != http.StatusCreated || tenantAResponse.Header().Get("X-Synapse-Assessment-Cycle-Dual-Write") != "true" || observer.count("created") != 1 {
+	if tenantAResponse.Code != http.StatusCreated || tenantAResponse.Header().Get("Idempotency-Replayed") != "true" || tenantAResponse.Body.String() != missingKeyResponse.Body.String() || observer.count("replayed") != 1 {
 		t.Fatalf("tenant-a create = %d headers=%v outcomes=%v body=%s", tenantAResponse.Code, tenantAResponse.Header(), observer.outcomes, tenantAResponse.Body.String())
-	}
-
-	replay := cycleRequest(http.MethodPost, "/api/v1/engagements", body, userdom.RoleConsultant, "tenant-a")
-	replay.Header.Set("Idempotency-Key", "tenant-a-create")
-	replayResponse := httptest.NewRecorder()
-	handler.ServeHTTP(replayResponse, replay)
-	if replayResponse.Code != http.StatusCreated || replayResponse.Header().Get("Idempotency-Replayed") != "true" || replayResponse.Body.String() != tenantAResponse.Body.String() || observer.count("replayed") != 1 {
-		t.Fatalf("tenant-a replay = %d headers=%v outcomes=%v body=%s", replayResponse.Code, replayResponse.Header(), observer.outcomes, replayResponse.Body.String())
 	}
 
 	tenantB := cycleRequest(http.MethodPost, "/api/v1/engagements", body, userdom.RoleConsultant, "tenant-b")

--- a/internal/adapter/httpapi/assessment_snapshot_handler.go
+++ b/internal/adapter/httpapi/assessment_snapshot_handler.go
@@ -1,0 +1,190 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+)
+
+const assessmentSnapshotRequestLimit = int64(64 << 10)
+
+type finalizeAssessmentSnapshotRequest struct {
+	SelectedRuns []finalizeAssessmentSnapshotRun `json:"selected_runs"`
+}
+
+type finalizeAssessmentSnapshotRun struct {
+	RunID    string   `json:"run_id"`
+	LaneKeys []string `json:"lane_keys,omitempty"`
+}
+
+type assessmentSnapshotResponse struct {
+	ID             shared.ID             `json:"id"`
+	CycleID        shared.ID             `json:"cycle_id"`
+	AssessmentID   shared.ID             `json:"assessment_id"`
+	SnapshotNumber int                   `json:"snapshot_number"`
+	Lifecycle      domain.Lifecycle      `json:"lifecycle"`
+	Provenance     domain.Provenance     `json:"provenance"`
+	Boundary       domain.Boundary       `json:"boundary"`
+	RunReferences  []domain.RunReference `json:"run_references"`
+	Dimensions     []domain.Dimension    `json:"dimensions"`
+	SchemaVersion  int                   `json:"schema_version"`
+	ContentHash    string                `json:"content_hash"`
+	CreatedAt      time.Time             `json:"created_at"`
+	CreatedBy      string                `json:"created_by"`
+	FinalizedAt    *time.Time            `json:"finalized_at"`
+	FinalizedBy    string                `json:"finalized_by"`
+	SupersededAt   *time.Time            `json:"superseded_at,omitempty"`
+	SupersededBy   string                `json:"superseded_by,omitempty"`
+}
+
+type finalizedAssessmentSnapshotResponse struct {
+	Snapshot       assessmentSnapshotResponse `json:"snapshot"`
+	DefaultVersion int64                      `json:"default_version"`
+}
+
+type assessmentSnapshotListResponse struct {
+	Items             []assessmentSnapshotResponse `json:"items"`
+	DefaultSnapshotID shared.ID                    `json:"default_snapshot_id,omitempty"`
+	DefaultVersion    int64                        `json:"default_version"`
+}
+
+func (rt *Router) finalizeAssessmentSnapshot(w http.ResponseWriter, r *http.Request) {
+	requestKey := strings.TrimSpace(r.Header.Get("Idempotency-Key"))
+	if requestKey == "" {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "idempotency_key_required"})
+		return
+	}
+	if strings.TrimSpace(r.Header.Get("If-Match")) == "" {
+		writeJSON(w, http.StatusPreconditionRequired, errorBody{Error: "precondition_required"})
+		return
+	}
+	expectedVersion, err := parseSnapshotIfMatch(r.Header.Get("If-Match"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_if_match"})
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, assessmentSnapshotRequestLimit)
+	var request finalizeAssessmentSnapshotRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		var sizeErr *http.MaxBytesError
+		if errors.As(err, &sizeErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, errorBody{Error: "request_too_large"})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_request"})
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_request"})
+		return
+	}
+	selectedRuns := make([]snapshotuc.RunSelection, len(request.SelectedRuns))
+	for index, selected := range request.SelectedRuns {
+		selectedRuns[index] = snapshotuc.RunSelection{RunID: selected.RunID, LaneKeys: selected.LaneKeys}
+	}
+	snapshot, created, err := rt.assessmentSnapshots.Finalize(r.Context(), snapshotuc.FinalizeInput{
+		TenantID: shared.ID(TenantFrom(r.Context())), AssessmentID: shared.ID(r.PathValue("id")), SelectedRuns: selectedRuns,
+		RequestKey: requestKey, ExpectedDefaultVersion: expectedVersion, Actor: PrincipalFrom(r.Context()),
+	})
+	if err != nil {
+		writeAssessmentSnapshotError(w, rt.log, err)
+		return
+	}
+	if !created {
+		w.Header().Set("Idempotency-Replayed", "true")
+	}
+	w.Header().Set("ETag", snapshotETag(snapshot.DefaultVersion))
+	writeJSON(w, http.StatusCreated, finalizedAssessmentSnapshotResponse{Snapshot: newAssessmentSnapshotResponse(snapshot), DefaultVersion: snapshot.DefaultVersion})
+}
+
+func (rt *Router) listAssessmentSnapshots(w http.ResponseWriter, r *http.Request) {
+	tenantID := shared.ID(TenantFrom(r.Context()))
+	assessmentID := shared.ID(r.PathValue("id"))
+	snapshots, err := rt.assessmentSnapshots.ListByAssessment(r.Context(), tenantID, assessmentID)
+	if err != nil {
+		writeAssessmentSnapshotError(w, rt.log, err)
+		return
+	}
+	response := assessmentSnapshotListResponse{Items: make([]assessmentSnapshotResponse, 0, len(snapshots))}
+	for index := range snapshots {
+		response.Items = append(response.Items, newAssessmentSnapshotResponse(&snapshots[index]))
+	}
+	if len(snapshots) > 0 {
+		_, pointer, err := rt.assessmentSnapshots.GetDefault(r.Context(), tenantID, assessmentID)
+		if err != nil && !errors.Is(err, shared.ErrNotFound) {
+			writeAssessmentSnapshotError(w, rt.log, err)
+			return
+		}
+		if err == nil {
+			response.DefaultSnapshotID, response.DefaultVersion = pointer.SnapshotID, pointer.Version
+		}
+	}
+	w.Header().Set("ETag", snapshotETag(response.DefaultVersion))
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (rt *Router) getAssessmentSnapshot(w http.ResponseWriter, r *http.Request) {
+	snapshot, err := rt.assessmentSnapshots.Get(r.Context(), shared.ID(TenantFrom(r.Context())), shared.ID(r.PathValue("snapshotId")))
+	if err != nil {
+		writeAssessmentSnapshotError(w, rt.log, err)
+		return
+	}
+	w.Header().Set("ETag", fmt.Sprintf("\"sha256:%s\"", snapshot.ContentHash))
+	writeJSON(w, http.StatusOK, newAssessmentSnapshotResponse(snapshot))
+}
+
+func parseSnapshotIfMatch(value string) (int64, error) {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "W/") {
+		value = strings.TrimSpace(strings.TrimPrefix(value, "W/"))
+	}
+	value = strings.Trim(value, "\"")
+	version, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || version < 0 {
+		return 0, errors.New("invalid If-Match")
+	}
+	return version, nil
+}
+
+func snapshotETag(version int64) string { return fmt.Sprintf("\"%d\"", version) }
+
+func newAssessmentSnapshotResponse(snapshot *domain.Snapshot) assessmentSnapshotResponse {
+	return assessmentSnapshotResponse{
+		ID: snapshot.ID, CycleID: snapshot.CycleID, AssessmentID: snapshot.AssessmentID, SnapshotNumber: snapshot.SnapshotNumber,
+		Lifecycle: snapshot.Lifecycle, Provenance: snapshot.Provenance, Boundary: snapshot.Boundary,
+		RunReferences: snapshot.RunReferences, Dimensions: snapshot.Dimensions, SchemaVersion: snapshot.SchemaVersion,
+		ContentHash: snapshot.ContentHash, CreatedAt: snapshot.CreatedAt, CreatedBy: snapshot.CreatedBy,
+		FinalizedAt: snapshot.FinalizedAt, FinalizedBy: snapshot.FinalizedBy, SupersededAt: snapshot.SupersededAt, SupersededBy: snapshot.SupersededBy,
+	}
+}
+
+func writeAssessmentSnapshotError(w http.ResponseWriter, log *slog.Logger, err error) {
+	status, code := http.StatusInternalServerError, "internal_error"
+	switch {
+	case errors.Is(err, snapshotuc.ErrIdempotencyBodyMismatch):
+		status, code = http.StatusConflict, "idempotency_body_mismatch"
+	case errors.Is(err, shared.ErrValidation):
+		status, code = http.StatusBadRequest, "invalid_request"
+	case errors.Is(err, shared.ErrConflict):
+		status, code = http.StatusConflict, "snapshot_conflict"
+	case errors.Is(err, shared.ErrNotFound):
+		status, code = http.StatusNotFound, "not_found"
+	case errors.Is(err, shared.ErrForbidden):
+		status, code = http.StatusForbidden, "forbidden"
+	default:
+		requestLogger(w, log).Error("assessment snapshot request failed", "err", err)
+	}
+	writeJSON(w, status, errorBody{Error: code})
+}

--- a/internal/adapter/httpapi/assessment_snapshot_handler.go
+++ b/internal/adapter/httpapi/assessment_snapshot_handler.go
@@ -54,6 +54,7 @@ type finalizedAssessmentSnapshotResponse struct {
 
 type assessmentSnapshotListResponse struct {
 	Items             []assessmentSnapshotResponse `json:"items"`
+	NextCursor        string                       `json:"next_cursor,omitempty"`
 	DefaultSnapshotID shared.ID                    `json:"default_snapshot_id,omitempty"`
 	DefaultVersion    int64                        `json:"default_version"`
 }
@@ -112,16 +113,25 @@ func (rt *Router) finalizeAssessmentSnapshot(w http.ResponseWriter, r *http.Requ
 func (rt *Router) listAssessmentSnapshots(w http.ResponseWriter, r *http.Request) {
 	tenantID := shared.ID(TenantFrom(r.Context()))
 	assessmentID := shared.ID(r.PathValue("id"))
-	snapshots, err := rt.assessmentSnapshots.ListByAssessment(r.Context(), tenantID, assessmentID)
+	limit := 0
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_page_size"})
+			return
+		}
+		limit = parsed
+	}
+	page, err := rt.assessmentSnapshots.ListByAssessment(r.Context(), tenantID, assessmentID, r.URL.Query().Get("cursor"), limit)
 	if err != nil {
 		writeAssessmentSnapshotError(w, rt.log, err)
 		return
 	}
-	response := assessmentSnapshotListResponse{Items: make([]assessmentSnapshotResponse, 0, len(snapshots))}
-	for index := range snapshots {
-		response.Items = append(response.Items, newAssessmentSnapshotResponse(&snapshots[index]))
+	response := assessmentSnapshotListResponse{Items: make([]assessmentSnapshotResponse, 0, len(page.Items)), NextCursor: page.NextCursor}
+	for index := range page.Items {
+		response.Items = append(response.Items, newAssessmentSnapshotResponse(&page.Items[index]))
 	}
-	if len(snapshots) > 0 {
+	if len(page.Items) > 0 {
 		_, pointer, err := rt.assessmentSnapshots.GetDefault(r.Context(), tenantID, assessmentID)
 		if err != nil && !errors.Is(err, shared.ErrNotFound) {
 			writeAssessmentSnapshotError(w, rt.log, err)

--- a/internal/adapter/httpapi/assessment_snapshot_handler_test.go
+++ b/internal/adapter/httpapi/assessment_snapshot_handler_test.go
@@ -1,0 +1,203 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
+)
+
+func TestAssessmentSnapshotRoutesContractsPermissionsAndTenantIsolation(t *testing.T) {
+	router := newAssessmentSnapshotHTTPRouter(t)
+	handler := router.routes()
+	path := "/api/v1/engagements/assessment-snapshot-http/snapshots/finalize"
+	body := `{"selected_runs":[{"run_id":"snapshot-http-run","lane_keys":["sca"]}]}`
+
+	reviewer := cycleRequest(http.MethodPost, path, body, userdom.RoleReviewer, "tenant-snapshot-http")
+	reviewer.Header.Set("Idempotency-Key", "snapshot-http-reviewer")
+	reviewer.Header.Set("If-Match", "0")
+	reviewerResponse := httptest.NewRecorder()
+	handler.ServeHTTP(reviewerResponse, reviewer)
+	if reviewerResponse.Code != http.StatusForbidden {
+		t.Fatalf("reviewer finalize=%d body=%s", reviewerResponse.Code, reviewerResponse.Body.String())
+	}
+
+	missingKey := cycleRequest(http.MethodPost, path, body, userdom.RoleConsultant, "tenant-snapshot-http")
+	missingKey.Header.Set("If-Match", "0")
+	missingKeyResponse := httptest.NewRecorder()
+	handler.ServeHTTP(missingKeyResponse, missingKey)
+	if missingKeyResponse.Code != http.StatusBadRequest || !strings.Contains(missingKeyResponse.Body.String(), "idempotency_key_required") {
+		t.Fatalf("missing key=%d body=%s", missingKeyResponse.Code, missingKeyResponse.Body.String())
+	}
+
+	missingIfMatch := cycleRequest(http.MethodPost, path, body, userdom.RoleConsultant, "tenant-snapshot-http")
+	missingIfMatch.Header.Set("Idempotency-Key", "snapshot-http-missing-if-match")
+	missingIfMatchResponse := httptest.NewRecorder()
+	handler.ServeHTTP(missingIfMatchResponse, missingIfMatch)
+	if missingIfMatchResponse.Code != http.StatusPreconditionRequired || !strings.Contains(missingIfMatchResponse.Body.String(), "precondition_required") {
+		t.Fatalf("missing If-Match=%d body=%s", missingIfMatchResponse.Code, missingIfMatchResponse.Body.String())
+	}
+
+	create := cycleRequest(http.MethodPost, path, body, userdom.RoleConsultant, "tenant-snapshot-http")
+	create.Header.Set("Idempotency-Key", "snapshot-http-create")
+	create.Header.Set("If-Match", `W/"0"`)
+	created := httptest.NewRecorder()
+	handler.ServeHTTP(created, create)
+	if created.Code != http.StatusCreated || created.Header().Get("ETag") != `"1"` || strings.Contains(created.Body.String(), "snapshot-http-create") || strings.Contains(created.Body.String(), "request_hash") {
+		t.Fatalf("create=%d headers=%v body=%s", created.Code, created.Header(), created.Body.String())
+	}
+	var finalized finalizedAssessmentSnapshotResponse
+	if err := json.Unmarshal(created.Body.Bytes(), &finalized); err != nil || finalized.Snapshot.ID.IsZero() || finalized.DefaultVersion != 1 {
+		t.Fatalf("decode finalized=%+v err=%v", finalized, err)
+	}
+
+	replay := cycleRequest(http.MethodPost, path, body, userdom.RoleConsultant, "tenant-snapshot-http")
+	replay.Header.Set("Idempotency-Key", "snapshot-http-create")
+	replay.Header.Set("If-Match", "0")
+	replayed := httptest.NewRecorder()
+	handler.ServeHTTP(replayed, replay)
+	if replayed.Code != http.StatusCreated || replayed.Header().Get("Idempotency-Replayed") != "true" || replayed.Body.String() != created.Body.String() {
+		t.Fatalf("replay=%d headers=%v body=%s", replayed.Code, replayed.Header(), replayed.Body.String())
+	}
+
+	mismatch := cycleRequest(http.MethodPost, path, `{"selected_runs":[{"run_id":"snapshot-http-run","lane_keys":["other"]}]}`, userdom.RoleConsultant, "tenant-snapshot-http")
+	mismatch.Header.Set("Idempotency-Key", "snapshot-http-create")
+	mismatch.Header.Set("If-Match", "0")
+	mismatchResponse := httptest.NewRecorder()
+	handler.ServeHTTP(mismatchResponse, mismatch)
+	if mismatchResponse.Code != http.StatusConflict || !strings.Contains(mismatchResponse.Body.String(), "idempotency_body_mismatch") {
+		t.Fatalf("mismatch=%d body=%s", mismatchResponse.Code, mismatchResponse.Body.String())
+	}
+
+	listPath := "/api/v1/engagements/assessment-snapshot-http/snapshots"
+	list := httptest.NewRecorder()
+	handler.ServeHTTP(list, cycleRequest(http.MethodGet, listPath, "", userdom.RoleReadOnly, "tenant-snapshot-http"))
+	if list.Code != http.StatusOK || list.Header().Get("ETag") != `"1"` {
+		t.Fatalf("list=%d headers=%v body=%s", list.Code, list.Header(), list.Body.String())
+	}
+	var page assessmentSnapshotListResponse
+	if err := json.Unmarshal(list.Body.Bytes(), &page); err != nil || len(page.Items) != 1 || page.DefaultSnapshotID != finalized.Snapshot.ID || page.DefaultVersion != 1 {
+		t.Fatalf("list page=%+v err=%v", page, err)
+	}
+
+	get := httptest.NewRecorder()
+	handler.ServeHTTP(get, cycleRequest(http.MethodGet, "/api/v1/assessment-snapshots/"+finalized.Snapshot.ID.String(), "", userdom.RoleReadOnly, "tenant-snapshot-http"))
+	if get.Code != http.StatusOK || get.Header().Get("ETag") != `"sha256:`+finalized.Snapshot.ContentHash+`"` {
+		t.Fatalf("get=%d headers=%v body=%s", get.Code, get.Header(), get.Body.String())
+	}
+
+	crossTenantList := httptest.NewRecorder()
+	handler.ServeHTTP(crossTenantList, cycleRequest(http.MethodGet, listPath, "", userdom.RoleReadOnly, "tenant-other"))
+	if crossTenantList.Code != http.StatusNotFound {
+		t.Fatalf("cross-tenant list=%d body=%s", crossTenantList.Code, crossTenantList.Body.String())
+	}
+	crossTenantGet := httptest.NewRecorder()
+	handler.ServeHTTP(crossTenantGet, cycleRequest(http.MethodGet, "/api/v1/assessment-snapshots/"+finalized.Snapshot.ID.String(), "", userdom.RoleReadOnly, "tenant-other"))
+	if crossTenantGet.Code != http.StatusNotFound || !strings.Contains(crossTenantGet.Body.String(), "not_found") {
+		t.Fatalf("cross-tenant get=%d body=%s", crossTenantGet.Code, crossTenantGet.Body.String())
+	}
+}
+
+func TestAssessmentSnapshotFinalizeRejectsOversizedBody(t *testing.T) {
+	router := newAssessmentSnapshotHTTPRouter(t)
+	request := cycleRequest(http.MethodPost, "/api/v1/engagements/assessment-snapshot-http/snapshots/finalize", `{"selected_runs":[{"run_id":"`+strings.Repeat("a", int(assessmentSnapshotRequestLimit))+`"}]}`, userdom.RoleConsultant, "tenant-snapshot-http")
+	request.Header.Set("Idempotency-Key", "snapshot-http-oversized")
+	request.Header.Set("If-Match", "0")
+	response := httptest.NewRecorder()
+	router.routes().ServeHTTP(response, request)
+	if response.Code != http.StatusRequestEntityTooLarge || !strings.Contains(response.Body.String(), "request_too_large") {
+		t.Fatalf("oversized=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func newAssessmentSnapshotHTTPRouter(t *testing.T) *Router {
+	t.Helper()
+	ctx := context.Background()
+	clock := fixedClock{t: time.Date(2026, 9, 1, 14, 0, 0, 0, time.UTC)}
+	ids := &assessmentCycleHTTPIDs{}
+	audit := &fakeAudit{}
+	engagements := memory.NewEngagementRepository()
+	assessment, err := engagement.New("assessment-snapshot-http", "tenant-snapshot-http", "Snapshot API", "", clock.t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := assessment.Transition(engagement.StatusActive, clock.t); err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(ctx, assessment); err != nil {
+		t.Fatal(err)
+	}
+	cycles := memory.NewAssessmentCycleRepository()
+	cycle, err := assessmentcycle.NewAssessmentCycle("cycle-snapshot-http", "tenant-snapshot-http", "Snapshot API", assessmentcycle.BoundaryStandalone, "", "", assessment.ID, "operator", clock.t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember("tenant-snapshot-http", cycle.ID, assessment.ID, "operator", clock.t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+	runs := memory.NewScanRunStore()
+	run := assessmentSnapshotHTTPRun(t, clock.t)
+	if err := runs.SaveScanRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	transactions := memory.NewTenantTransactionRunner()
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	service, err := snapshotuc.NewService(snapshots, cycles, engagements, runs, transactions, ids, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	engagementService := enguc.NewService(engagements, clock, ids, audit)
+	router := &Router{log: discardLog(), eng: engagementService}
+	router.SetAssessmentSnapshots(service)
+	return router
+}
+
+func assessmentSnapshotHTTPRun(t *testing.T, now time.Time) scanrun.ScanRun {
+	t.Helper()
+	target, err := scanrun.CanonicalizeRepositoryTarget("https://example.com/repo.git", "0123456789abcdef0123456789abcdef01234567")
+	if err != nil {
+		t.Fatal(err)
+	}
+	finished := now.Add(time.Minute)
+	run := scanrun.ScanRun{
+		TenantID: "tenant-snapshot-http", ID: "snapshot-http-run", EngagementID: "assessment-snapshot-http", CreatedAt: now, UpdatedAt: now,
+		Provenance: scanrun.ProvenanceNative, TerminalStatus: scanrun.StatusSucceeded, ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion,
+		Lanes: []scanrun.Lane{{
+			TenantID: "tenant-snapshot-http", EngagementID: "assessment-snapshot-http", ScanRunID: "snapshot-http-run",
+			LaneKey: "sca", Producer: "sca", TerminalStatus: scanrun.StatusSucceeded, Target: target,
+			AuthoritativeFindingKinds: []string{"vulnerability"}, IncludedScope: []string{"src/**"}, StartedAt: now, FinishedAt: &finished,
+			ResultRef: "result:snapshot-http", EvidenceRef: "evidence:snapshot-http", ResultSHA256: strings.Repeat("a", 64), ManifestSchemaVersion: 1,
+			Versions: []scanrun.LaneVersion{{VersionKind: scanrun.VersionScanner, Name: "sca", Version: "1"}},
+			Stages:   []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSucceeded, StartedAt: now, FinishedAt: &finished}},
+		}},
+	}
+	run.Lanes[0].SealedAt = &finished
+	run.Lanes[0].ManifestHash, err = scanrun.ComputeManifestHash(run.Lanes[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.ManifestHash, err = scanrun.ComputeRunManifestHash(run.Lanes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.SealedAt, run.UpdatedAt = &finished, finished
+	return run
+}

--- a/internal/adapter/httpapi/assessment_snapshot_handler_test.go
+++ b/internal/adapter/httpapi/assessment_snapshot_handler_test.go
@@ -71,6 +71,15 @@ func TestAssessmentSnapshotRoutesContractsPermissionsAndTenantIsolation(t *testi
 		t.Fatalf("replay=%d headers=%v body=%s", replayed.Code, replayed.Header(), replayed.Body.String())
 	}
 
+	staleReplay := cycleRequest(http.MethodPost, path, body, userdom.RoleConsultant, "tenant-snapshot-http")
+	staleReplay.Header.Set("Idempotency-Key", "snapshot-http-create")
+	staleReplay.Header.Set("If-Match", "77")
+	staleReplayResponse := httptest.NewRecorder()
+	handler.ServeHTTP(staleReplayResponse, staleReplay)
+	if staleReplayResponse.Code != http.StatusConflict || !strings.Contains(staleReplayResponse.Body.String(), "snapshot_conflict") {
+		t.Fatalf("stale replay=%d body=%s", staleReplayResponse.Code, staleReplayResponse.Body.String())
+	}
+
 	mismatch := cycleRequest(http.MethodPost, path, `{"selected_runs":[{"run_id":"snapshot-http-run","lane_keys":["other"]}]}`, userdom.RoleConsultant, "tenant-snapshot-http")
 	mismatch.Header.Set("Idempotency-Key", "snapshot-http-create")
 	mismatch.Header.Set("If-Match", "0")
@@ -166,6 +175,7 @@ func newAssessmentSnapshotHTTPRouter(t *testing.T) *Router {
 	}
 	engagementService := enguc.NewService(engagements, clock, ids, audit)
 	router := &Router{log: discardLog(), eng: engagementService}
+	router.SetAssessmentLifecycleRollout(func(string) bool { return true }, func(string) bool { return true })
 	router.SetAssessmentSnapshots(service)
 	return router
 }

--- a/internal/adapter/httpapi/engagement_handler.go
+++ b/internal/adapter/httpapi/engagement_handler.go
@@ -17,6 +17,7 @@ import (
 	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
 	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
 )
 
@@ -195,6 +196,36 @@ func (rt *Router) createEngagement(w http.ResponseWriter, r *http.Request) {
 		AuthorizedTo:    to,
 		Timezone:        req.Timezone,
 	}
+	dualWrite := rt.assessmentCycles != nil && rt.assessmentCycleDualWrite != nil && rt.assessmentCycleDualWrite(tenantID.String())
+	if dualWrite {
+		cycleInput := cycleuc.CreateInitialAssessmentInput{
+			Request: cycleuc.RetainedRequest{
+				TenantID: tenantID, Actor: PrincipalFrom(r.Context()), Route: "/api/v1/engagements",
+				IdempotencyKey: r.Header.Get("Idempotency-Key"),
+			},
+			Engagement: input,
+		}
+		if sourceFile != nil {
+			cycleInput.Source = &cycleuc.SourceUpload{Filename: sourceFilename, Size: sourceSize, SHA256: sourceSHA256, Reader: sourceFile}
+		}
+		response, err := rt.assessmentCycles.CreateInitialAssessment(r.Context(), cycleInput)
+		if err != nil {
+			rt.observeAssessmentCycleDualWrite("failed")
+			writeAssessmentCycleError(w, rt.log, err)
+			return
+		}
+		if response.Replayed {
+			rt.observeAssessmentCycleDualWrite("replayed")
+		} else {
+			rt.observeAssessmentCycleDualWrite("created")
+		}
+		w.Header().Set("X-Synapse-Assessment-Cycle-Dual-Write", "true")
+		writeRetainedJSON(w, response)
+		return
+	}
+	if rt.assessmentCycles != nil {
+		rt.observeAssessmentCycleDualWrite("legacy")
+	}
 	var e *engdom.Engagement
 	if sourceFile != nil {
 		e, _, err = rt.eng.CreateFromSourcePackage(r.Context(), input, sourceFilename, sourceSize, sourceSHA256, sourceFile)
@@ -206,6 +237,16 @@ func (rt *Router) createEngagement(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusCreated, e)
+}
+
+type assessmentCycleDualWriteObserver interface {
+	ObserveAssessmentCycleDualWrite(outcome string)
+}
+
+func (rt *Router) observeAssessmentCycleDualWrite(outcome string) {
+	if observer, ok := rt.httpObserver.(assessmentCycleDualWriteObserver); ok {
+		observer.ObserveAssessmentCycleDualWrite(outcome)
+	}
 }
 
 func (rt *Router) listEngagements(w http.ResponseWriter, r *http.Request) {

--- a/internal/adapter/httpapi/engagement_handler.go
+++ b/internal/adapter/httpapi/engagement_handler.go
@@ -198,10 +198,25 @@ func (rt *Router) createEngagement(w http.ResponseWriter, r *http.Request) {
 	}
 	dualWrite := rt.assessmentCycles != nil && rt.assessmentCycleDualWrite != nil && rt.assessmentCycleDualWrite(tenantID.String())
 	if dualWrite {
+		idempotencyKey := strings.TrimSpace(r.Header.Get("Idempotency-Key"))
+		if idempotencyKey == "" {
+			canonical, marshalErr := json.Marshal(struct {
+				Engagement     enguc.CreateInput `json:"engagement"`
+				SourceFilename string            `json:"source_filename,omitempty"`
+				SourceSize     int64             `json:"source_size,omitempty"`
+				SourceSHA256   string            `json:"source_sha256,omitempty"`
+			}{Engagement: input, SourceFilename: sourceFilename, SourceSize: sourceSize, SourceSHA256: sourceSHA256})
+			if marshalErr != nil {
+				writeError(w, rt.log, fmt.Errorf("derive assessment creation idempotency key: %w", marshalErr))
+				return
+			}
+			digest := sha256.Sum256(canonical)
+			idempotencyKey = "server-" + hex.EncodeToString(digest[:])
+		}
 		cycleInput := cycleuc.CreateInitialAssessmentInput{
 			Request: cycleuc.RetainedRequest{
 				TenantID: tenantID, Actor: PrincipalFrom(r.Context()), Route: "/api/v1/engagements",
-				IdempotencyKey: r.Header.Get("Idempotency-Key"),
+				IdempotencyKey: idempotencyKey,
 			},
 			Engagement: input,
 		}

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	snapshotdom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
 	ap "github.com/KKloudTarus/synapse-ce/internal/domain/attackpath"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
@@ -21,11 +23,14 @@ import (
 	projectdom "github.com/KKloudTarus/synapse-ce/internal/domain/project"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/purplecoverage"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/threatmodel"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/writeupdraft"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	analysisuc "github.com/KKloudTarus/synapse-ce/internal/usecase/analysis"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
 	attackpathuc "github.com/KKloudTarus/synapse-ce/internal/usecase/attackpath"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/dastrunner"
 	dastverifieruc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastverifier"
@@ -342,9 +347,51 @@ func TestHostileHarness(t *testing.T) {
 	if err != nil {
 		t.Fatalf("users svc: %v", err)
 	}
+	lifecycleClock := fixedClock{t: time.Unix(1, 0).UTC()}
+	lifecycleIDs := engIDs{}
+	lifecycleTransactions := memory.NewTenantTransactionRunner()
+	lifecycleCycles := memory.NewAssessmentCycleRepository()
+	lifecycleCycle, err := cycledom.NewAssessmentCycle("cycle-A", "tenantA", "tenant-A-cycle-marker", cycledom.BoundaryStandalone, "", "", "engA", "p", lifecycleClock.Now())
+	if err != nil {
+		t.Fatalf("seed assessment cycle: %v", err)
+	}
+	lifecycleMember, err := cycledom.NewInitialMember("tenantA", lifecycleCycle.ID, "engA", "p", lifecycleClock.Now())
+	if err != nil {
+		t.Fatalf("seed assessment cycle member: %v", err)
+	}
+	if err := lifecycleCycles.CreateCycle(context.Background(), lifecycleCycle); err != nil {
+		t.Fatalf("store assessment cycle: %v", err)
+	}
+	if err := lifecycleCycles.CreateMember(context.Background(), lifecycleMember); err != nil {
+		t.Fatalf("store assessment cycle member: %v", err)
+	}
+	engagementService := enguc.NewService(engRepo, lifecycleClock, lifecycleIDs, audit)
+	lifecycleService, err := cycleuc.NewService(lifecycleCycles, engRepo, nil, nil, lifecycleTransactions, lifecycleIDs, lifecycleClock, audit)
+	if err != nil {
+		t.Fatalf("assessment cycle service: %v", err)
+	}
+	lifecycleAPI, err := cycleuc.NewAPIService(lifecycleService, lifecycleCycles, memory.NewAssessmentCycleRequestRepository(), engagementService, lifecycleTransactions, lifecycleClock, audit)
+	if err != nil {
+		t.Fatalf("assessment cycle API: %v", err)
+	}
+	lifecycleSnapshots := memory.NewAssessmentSnapshotRepository()
+	lifecycleRuns := memory.NewScanRunStore()
+	lifecycleSnapshotService, err := snapshotuc.NewService(lifecycleSnapshots, lifecycleCycles, engRepo, lifecycleRuns, lifecycleTransactions, lifecycleIDs, lifecycleClock, audit)
+	if err != nil {
+		t.Fatalf("assessment snapshot service: %v", err)
+	}
+	legacySnapshot, err := snapshotdom.NewFinalized("tenantA", "snapshot-A", lifecycleCycle.ID, "engA", snapshotdom.Boundary{Kind: cycledom.BoundaryStandalone}, "legacy-snapshot-A", "p", lifecycleClock.Now(), []snapshotdom.SelectedRun{{
+		ID: "legacy-run-A", ManifestHash: strings.Repeat("a", 64), Provenance: scanrun.ProvenanceLegacy, TerminalStatus: scanrun.StatusUnknown,
+	}})
+	if err != nil {
+		t.Fatalf("seed assessment snapshot: %v", err)
+	}
+	if _, _, err := lifecycleSnapshots.CreateLegacyProjection(context.Background(), legacySnapshot); err != nil {
+		t.Fatalf("store assessment snapshot: %v", err)
+	}
 	rt := &Router{
 		log:      discardLog(),
-		eng:      enguc.NewService(engRepo, fixedClock{}, engIDs{}, &fakeAudit{}),
+		eng:      engagementService,
 		projects: projectSvc,
 		users:    usersSvc,
 	}
@@ -368,6 +415,9 @@ func TestHostileHarness(t *testing.T) {
 	rt.SetDetectionReader(harnessDetections{})  // register the #423 detection-ledger read route
 	rt.SetPurpleCoverageReader(harnessPurple{}) // register the #426 purple-coverage read route
 	rt.SetFleetRolloutAdmin(harnessRollout{})
+	rt.SetAssessmentCycles(lifecycleAPI, true, func(string) bool { return true })
+	rt.SetAssessmentLifecycleRollout(func(string) bool { return true }, func(string) bool { return true })
+	rt.SetAssessmentSnapshots(lifecycleSnapshotService)
 	rt.EnableAgent(nil, nil, nil, nil, nil, 1, 8)
 	mux := rt.routes()
 
@@ -384,6 +434,17 @@ func TestHostileHarness(t *testing.T) {
 	verifyPromotion := func(role, tenant string) (int, string) {
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/engagements/engA/judgments/eng-1/verify", strings.NewReader(`{"score":75,"rationale":"hostile verification","version":1}`))
 		req = req.WithContext(context.WithValue(req.Context(), principalKey, Principal{ID: "p", Role: role, TenantID: tenant}))
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		return rec.Code, rec.Body.String()
+	}
+
+	sendLifecycleWrite := func(role, tenant, method, path, body string, headers map[string]string) (int, string) {
+		req := httptest.NewRequest(method, path, strings.NewReader(body))
+		req = req.WithContext(context.WithValue(req.Context(), principalKey, Principal{ID: "p", Role: role, TenantID: tenant}))
+		for name, value := range headers {
+			req.Header.Set(name, value)
+		}
 		rec := httptest.NewRecorder()
 		mux.ServeHTTP(rec, req)
 		return rec.Code, rec.Body.String()
@@ -469,6 +530,11 @@ func TestHostileHarness(t *testing.T) {
 		// 403 that would reveal the engagement exists.
 		{"cross-tenant engagement read → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA", http.StatusNotFound},
 		{"cross-tenant child resource → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA/findings", http.StatusNotFound},
+		{"cross-tenant assessment lifecycle → 404", "readonly", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA/lifecycle", http.StatusNotFound},
+		{"cross-tenant assessment cycle → 404", "readonly", "tenantB", true, http.MethodGet, "/api/v1/assessment-cycles/cycle-A", http.StatusNotFound},
+		{"cross-tenant assessment cycle members → 404", "readonly", "tenantB", true, http.MethodGet, "/api/v1/assessment-cycles/cycle-A/members", http.StatusNotFound},
+		{"cross-tenant assessment snapshots → 404", "readonly", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA/snapshots", http.StatusNotFound},
+		{"cross-tenant assessment snapshot → 404", "readonly", "tenantB", true, http.MethodGet, "/api/v1/assessment-snapshots/snapshot-A", http.StatusNotFound},
 		// Same-tenant read still works (isolation does not over-block).
 		{"same-tenant engagement read → 200", "consultant", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA", http.StatusOK},
 		{"cross-tenant project read → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/projects/project-a", http.StatusNotFound},
@@ -573,6 +639,26 @@ func TestHostileHarness(t *testing.T) {
 		if got, body := send(c.role, c.tenant, c.method, c.path, c.authed); got != c.want {
 			t.Errorf("%s: %s %s (role=%q tenant=%q) → %d, body: %s, want %d", c.name, c.method, c.path, c.role, c.tenant, got, body, c.want)
 		}
+	}
+
+	for _, probe := range []struct {
+		name, role, method, path, body string
+		headers                        map[string]string
+	}{
+		{"cross-tenant assessment retest", "consultant", http.MethodPost, "/api/v1/engagements/engA/retests", `{}`, map[string]string{"Idempotency-Key": "hostile-retest"}},
+		{"cross-tenant assessment cycle archive", "reviewer", http.MethodPost, "/api/v1/assessment-cycles/cycle-A/archive", `{}`, map[string]string{"Idempotency-Key": "hostile-archive", "If-Match": `"1"`}},
+		{"cross-tenant assessment cycle reopen", "reviewer", http.MethodPost, "/api/v1/assessment-cycles/cycle-A/reopen", `{"reason":"hostile probe"}`, map[string]string{"Idempotency-Key": "hostile-reopen", "If-Match": `"1"`}},
+		{"cross-tenant assessment snapshot finalize", "consultant", http.MethodPost, "/api/v1/engagements/engA/snapshots/finalize", `{"selected_run_ids":["legacy-run-A"]}`, map[string]string{"Idempotency-Key": "hostile-finalize", "If-Match": `"0"`}},
+	} {
+		if code, body := sendLifecycleWrite(probe.role, "tenantB", probe.method, probe.path, probe.body, probe.headers); code != http.StatusNotFound || strings.Contains(body, "tenant-A-cycle-marker") || strings.Contains(body, "snapshot-A") {
+			t.Errorf("%s leaked tenantA lifecycle state: code=%d body=%s", probe.name, code, body)
+		}
+	}
+	if code, body := send("readonly", "tenantA", http.MethodGet, "/api/v1/assessment-cycles", true); code != http.StatusOK || !strings.Contains(body, "tenant-A-cycle-marker") {
+		t.Fatalf("tenantA must see its assessment cycle marker (code=%d body=%s)", code, body)
+	}
+	if code, body := send("readonly", "tenantB", http.MethodGet, "/api/v1/assessment-cycles", true); code != http.StatusOK || strings.Contains(body, "tenant-A-cycle-marker") || strings.Contains(body, "cycle-A") {
+		t.Errorf("tenantB assessment cycle list leaked tenantA data (code=%d body=%s)", code, body)
 	}
 
 	if code, body := send("readonly", "tenantA", http.MethodGet, "/api/v1/attack-paths", true); code != http.StatusOK || !strings.Contains(body, "tenant-A-secret-marker") {

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -15,6 +15,8 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/writeupdraft"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
 	audituc "github.com/KKloudTarus/synapse-ce/internal/usecase/audit"
 	aupuc "github.com/KKloudTarus/synapse-ce/internal/usecase/aup"
 	credentialsuc "github.com/KKloudTarus/synapse-ce/internal/usecase/credentials"
@@ -43,78 +45,84 @@ import (
 
 // Router wires HTTP routes to use case services.
 type Router struct {
-	log                    *slog.Logger
-	accessLogEnabled       bool
-	httpObserver           HTTPObserver
-	auth                   *Authenticator
-	oidc                   OIDCService
-	oidcFrontendURL        string
-	eng                    *enguc.Service
-	sca                    *scauc.Service
-	aup                    *aupuc.Service
-	findings               *findingsuc.Service
-	export                 *exportuc.Service
-	report                 *reportuc.Service
-	evidence               *evidenceuc.Service
-	recon                  *reconuc.Service
-	logs                   ports.LogStream
-	transfer               *transferuc.Service
-	audit                  *audituc.Service
-	vex                    *vexuc.Service
-	users                  *usersuc.Service
-	credentials            *credentialsuc.Service
-	dastVerifier           runtimeVerifierService
-	dastWorkflow           dastWorkflowService
-	agent                  *agentDeps                // optional; nil ⇒ agent routes are not registered
-	exploitation           findingVerifier           // optional; nil ⇒ the verify route is not registered
-	judgments              judgmentService           // optional; nil ⇒ judgment routes are not registered
-	autoVerifier           autoVerifierService       // optional; nil ⇒ the LLM auto-verify route is not registered
-	threatModels           threatModelService        // optional; nil ⇒ threat-model routes are not registered
-	drafts                 writeupDraftService       // optional; nil ⇒ writeup-draft sign-off routes are not registered
-	aiTriageReviews        aiTriageReviewService     // optional; nil ⇒ AI-triage review queue routes are not registered
-	projects               projectService            // optional; nil ⇒ project routes are not registered
-	assets                 assetService              // optional; nil ⇒ fleet asset routes are not registered
-	cspm                   *cspm.Service             // optional; nil ⇒ CSPM routes are not registered
-	businessAssets         businessAssetService      // optional; nil ⇒ business-level Asset routes are not registered
-	attackPaths            attackPathService         // optional; nil ⇒ attack-path routes are not registered
-	coverage               coverageService           // optional; nil ⇒ fleet coverage/agent-view routes are not registered
-	coverageWindows        coverageWindowReader      // optional; nil ⇒ immutable telemetry coverage-window routes are not registered
-	privacyPolicies        privacyPolicyService      // optional; nil ⇒ tenant source-privacy policy routes are not registered
-	incidents              incidentReader            // optional; nil ⇒ incident read routes are not registered (#594 C7)
-	incidentTriage         incidentTriager           // optional; nil ⇒ incident triage routes are not registered (#594 C5)
-	incidentRiskReassessor incidentRiskReassessor    // optional; nil ⇒ the tri-score reassess route is not registered (#594 C3/D/X5)
-	incidentCorrelator     incidentCorrelator        // optional; nil ⇒ the correlation route is not registered (#594 C2/C3)
-	endpointProcesses      endpointProcessStore      // optional; nil ⇒ the process-report routes are not registered (#594 B5)
-	processLearner         processLearner            // optional; nil ⇒ reported processes are not folded into the behavior baseline (#594 D)
-	desiredCapabilities    desiredCapabilityService  // optional; nil ⇒ the desired-vs-observed routes are not registered (#633)
-	legalHolds             legalHoldService          // optional; nil ⇒ the legal-hold routes are not registered (#635)
-	privacyExport          privacyExporter           // optional; nil ⇒ the data-export route is not registered (#635)
-	dataPurge              dataPurger                // optional; nil ⇒ the on-demand data-deletion route is not registered (#635)
-	endpointTimeline       endpointTimelineReader    // optional; nil ⇒ the State-Timeline read route is not registered (#594 B7)
-	retroHunter            retroHunter               // optional; nil ⇒ the retro-hunt route is not registered (#594 B7)
-	sarif                  sarifIngester             // optional; nil ⇒ the third-party SARIF import route is not registered
-	importedFindings       sarifReader               // optional read side for imported findings
-	fleetRolloutAdmin      fleetRolloutService       // optional; nil ⇒ the operator rollout routes are not served
-	offensiveHalt          offensiveKillSwitch       // optional; nil ⇒ the red-team halt route is not served
-	detections             detectionReader           // optional read side for the detection ledger (#423)
-	detectionProvenance    detectionProvenanceReader // optional read side for durable detection provenance (#610)
-	riskStories            riskStoryReader           // optional read side for the unified per-asset risk story (#427)
-	purpleCoverage         purpleCoverageReader      // optional read side for purple-team coverage (#426)
-	fleet                  *fleetRouter              // optional; nil ⇒ agent transport plane is not served
-	fleetAdmin             fleetAdminService         // optional; nil ⇒ operator agent-admin routes not registered
-	fleetKeys              fleetKeyAdmin             // optional; nil ⇒ operator signing-key routes not registered (A4 #625)
-	qualityGates           qualityGateService        // optional; nil ⇒ quality-gate routes are not registered
-	qualityProfiles        qualityProfileService     // optional; nil ⇒ quality-profile routes are not registered
-	rules                  rulesService              // optional; nil ⇒ rule catalog routes are not registered
-	dastScan               dastScanService
-	vulnerabilitySources   *vulnerabilitysourceuc.Service
-	vulnerabilityMonitor   *vulnerabilitymonitor.Service
-	vulnerabilityReconcile *vulnerabilityreconciliation.Service
-	vulnerabilityAudit     ports.AuditLogger
-	vulnerabilityRead      *vulnerabilityinteluc.Service
-	vulnerabilityActions   *vulnerabilityactionuc.Service
-	sla                    *slauc.Service
-	readiness              readinessConfig
+	log                      *slog.Logger
+	accessLogEnabled         bool
+	httpObserver             HTTPObserver
+	auth                     *Authenticator
+	oidc                     OIDCService
+	oidcFrontendURL          string
+	eng                      *enguc.Service
+	sca                      *scauc.Service
+	aup                      *aupuc.Service
+	findings                 *findingsuc.Service
+	export                   *exportuc.Service
+	report                   *reportuc.Service
+	evidence                 *evidenceuc.Service
+	recon                    *reconuc.Service
+	logs                     ports.LogStream
+	transfer                 *transferuc.Service
+	audit                    *audituc.Service
+	vex                      *vexuc.Service
+	users                    *usersuc.Service
+	credentials              *credentialsuc.Service
+	assessmentCycles         *cycleuc.APIService
+	assessmentSnapshots      *snapshotuc.Service
+	assessmentCycleAPI       bool
+	assessmentCycleDualWrite func(string) bool
+	assessmentLifecycleRead  func(string) bool
+	assessmentLifecycleUI    func(string) bool
+	dastVerifier             runtimeVerifierService
+	dastWorkflow             dastWorkflowService
+	agent                    *agentDeps                // optional; nil ⇒ agent routes are not registered
+	exploitation             findingVerifier           // optional; nil ⇒ the verify route is not registered
+	judgments                judgmentService           // optional; nil ⇒ judgment routes are not registered
+	autoVerifier             autoVerifierService       // optional; nil ⇒ the LLM auto-verify route is not registered
+	threatModels             threatModelService        // optional; nil ⇒ threat-model routes are not registered
+	drafts                   writeupDraftService       // optional; nil ⇒ writeup-draft sign-off routes are not registered
+	aiTriageReviews          aiTriageReviewService     // optional; nil ⇒ AI-triage review queue routes are not registered
+	projects                 projectService            // optional; nil ⇒ project routes are not registered
+	assets                   assetService              // optional; nil ⇒ fleet asset routes are not registered
+	cspm                     *cspm.Service             // optional; nil ⇒ CSPM routes are not registered
+	businessAssets           businessAssetService      // optional; nil ⇒ business-level Asset routes are not registered
+	attackPaths              attackPathService         // optional; nil ⇒ attack-path routes are not registered
+	coverage                 coverageService           // optional; nil ⇒ fleet coverage/agent-view routes are not registered
+	coverageWindows          coverageWindowReader      // optional; nil ⇒ immutable telemetry coverage-window routes are not registered
+	privacyPolicies          privacyPolicyService      // optional; nil ⇒ tenant source-privacy policy routes are not registered
+	incidents                incidentReader            // optional; nil ⇒ incident read routes are not registered (#594 C7)
+	incidentTriage           incidentTriager           // optional; nil ⇒ incident triage routes are not registered (#594 C5)
+	incidentRiskReassessor   incidentRiskReassessor    // optional; nil ⇒ the tri-score reassess route is not registered (#594 C3/D/X5)
+	incidentCorrelator       incidentCorrelator        // optional; nil ⇒ the correlation route is not registered (#594 C2/C3)
+	endpointProcesses        endpointProcessStore      // optional; nil ⇒ the process-report routes are not registered (#594 B5)
+	processLearner           processLearner            // optional; nil ⇒ reported processes are not folded into the behavior baseline (#594 D)
+	desiredCapabilities      desiredCapabilityService  // optional; nil ⇒ the desired-vs-observed routes are not registered (#633)
+	legalHolds               legalHoldService          // optional; nil ⇒ the legal-hold routes are not registered (#635)
+	privacyExport            privacyExporter           // optional; nil ⇒ the data-export route is not registered (#635)
+	dataPurge                dataPurger                // optional; nil ⇒ the on-demand data-deletion route is not registered (#635)
+	endpointTimeline         endpointTimelineReader    // optional; nil ⇒ the State-Timeline read route is not registered (#594 B7)
+	retroHunter              retroHunter               // optional; nil ⇒ the retro-hunt route is not registered (#594 B7)
+	sarif                    sarifIngester             // optional; nil ⇒ the third-party SARIF import route is not registered
+	importedFindings         sarifReader               // optional read side for imported findings
+	fleetRolloutAdmin        fleetRolloutService       // optional; nil ⇒ the operator rollout routes are not served
+	offensiveHalt            offensiveKillSwitch       // optional; nil ⇒ the red-team halt route is not served
+	detections               detectionReader           // optional read side for the detection ledger (#423)
+	detectionProvenance      detectionProvenanceReader // optional read side for durable detection provenance (#610)
+	riskStories              riskStoryReader           // optional read side for the unified per-asset risk story (#427)
+	purpleCoverage           purpleCoverageReader      // optional read side for purple-team coverage (#426)
+	fleet                    *fleetRouter              // optional; nil ⇒ agent transport plane is not served
+	fleetAdmin               fleetAdminService         // optional; nil ⇒ operator agent-admin routes not registered
+	fleetKeys                fleetKeyAdmin             // optional; nil ⇒ operator signing-key routes not registered (A4 #625)
+	qualityGates             qualityGateService        // optional; nil ⇒ quality-gate routes are not registered
+	qualityProfiles          qualityProfileService     // optional; nil ⇒ quality-profile routes are not registered
+	rules                    rulesService              // optional; nil ⇒ rule catalog routes are not registered
+	dastScan                 dastScanService
+	vulnerabilitySources     *vulnerabilitysourceuc.Service
+	vulnerabilityMonitor     *vulnerabilitymonitor.Service
+	vulnerabilityReconcile   *vulnerabilityreconciliation.Service
+	vulnerabilityAudit       ports.AuditLogger
+	vulnerabilityRead        *vulnerabilityinteluc.Service
+	vulnerabilityActions     *vulnerabilityactionuc.Service
+	sla                      *slauc.Service
+	readiness                readinessConfig
 }
 
 // findingVerifier is the narrow slice of the exploitation use-case the verify endpoint needs:
@@ -230,6 +238,31 @@ func (rt *Router) SetVulnerabilityReadModel(service *vulnerabilityinteluc.Servic
 
 func (rt *Router) SetVulnerabilityActions(actions *vulnerabilityactionuc.Service) {
 	rt.vulnerabilityActions = actions
+}
+
+func (rt *Router) SetAssessmentCycles(service *cycleuc.APIService, apiEnabled bool, dualWrite func(string) bool) {
+	rt.assessmentCycles = service
+	rt.assessmentCycleAPI = apiEnabled
+	rt.assessmentCycleDualWrite = dualWrite
+}
+
+func (rt *Router) SetAssessmentLifecycleRollout(readEnabled, uiEnabled func(string) bool) {
+	rt.assessmentLifecycleRead = readEnabled
+	rt.assessmentLifecycleUI = uiEnabled
+}
+
+func (rt *Router) SetAssessmentSnapshots(service *snapshotuc.Service) {
+	rt.assessmentSnapshots = service
+}
+
+func (rt *Router) requireAssessmentLifecycleRead(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if rt.assessmentLifecycleRead != nil && !rt.assessmentLifecycleRead(TenantFrom(r.Context())) {
+			writeJSON(w, http.StatusNotFound, errorBody{Error: "assessment_lifecycle_read_disabled"})
+			return
+		}
+		next(w, r)
+	}
 }
 
 // SetSLA wires the opt-in risk-based remediation governance API.
@@ -505,6 +538,19 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("GET /api/v1/projects/{key}/analysis", rt.authz(userdom.PermView, rt.latestProjectAnalysis))
 	}
 	mux.HandleFunc("POST /api/v1/engagements", rt.authz(userdom.PermOperate, rt.createEngagement))
+	if rt.assessmentCycles != nil && rt.assessmentCycleAPI {
+		mux.HandleFunc("POST /api/v1/engagements/{assessmentId}/retests", rt.authz(userdom.PermOperate, rt.createAssessmentRetest))
+		mux.HandleFunc("GET /api/v1/engagements/{assessmentId}/lifecycle", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.getAssessmentLifecycle)))
+		mux.HandleFunc("GET /api/v1/assessment-cycles/{cycleId}", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.getAssessmentCycle)))
+		mux.HandleFunc("GET /api/v1/assessment-cycles/{cycleId}/members", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.listAssessmentCycleMembers)))
+		mux.HandleFunc("GET /api/v1/assessment-cycles", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.listAssessmentCycles)))
+		mux.HandleFunc("POST /api/v1/assessment-cycles/{cycleId}/archive", rt.authz(userdom.PermReview, rt.requireAssessmentLifecycleRead(rt.archiveAssessmentCycle)))
+	}
+	if rt.assessmentSnapshots != nil {
+		mux.HandleFunc("POST /api/v1/engagements/{id}/snapshots/finalize", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.finalizeAssessmentSnapshot)))
+		mux.HandleFunc("GET /api/v1/engagements/{id}/snapshots", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.withEngTenant(rt.listAssessmentSnapshots))))
+		mux.HandleFunc("GET /api/v1/assessment-snapshots/{snapshotId}", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.getAssessmentSnapshot)))
+	}
 	if rt.fleetRolloutAdmin != nil {
 		// These are OPERATOR routes and they live under /api/v1/agents, not /api/v1/fleet.
 		// Handler() mounts /api/v1/fleet/ on the untrusted AGENT auth plane, which deliberately

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -265,6 +265,16 @@ func (rt *Router) requireAssessmentLifecycleRead(next http.HandlerFunc) http.Han
 	}
 }
 
+func (rt *Router) requireAssessmentLifecycleWrite(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if rt.assessmentLifecycleRead == nil || !rt.assessmentLifecycleRead(TenantFrom(r.Context())) {
+			writeJSON(w, http.StatusNotFound, errorBody{Error: "assessment_lifecycle_write_disabled"})
+			return
+		}
+		next(w, r)
+	}
+}
+
 // SetSLA wires the opt-in risk-based remediation governance API.
 func (rt *Router) SetSLA(service *slauc.Service) { rt.sla = service }
 
@@ -539,15 +549,16 @@ func (rt *Router) routes() *http.ServeMux {
 	}
 	mux.HandleFunc("POST /api/v1/engagements", rt.authz(userdom.PermOperate, rt.createEngagement))
 	if rt.assessmentCycles != nil && rt.assessmentCycleAPI {
-		mux.HandleFunc("POST /api/v1/engagements/{assessmentId}/retests", rt.authz(userdom.PermOperate, rt.createAssessmentRetest))
+		mux.HandleFunc("POST /api/v1/engagements/{assessmentId}/retests", rt.authz(userdom.PermOperate, rt.requireAssessmentLifecycleWrite(rt.createAssessmentRetest)))
 		mux.HandleFunc("GET /api/v1/engagements/{assessmentId}/lifecycle", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.getAssessmentLifecycle)))
 		mux.HandleFunc("GET /api/v1/assessment-cycles/{cycleId}", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.getAssessmentCycle)))
 		mux.HandleFunc("GET /api/v1/assessment-cycles/{cycleId}/members", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.listAssessmentCycleMembers)))
 		mux.HandleFunc("GET /api/v1/assessment-cycles", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.listAssessmentCycles)))
-		mux.HandleFunc("POST /api/v1/assessment-cycles/{cycleId}/archive", rt.authz(userdom.PermReview, rt.requireAssessmentLifecycleRead(rt.archiveAssessmentCycle)))
+		mux.HandleFunc("POST /api/v1/assessment-cycles/{cycleId}/archive", rt.authz(userdom.PermReview, rt.requireAssessmentLifecycleWrite(rt.archiveAssessmentCycle)))
+		mux.HandleFunc("POST /api/v1/assessment-cycles/{cycleId}/reopen", rt.authz(userdom.PermReview, rt.requireAssessmentLifecycleWrite(rt.reopenAssessmentCycle)))
 	}
 	if rt.assessmentSnapshots != nil {
-		mux.HandleFunc("POST /api/v1/engagements/{id}/snapshots/finalize", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.finalizeAssessmentSnapshot)))
+		mux.HandleFunc("POST /api/v1/engagements/{id}/snapshots/finalize", rt.authz(userdom.PermOperate, rt.requireAssessmentLifecycleWrite(rt.withEngTenant(rt.finalizeAssessmentSnapshot))))
 		mux.HandleFunc("GET /api/v1/engagements/{id}/snapshots", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.withEngTenant(rt.listAssessmentSnapshots))))
 		mux.HandleFunc("GET /api/v1/assessment-snapshots/{snapshotId}", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.getAssessmentSnapshot)))
 	}

--- a/internal/adapter/httpapi/user_handler.go
+++ b/internal/adapter/httpapi/user_handler.go
@@ -25,7 +25,13 @@ func toUserView(u *userdom.User) userView {
 // the logged-in consultant and gate admin-only surfaces.
 func (rt *Router) currentUser(w http.ResponseWriter, r *http.Request) {
 	p, _ := principalObj(r.Context())
-	writeJSON(w, http.StatusOK, map[string]any{"id": p.ID, "name": p.Name, "role": p.Role})
+	tenantID := TenantFrom(r.Context())
+	readEnabled := rt.assessmentLifecycleRead != nil && rt.assessmentLifecycleRead(tenantID)
+	uiEnabled := rt.assessmentLifecycleUI != nil && rt.assessmentLifecycleUI(tenantID)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"id": p.ID, "name": p.Name, "role": p.Role,
+		"features": map[string]bool{"assessment_lifecycle_read": readEnabled, "assessment_lifecycle_ui_default": uiEnabled},
+	})
 }
 
 // listUsers returns the team roster (admin only).

--- a/internal/adapter/httpapi/user_handler_test.go
+++ b/internal/adapter/httpapi/user_handler_test.go
@@ -62,6 +62,29 @@ func TestCreateUserAdminOnly(t *testing.T) {
 	}
 }
 
+func TestCurrentUserReportsTenantLifecycleRollout(t *testing.T) {
+	router := newUsersRouter(t)
+	router.SetAssessmentLifecycleRollout(
+		func(tenantID string) bool { return tenantID == "tenant-canary" },
+		func(tenantID string) bool { return tenantID == "tenant-canary" },
+	)
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/me", nil).WithContext(context.WithValue(
+		context.Background(), principalKey,
+		Principal{ID: "p1", Name: "P", Role: "member", TenantID: "tenant-other"},
+	))
+	recorder := httptest.NewRecorder()
+	router.currentUser(recorder, request)
+	var response struct {
+		Features map[string]bool `json:"features"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Features["assessment_lifecycle_read"] || response.Features["assessment_lifecycle_ui_default"] {
+		t.Fatalf("non-canary features = %v", response.Features)
+	}
+}
+
 func TestListUsersAdminOnly(t *testing.T) {
 	rt := newUsersRouter(t)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil).WithContext(ctxAs("member"))

--- a/internal/domain/assessmentcycle/errors.go
+++ b/internal/domain/assessmentcycle/errors.go
@@ -16,4 +16,6 @@ var (
 	ErrCannotArchiveSelectedHead = fmt.Errorf("%w: currently selected head cannot be archived", shared.ErrValidation)
 	ErrCycleBoundaryMismatch     = fmt.Errorf("%w: assessment does not match cycle boundary", shared.ErrValidation)
 	ErrHiddenProjectContext      = fmt.Errorf("%w: hidden project analysis context assessment cannot become cycle member", shared.ErrValidation)
+	ErrCycleReopenRequired       = fmt.Errorf("%w: cycle_reopen_required", shared.ErrConflict)
+	ErrCycleArchived             = fmt.Errorf("%w: cycle_archived", shared.ErrConflict)
 )

--- a/internal/domain/assessmentsnapshot/comparison.go
+++ b/internal/domain/assessmentsnapshot/comparison.go
@@ -1,0 +1,132 @@
+package assessmentsnapshot
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type Comparability string
+
+const (
+	Comparable          Comparability = "comparable"
+	PartiallyComparable Comparability = "partially_comparable"
+	NotComparable       Comparability = "not_comparable"
+)
+
+const (
+	CompareCompleteReevaluation    = "complete_re_evaluation"
+	CompareBaselineIncomplete      = "baseline_coverage_incomplete"
+	CompareCurrentDimensionMissing = "current_dimension_missing"
+	CompareTargetMismatch          = "target_mismatch"
+	CompareCurrentPartial          = "current_coverage_partial"
+	CompareCurrentUnknown          = "current_coverage_unknown"
+	CompareScopeChanged            = "scope_changed"
+	CompareRuleOrProfileChanged    = "rule_or_profile_changed"
+	CompareAdvisoryDatabaseChanged = "advisory_database_changed"
+	CompareProducerVersionChanged  = "producer_version_changed"
+)
+
+type DimensionComparison struct {
+	Baseline      Dimension     `json:"baseline"`
+	Current       *Dimension    `json:"current,omitempty"`
+	Comparability Comparability `json:"comparability"`
+	ReasonCode    string        `json:"reason_code"`
+}
+
+func Compare(baseline, current *Snapshot) ([]DimensionComparison, error) {
+	if baseline == nil || current == nil {
+		return nil, fmt.Errorf("%w: baseline and current snapshots are required", shared.ErrValidation)
+	}
+	if baseline.Lifecycle == LifecycleBuilding || current.Lifecycle == LifecycleBuilding {
+		return nil, fmt.Errorf("%w: only finalized snapshots are comparable", shared.ErrValidation)
+	}
+	if baseline.TenantID != current.TenantID || baseline.CycleID != current.CycleID {
+		return nil, fmt.Errorf("%w: snapshots must belong to the same tenant and cycle", shared.ErrValidation)
+	}
+
+	currentByKey := make(map[string]Dimension, len(current.Dimensions))
+	currentByProducerKind := make(map[string][]Dimension, len(current.Dimensions))
+	for _, dimension := range current.Dimensions {
+		currentByKey[dimensionKey(dimension)] = dimension
+		key := dimension.Producer + "\x00" + dimension.FindingKind
+		currentByProducerKind[key] = append(currentByProducerKind[key], dimension)
+	}
+	comparisons := make([]DimensionComparison, 0, len(baseline.Dimensions))
+	for _, base := range baseline.Dimensions {
+		candidate, found := currentByKey[dimensionKey(base)]
+		if !found {
+			reason := CompareCurrentDimensionMissing
+			if len(currentByProducerKind[base.Producer+"\x00"+base.FindingKind]) > 0 {
+				reason = CompareTargetMismatch
+			}
+			comparisons = append(comparisons, DimensionComparison{Baseline: base, Comparability: NotComparable, ReasonCode: reason})
+			continue
+		}
+		state, reason := compareDimension(base, candidate)
+		copyCandidate := candidate
+		comparisons = append(comparisons, DimensionComparison{Baseline: base, Current: &copyCandidate, Comparability: state, ReasonCode: reason})
+	}
+	sort.Slice(comparisons, func(i, j int) bool {
+		return dimensionKey(comparisons[i].Baseline) < dimensionKey(comparisons[j].Baseline)
+	})
+	return comparisons, nil
+}
+
+func compareDimension(baseline, current Dimension) (Comparability, string) {
+	if current.State == CoverageUnknown {
+		return NotComparable, CompareCurrentUnknown
+	}
+	if current.State == CoveragePartial {
+		return PartiallyComparable, CompareCurrentPartial
+	}
+	if baseline.State != CoverageComplete {
+		return PartiallyComparable, CompareBaselineIncomplete
+	}
+	if !equalStrings(baseline.IncludedScope, current.IncludedScope) || !equalStrings(baseline.ExcludedScope, current.ExcludedScope) {
+		return PartiallyComparable, CompareScopeChanged
+	}
+	if !equalVersionKinds(baseline.Versions, current.Versions, scanrun.VersionRulePack, scanrun.VersionProfile) {
+		return NotComparable, CompareRuleOrProfileChanged
+	}
+	if !equalVersionKinds(baseline.Versions, current.Versions, scanrun.VersionAdvisoryDB) {
+		return PartiallyComparable, CompareAdvisoryDatabaseChanged
+	}
+	if !equalVersionKinds(baseline.Versions, current.Versions, scanrun.VersionTool, scanrun.VersionScanner, scanrun.VersionCorrelation, scanrun.VersionSchema) {
+		return PartiallyComparable, CompareProducerVersionChanged
+	}
+	return Comparable, CompareCompleteReevaluation
+}
+
+func equalVersionKinds(left, right []Version, kinds ...scanrun.VersionKind) bool {
+	allowed := make(map[scanrun.VersionKind]struct{}, len(kinds))
+	for _, kind := range kinds {
+		allowed[kind] = struct{}{}
+	}
+	project := func(values []Version) []string {
+		var out []string
+		for _, value := range values {
+			if _, ok := allowed[value.Kind]; ok {
+				out = append(out, strings.Join([]string{string(value.Kind), value.Name, value.Version, value.Digest}, "\x00"))
+			}
+		}
+		sort.Strings(out)
+		return out
+	}
+	return equalStrings(project(left), project(right))
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/domain/assessmentsnapshot/snapshot.go
+++ b/internal/domain/assessmentsnapshot/snapshot.go
@@ -1,0 +1,390 @@
+// Package assessmentsnapshot defines immutable, comparison-ready Assessment snapshots.
+package assessmentsnapshot
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const SchemaVersion = 1
+
+type Lifecycle string
+
+const (
+	LifecycleBuilding   Lifecycle = "building"
+	LifecycleFinalized  Lifecycle = "finalized"
+	LifecycleSuperseded Lifecycle = "superseded"
+)
+
+type Provenance string
+
+const (
+	ProvenanceNative Provenance = "native"
+	ProvenanceLegacy Provenance = "legacy"
+)
+
+type CoverageState string
+
+const (
+	CoverageComplete CoverageState = "complete"
+	CoveragePartial  CoverageState = "partial"
+	CoverageUnknown  CoverageState = "unknown"
+)
+
+const (
+	ReasonTrustedTerminalLane = "trusted_terminal_lane"
+	ReasonLegacyProvenance    = "legacy_provenance"
+	ReasonRunPartial          = "run_partial"
+	ReasonRunFailed           = "run_failed"
+	ReasonRunCancelled        = "run_cancelled"
+	ReasonLanePartial         = "lane_partial"
+	ReasonLaneFailed          = "lane_failed"
+	ReasonLaneCancelled       = "lane_cancelled"
+	ReasonStageFailed         = "stage_failed"
+	ReasonStageSkipped        = "stage_skipped"
+)
+
+type Boundary struct {
+	BusinessAssetID shared.ID                    `json:"business_asset_id,omitempty"`
+	Kind            assessmentcycle.BoundaryKind `json:"boundary_kind"`
+	ProjectID       shared.ID                    `json:"project_id,omitempty"`
+}
+
+type LaneReference struct {
+	LaneKey      string `json:"lane_key"`
+	ManifestHash string `json:"manifest_hash"`
+}
+
+type RunReference struct {
+	LaneReferences []LaneReference `json:"lane_refs"`
+	ManifestHash   string          `json:"manifest_hash"`
+	RunID          string          `json:"run_id"`
+}
+
+type Target struct {
+	Canonical         string             `json:"canonical"`
+	EvaluatedRevision string             `json:"evaluated_revision,omitempty"`
+	Kind              scanrun.TargetKind `json:"kind"`
+	SchemaVersion     int                `json:"schema_version"`
+}
+
+type Version struct {
+	Digest  string              `json:"digest,omitempty"`
+	Kind    scanrun.VersionKind `json:"kind"`
+	Name    string              `json:"name"`
+	Version string              `json:"version"`
+}
+
+type Dimension struct {
+	ExcludedScope    []string      `json:"excluded_scope"`
+	FindingKind      string        `json:"finding_kind"`
+	IncludedScope    []string      `json:"included_scope"`
+	LaneKey          string        `json:"lane_key"`
+	LaneManifestHash string        `json:"lane_manifest_hash"`
+	Producer         string        `json:"producer"`
+	ReasonCode       string        `json:"reason_code"`
+	RunID            string        `json:"run_id"`
+	State            CoverageState `json:"state"`
+	Target           Target        `json:"target"`
+	Versions         []Version     `json:"versions"`
+}
+
+type Snapshot struct {
+	TenantID       shared.ID
+	ID             shared.ID
+	CycleID        shared.ID
+	AssessmentID   shared.ID
+	SnapshotNumber int
+	DefaultVersion int64
+	Lifecycle      Lifecycle
+	Provenance     Provenance
+	Boundary       Boundary
+	RunReferences  []RunReference
+	Dimensions     []Dimension
+	SchemaVersion  int
+	ContentHash    string
+	RequestKey     string
+	RequestHash    string
+	CreatedAt      time.Time
+	CreatedBy      string
+	FinalizedAt    *time.Time
+	FinalizedBy    string
+	SupersededAt   *time.Time
+	SupersededBy   string
+}
+
+type SelectedRun struct {
+	ID             string
+	ManifestHash   string
+	Provenance     scanrun.ProvenanceKind
+	TerminalStatus scanrun.TerminalStatus
+	Trusted        bool
+	Lanes          []scanrun.Lane
+}
+
+func NewFinalized(tenantID, id, cycleID, assessmentID shared.ID, boundary Boundary, requestKey, actor string, now time.Time, runs []SelectedRun) (*Snapshot, error) {
+	if tenantID.IsZero() || id.IsZero() || cycleID.IsZero() || assessmentID.IsZero() {
+		return nil, fmt.Errorf("%w: snapshot tenant, id, cycle, and assessment are required", shared.ErrValidation)
+	}
+	if strings.TrimSpace(requestKey) == "" || strings.TrimSpace(actor) == "" || now.IsZero() {
+		return nil, fmt.Errorf("%w: snapshot request key, actor, and time are required", shared.ErrValidation)
+	}
+	if err := assessmentcycle.ValidateBoundaryEnforcement(boundary.Kind, boundary.BusinessAssetID, boundary.ProjectID); err != nil {
+		return nil, err
+	}
+	if len(runs) == 0 {
+		return nil, fmt.Errorf("%w: snapshot requires at least one selected run", shared.ErrValidation)
+	}
+
+	runReferences, dimensions, provenance, err := compileRuns(runs)
+	if err != nil {
+		return nil, err
+	}
+	now = now.UTC()
+	snapshot := &Snapshot{
+		TenantID: tenantID, ID: id, CycleID: cycleID, AssessmentID: assessmentID,
+		Lifecycle: LifecycleFinalized, Provenance: provenance, Boundary: boundary,
+		RunReferences: runReferences, Dimensions: dimensions, SchemaVersion: SchemaVersion,
+		RequestKey: strings.TrimSpace(requestKey), CreatedAt: now, CreatedBy: strings.TrimSpace(actor),
+		FinalizedAt: timePointer(now), FinalizedBy: strings.TrimSpace(actor),
+	}
+	contentHash, err := snapshot.computeContentHash()
+	if err != nil {
+		return nil, err
+	}
+	snapshot.ContentHash = contentHash
+	snapshot.RequestHash = contentHash
+	return snapshot, snapshot.Validate()
+}
+
+func (snapshot *Snapshot) Validate() error {
+	if snapshot == nil || snapshot.TenantID.IsZero() || snapshot.ID.IsZero() || snapshot.CycleID.IsZero() || snapshot.AssessmentID.IsZero() {
+		return fmt.Errorf("%w: snapshot identity is invalid", shared.ErrValidation)
+	}
+	if snapshot.SchemaVersion != SchemaVersion || !validSHA256(snapshot.ContentHash) || !validSHA256(snapshot.RequestHash) {
+		return fmt.Errorf("%w: snapshot schema or hash is invalid", shared.ErrValidation)
+	}
+	if snapshot.Lifecycle != LifecycleFinalized && snapshot.Lifecycle != LifecycleSuperseded {
+		return fmt.Errorf("%w: persisted snapshot must be finalized or superseded", shared.ErrValidation)
+	}
+	if snapshot.Provenance != ProvenanceNative && snapshot.Provenance != ProvenanceLegacy {
+		return fmt.Errorf("%w: snapshot provenance is invalid", shared.ErrValidation)
+	}
+	if snapshot.FinalizedAt == nil || snapshot.FinalizedAt.IsZero() || strings.TrimSpace(snapshot.FinalizedBy) == "" {
+		return fmt.Errorf("%w: snapshot finalization metadata is required", shared.ErrValidation)
+	}
+	if snapshot.Lifecycle == LifecycleSuperseded && (snapshot.SupersededAt == nil || strings.TrimSpace(snapshot.SupersededBy) == "") {
+		return fmt.Errorf("%w: superseded snapshot metadata is required", shared.ErrValidation)
+	}
+	want, err := snapshot.computeContentHash()
+	if err != nil {
+		return err
+	}
+	if want != snapshot.ContentHash {
+		return fmt.Errorf("%w: snapshot content hash mismatch", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (snapshot *Snapshot) Supersede(actor string, at time.Time) error {
+	if snapshot == nil || snapshot.Lifecycle != LifecycleFinalized || strings.TrimSpace(actor) == "" || at.IsZero() {
+		return fmt.Errorf("%w: only a finalized snapshot can be superseded", shared.ErrValidation)
+	}
+	snapshot.Lifecycle = LifecycleSuperseded
+	snapshot.SupersededAt = timePointer(at.UTC())
+	snapshot.SupersededBy = strings.TrimSpace(actor)
+	return snapshot.Validate()
+}
+
+func compileRuns(runs []SelectedRun) ([]RunReference, []Dimension, Provenance, error) {
+	ordered := append([]SelectedRun(nil), runs...)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].ID < ordered[j].ID })
+	provenance := ProvenanceNative
+	seenRuns := map[string]struct{}{}
+	seenDimensions := map[string]struct{}{}
+	runReferences := make([]RunReference, 0, len(ordered))
+	var dimensions []Dimension
+	for _, run := range ordered {
+		run.ID = strings.TrimSpace(run.ID)
+		if run.ID == "" || !validSHA256(run.ManifestHash) {
+			return nil, nil, "", fmt.Errorf("%w: selected run identity or manifest hash is invalid", shared.ErrValidation)
+		}
+		if _, exists := seenRuns[run.ID]; exists {
+			return nil, nil, "", fmt.Errorf("%w: selected run %q is duplicated", shared.ErrValidation, run.ID)
+		}
+		seenRuns[run.ID] = struct{}{}
+		if run.Provenance == scanrun.ProvenanceNative {
+			if !run.Trusted {
+				return nil, nil, "", fmt.Errorf("%w: selected native run %q is not trusted sealed provenance", shared.ErrValidation, run.ID)
+			}
+		} else if run.Provenance == scanrun.ProvenanceLegacy {
+			provenance = ProvenanceLegacy
+		} else {
+			return nil, nil, "", fmt.Errorf("%w: selected run provenance is invalid", shared.ErrValidation)
+		}
+
+		lanes := append([]scanrun.Lane(nil), run.Lanes...)
+		sort.Slice(lanes, func(i, j int) bool { return lanes[i].LaneKey < lanes[j].LaneKey })
+		reference := RunReference{RunID: run.ID, ManifestHash: run.ManifestHash}
+		for _, lane := range lanes {
+			if err := validateSealedLane(lane); err != nil {
+				return nil, nil, "", fmt.Errorf("validate selected lane %s/%s: %w", run.ID, lane.LaneKey, err)
+			}
+			reference.LaneReferences = append(reference.LaneReferences, LaneReference{LaneKey: lane.LaneKey, ManifestHash: lane.ManifestHash})
+			for _, findingKind := range sortedUnique(lane.AuthoritativeFindingKinds) {
+				dimension := dimensionFrom(run, lane, findingKind)
+				key := dimensionKey(dimension)
+				if _, exists := seenDimensions[key]; exists {
+					return nil, nil, "", fmt.Errorf("%w: duplicate snapshot coverage dimension %q", shared.ErrValidation, key)
+				}
+				seenDimensions[key] = struct{}{}
+				dimensions = append(dimensions, dimension)
+			}
+		}
+		runReferences = append(runReferences, reference)
+	}
+	sort.Slice(dimensions, func(i, j int) bool { return dimensionKey(dimensions[i]) < dimensionKey(dimensions[j]) })
+	return runReferences, dimensions, provenance, nil
+}
+
+func dimensionFrom(run SelectedRun, lane scanrun.Lane, findingKind string) Dimension {
+	state, reason := coverageDecision(run, lane)
+	versions := make([]Version, 0, len(lane.Versions))
+	for _, version := range lane.Versions {
+		versions = append(versions, Version{Digest: version.Digest, Kind: version.VersionKind, Name: version.Name, Version: version.Version})
+	}
+	sort.Slice(versions, func(i, j int) bool {
+		if versions[i].Kind != versions[j].Kind {
+			return versions[i].Kind < versions[j].Kind
+		}
+		return versions[i].Name < versions[j].Name
+	})
+	return Dimension{
+		ExcludedScope: sortedUnique(lane.ExcludedScope), FindingKind: findingKind,
+		IncludedScope: sortedUnique(lane.IncludedScope), LaneKey: lane.LaneKey, LaneManifestHash: lane.ManifestHash,
+		Producer: lane.Producer, ReasonCode: reason, RunID: run.ID, State: state,
+		Target: Target{
+			Canonical: lane.Target.TargetIdentityCanonical, EvaluatedRevision: lane.Target.EvaluatedRevision,
+			Kind: lane.Target.TargetKind, SchemaVersion: lane.Target.TargetIdentitySchemaVersion,
+		},
+		Versions: versions,
+	}
+}
+
+func validateSealedLane(lane scanrun.Lane) error {
+	if err := lane.Validate(); err != nil {
+		return err
+	}
+	if !lane.TerminalStatus.IsTerminal() || lane.SealedAt == nil || lane.SealedAt.IsZero() || !validSHA256(lane.ManifestHash) {
+		return fmt.Errorf("%w: lane must have terminal, sealed provenance", shared.ErrValidation)
+	}
+	want, err := scanrun.ComputeManifestHash(lane)
+	if err != nil {
+		return err
+	}
+	if want != lane.ManifestHash {
+		return fmt.Errorf("%w: lane manifest hash mismatch", shared.ErrValidation)
+	}
+	return nil
+}
+
+func coverageDecision(run SelectedRun, lane scanrun.Lane) (CoverageState, string) {
+	if run.Provenance == scanrun.ProvenanceLegacy {
+		return CoverageUnknown, ReasonLegacyProvenance
+	}
+	switch run.TerminalStatus {
+	case scanrun.StatusFailed:
+		return CoverageUnknown, ReasonRunFailed
+	case scanrun.StatusCancelled:
+		return CoverageUnknown, ReasonRunCancelled
+	case scanrun.StatusPartial:
+		return CoveragePartial, ReasonRunPartial
+	}
+	switch lane.TerminalStatus {
+	case scanrun.StatusFailed:
+		return CoverageUnknown, ReasonLaneFailed
+	case scanrun.StatusCancelled:
+		return CoverageUnknown, ReasonLaneCancelled
+	case scanrun.StatusPartial:
+		return CoveragePartial, ReasonLanePartial
+	}
+	for _, stage := range lane.Stages {
+		if stage.Status == scanrun.StageFailed {
+			return CoveragePartial, ReasonStageFailed
+		}
+		if stage.Status == scanrun.StageSkipped {
+			return CoveragePartial, ReasonStageSkipped
+		}
+	}
+	return CoverageComplete, ReasonTrustedTerminalLane
+}
+
+func (snapshot Snapshot) computeContentHash() (string, error) {
+	type canonicalSnapshot struct {
+		AssessmentID string         `json:"assessment_id"`
+		Boundary     Boundary       `json:"boundary"`
+		CycleID      string         `json:"cycle_id"`
+		Dimensions   []Dimension    `json:"dimensions"`
+		Provenance   Provenance     `json:"provenance"`
+		RunRefs      []RunReference `json:"run_refs"`
+		Schema       int            `json:"schema_version"`
+		TenantID     string         `json:"tenant_id"`
+	}
+	// ponytail: this schema intentionally contains no maps or floating-point values; use a full
+	// RFC 8785 encoder if future snapshot schemas add either.
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(canonicalSnapshot{
+		AssessmentID: snapshot.AssessmentID.String(), Boundary: snapshot.Boundary,
+		CycleID: snapshot.CycleID.String(), Dimensions: snapshot.Dimensions,
+		Provenance: snapshot.Provenance, RunRefs: snapshot.RunReferences, Schema: snapshot.SchemaVersion,
+		TenantID: snapshot.TenantID.String(),
+	}); err != nil {
+		return "", fmt.Errorf("marshal canonical assessment snapshot: %w", err)
+	}
+	sum := sha256.Sum256(bytes.TrimSuffix(buffer.Bytes(), []byte("\n")))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func dimensionKey(dimension Dimension) string {
+	return strings.Join([]string{string(dimension.Target.Kind), fmt.Sprintf("%d", dimension.Target.SchemaVersion), dimension.Target.Canonical, dimension.Producer, dimension.FindingKind}, "\x00")
+}
+
+func sortedUnique(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func validSHA256(value string) bool {
+	if len(value) != 64 || strings.ToLower(value) != value {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func timePointer(value time.Time) *time.Time { return &value }

--- a/internal/domain/assessmentsnapshot/snapshot_test.go
+++ b/internal/domain/assessmentsnapshot/snapshot_test.go
@@ -1,0 +1,192 @@
+package assessmentsnapshot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+)
+
+func TestSnapshotHashIsStableAcrossInputOrder(t *testing.T) {
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	left, err := NewFinalized("tenant", "snapshot-a", "cycle", "assessment", Boundary{Kind: assessmentcycle.BoundaryStandalone}, "request-a", "operator", now, []SelectedRun{
+		selectedRun("run-b", "producer-b", "secret", "sast"),
+		selectedRun("run-a", "producer-a", "vulnerability", "license"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := NewFinalized("tenant", "snapshot-b", "cycle", "assessment", Boundary{Kind: assessmentcycle.BoundaryStandalone}, "request-b", "operator", now.Add(time.Hour), []SelectedRun{
+		selectedRun("run-a", "producer-a", "license", "vulnerability"),
+		selectedRun("run-b", "producer-b", "sast", "secret"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if left.ContentHash != right.ContentHash {
+		t.Fatalf("canonical hash changed across order/time/id variation: %s != %s", left.ContentHash, right.ContentHash)
+	}
+}
+
+func TestCoverageAndDirectionalComparability(t *testing.T) {
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	baseline, err := NewFinalized("tenant", "baseline", "cycle", "assessment-a", Boundary{Kind: assessmentcycle.BoundaryStandalone}, "request-a", "operator", now, []SelectedRun{selectedRun("run-a", "sca", "vulnerability")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	current, err := NewFinalized("tenant", "current", "cycle", "assessment-b", Boundary{Kind: assessmentcycle.BoundaryStandalone}, "request-b", "operator", now, []SelectedRun{selectedRun("run-b", "sca", "vulnerability")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	comparisons, err := Compare(baseline, current)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comparisons) != 1 || comparisons[0].Comparability != Comparable || comparisons[0].ReasonCode != CompareCompleteReevaluation {
+		t.Fatalf("comparison = %+v", comparisons)
+	}
+
+	current.Dimensions[0].State = CoverageUnknown
+	current.Dimensions[0].ReasonCode = ReasonRunFailed
+	comparisons, err = Compare(baseline, current)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if comparisons[0].Comparability != NotComparable || comparisons[0].ReasonCode != CompareCurrentUnknown {
+		t.Fatalf("unknown current coverage upgraded: %+v", comparisons[0])
+	}
+}
+
+func TestCoverageDecisionReasonTable(t *testing.T) {
+	base := selectedRun("run", "sca", "vulnerability")
+	baseLane := base.Lanes[0]
+	cases := []struct {
+		name   string
+		run    SelectedRun
+		lane   scanrun.Lane
+		state  CoverageState
+		reason string
+	}{
+		{"complete", base, baseLane, CoverageComplete, ReasonTrustedTerminalLane},
+		{"legacy", func() SelectedRun { item := base; item.Provenance = scanrun.ProvenanceLegacy; return item }(), baseLane, CoverageUnknown, ReasonLegacyProvenance},
+		{"run partial", func() SelectedRun { item := base; item.TerminalStatus = scanrun.StatusPartial; return item }(), baseLane, CoveragePartial, ReasonRunPartial},
+		{"run failed", func() SelectedRun { item := base; item.TerminalStatus = scanrun.StatusFailed; return item }(), baseLane, CoverageUnknown, ReasonRunFailed},
+		{"run cancelled", func() SelectedRun { item := base; item.TerminalStatus = scanrun.StatusCancelled; return item }(), baseLane, CoverageUnknown, ReasonRunCancelled},
+		{"lane partial", base, func() scanrun.Lane { item := baseLane; item.TerminalStatus = scanrun.StatusPartial; return item }(), CoveragePartial, ReasonLanePartial},
+		{"lane failed", base, func() scanrun.Lane { item := baseLane; item.TerminalStatus = scanrun.StatusFailed; return item }(), CoverageUnknown, ReasonLaneFailed},
+		{"lane cancelled", base, func() scanrun.Lane { item := baseLane; item.TerminalStatus = scanrun.StatusCancelled; return item }(), CoverageUnknown, ReasonLaneCancelled},
+		{"stage failed", base, func() scanrun.Lane {
+			item := baseLane
+			item.Stages = []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageFailed, StartedAt: item.StartedAt}}
+			return item
+		}(), CoveragePartial, ReasonStageFailed},
+		{"stage skipped", base, func() scanrun.Lane {
+			item := baseLane
+			item.Stages = []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSkipped, StartedAt: item.StartedAt}}
+			return item
+		}(), CoveragePartial, ReasonStageSkipped},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			state, reason := coverageDecision(testCase.run, testCase.lane)
+			if state != testCase.state || reason != testCase.reason {
+				t.Fatalf("coverage=(%s,%s), want (%s,%s)", state, reason, testCase.state, testCase.reason)
+			}
+		})
+	}
+}
+
+func TestComparabilityReasonTable(t *testing.T) {
+	base := Dimension{
+		ExcludedScope: []string{"vendor/**"}, FindingKind: "vulnerability", IncludedScope: []string{"src/**"},
+		Producer: "sca", State: CoverageComplete,
+		Target: Target{Kind: scanrun.TargetRepository, SchemaVersion: 1, Canonical: "https://example.com/repo"},
+		Versions: []Version{
+			{Kind: scanrun.VersionRulePack, Name: "rules", Version: "1"},
+			{Kind: scanrun.VersionProfile, Name: "profile", Version: "1"},
+			{Kind: scanrun.VersionAdvisoryDB, Name: "advisories", Version: "1"},
+			{Kind: scanrun.VersionScanner, Name: "scanner", Version: "1"},
+		},
+	}
+	clone := func(dimension Dimension) Dimension {
+		dimension.IncludedScope = append([]string(nil), dimension.IncludedScope...)
+		dimension.ExcludedScope = append([]string(nil), dimension.ExcludedScope...)
+		dimension.Versions = append([]Version(nil), dimension.Versions...)
+		return dimension
+	}
+	setVersion := func(dimension *Dimension, kind scanrun.VersionKind, version string) {
+		for index := range dimension.Versions {
+			if dimension.Versions[index].Kind == kind {
+				dimension.Versions[index].Version = version
+				return
+			}
+		}
+	}
+	cases := []struct {
+		name   string
+		mutate func(*Dimension, *[]Dimension)
+		state  Comparability
+		reason string
+	}{
+		{"complete", func(_ *Dimension, _ *[]Dimension) {}, Comparable, CompareCompleteReevaluation},
+		{"baseline incomplete", func(baseline *Dimension, _ *[]Dimension) { baseline.State = CoveragePartial }, PartiallyComparable, CompareBaselineIncomplete},
+		{"current partial", func(_ *Dimension, current *[]Dimension) { (*current)[0].State = CoveragePartial }, PartiallyComparable, CompareCurrentPartial},
+		{"current unknown", func(_ *Dimension, current *[]Dimension) { (*current)[0].State = CoverageUnknown }, NotComparable, CompareCurrentUnknown},
+		{"scope changed", func(_ *Dimension, current *[]Dimension) { (*current)[0].IncludedScope = []string{"cmd/**"} }, PartiallyComparable, CompareScopeChanged},
+		{"rule changed", func(_ *Dimension, current *[]Dimension) { setVersion(&(*current)[0], scanrun.VersionRulePack, "2") }, NotComparable, CompareRuleOrProfileChanged},
+		{"profile changed", func(_ *Dimension, current *[]Dimension) { setVersion(&(*current)[0], scanrun.VersionProfile, "2") }, NotComparable, CompareRuleOrProfileChanged},
+		{"advisory database changed", func(_ *Dimension, current *[]Dimension) {
+			setVersion(&(*current)[0], scanrun.VersionAdvisoryDB, "2")
+		}, PartiallyComparable, CompareAdvisoryDatabaseChanged},
+		{"scanner changed", func(_ *Dimension, current *[]Dimension) { setVersion(&(*current)[0], scanrun.VersionScanner, "2") }, PartiallyComparable, CompareProducerVersionChanged},
+		{"target mismatch", func(_ *Dimension, current *[]Dimension) { (*current)[0].Target.Canonical = "https://example.com/other" }, NotComparable, CompareTargetMismatch},
+		{"dimension missing", func(_ *Dimension, current *[]Dimension) { *current = nil }, NotComparable, CompareCurrentDimensionMissing},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			baselineDimension := clone(base)
+			currentDimensions := []Dimension{clone(base)}
+			testCase.mutate(&baselineDimension, &currentDimensions)
+			comparisons, err := Compare(
+				&Snapshot{TenantID: "tenant", CycleID: "cycle", Lifecycle: LifecycleFinalized, Dimensions: []Dimension{baselineDimension}},
+				&Snapshot{TenantID: "tenant", CycleID: "cycle", Lifecycle: LifecycleFinalized, Dimensions: currentDimensions},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(comparisons) != 1 || comparisons[0].Comparability != testCase.state || comparisons[0].ReasonCode != testCase.reason {
+				t.Fatalf("comparison=%+v, want (%s,%s)", comparisons, testCase.state, testCase.reason)
+			}
+		})
+	}
+}
+
+func TestUntrustedNativeRunCannotFinalize(t *testing.T) {
+	run := selectedRun("run", "sca", "vulnerability")
+	run.Trusted = false
+	if _, err := NewFinalized("tenant", "snapshot", "cycle", "assessment", Boundary{Kind: assessmentcycle.BoundaryStandalone}, "request", "operator", time.Now().UTC(), []SelectedRun{run}); err == nil {
+		t.Fatal("untrusted native run produced a finalized snapshot")
+	}
+}
+
+func selectedRun(id, producer string, findingKinds ...string) SelectedRun {
+	finished := time.Date(2026, 8, 31, 11, 5, 0, 0, time.UTC)
+	lane := scanrun.Lane{
+		TenantID: "tenant", EngagementID: "assessment", ScanRunID: id,
+		LaneKey: id + "-lane", Producer: producer, TerminalStatus: scanrun.StatusSucceeded,
+		Target:                    scanrun.TargetIdentity{TargetKind: scanrun.TargetRepository, TargetIdentitySchemaVersion: 1, TargetIdentityCanonical: "https://example.com/repo", EvaluatedRevision: "0123456789abcdef0123456789abcdef01234567"},
+		AuthoritativeFindingKinds: findingKinds, IncludedScope: []string{"src/**"}, ExcludedScope: []string{"vendor/**"},
+		StartedAt: finished.Add(-time.Minute), FinishedAt: &finished, ResultRef: "result:" + id, EvidenceRef: "evidence:" + id,
+		ResultSHA256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ManifestSchemaVersion: 1,
+		Versions: []scanrun.LaneVersion{{VersionKind: scanrun.VersionScanner, Name: "sca", Version: "1"}, {VersionKind: scanrun.VersionRulePack, Name: "rules", Version: "1"}},
+		Stages:   []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSucceeded, StartedAt: finished.Add(-time.Minute), FinishedAt: &finished}},
+	}
+	lane.SealedAt = &finished
+	manifestHash, err := scanrun.ComputeManifestHash(lane)
+	if err != nil {
+		panic(err)
+	}
+	lane.ManifestHash = manifestHash
+	return SelectedRun{ID: id, ManifestHash: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", Provenance: scanrun.ProvenanceNative, TerminalStatus: scanrun.StatusSucceeded, Trusted: true, Lanes: []scanrun.Lane{lane}}
+}

--- a/internal/domain/engagement/engagement.go
+++ b/internal/domain/engagement/engagement.go
@@ -71,6 +71,9 @@ type Engagement struct {
 	// sandbox + egress allowlist exist, active recon is lab-only and must be
 	// explicitly enabled per engagement. Default false (off).
 	LiveReconEnabled bool
+	// RequiresExplicitExecutionAuthorization is set on Assessment Re-tests so
+	// legacy open-window/empty-RoE defaults cannot authorize execution.
+	RequiresExplicitExecutionAuthorization bool
 
 	Audit shared.Audit
 }
@@ -133,7 +136,13 @@ func (e *Engagement) IsAuthorizedAt(t time.Time) bool {
 // no tool may run regardless of the authorization window. Draft + Active are both
 // permitted. Enforced by the execution guard before any tool starts.
 func (e *Engagement) AllowsExecution() bool {
-	return e.Status != StatusCompleted && e.Status != StatusArchived
+	if e.Status == StatusCompleted || e.Status == StatusArchived {
+		return false
+	}
+	if !e.RequiresExplicitExecutionAuthorization {
+		return true
+	}
+	return e.AuthorizedFrom != nil && e.AuthorizedTo != nil && (len(e.RoE.AllowedToolClasses) > 0 || len(e.RoE.Blackouts) > 0)
 }
 
 // Transition validates and applies a lifecycle status change, stamping UpdatedAt.

--- a/internal/domain/engagement/engagement.go
+++ b/internal/domain/engagement/engagement.go
@@ -142,7 +142,11 @@ func (e *Engagement) AllowsExecution() bool {
 	if !e.RequiresExplicitExecutionAuthorization {
 		return true
 	}
-	return e.AuthorizedFrom != nil && e.AuthorizedTo != nil && (len(e.RoE.AllowedToolClasses) > 0 || len(e.RoE.Blackouts) > 0)
+	// A Re-test must positively name at least one executable tool class. A
+	// blackout-only RoE is merely a negative constraint and, because an empty
+	// allowlist means "all" for legacy engagements, cannot serve as explicit
+	// execution authorization.
+	return e.AuthorizedFrom != nil && e.AuthorizedTo != nil && len(e.RoE.AllowedToolClasses) > 0
 }
 
 // Transition validates and applies a lifecycle status change, stamping UpdatedAt.

--- a/internal/domain/engagement/engagement_test.go
+++ b/internal/domain/engagement/engagement_test.go
@@ -54,6 +54,23 @@ func TestAllowsExecution(t *testing.T) {
 	}
 }
 
+func TestRetestRequiresExplicitExecutionAuthorization(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	engagement := &Engagement{Status: StatusDraft, RequiresExplicitExecutionAuthorization: true}
+	if engagement.AllowsExecution() {
+		t.Fatal("Re-test without explicit authorization and RoE must not execute")
+	}
+	from, to := now.Add(-time.Hour), now.Add(time.Hour)
+	engagement.AuthorizedFrom, engagement.AuthorizedTo = &from, &to
+	if engagement.AllowsExecution() {
+		t.Fatal("authorization window without explicit RoE must not execute")
+	}
+	engagement.RoE = RoE{AllowedToolClasses: []ToolClass{"sca"}}
+	if !engagement.AllowsExecution() {
+		t.Fatal("Re-test with explicit authorization window and RoE should execute")
+	}
+}
+
 func TestTransition(t *testing.T) {
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 	cases := []struct {

--- a/internal/domain/engagement/engagement_test.go
+++ b/internal/domain/engagement/engagement_test.go
@@ -65,6 +65,10 @@ func TestRetestRequiresExplicitExecutionAuthorization(t *testing.T) {
 	if engagement.AllowsExecution() {
 		t.Fatal("authorization window without explicit RoE must not execute")
 	}
+	engagement.RoE = RoE{Blackouts: []Blackout{{From: now.Add(2 * time.Hour), To: now.Add(3 * time.Hour)}}}
+	if engagement.AllowsExecution() {
+		t.Fatal("a blackout-only RoE must not authorize every tool class")
+	}
 	engagement.RoE = RoE{AllowedToolClasses: []ToolClass{"sca"}}
 	if !engagement.AllowsExecution() {
 		t.Fatal("Re-test with explicit authorization window and RoE should execute")

--- a/internal/domain/scanrun/model.go
+++ b/internal/domain/scanrun/model.go
@@ -338,6 +338,16 @@ func ComputeManifestHash(lane Lane) (string, error) {
 
 	stages := make([]LaneStage, len(lane.Stages))
 	copy(stages, lane.Stages)
+	// PostgreSQL timestamptz stores microsecond precision. Hash the durable
+	// representation so a lane sealed with nanosecond Go timestamps verifies
+	// identically after a database round trip.
+	for index := range stages {
+		stages[index].StartedAt = stages[index].StartedAt.UTC().Truncate(time.Microsecond)
+		if stages[index].FinishedAt != nil {
+			finishedAt := stages[index].FinishedAt.UTC().Truncate(time.Microsecond)
+			stages[index].FinishedAt = &finishedAt
+		}
+	}
 	sort.SliceStable(stages, func(i, j int) bool {
 		return stages[i].StageKey < stages[j].StageKey
 	})

--- a/internal/domain/scanrun/model_test.go
+++ b/internal/domain/scanrun/model_test.go
@@ -198,6 +198,32 @@ func TestComputeManifestHash_LaneKeyAndStatusSensitivity(t *testing.T) {
 	}
 }
 
+func TestComputeManifestHashUsesDurableTimestampPrecision(t *testing.T) {
+	started := time.Date(2026, 9, 4, 10, 11, 12, 987654321, time.FixedZone("fixture", 7*60*60))
+	finished := started.Add(3*time.Second + 123*time.Nanosecond)
+	lane := scanrun.Lane{
+		LaneKey: "sca", Producer: "sca", TerminalStatus: scanrun.StatusSucceeded,
+		ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion,
+		Stages:                []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSucceeded, StartedAt: started, FinishedAt: &finished}},
+	}
+	original, err := scanrun.ComputeManifestHash(lane)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roundTripped := lane
+	roundTripped.Stages = append([]scanrun.LaneStage(nil), lane.Stages...)
+	roundTripped.Stages[0].StartedAt = started.UTC().Truncate(time.Microsecond)
+	roundTrippedFinished := finished.UTC().Truncate(time.Microsecond)
+	roundTripped.Stages[0].FinishedAt = &roundTrippedFinished
+	afterDatabase, err := scanrun.ComputeManifestHash(roundTripped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if original != afterDatabase {
+		t.Fatalf("manifest hash changed after timestamptz round trip: before=%s after=%s", original, afterDatabase)
+	}
+}
+
 func TestComputeRunManifestHash_OrderInvariance(t *testing.T) {
 	now := time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)
 	target, _ := scanrun.CanonicalizeRepositoryTarget("https://github.com/org/repo", "e54b4a04e54b4a04e54b4a04e54b4a04e54b4a04")

--- a/internal/infrastructure/persistence/memory/assessment_cycle_backfill_repo.go
+++ b/internal/infrastructure/persistence/memory/assessment_cycle_backfill_repo.go
@@ -1,0 +1,200 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AssessmentCycleBackfillRepository struct {
+	mu    sync.Mutex
+	runs  map[shared.ID]map[shared.ID]ports.AssessmentCycleBackfillRun
+	items map[shared.ID]map[shared.ID]map[shared.ID]ports.AssessmentCycleBackfillItem
+}
+
+func NewAssessmentCycleBackfillRepository() *AssessmentCycleBackfillRepository {
+	return &AssessmentCycleBackfillRepository{
+		runs:  map[shared.ID]map[shared.ID]ports.AssessmentCycleBackfillRun{},
+		items: map[shared.ID]map[shared.ID]map[shared.ID]ports.AssessmentCycleBackfillItem{},
+	}
+}
+
+var _ ports.AssessmentCycleBackfillStore = (*AssessmentCycleBackfillRepository)(nil)
+
+func (repository *AssessmentCycleBackfillRepository) AcquireAssessmentCycleBackfillRun(_ context.Context, request ports.AssessmentCycleBackfillAcquireRequest) (ports.AssessmentCycleBackfillRun, bool, error) {
+	if err := validateBackfillAcquire(request); err != nil {
+		return ports.AssessmentCycleBackfillRun{}, false, err
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantRuns := repository.runs[request.Run.TenantID]
+	if tenantRuns == nil {
+		tenantRuns = map[shared.ID]ports.AssessmentCycleBackfillRun{}
+		repository.runs[request.Run.TenantID] = tenantRuns
+	}
+	for id, run := range tenantRuns {
+		if run.State != ports.AssessmentCycleBackfillRunning {
+			continue
+		}
+		if run.LeaseOwner != request.Run.LeaseOwner && run.LeaseExpiresAt.After(request.Run.CreatedAt) {
+			return ports.AssessmentCycleBackfillRun{}, false, fmt.Errorf("%w: assessment cycle backfill already running for tenant", shared.ErrConflict)
+		}
+		if run.SchemaVersion != request.Run.SchemaVersion || run.DryRun != request.Run.DryRun || run.BatchSize != request.Run.BatchSize {
+			return ports.AssessmentCycleBackfillRun{}, false, fmt.Errorf("%w: requested assessment cycle backfill config (schema=%d dry_run=%t batch_size=%d) differs from persisted config (schema=%d dry_run=%t batch_size=%d)", shared.ErrConflict,
+				request.Run.SchemaVersion, request.Run.DryRun, request.Run.BatchSize, run.SchemaVersion, run.DryRun, run.BatchSize)
+		}
+		run.LeaseOwner = request.Run.LeaseOwner
+		run.LeaseToken = request.Run.LeaseToken
+		run.LeaseExpiresAt = request.Run.CreatedAt.Add(request.LeaseDuration)
+		run.UpdatedAt = request.Run.CreatedAt
+		tenantRuns[id] = run
+		return cloneBackfillRun(run), true, nil
+	}
+	run := request.Run
+	run.CheckpointAssessment = request.InitialCheckpoint
+	tenantRuns[run.ID] = run
+	return cloneBackfillRun(run), false, nil
+}
+
+func (repository *AssessmentCycleBackfillRepository) GetAssessmentCycleBackfillRun(_ context.Context, tenantID, runID shared.ID) (ports.AssessmentCycleBackfillRun, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	run, ok := repository.runs[shared.TenantOrDefault(tenantID)][runID]
+	if !ok {
+		return ports.AssessmentCycleBackfillRun{}, shared.ErrNotFound
+	}
+	return cloneBackfillRun(run), nil
+}
+
+func (repository *AssessmentCycleBackfillRepository) GetAssessmentCycleBackfillItem(_ context.Context, tenantID, runID, assessmentID shared.ID) (ports.AssessmentCycleBackfillItem, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	item, ok := repository.items[shared.TenantOrDefault(tenantID)][runID][assessmentID]
+	if !ok {
+		return ports.AssessmentCycleBackfillItem{}, shared.ErrNotFound
+	}
+	return item, nil
+}
+
+func (repository *AssessmentCycleBackfillRepository) CommitAssessmentCycleBackfillItem(ctx context.Context, tenantID, runID, leaseToken shared.ID, now time.Time, build func(context.Context) (ports.AssessmentCycleBackfillItem, error)) (ports.AssessmentCycleBackfillItem, bool, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID, now = shared.TenantOrDefault(tenantID), now.UTC()
+	run, ok := repository.runs[tenantID][runID]
+	if !ok {
+		return ports.AssessmentCycleBackfillItem{}, false, shared.ErrNotFound
+	}
+	if run.State != ports.AssessmentCycleBackfillRunning || run.LeaseToken != leaseToken || !run.LeaseExpiresAt.After(now) {
+		return ports.AssessmentCycleBackfillItem{}, false, fmt.Errorf("%w: assessment cycle backfill lease is stale", shared.ErrConflict)
+	}
+	item, err := build(shared.WithTenant(ctx, tenantID))
+	if err != nil {
+		return ports.AssessmentCycleBackfillItem{}, false, err
+	}
+	if item.TenantID != tenantID || item.RunID != runID {
+		return ports.AssessmentCycleBackfillItem{}, false, fmt.Errorf("%w: assessment cycle backfill item ownership differs from lease", shared.ErrValidation)
+	}
+	if err := validateBackfillItem(item); err != nil {
+		return ports.AssessmentCycleBackfillItem{}, false, err
+	}
+	tenantItems := repository.items[item.TenantID]
+	if tenantItems == nil {
+		tenantItems = map[shared.ID]map[shared.ID]ports.AssessmentCycleBackfillItem{}
+		repository.items[item.TenantID] = tenantItems
+	}
+	runItems := tenantItems[item.RunID]
+	if runItems == nil {
+		runItems = map[shared.ID]ports.AssessmentCycleBackfillItem{}
+		tenantItems[item.RunID] = runItems
+	}
+	if _, exists := runItems[item.AssessmentID]; exists {
+		return item, false, nil
+	}
+	runItems[item.AssessmentID] = item
+	return item, true, nil
+}
+
+func (repository *AssessmentCycleBackfillRepository) AdvanceAssessmentCycleBackfillRun(_ context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken, checkpoint shared.ID, now time.Time, leaseDuration time.Duration) (ports.AssessmentCycleBackfillRun, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	run, ok := repository.runs[tenantID][runID]
+	if !ok {
+		return ports.AssessmentCycleBackfillRun{}, shared.ErrNotFound
+	}
+	if run.State != ports.AssessmentCycleBackfillRunning || run.LeaseOwner != strings.TrimSpace(leaseOwner) || run.LeaseToken != leaseToken || !run.LeaseExpiresAt.After(now.UTC()) || checkpoint < run.CheckpointAssessment || leaseDuration <= 0 {
+		return ports.AssessmentCycleBackfillRun{}, fmt.Errorf("%w: assessment cycle backfill checkpoint rejected", shared.ErrConflict)
+	}
+	run.CheckpointAssessment, run.UpdatedAt, run.LeaseExpiresAt = checkpoint, now.UTC(), now.UTC().Add(leaseDuration)
+	recomputeBackfillCounts(&run, repository.items[tenantID][runID])
+	repository.runs[tenantID][runID] = run
+	return cloneBackfillRun(run), nil
+}
+
+func (repository *AssessmentCycleBackfillRepository) FinishAssessmentCycleBackfillRun(_ context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken shared.ID, state ports.AssessmentCycleBackfillState, now time.Time) (ports.AssessmentCycleBackfillRun, error) {
+	if state != ports.AssessmentCycleBackfillCompleted && state != ports.AssessmentCycleBackfillCancelled && state != ports.AssessmentCycleBackfillFailed {
+		return ports.AssessmentCycleBackfillRun{}, fmt.Errorf("%w: invalid assessment cycle backfill terminal state", shared.ErrValidation)
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	run, ok := repository.runs[tenantID][runID]
+	if !ok {
+		return ports.AssessmentCycleBackfillRun{}, shared.ErrNotFound
+	}
+	if run.State != ports.AssessmentCycleBackfillRunning || run.LeaseOwner != strings.TrimSpace(leaseOwner) || run.LeaseToken != leaseToken || !run.LeaseExpiresAt.After(now.UTC()) {
+		return ports.AssessmentCycleBackfillRun{}, fmt.Errorf("%w: assessment cycle backfill completion rejected", shared.ErrConflict)
+	}
+	completedAt := now.UTC()
+	run.State, run.UpdatedAt, run.CompletedAt = state, completedAt, &completedAt
+	run.LeaseOwner, run.LeaseToken, run.LeaseExpiresAt = "", "", time.Time{}
+	recomputeBackfillCounts(&run, repository.items[tenantID][runID])
+	repository.runs[tenantID][runID] = run
+	return cloneBackfillRun(run), nil
+}
+
+func validateBackfillAcquire(request ports.AssessmentCycleBackfillAcquireRequest) error {
+	run := request.Run
+	if run.TenantID.IsZero() || run.ID.IsZero() || run.LeaseToken.IsZero() || run.SchemaVersion <= 0 || run.BatchSize < 1 || run.BatchSize > 2000 || run.SnapshotAt.IsZero() || run.State != ports.AssessmentCycleBackfillRunning || strings.TrimSpace(run.LeaseOwner) == "" || len(run.LeaseOwner) > 256 || run.LeaseExpiresAt.IsZero() || strings.TrimSpace(run.CreatedBy) == "" || len(run.CreatedBy) > 256 || run.CreatedAt.IsZero() || request.LeaseDuration <= 0 {
+		return fmt.Errorf("%w: assessment cycle backfill run is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validateBackfillItem(item ports.AssessmentCycleBackfillItem) error {
+	validOutcome := item.Outcome == "created" || item.Outcome == "would_create" || item.Outcome == "skipped" || item.Outcome == "failed"
+	if item.TenantID.IsZero() || item.RunID.IsZero() || item.AssessmentID.IsZero() || item.SchemaVersion <= 0 || strings.TrimSpace(item.IdempotencyKey) == "" || len(item.IdempotencyKey) > 128 || !validOutcome || strings.TrimSpace(item.ReasonCode) == "" || len(item.ReasonCode) > 64 || len(item.RepairGuidance) > 1024 || item.ProcessedAt.IsZero() {
+		return fmt.Errorf("%w: assessment cycle backfill item is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func recomputeBackfillCounts(run *ports.AssessmentCycleBackfillRun, items map[shared.ID]ports.AssessmentCycleBackfillItem) {
+	run.ProcessedCount, run.CreatedCount, run.WouldCreateCount, run.SkippedCount, run.FailedCount = 0, 0, 0, 0, 0
+	for _, item := range items {
+		run.ProcessedCount++
+		switch item.Outcome {
+		case "created":
+			run.CreatedCount++
+		case "would_create":
+			run.WouldCreateCount++
+		case "skipped":
+			run.SkippedCount++
+		case "failed":
+			run.FailedCount++
+		}
+	}
+}
+
+func cloneBackfillRun(run ports.AssessmentCycleBackfillRun) ports.AssessmentCycleBackfillRun {
+	if run.CompletedAt != nil {
+		completedAt := *run.CompletedAt
+		run.CompletedAt = &completedAt
+	}
+	return run
+}

--- a/internal/infrastructure/persistence/memory/assessment_cycle_integrity_repo.go
+++ b/internal/infrastructure/persistence/memory/assessment_cycle_integrity_repo.go
@@ -1,0 +1,290 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AssessmentCycleIntegrityRepository struct {
+	mu          sync.Mutex
+	engagements *EngagementRepository
+	cycles      *AssessmentCycleRepository
+	runs        map[shared.ID]map[shared.ID]ports.AssessmentCycleIntegrityRun
+	subjects    map[shared.ID]map[shared.ID]map[shared.ID]ports.AssessmentCycleIntegritySubjectResult
+	findings    map[shared.ID]map[shared.ID]map[string]ports.AssessmentCycleIntegrityFinding
+}
+
+func NewAssessmentCycleIntegrityRepository(engagements *EngagementRepository, cycles *AssessmentCycleRepository) *AssessmentCycleIntegrityRepository {
+	return &AssessmentCycleIntegrityRepository{
+		engagements: engagements, cycles: cycles,
+		runs:     map[shared.ID]map[shared.ID]ports.AssessmentCycleIntegrityRun{},
+		subjects: map[shared.ID]map[shared.ID]map[shared.ID]ports.AssessmentCycleIntegritySubjectResult{},
+		findings: map[shared.ID]map[shared.ID]map[string]ports.AssessmentCycleIntegrityFinding{},
+	}
+}
+
+var _ ports.AssessmentCycleIntegritySource = (*AssessmentCycleIntegrityRepository)(nil)
+var _ ports.AssessmentCycleIntegrityStore = (*AssessmentCycleIntegrityRepository)(nil)
+
+func (repository *AssessmentCycleIntegrityRepository) ListAssessmentCycleIntegritySubjects(_ context.Context, tenantID, after shared.ID, snapshotAt time.Time, limit int) ([]ports.AssessmentCycleIntegritySubject, error) {
+	if repository.engagements == nil || repository.cycles == nil || snapshotAt.IsZero() || limit < 1 || limit > 2000 {
+		return nil, fmt.Errorf("%w: assessment cycle integrity source is invalid", shared.ErrValidation)
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.engagements.mu.RLock()
+	repository.cycles.mu.Lock()
+	defer repository.engagements.mu.RUnlock()
+	defer repository.cycles.mu.Unlock()
+	ids := make([]shared.ID, 0, limit)
+	for id, engagement := range repository.engagements.data {
+		if engagement.TenantID == tenantID && engagement.ProjectID.IsZero() && id > after && !engagement.Audit.CreatedAt.After(snapshotAt) {
+			ids = append(ids, id)
+		}
+	}
+	sort.Slice(ids, func(left, right int) bool { return ids[left] < ids[right] })
+	if len(ids) > limit {
+		ids = ids[:limit]
+	}
+	subjects := make([]ports.AssessmentCycleIntegritySubject, 0, len(ids))
+	for _, assessmentID := range ids {
+		subject := ports.AssessmentCycleIntegritySubject{TenantID: tenantID, AssessmentID: assessmentID}
+		cycleID := repository.cycles.assessmentToCycle[tenantID][assessmentID]
+		if !cycleID.IsZero() {
+			cycle := repository.cycles.cycles[tenantID][cycleID]
+			if cycle != nil {
+				record := ports.AssessmentCycleIntegrityCycle{Cycle: *cloneCycle(cycle), CycleExists: true, SubjectMembershipCount: 1}
+				for _, member := range repository.cycles.members[tenantID][cycleID] {
+					wrapped := ports.AssessmentCycleIntegrityMember{Member: *cloneMember(member)}
+					if engagement := repository.engagements.data[member.AssessmentID]; engagement != nil {
+						wrapped.AssessmentExists = true
+						wrapped.AssessmentStatus, wrapped.BusinessAssetID, wrapped.ProjectID = engagement.Status, engagement.BusinessAssetID, engagement.ProjectID
+					}
+					record.Members = append(record.Members, wrapped)
+				}
+				sort.Slice(record.Members, func(left, right int) bool {
+					leftMember, rightMember := record.Members[left].Member, record.Members[right].Member
+					if leftMember.RetestNumber == rightMember.RetestNumber {
+						return leftMember.AssessmentID < rightMember.AssessmentID
+					}
+					return leftMember.RetestNumber < rightMember.RetestNumber
+				})
+				subject.Cycles = append(subject.Cycles, record)
+			}
+		}
+		subjects = append(subjects, subject)
+	}
+	return subjects, nil
+}
+
+func (repository *AssessmentCycleIntegrityRepository) CountAssessmentCycleIntegritySubjects(_ context.Context, tenantID shared.ID, snapshotAt time.Time) (eligible int, memberships int, err error) {
+	if repository.engagements == nil || repository.cycles == nil || snapshotAt.IsZero() {
+		return 0, 0, fmt.Errorf("%w: assessment cycle integrity count is invalid", shared.ErrValidation)
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.engagements.mu.RLock()
+	repository.cycles.mu.Lock()
+	defer repository.engagements.mu.RUnlock()
+	defer repository.cycles.mu.Unlock()
+	for assessmentID, engagement := range repository.engagements.data {
+		if engagement.TenantID != tenantID || !engagement.ProjectID.IsZero() || engagement.Audit.CreatedAt.After(snapshotAt) {
+			continue
+		}
+		eligible++
+		if !repository.cycles.assessmentToCycle[tenantID][assessmentID].IsZero() {
+			memberships++
+		}
+	}
+	return eligible, memberships, nil
+}
+
+func (repository *AssessmentCycleIntegrityRepository) AcquireAssessmentCycleIntegrityRun(_ context.Context, request ports.AssessmentCycleIntegrityAcquireRequest) (ports.AssessmentCycleIntegrityRun, bool, error) {
+	if err := validateIntegrityAcquire(request); err != nil {
+		return ports.AssessmentCycleIntegrityRun{}, false, err
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantRuns := repository.runs[request.Run.TenantID]
+	if tenantRuns == nil {
+		tenantRuns = map[shared.ID]ports.AssessmentCycleIntegrityRun{}
+		repository.runs[request.Run.TenantID] = tenantRuns
+	}
+	for id, run := range tenantRuns {
+		if run.State != ports.AssessmentCycleIntegrityRunning {
+			continue
+		}
+		if run.LeaseOwner != request.Run.LeaseOwner && run.LeaseExpiresAt.After(request.Run.CreatedAt) {
+			return ports.AssessmentCycleIntegrityRun{}, false, fmt.Errorf("%w: assessment cycle integrity verifier already running for tenant", shared.ErrConflict)
+		}
+		if run.BatchSize != request.Run.BatchSize {
+			return ports.AssessmentCycleIntegrityRun{}, false, fmt.Errorf("%w: requested assessment cycle integrity batch size %d differs from persisted batch size %d", shared.ErrConflict, request.Run.BatchSize, run.BatchSize)
+		}
+		run.LeaseOwner, run.LeaseToken, run.LeaseExpiresAt, run.UpdatedAt = request.Run.LeaseOwner, request.Run.LeaseToken, request.Run.CreatedAt.Add(request.LeaseDuration), request.Run.CreatedAt
+		tenantRuns[id] = run
+		return cloneIntegrityRun(run), true, nil
+	}
+	tenantRuns[request.Run.ID] = request.Run
+	return cloneIntegrityRun(request.Run), false, nil
+}
+
+func (repository *AssessmentCycleIntegrityRepository) GetAssessmentCycleIntegrityRun(_ context.Context, tenantID, runID shared.ID) (ports.AssessmentCycleIntegrityRun, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	run, ok := repository.runs[shared.TenantOrDefault(tenantID)][runID]
+	if !ok {
+		return ports.AssessmentCycleIntegrityRun{}, shared.ErrNotFound
+	}
+	return cloneIntegrityRun(run), nil
+}
+
+func (repository *AssessmentCycleIntegrityRepository) GetAssessmentCycleIntegritySubject(_ context.Context, tenantID, runID, assessmentID shared.ID) (ports.AssessmentCycleIntegritySubjectResult, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	result, ok := repository.subjects[shared.TenantOrDefault(tenantID)][runID][assessmentID]
+	if !ok {
+		return ports.AssessmentCycleIntegritySubjectResult{}, shared.ErrNotFound
+	}
+	return result, nil
+}
+
+func (repository *AssessmentCycleIntegrityRepository) ListAssessmentCycleIntegrityFindings(_ context.Context, tenantID, runID shared.ID) ([]ports.AssessmentCycleIntegrityFinding, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	items := repository.findings[shared.TenantOrDefault(tenantID)][runID]
+	findings := make([]ports.AssessmentCycleIntegrityFinding, 0, len(items))
+	for _, finding := range items {
+		finding.RepairPlan = append([]byte(nil), finding.RepairPlan...)
+		findings = append(findings, finding)
+	}
+	sort.Slice(findings, func(left, right int) bool { return findings[left].OccurrenceID < findings[right].OccurrenceID })
+	return findings, nil
+}
+
+func (repository *AssessmentCycleIntegrityRepository) SaveAssessmentCycleIntegritySubject(_ context.Context, leaseToken shared.ID, now time.Time, result ports.AssessmentCycleIntegritySubjectResult, findings []ports.AssessmentCycleIntegrityFinding) (bool, error) {
+	if err := validateIntegritySubject(result, findings); err != nil {
+		return false, err
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	run, ok := repository.runs[result.TenantID][result.RunID]
+	if !ok {
+		return false, shared.ErrNotFound
+	}
+	if run.State != ports.AssessmentCycleIntegrityRunning || run.LeaseToken != leaseToken || !run.LeaseExpiresAt.After(now.UTC()) {
+		return false, fmt.Errorf("%w: assessment cycle integrity lease is stale", shared.ErrConflict)
+	}
+	tenantSubjects := repository.subjects[result.TenantID]
+	if tenantSubjects == nil {
+		tenantSubjects = map[shared.ID]map[shared.ID]ports.AssessmentCycleIntegritySubjectResult{}
+		repository.subjects[result.TenantID] = tenantSubjects
+	}
+	runSubjects := tenantSubjects[result.RunID]
+	if runSubjects == nil {
+		runSubjects = map[shared.ID]ports.AssessmentCycleIntegritySubjectResult{}
+		tenantSubjects[result.RunID] = runSubjects
+	}
+	if _, exists := runSubjects[result.AssessmentID]; exists {
+		return false, nil
+	}
+	runSubjects[result.AssessmentID] = result
+	tenantFindings := repository.findings[result.TenantID]
+	if tenantFindings == nil {
+		tenantFindings = map[shared.ID]map[string]ports.AssessmentCycleIntegrityFinding{}
+		repository.findings[result.TenantID] = tenantFindings
+	}
+	runFindings := tenantFindings[result.RunID]
+	if runFindings == nil {
+		runFindings = map[string]ports.AssessmentCycleIntegrityFinding{}
+		tenantFindings[result.RunID] = runFindings
+	}
+	for _, finding := range findings {
+		finding.RepairPlan = append([]byte(nil), finding.RepairPlan...)
+		runFindings[finding.OccurrenceID] = finding
+	}
+	return true, nil
+}
+
+func (repository *AssessmentCycleIntegrityRepository) AdvanceAssessmentCycleIntegrityRun(_ context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken, checkpoint shared.ID, now time.Time, leaseDuration time.Duration) (ports.AssessmentCycleIntegrityRun, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	run, ok := repository.runs[tenantID][runID]
+	if !ok {
+		return ports.AssessmentCycleIntegrityRun{}, shared.ErrNotFound
+	}
+	if run.State != ports.AssessmentCycleIntegrityRunning || run.LeaseOwner != strings.TrimSpace(leaseOwner) || run.LeaseToken != leaseToken || !run.LeaseExpiresAt.After(now.UTC()) || checkpoint < run.CheckpointAssessment || leaseDuration <= 0 {
+		return ports.AssessmentCycleIntegrityRun{}, fmt.Errorf("%w: assessment cycle integrity checkpoint rejected", shared.ErrConflict)
+	}
+	run.CheckpointAssessment, run.UpdatedAt, run.LeaseExpiresAt = checkpoint, now.UTC(), now.UTC().Add(leaseDuration)
+	recomputeIntegrityCounts(&run, repository.subjects[tenantID][runID])
+	repository.runs[tenantID][runID] = run
+	return cloneIntegrityRun(run), nil
+}
+
+func (repository *AssessmentCycleIntegrityRepository) FinishAssessmentCycleIntegrityRun(_ context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken shared.ID, state ports.AssessmentCycleIntegrityState, now time.Time) (ports.AssessmentCycleIntegrityRun, error) {
+	if state != ports.AssessmentCycleIntegrityCompleted && state != ports.AssessmentCycleIntegrityCancelled && state != ports.AssessmentCycleIntegrityFailed {
+		return ports.AssessmentCycleIntegrityRun{}, fmt.Errorf("%w: invalid assessment cycle integrity terminal state", shared.ErrValidation)
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	run, ok := repository.runs[tenantID][runID]
+	if !ok {
+		return ports.AssessmentCycleIntegrityRun{}, shared.ErrNotFound
+	}
+	if run.State != ports.AssessmentCycleIntegrityRunning || run.LeaseOwner != strings.TrimSpace(leaseOwner) || run.LeaseToken != leaseToken || !run.LeaseExpiresAt.After(now.UTC()) {
+		return ports.AssessmentCycleIntegrityRun{}, fmt.Errorf("%w: assessment cycle integrity completion rejected", shared.ErrConflict)
+	}
+	completedAt := now.UTC()
+	run.State, run.UpdatedAt, run.CompletedAt = state, completedAt, &completedAt
+	run.LeaseOwner, run.LeaseToken, run.LeaseExpiresAt = "", "", time.Time{}
+	recomputeIntegrityCounts(&run, repository.subjects[tenantID][runID])
+	repository.runs[tenantID][runID] = run
+	return cloneIntegrityRun(run), nil
+}
+
+func validateIntegrityAcquire(request ports.AssessmentCycleIntegrityAcquireRequest) error {
+	run := request.Run
+	if run.TenantID.IsZero() || run.ID.IsZero() || run.LeaseToken.IsZero() || run.BatchSize < 1 || run.BatchSize > 2000 || run.SnapshotAt.IsZero() || run.State != ports.AssessmentCycleIntegrityRunning || strings.TrimSpace(run.LeaseOwner) == "" || len(run.LeaseOwner) > 256 || strings.TrimSpace(run.CreatedBy) == "" || len(run.CreatedBy) > 256 || run.CreatedAt.IsZero() || request.LeaseDuration <= 0 {
+		return fmt.Errorf("%w: assessment cycle integrity run is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validateIntegritySubject(result ports.AssessmentCycleIntegritySubjectResult, findings []ports.AssessmentCycleIntegrityFinding) error {
+	if result.TenantID.IsZero() || result.RunID.IsZero() || result.AssessmentID.IsZero() || result.FindingCount != len(findings) || result.Clean != (len(findings) == 0) || result.ProcessedAt.IsZero() {
+		return fmt.Errorf("%w: assessment cycle integrity subject result is invalid", shared.ErrValidation)
+	}
+	for _, finding := range findings {
+		validSeverity := finding.Severity == "medium" || finding.Severity == "high" || finding.Severity == "critical"
+		if finding.TenantID != result.TenantID || finding.RunID != result.RunID || finding.AssessmentID != result.AssessmentID || strings.TrimSpace(finding.OccurrenceID) == "" || len(finding.OccurrenceID) > 64 || strings.TrimSpace(finding.ReasonCode) == "" || len(finding.ReasonCode) > 64 || !validSeverity || len(finding.RepairPlan) == 0 || len(finding.RepairPlan) > 8192 || finding.DetectedAt.IsZero() {
+			return fmt.Errorf("%w: assessment cycle integrity finding is invalid", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+func recomputeIntegrityCounts(run *ports.AssessmentCycleIntegrityRun, subjects map[shared.ID]ports.AssessmentCycleIntegritySubjectResult) {
+	run.ScannedCount, run.CleanCount, run.FindingCount = 0, 0, 0
+	for _, subject := range subjects {
+		run.ScannedCount++
+		if subject.Clean {
+			run.CleanCount++
+		}
+		run.FindingCount += subject.FindingCount
+	}
+}
+
+func cloneIntegrityRun(run ports.AssessmentCycleIntegrityRun) ports.AssessmentCycleIntegrityRun {
+	if run.CompletedAt != nil {
+		completedAt := *run.CompletedAt
+		run.CompletedAt = &completedAt
+	}
+	return run
+}

--- a/internal/infrastructure/persistence/memory/assessment_cycle_integrity_repo.go
+++ b/internal/infrastructure/persistence/memory/assessment_cycle_integrity_repo.go
@@ -2,6 +2,9 @@ package memory
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -32,6 +35,18 @@ func NewAssessmentCycleIntegrityRepository(engagements *EngagementRepository, cy
 
 var _ ports.AssessmentCycleIntegritySource = (*AssessmentCycleIntegrityRepository)(nil)
 var _ ports.AssessmentCycleIntegrityStore = (*AssessmentCycleIntegrityRepository)(nil)
+
+func (repository *AssessmentCycleIntegrityRepository) AssessmentCycleIntegrityGeneration(_ context.Context, tenantID shared.ID) (int64, error) {
+	if repository.engagements == nil || repository.cycles == nil {
+		return 0, fmt.Errorf("%w: assessment cycle integrity source is invalid", shared.ErrValidation)
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.engagements.mu.RLock()
+	repository.cycles.mu.Lock()
+	defer repository.engagements.mu.RUnlock()
+	defer repository.cycles.mu.Unlock()
+	return repository.currentSourceGenerationLocked(tenantID)
+}
 
 func (repository *AssessmentCycleIntegrityRepository) ListAssessmentCycleIntegritySubjects(_ context.Context, tenantID, after shared.ID, snapshotAt time.Time, limit int) ([]ports.AssessmentCycleIntegritySubject, error) {
 	if repository.engagements == nil || repository.cycles == nil || snapshotAt.IsZero() || limit < 1 || limit > 2000 {
@@ -241,6 +256,23 @@ func (repository *AssessmentCycleIntegrityRepository) FinishAssessmentCycleInteg
 	if run.State != ports.AssessmentCycleIntegrityRunning || run.LeaseOwner != strings.TrimSpace(leaseOwner) || run.LeaseToken != leaseToken || !run.LeaseExpiresAt.After(now.UTC()) {
 		return ports.AssessmentCycleIntegrityRun{}, fmt.Errorf("%w: assessment cycle integrity completion rejected", shared.ErrConflict)
 	}
+	if state == ports.AssessmentCycleIntegrityCompleted {
+		repository.engagements.mu.RLock()
+		repository.cycles.mu.Lock()
+		generation, err := repository.currentSourceGenerationLocked(tenantID)
+		if err != nil {
+			repository.cycles.mu.Unlock()
+			repository.engagements.mu.RUnlock()
+			return ports.AssessmentCycleIntegrityRun{}, err
+		}
+		if generation != run.SourceGeneration {
+			repository.cycles.mu.Unlock()
+			repository.engagements.mu.RUnlock()
+			return ports.AssessmentCycleIntegrityRun{}, fmt.Errorf("%w: assessment cycle integrity source changed", shared.ErrConflict)
+		}
+		defer repository.engagements.mu.RUnlock()
+		defer repository.cycles.mu.Unlock()
+	}
 	completedAt := now.UTC()
 	run.State, run.UpdatedAt, run.CompletedAt = state, completedAt, &completedAt
 	run.LeaseOwner, run.LeaseToken, run.LeaseExpiresAt = "", "", time.Time{}
@@ -287,4 +319,45 @@ func cloneIntegrityRun(run ports.AssessmentCycleIntegrityRun) ports.AssessmentCy
 		run.CompletedAt = &completedAt
 	}
 	return run
+}
+
+func (repository *AssessmentCycleIntegrityRepository) currentSourceGenerationLocked(tenantID shared.ID) (int64, error) {
+	type sourceState struct {
+		Engagements []any `json:"engagements"`
+		Cycles      []any `json:"cycles"`
+		Members     []any `json:"members"`
+	}
+	state := sourceState{}
+	engagementIDs := make([]shared.ID, 0)
+	for assessmentID, assessment := range repository.engagements.data {
+		if assessment.TenantID == tenantID && assessment.ProjectID.IsZero() {
+			engagementIDs = append(engagementIDs, assessmentID)
+		}
+	}
+	sort.Slice(engagementIDs, func(left, right int) bool { return engagementIDs[left] < engagementIDs[right] })
+	for _, assessmentID := range engagementIDs {
+		state.Engagements = append(state.Engagements, repository.engagements.data[assessmentID])
+	}
+	cycleIDs := make([]shared.ID, 0, len(repository.cycles.cycles[tenantID]))
+	for cycleID := range repository.cycles.cycles[tenantID] {
+		cycleIDs = append(cycleIDs, cycleID)
+	}
+	sort.Slice(cycleIDs, func(left, right int) bool { return cycleIDs[left] < cycleIDs[right] })
+	for _, cycleID := range cycleIDs {
+		state.Cycles = append(state.Cycles, repository.cycles.cycles[tenantID][cycleID])
+		memberIDs := make([]shared.ID, 0, len(repository.cycles.members[tenantID][cycleID]))
+		for assessmentID := range repository.cycles.members[tenantID][cycleID] {
+			memberIDs = append(memberIDs, assessmentID)
+		}
+		sort.Slice(memberIDs, func(left, right int) bool { return memberIDs[left] < memberIDs[right] })
+		for _, assessmentID := range memberIDs {
+			state.Members = append(state.Members, repository.cycles.members[tenantID][cycleID][assessmentID])
+		}
+	}
+	payload, err := json.Marshal(state)
+	if err != nil {
+		return 0, fmt.Errorf("hash assessment cycle integrity source: %w", err)
+	}
+	digest := sha256.Sum256(payload)
+	return int64(binary.BigEndian.Uint64(digest[:8]) & uint64(^uint64(0)>>1)), nil
 }

--- a/internal/infrastructure/persistence/memory/assessment_cycle_repo.go
+++ b/internal/infrastructure/persistence/memory/assessment_cycle_repo.go
@@ -3,6 +3,8 @@ package memory
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
@@ -28,6 +30,8 @@ func NewAssessmentCycleRepository() *AssessmentCycleRepository {
 }
 
 var _ ports.AssessmentCycleRepository = (*AssessmentCycleRepository)(nil)
+var _ ports.AssessmentCycleListRepository = (*AssessmentCycleRepository)(nil)
+var _ ports.AssessmentCycleCompensationRepository = (*AssessmentCycleRepository)(nil)
 
 func (r *AssessmentCycleRepository) CreateCycle(ctx context.Context, cycle *assessmentcycle.AssessmentCycle) error {
 	if cycle == nil {
@@ -234,6 +238,114 @@ func (r *AssessmentCycleRepository) UpdateMemberCAS(ctx context.Context, member 
 
 func (r *AssessmentCycleRepository) LockCycleForUpdate(ctx context.Context, tenantID, cycleID shared.ID) (*assessmentcycle.AssessmentCycle, error) {
 	return r.GetCycle(ctx, tenantID, cycleID)
+}
+
+func (r *AssessmentCycleRepository) DeleteCycle(_ context.Context, tenantID, cycleID shared.ID) error {
+	tenantID = shared.TenantOrDefault(tenantID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for assessmentID := range r.members[tenantID][cycleID] {
+		delete(r.assessmentToCycle[tenantID], assessmentID)
+	}
+	delete(r.members[tenantID], cycleID)
+	delete(r.cycles[tenantID], cycleID)
+	return nil
+}
+
+func (r *AssessmentCycleRepository) DeleteMember(_ context.Context, tenantID, cycleID, assessmentID shared.ID) error {
+	tenantID = shared.TenantOrDefault(tenantID)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.members[tenantID][cycleID], assessmentID)
+	delete(r.assessmentToCycle[tenantID], assessmentID)
+	return nil
+}
+
+func (r *AssessmentCycleRepository) ListCycles(_ context.Context, query ports.AssessmentCycleListQuery) ([]ports.AssessmentCycleListRecord, error) {
+	tenantID := shared.TenantOrDefault(query.TenantID)
+	if tenantID.IsZero() || query.Limit <= 0 {
+		return nil, fmt.Errorf("%w: tenant and positive cycle list limit are required", shared.ErrValidation)
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if query.MemberLimit <= 0 {
+		query.MemberLimit = 10
+	}
+	records := make([]ports.AssessmentCycleListRecord, 0, len(r.cycles[tenantID]))
+	for _, cycle := range r.cycles[tenantID] {
+		if cycle.TenantID != tenantID || query.Status != "" && cycle.Status != query.Status || query.BoundaryKind != "" && cycle.BoundaryKind != query.BoundaryKind {
+			continue
+		}
+		if !query.SelectedHeadID.IsZero() && cycle.SelectedHeadAssessmentID != query.SelectedHeadID {
+			continue
+		}
+		if query.Search != "" {
+			needle := strings.ToLower(query.Search)
+			if !strings.Contains(strings.ToLower(cycle.Name), needle) && !strings.Contains(strings.ToLower(cycle.ID.String()), needle) &&
+				!strings.Contains(strings.ToLower(cycle.RootAssessmentID.String()), needle) && !strings.Contains(strings.ToLower(cycle.SelectedHeadAssessmentID.String()), needle) {
+				continue
+			}
+		}
+		if query.AssessmentStatus != "" || query.ScanStaleness != "" {
+			continue
+		}
+		if !query.AfterUpdatedAt.IsZero() && (cycle.UpdatedAt.After(query.AfterUpdatedAt) || cycle.UpdatedAt.Equal(query.AfterUpdatedAt) && cycle.ID >= query.AfterCycleID) {
+			continue
+		}
+		members := make([]assessmentcycle.Member, 0)
+		for _, member := range r.members[tenantID][cycle.ID] {
+			members = append(members, *cloneMember(member))
+		}
+		if query.AssessmentType != "" {
+			matched := false
+			for _, member := range members {
+				if member.AssessmentType == query.AssessmentType {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+		sort.Slice(members, func(left, right int) bool {
+			if members[left].RetestNumber == members[right].RetestNumber {
+				return members[left].AssessmentID < members[right].AssessmentID
+			}
+			return members[left].RetestNumber < members[right].RetestNumber
+		})
+		latestID, latestNumber := shared.ID(""), -1
+		activeCount := 0
+		for _, member := range members {
+			if member.IsArchived() {
+				continue
+			}
+			activeCount++
+			if member.RetestNumber > latestNumber || member.RetestNumber == latestNumber && member.AssessmentID > latestID {
+				latestID, latestNumber = member.AssessmentID, member.RetestNumber
+			}
+		}
+		records = append(records, ports.AssessmentCycleListRecord{
+			Cycle: *cloneCycle(cycle), MemberCount: activeCount, ActiveBranchCount: len(assessmentcycle.DeriveBranchHeads(members)),
+			LatestAssessmentID: latestID, LatestRetestNumber: latestNumber,
+			Members:         append([]assessmentcycle.Member(nil), members[:min(len(members), query.MemberLimit)]...),
+			MembersHaveMore: len(members) > query.MemberLimit,
+		})
+	}
+	sort.Slice(records, func(left, right int) bool {
+		if records[left].Cycle.UpdatedAt.Equal(records[right].Cycle.UpdatedAt) {
+			return records[left].Cycle.ID > records[right].Cycle.ID
+		}
+		return records[left].Cycle.UpdatedAt.After(records[right].Cycle.UpdatedAt)
+	})
+	if len(records) > query.Limit {
+		records = records[:query.Limit]
+	}
+	return records, nil
+}
+
+func (r *AssessmentCycleRepository) ListMigrationPendingAssessments(context.Context, ports.AssessmentCycleListQuery) ([]ports.AssessmentCycleMigrationPendingRecord, int, error) {
+	return nil, 0, nil
 }
 
 func cloneCycle(c *assessmentcycle.AssessmentCycle) *assessmentcycle.AssessmentCycle {

--- a/internal/infrastructure/persistence/memory/assessment_cycle_repo.go
+++ b/internal/infrastructure/persistence/memory/assessment_cycle_repo.go
@@ -45,6 +45,7 @@ func (r *AssessmentCycleRepository) CreateCycle(ctx context.Context, cycle *asse
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.registerRollback(ctx)
 
 	tenantCycles := r.cycles[tenantID]
 	if tenantCycles == nil {
@@ -121,6 +122,7 @@ func (r *AssessmentCycleRepository) UpdateCycleCAS(ctx context.Context, cycle *a
 		return fmt.Errorf("%w: cycle version mismatch (expected %d, found %d)", shared.ErrConflict, expectedVersion, existing.Version)
 	}
 
+	r.registerRollback(ctx)
 	r.cycles[tenantID][cycle.ID] = cloneCycle(cycle)
 	return nil
 }
@@ -137,6 +139,7 @@ func (r *AssessmentCycleRepository) CreateMember(ctx context.Context, member *as
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.registerRollback(ctx)
 
 	// Enforce global uniqueness: one Assessment in at most one Cycle
 	tenantAssToCycle := r.assessmentToCycle[tenantID]
@@ -232,6 +235,7 @@ func (r *AssessmentCycleRepository) UpdateMemberCAS(ctx context.Context, member 
 		return fmt.Errorf("%w: member relationship version mismatch (expected %d, found %d)", shared.ErrConflict, expectedVersion, existing.RelationshipVersion)
 	}
 
+	r.registerRollback(ctx)
 	r.members[tenantID][member.CycleID][member.AssessmentID] = cloneMember(member)
 	return nil
 }
@@ -240,10 +244,11 @@ func (r *AssessmentCycleRepository) LockCycleForUpdate(ctx context.Context, tena
 	return r.GetCycle(ctx, tenantID, cycleID)
 }
 
-func (r *AssessmentCycleRepository) DeleteCycle(_ context.Context, tenantID, cycleID shared.ID) error {
+func (r *AssessmentCycleRepository) DeleteCycle(ctx context.Context, tenantID, cycleID shared.ID) error {
 	tenantID = shared.TenantOrDefault(tenantID)
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.registerRollback(ctx)
 	for assessmentID := range r.members[tenantID][cycleID] {
 		delete(r.assessmentToCycle[tenantID], assessmentID)
 	}
@@ -252,10 +257,11 @@ func (r *AssessmentCycleRepository) DeleteCycle(_ context.Context, tenantID, cyc
 	return nil
 }
 
-func (r *AssessmentCycleRepository) DeleteMember(_ context.Context, tenantID, cycleID, assessmentID shared.ID) error {
+func (r *AssessmentCycleRepository) DeleteMember(ctx context.Context, tenantID, cycleID, assessmentID shared.ID) error {
 	tenantID = shared.TenantOrDefault(tenantID)
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	r.registerRollback(ctx)
 	delete(r.members[tenantID][cycleID], assessmentID)
 	delete(r.assessmentToCycle[tenantID], assessmentID)
 	return nil
@@ -366,4 +372,49 @@ func cloneMember(m *assessmentcycle.Member) *assessmentcycle.Member {
 		copy.ArchivedAt = &t
 	}
 	return &copy
+}
+
+type assessmentCycleRepositoryState struct {
+	cycles            map[shared.ID]map[shared.ID]*assessmentcycle.AssessmentCycle
+	members           map[shared.ID]map[shared.ID]map[shared.ID]*assessmentcycle.Member
+	assessmentToCycle map[shared.ID]map[shared.ID]shared.ID
+}
+
+func (r *AssessmentCycleRepository) registerRollback(ctx context.Context) {
+	state := r.cloneState()
+	registerTenantRollback(ctx, func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.cycles, r.members, r.assessmentToCycle = state.cycles, state.members, state.assessmentToCycle
+	})
+}
+
+func (r *AssessmentCycleRepository) cloneState() assessmentCycleRepositoryState {
+	state := assessmentCycleRepositoryState{
+		cycles:            make(map[shared.ID]map[shared.ID]*assessmentcycle.AssessmentCycle, len(r.cycles)),
+		members:           make(map[shared.ID]map[shared.ID]map[shared.ID]*assessmentcycle.Member, len(r.members)),
+		assessmentToCycle: make(map[shared.ID]map[shared.ID]shared.ID, len(r.assessmentToCycle)),
+	}
+	for tenantID, tenantCycles := range r.cycles {
+		state.cycles[tenantID] = make(map[shared.ID]*assessmentcycle.AssessmentCycle, len(tenantCycles))
+		for cycleID, cycle := range tenantCycles {
+			state.cycles[tenantID][cycleID] = cloneCycle(cycle)
+		}
+	}
+	for tenantID, tenantMembers := range r.members {
+		state.members[tenantID] = make(map[shared.ID]map[shared.ID]*assessmentcycle.Member, len(tenantMembers))
+		for cycleID, cycleMembers := range tenantMembers {
+			state.members[tenantID][cycleID] = make(map[shared.ID]*assessmentcycle.Member, len(cycleMembers))
+			for assessmentID, member := range cycleMembers {
+				state.members[tenantID][cycleID][assessmentID] = cloneMember(member)
+			}
+		}
+	}
+	for tenantID, mappings := range r.assessmentToCycle {
+		state.assessmentToCycle[tenantID] = make(map[shared.ID]shared.ID, len(mappings))
+		for assessmentID, cycleID := range mappings {
+			state.assessmentToCycle[tenantID][assessmentID] = cycleID
+		}
+	}
+	return state
 }

--- a/internal/infrastructure/persistence/memory/assessment_cycle_request_repo.go
+++ b/internal/infrastructure/persistence/memory/assessment_cycle_request_repo.go
@@ -1,0 +1,85 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AssessmentCycleRequestRepository struct {
+	mu       sync.Mutex
+	requests map[string]ports.AssessmentCycleRequest
+}
+
+func NewAssessmentCycleRequestRepository() *AssessmentCycleRequestRepository {
+	return &AssessmentCycleRequestRepository{requests: map[string]ports.AssessmentCycleRequest{}}
+}
+
+var _ ports.AssessmentCycleRequestStore = (*AssessmentCycleRequestRepository)(nil)
+
+func (repository *AssessmentCycleRequestRepository) BeginAssessmentCycleRequest(_ context.Context, request ports.AssessmentCycleRequest) (ports.AssessmentCycleRequest, bool, error) {
+	if err := validateAssessmentCycleRequest(request); err != nil {
+		return ports.AssessmentCycleRequest{}, false, err
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	key := assessmentCycleRequestKey(request.Scope)
+	if stored, exists := repository.requests[key]; exists {
+		return cloneAssessmentCycleRequest(stored), false, nil
+	}
+	repository.requests[key] = cloneAssessmentCycleRequest(request)
+	return cloneAssessmentCycleRequest(request), true, nil
+}
+
+func (repository *AssessmentCycleRequestRepository) CompleteAssessmentCycleRequest(_ context.Context, scope ports.AssessmentCycleRequestScope, requestHash string, statusCode int, responseBody []byte, completedAt time.Time) error {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	key := assessmentCycleRequestKey(scope)
+	stored, exists := repository.requests[key]
+	if !exists {
+		return fmt.Errorf("%w: assessment cycle request reservation not found", shared.ErrNotFound)
+	}
+	if stored.RequestHash != requestHash || stored.CompletedAt != nil {
+		return fmt.Errorf("%w: assessment cycle request completion conflict", shared.ErrConflict)
+	}
+	completedAt = completedAt.UTC()
+	stored.StatusCode, stored.ResponseBody, stored.CompletedAt = statusCode, append([]byte(nil), responseBody...), &completedAt
+	repository.requests[key] = stored
+	return nil
+}
+
+func (repository *AssessmentCycleRequestRepository) AbortAssessmentCycleRequest(_ context.Context, scope ports.AssessmentCycleRequestScope, requestHash string) error {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	key := assessmentCycleRequestKey(scope)
+	stored, exists := repository.requests[key]
+	if exists && stored.RequestHash == requestHash && stored.CompletedAt == nil {
+		delete(repository.requests, key)
+	}
+	return nil
+}
+
+func validateAssessmentCycleRequest(request ports.AssessmentCycleRequest) error {
+	if shared.TenantOrDefault(request.Scope.TenantID).IsZero() || strings.TrimSpace(request.Scope.Actor) == "" || strings.TrimSpace(request.Scope.Route) == "" || strings.TrimSpace(request.Scope.IdempotencyKey) == "" || len(request.Scope.IdempotencyKey) > 128 || len(request.RequestHash) != 64 || request.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: assessment cycle idempotency request is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func assessmentCycleRequestKey(scope ports.AssessmentCycleRequestScope) string {
+	return strings.Join([]string{shared.TenantOrDefault(scope.TenantID).String(), scope.Actor, scope.Route, scope.IdempotencyKey}, "\x00")
+}
+
+func cloneAssessmentCycleRequest(request ports.AssessmentCycleRequest) ports.AssessmentCycleRequest {
+	request.ResponseBody = append([]byte(nil), request.ResponseBody...)
+	if request.CompletedAt != nil {
+		completedAt := *request.CompletedAt
+		request.CompletedAt = &completedAt
+	}
+	return request
+}

--- a/internal/infrastructure/persistence/memory/assessment_cycle_request_repo.go
+++ b/internal/infrastructure/persistence/memory/assessment_cycle_request_repo.go
@@ -22,12 +22,21 @@ func NewAssessmentCycleRequestRepository() *AssessmentCycleRequestRepository {
 
 var _ ports.AssessmentCycleRequestStore = (*AssessmentCycleRequestRepository)(nil)
 
-func (repository *AssessmentCycleRequestRepository) BeginAssessmentCycleRequest(_ context.Context, request ports.AssessmentCycleRequest) (ports.AssessmentCycleRequest, bool, error) {
+func (repository *AssessmentCycleRequestRepository) BeginAssessmentCycleRequest(ctx context.Context, request ports.AssessmentCycleRequest) (ports.AssessmentCycleRequest, bool, error) {
+	if request.ExpiresAt.IsZero() {
+		request.ExpiresAt = request.CreatedAt.Add(24 * time.Hour)
+	}
 	if err := validateAssessmentCycleRequest(request); err != nil {
 		return ports.AssessmentCycleRequest{}, false, err
 	}
 	repository.mu.Lock()
 	defer repository.mu.Unlock()
+	repository.registerRollback(ctx)
+	for storedKey, stored := range repository.requests {
+		if !stored.ExpiresAt.After(request.CreatedAt) {
+			delete(repository.requests, storedKey)
+		}
+	}
 	key := assessmentCycleRequestKey(request.Scope)
 	if stored, exists := repository.requests[key]; exists {
 		return cloneAssessmentCycleRequest(stored), false, nil
@@ -36,7 +45,7 @@ func (repository *AssessmentCycleRequestRepository) BeginAssessmentCycleRequest(
 	return cloneAssessmentCycleRequest(request), true, nil
 }
 
-func (repository *AssessmentCycleRequestRepository) CompleteAssessmentCycleRequest(_ context.Context, scope ports.AssessmentCycleRequestScope, requestHash string, statusCode int, responseBody []byte, completedAt time.Time) error {
+func (repository *AssessmentCycleRequestRepository) CompleteAssessmentCycleRequest(ctx context.Context, scope ports.AssessmentCycleRequestScope, requestHash string, statusCode int, responseBody []byte, completedAt time.Time) error {
 	repository.mu.Lock()
 	defer repository.mu.Unlock()
 	key := assessmentCycleRequestKey(scope)
@@ -47,28 +56,42 @@ func (repository *AssessmentCycleRequestRepository) CompleteAssessmentCycleReque
 	if stored.RequestHash != requestHash || stored.CompletedAt != nil {
 		return fmt.Errorf("%w: assessment cycle request completion conflict", shared.ErrConflict)
 	}
+	repository.registerRollback(ctx)
 	completedAt = completedAt.UTC()
 	stored.StatusCode, stored.ResponseBody, stored.CompletedAt = statusCode, append([]byte(nil), responseBody...), &completedAt
 	repository.requests[key] = stored
 	return nil
 }
 
-func (repository *AssessmentCycleRequestRepository) AbortAssessmentCycleRequest(_ context.Context, scope ports.AssessmentCycleRequestScope, requestHash string) error {
+func (repository *AssessmentCycleRequestRepository) AbortAssessmentCycleRequest(ctx context.Context, scope ports.AssessmentCycleRequestScope, requestHash string) error {
 	repository.mu.Lock()
 	defer repository.mu.Unlock()
 	key := assessmentCycleRequestKey(scope)
 	stored, exists := repository.requests[key]
 	if exists && stored.RequestHash == requestHash && stored.CompletedAt == nil {
+		repository.registerRollback(ctx)
 		delete(repository.requests, key)
 	}
 	return nil
 }
 
 func validateAssessmentCycleRequest(request ports.AssessmentCycleRequest) error {
-	if shared.TenantOrDefault(request.Scope.TenantID).IsZero() || strings.TrimSpace(request.Scope.Actor) == "" || strings.TrimSpace(request.Scope.Route) == "" || strings.TrimSpace(request.Scope.IdempotencyKey) == "" || len(request.Scope.IdempotencyKey) > 128 || len(request.RequestHash) != 64 || request.CreatedAt.IsZero() {
+	if shared.TenantOrDefault(request.Scope.TenantID).IsZero() || strings.TrimSpace(request.Scope.Actor) == "" || strings.TrimSpace(request.Scope.Route) == "" || strings.TrimSpace(request.Scope.IdempotencyKey) == "" || len(request.Scope.IdempotencyKey) > 128 || len(request.RequestHash) != 64 || request.CreatedAt.IsZero() || !request.ExpiresAt.After(request.CreatedAt) {
 		return fmt.Errorf("%w: assessment cycle idempotency request is invalid", shared.ErrValidation)
 	}
 	return nil
+}
+
+func (repository *AssessmentCycleRequestRepository) registerRollback(ctx context.Context) {
+	previous := make(map[string]ports.AssessmentCycleRequest, len(repository.requests))
+	for key, request := range repository.requests {
+		previous[key] = cloneAssessmentCycleRequest(request)
+	}
+	registerTenantRollback(ctx, func() {
+		repository.mu.Lock()
+		defer repository.mu.Unlock()
+		repository.requests = previous
+	})
 }
 
 func assessmentCycleRequestKey(scope ports.AssessmentCycleRequestScope) string {

--- a/internal/infrastructure/persistence/memory/assessment_snapshot_backfill_repo.go
+++ b/internal/infrastructure/persistence/memory/assessment_snapshot_backfill_repo.go
@@ -1,0 +1,208 @@
+package memory
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AssessmentSnapshotBackfillRepository struct {
+	mu    sync.Mutex
+	runs  map[shared.ID]map[shared.ID]ports.AssessmentSnapshotBackfillRun
+	items map[shared.ID]map[shared.ID]map[shared.ID]ports.AssessmentSnapshotBackfillItem
+}
+
+func NewAssessmentSnapshotBackfillRepository() *AssessmentSnapshotBackfillRepository {
+	return &AssessmentSnapshotBackfillRepository{
+		runs:  map[shared.ID]map[shared.ID]ports.AssessmentSnapshotBackfillRun{},
+		items: map[shared.ID]map[shared.ID]map[shared.ID]ports.AssessmentSnapshotBackfillItem{},
+	}
+}
+
+var _ ports.AssessmentSnapshotBackfillStore = (*AssessmentSnapshotBackfillRepository)(nil)
+
+func (repository *AssessmentSnapshotBackfillRepository) AcquireAssessmentSnapshotBackfillRun(_ context.Context, request ports.AssessmentSnapshotBackfillAcquireRequest) (ports.AssessmentSnapshotBackfillRun, bool, error) {
+	if err := validateAssessmentSnapshotBackfillAcquire(request); err != nil {
+		return ports.AssessmentSnapshotBackfillRun{}, false, err
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantRuns := repository.runs[request.Run.TenantID]
+	if tenantRuns == nil {
+		tenantRuns = map[shared.ID]ports.AssessmentSnapshotBackfillRun{}
+		repository.runs[request.Run.TenantID] = tenantRuns
+	}
+	for id, run := range tenantRuns {
+		if run.State != ports.AssessmentSnapshotBackfillRunning {
+			continue
+		}
+		if run.LeaseOwner != request.Run.LeaseOwner && run.LeaseExpiresAt.After(request.Run.CreatedAt) {
+			return ports.AssessmentSnapshotBackfillRun{}, false, fmt.Errorf("%w: assessment snapshot backfill already running for tenant", shared.ErrConflict)
+		}
+		if run.SchemaVersion != request.Run.SchemaVersion || run.DryRun != request.Run.DryRun || run.BatchSize != request.Run.BatchSize {
+			return ports.AssessmentSnapshotBackfillRun{}, false, fmt.Errorf("%w: requested assessment snapshot backfill config (schema=%d dry_run=%t batch_size=%d) differs from persisted config (schema=%d dry_run=%t batch_size=%d)", shared.ErrConflict,
+				request.Run.SchemaVersion, request.Run.DryRun, request.Run.BatchSize, run.SchemaVersion, run.DryRun, run.BatchSize)
+		}
+		run.LeaseOwner = request.Run.LeaseOwner
+		run.LeaseToken = request.Run.LeaseToken
+		run.LeaseExpiresAt = request.Run.CreatedAt.Add(request.LeaseDuration)
+		run.UpdatedAt = request.Run.CreatedAt
+		tenantRuns[id] = run
+		return cloneAssessmentSnapshotBackfillRun(run), true, nil
+	}
+	run := request.Run
+	run.CheckpointAssessment = request.InitialCheckpoint
+	run.LeaseExpiresAt = run.CreatedAt.Add(request.LeaseDuration)
+	tenantRuns[run.ID] = run
+	return cloneAssessmentSnapshotBackfillRun(run), false, nil
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) GetAssessmentSnapshotBackfillRun(_ context.Context, tenantID, runID shared.ID) (ports.AssessmentSnapshotBackfillRun, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	run, ok := repository.runs[tenantID][runID]
+	if !ok {
+		return ports.AssessmentSnapshotBackfillRun{}, shared.ErrNotFound
+	}
+	return cloneAssessmentSnapshotBackfillRun(run), nil
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) GetAssessmentSnapshotBackfillItem(_ context.Context, tenantID, runID, assessmentID shared.ID) (ports.AssessmentSnapshotBackfillItem, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	item, ok := repository.items[tenantID][runID][assessmentID]
+	if !ok {
+		return ports.AssessmentSnapshotBackfillItem{}, shared.ErrNotFound
+	}
+	return item, nil
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) CommitAssessmentSnapshotBackfillItem(ctx context.Context, tenantID, runID, leaseToken shared.ID, now time.Time, build func(context.Context) (ports.AssessmentSnapshotBackfillItem, error)) (ports.AssessmentSnapshotBackfillItem, bool, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID, now = shared.TenantOrDefault(tenantID), now.UTC()
+	run, ok := repository.runs[tenantID][runID]
+	if !ok {
+		return ports.AssessmentSnapshotBackfillItem{}, false, shared.ErrNotFound
+	}
+	if run.State != ports.AssessmentSnapshotBackfillRunning || run.LeaseToken != leaseToken || !run.LeaseExpiresAt.After(now) {
+		return ports.AssessmentSnapshotBackfillItem{}, false, fmt.Errorf("%w: assessment snapshot backfill lease is stale", shared.ErrConflict)
+	}
+	item, err := build(shared.WithTenant(ctx, tenantID))
+	if err != nil {
+		return ports.AssessmentSnapshotBackfillItem{}, false, err
+	}
+	if item.TenantID != tenantID || item.RunID != runID {
+		return ports.AssessmentSnapshotBackfillItem{}, false, fmt.Errorf("%w: assessment snapshot backfill item ownership differs from lease", shared.ErrValidation)
+	}
+	if err := validateAssessmentSnapshotBackfillItem(item); err != nil {
+		return ports.AssessmentSnapshotBackfillItem{}, false, err
+	}
+	tenantItems := repository.items[item.TenantID]
+	if tenantItems == nil {
+		tenantItems = map[shared.ID]map[shared.ID]ports.AssessmentSnapshotBackfillItem{}
+		repository.items[item.TenantID] = tenantItems
+	}
+	runItems := tenantItems[item.RunID]
+	if runItems == nil {
+		runItems = map[shared.ID]ports.AssessmentSnapshotBackfillItem{}
+		tenantItems[item.RunID] = runItems
+	}
+	if _, exists := runItems[item.AssessmentID]; exists {
+		return item, false, nil
+	}
+	runItems[item.AssessmentID] = item
+	return item, true, nil
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) AdvanceAssessmentSnapshotBackfillRun(_ context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken, checkpoint shared.ID, now time.Time, leaseDuration time.Duration) (ports.AssessmentSnapshotBackfillRun, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	run, ok := repository.runs[tenantID][runID]
+	if !ok {
+		return ports.AssessmentSnapshotBackfillRun{}, shared.ErrNotFound
+	}
+	if run.State != ports.AssessmentSnapshotBackfillRunning || run.LeaseOwner != strings.TrimSpace(leaseOwner) || run.LeaseToken != leaseToken || !run.LeaseExpiresAt.After(now.UTC()) || checkpoint < run.CheckpointAssessment || leaseDuration <= 0 {
+		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: assessment snapshot backfill checkpoint rejected", shared.ErrConflict)
+	}
+	run.CheckpointAssessment, run.UpdatedAt, run.LeaseExpiresAt = checkpoint, now.UTC(), now.UTC().Add(leaseDuration)
+	recomputeAssessmentSnapshotBackfillCounts(&run, repository.items[tenantID][runID])
+	repository.runs[tenantID][runID] = run
+	return cloneAssessmentSnapshotBackfillRun(run), nil
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) FinishAssessmentSnapshotBackfillRun(_ context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken shared.ID, state ports.AssessmentSnapshotBackfillState, now time.Time) (ports.AssessmentSnapshotBackfillRun, error) {
+	if state != ports.AssessmentSnapshotBackfillCompleted && state != ports.AssessmentSnapshotBackfillCancelled && state != ports.AssessmentSnapshotBackfillFailed {
+		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: invalid assessment snapshot backfill terminal state", shared.ErrValidation)
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	run, ok := repository.runs[tenantID][runID]
+	if !ok {
+		return ports.AssessmentSnapshotBackfillRun{}, shared.ErrNotFound
+	}
+	if run.State != ports.AssessmentSnapshotBackfillRunning || run.LeaseOwner != strings.TrimSpace(leaseOwner) || run.LeaseToken != leaseToken || !run.LeaseExpiresAt.After(now.UTC()) {
+		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: assessment snapshot backfill completion rejected", shared.ErrConflict)
+	}
+	completedAt := now.UTC()
+	run.State, run.UpdatedAt, run.CompletedAt = state, completedAt, &completedAt
+	run.LeaseOwner, run.LeaseToken, run.LeaseExpiresAt = "", "", time.Time{}
+	recomputeAssessmentSnapshotBackfillCounts(&run, repository.items[tenantID][runID])
+	repository.runs[tenantID][runID] = run
+	return cloneAssessmentSnapshotBackfillRun(run), nil
+}
+
+func validateAssessmentSnapshotBackfillAcquire(request ports.AssessmentSnapshotBackfillAcquireRequest) error {
+	run := request.Run
+	if run.TenantID.IsZero() || run.ID.IsZero() || run.LeaseToken.IsZero() || run.SchemaVersion <= 0 || run.BatchSize < 1 || run.BatchSize > 2000 || run.SnapshotAt.IsZero() || run.State != ports.AssessmentSnapshotBackfillRunning || strings.TrimSpace(run.LeaseOwner) == "" || len(run.LeaseOwner) > 256 || run.LeaseExpiresAt.IsZero() || strings.TrimSpace(run.CreatedBy) == "" || len(run.CreatedBy) > 256 || run.CreatedAt.IsZero() || request.LeaseDuration <= 0 {
+		return fmt.Errorf("%w: assessment snapshot backfill run is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validateAssessmentSnapshotBackfillItem(item ports.AssessmentSnapshotBackfillItem) error {
+	validOutcome := item.Outcome == "created" || item.Outcome == "would_create" || item.Outcome == "skipped" || item.Outcome == "failed"
+	_, hashErr := hex.DecodeString(item.SourceHash)
+	if item.TenantID.IsZero() || item.RunID.IsZero() || item.AssessmentID.IsZero() || item.SchemaVersion <= 0 || strings.TrimSpace(item.IdempotencyKey) == "" || len(item.IdempotencyKey) > 128 || len(item.SourceHash) != 64 || strings.ToLower(item.SourceHash) != item.SourceHash || hashErr != nil || !validOutcome || strings.TrimSpace(item.ReasonCode) == "" || len(item.ReasonCode) > 64 || len(item.RepairGuidance) > 1024 || item.ProcessedAt.IsZero() {
+		return fmt.Errorf("%w: assessment snapshot backfill item is invalid", shared.ErrValidation)
+	}
+	if item.Outcome == "created" && item.SnapshotID.IsZero() {
+		return fmt.Errorf("%w: created assessment snapshot backfill item requires a snapshot", shared.ErrValidation)
+	}
+	return nil
+}
+
+func recomputeAssessmentSnapshotBackfillCounts(run *ports.AssessmentSnapshotBackfillRun, items map[shared.ID]ports.AssessmentSnapshotBackfillItem) {
+	run.ProcessedCount, run.CreatedCount, run.WouldCreateCount, run.SkippedCount, run.FailedCount = 0, 0, 0, 0, 0
+	for _, item := range items {
+		run.ProcessedCount++
+		switch item.Outcome {
+		case "created":
+			run.CreatedCount++
+		case "would_create":
+			run.WouldCreateCount++
+		case "skipped":
+			run.SkippedCount++
+		case "failed":
+			run.FailedCount++
+		}
+	}
+}
+
+func cloneAssessmentSnapshotBackfillRun(run ports.AssessmentSnapshotBackfillRun) ports.AssessmentSnapshotBackfillRun {
+	if run.CompletedAt != nil {
+		completedAt := *run.CompletedAt
+		run.CompletedAt = &completedAt
+	}
+	return run
+}

--- a/internal/infrastructure/persistence/memory/assessment_snapshot_repo.go
+++ b/internal/infrastructure/persistence/memory/assessment_snapshot_repo.go
@@ -1,0 +1,230 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AssessmentSnapshotRepository struct {
+	mu       sync.RWMutex
+	byID     map[shared.ID]map[shared.ID]*assessmentsnapshot.Snapshot
+	requests map[shared.ID]map[shared.ID]map[string]shared.ID
+	defaults map[shared.ID]map[shared.ID]ports.AssessmentSnapshotDefault
+	counters map[shared.ID]map[shared.ID]int
+}
+
+func NewAssessmentSnapshotRepository() *AssessmentSnapshotRepository {
+	return &AssessmentSnapshotRepository{
+		byID:     map[shared.ID]map[shared.ID]*assessmentsnapshot.Snapshot{},
+		requests: map[shared.ID]map[shared.ID]map[string]shared.ID{},
+		defaults: map[shared.ID]map[shared.ID]ports.AssessmentSnapshotDefault{},
+		counters: map[shared.ID]map[shared.ID]int{},
+	}
+}
+
+var _ ports.AssessmentSnapshotRepository = (*AssessmentSnapshotRepository)(nil)
+
+func (repository *AssessmentSnapshotRepository) CreateFinalizedCAS(_ context.Context, snapshot *assessmentsnapshot.Snapshot, expectedDefaultVersion int64) (*assessmentsnapshot.Snapshot, bool, error) {
+	if snapshot == nil {
+		return nil, false, fmt.Errorf("%w: assessment snapshot is required", shared.ErrValidation)
+	}
+	if err := snapshot.Validate(); err != nil {
+		return nil, false, err
+	}
+	tenantID := shared.TenantOrDefault(snapshot.TenantID)
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+
+	if tenantRequests := repository.requests[tenantID]; tenantRequests != nil {
+		if assessmentRequests := tenantRequests[snapshot.AssessmentID]; assessmentRequests != nil {
+			if existingID, ok := assessmentRequests[snapshot.RequestKey]; ok {
+				existing := repository.byID[tenantID][existingID]
+				if existing.RequestHash != snapshot.RequestHash {
+					return nil, false, fmt.Errorf("%w: snapshot request key was reused with different content", shared.ErrConflict)
+				}
+				return cloneAssessmentSnapshot(existing), false, nil
+			}
+		}
+	}
+
+	current, hasDefault := repository.defaults[tenantID][snapshot.AssessmentID]
+	if (!hasDefault && expectedDefaultVersion != 0) || (hasDefault && current.Version != expectedDefaultVersion) {
+		return nil, false, fmt.Errorf("%w: assessment snapshot default version mismatch", shared.ErrConflict)
+	}
+	if repository.byID[tenantID] != nil {
+		if _, exists := repository.byID[tenantID][snapshot.ID]; exists {
+			return nil, false, fmt.Errorf("%w: assessment snapshot %q already exists", shared.ErrConflict, snapshot.ID)
+		}
+	}
+
+	if repository.counters[tenantID] == nil {
+		repository.counters[tenantID] = map[shared.ID]int{}
+	}
+	next := repository.counters[tenantID][snapshot.AssessmentID] + 1
+	repository.counters[tenantID][snapshot.AssessmentID] = next
+	stored := cloneAssessmentSnapshot(snapshot)
+	stored.SnapshotNumber = next
+
+	if repository.byID[tenantID] == nil {
+		repository.byID[tenantID] = map[shared.ID]*assessmentsnapshot.Snapshot{}
+	}
+	if hasDefault {
+		previous := repository.byID[tenantID][current.SnapshotID]
+		if previous == nil {
+			return nil, false, fmt.Errorf("%w: current default snapshot is missing", shared.ErrConflict)
+		}
+		if err := previous.Supersede(stored.FinalizedBy, *stored.FinalizedAt); err != nil {
+			return nil, false, err
+		}
+	}
+	repository.byID[tenantID][stored.ID] = stored
+	if repository.requests[tenantID] == nil {
+		repository.requests[tenantID] = map[shared.ID]map[string]shared.ID{}
+	}
+	if repository.requests[tenantID][stored.AssessmentID] == nil {
+		repository.requests[tenantID][stored.AssessmentID] = map[string]shared.ID{}
+	}
+	repository.requests[tenantID][stored.AssessmentID][stored.RequestKey] = stored.ID
+	if repository.defaults[tenantID] == nil {
+		repository.defaults[tenantID] = map[shared.ID]ports.AssessmentSnapshotDefault{}
+	}
+	pointer := ports.AssessmentSnapshotDefault{
+		TenantID: tenantID, AssessmentID: stored.AssessmentID, SnapshotID: stored.ID,
+		Version: current.Version + 1, UpdatedAt: *stored.FinalizedAt, UpdatedBy: stored.FinalizedBy,
+	}
+	stored.DefaultVersion = pointer.Version
+	repository.defaults[tenantID][stored.AssessmentID] = pointer
+	return cloneAssessmentSnapshot(stored), true, nil
+}
+
+func (repository *AssessmentSnapshotRepository) CreateLegacyProjection(_ context.Context, snapshot *assessmentsnapshot.Snapshot) (*assessmentsnapshot.Snapshot, bool, error) {
+	if snapshot == nil || snapshot.Provenance != assessmentsnapshot.ProvenanceLegacy {
+		return nil, false, fmt.Errorf("%w: legacy assessment snapshot is required", shared.ErrValidation)
+	}
+	if err := snapshot.Validate(); err != nil {
+		return nil, false, err
+	}
+	tenantID := shared.TenantOrDefault(snapshot.TenantID)
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+
+	if tenantRequests := repository.requests[tenantID]; tenantRequests != nil {
+		if assessmentRequests := tenantRequests[snapshot.AssessmentID]; assessmentRequests != nil {
+			if existingID, ok := assessmentRequests[snapshot.RequestKey]; ok {
+				existing := repository.byID[tenantID][existingID]
+				if existing.RequestHash != snapshot.RequestHash {
+					return nil, false, fmt.Errorf("%w: snapshot request key was reused with different content", shared.ErrConflict)
+				}
+				return cloneAssessmentSnapshot(existing), false, nil
+			}
+		}
+	}
+	if repository.byID[tenantID] != nil {
+		if _, exists := repository.byID[tenantID][snapshot.ID]; exists {
+			return nil, false, fmt.Errorf("%w: assessment snapshot %q already exists", shared.ErrConflict, snapshot.ID)
+		}
+	}
+	if repository.counters[tenantID] == nil {
+		repository.counters[tenantID] = map[shared.ID]int{}
+	}
+	next := repository.counters[tenantID][snapshot.AssessmentID] + 1
+	repository.counters[tenantID][snapshot.AssessmentID] = next
+	stored := cloneAssessmentSnapshot(snapshot)
+	stored.SnapshotNumber = next
+	if repository.byID[tenantID] == nil {
+		repository.byID[tenantID] = map[shared.ID]*assessmentsnapshot.Snapshot{}
+	}
+	repository.byID[tenantID][stored.ID] = stored
+	if repository.requests[tenantID] == nil {
+		repository.requests[tenantID] = map[shared.ID]map[string]shared.ID{}
+	}
+	if repository.requests[tenantID][stored.AssessmentID] == nil {
+		repository.requests[tenantID][stored.AssessmentID] = map[string]shared.ID{}
+	}
+	repository.requests[tenantID][stored.AssessmentID][stored.RequestKey] = stored.ID
+	return cloneAssessmentSnapshot(stored), true, nil
+}
+
+func (repository *AssessmentSnapshotRepository) Get(_ context.Context, tenantID, snapshotID shared.ID) (*assessmentsnapshot.Snapshot, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	snapshot := repository.byID[tenantID][snapshotID]
+	if snapshot == nil {
+		return nil, fmt.Errorf("assessment snapshot %s: %w", snapshotID, shared.ErrNotFound)
+	}
+	return cloneAssessmentSnapshot(snapshot), nil
+}
+
+func (repository *AssessmentSnapshotRepository) GetByRequestKey(_ context.Context, tenantID, assessmentID shared.ID, requestKey string) (*assessmentsnapshot.Snapshot, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	id, ok := repository.requests[tenantID][assessmentID][strings.TrimSpace(requestKey)]
+	if !ok {
+		return nil, shared.ErrNotFound
+	}
+	return cloneAssessmentSnapshot(repository.byID[tenantID][id]), nil
+}
+
+func (repository *AssessmentSnapshotRepository) GetDefault(_ context.Context, tenantID, assessmentID shared.ID) (*assessmentsnapshot.Snapshot, ports.AssessmentSnapshotDefault, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	pointer, ok := repository.defaults[tenantID][assessmentID]
+	if !ok {
+		return nil, ports.AssessmentSnapshotDefault{}, shared.ErrNotFound
+	}
+	snapshot := repository.byID[tenantID][pointer.SnapshotID]
+	if snapshot == nil {
+		return nil, ports.AssessmentSnapshotDefault{}, fmt.Errorf("default assessment snapshot: %w", shared.ErrNotFound)
+	}
+	return cloneAssessmentSnapshot(snapshot), pointer, nil
+}
+
+func (repository *AssessmentSnapshotRepository) ListByAssessment(_ context.Context, tenantID, assessmentID shared.ID) ([]assessmentsnapshot.Snapshot, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	var out []assessmentsnapshot.Snapshot
+	for _, snapshot := range repository.byID[tenantID] {
+		if snapshot.AssessmentID == assessmentID {
+			out = append(out, *cloneAssessmentSnapshot(snapshot))
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].SnapshotNumber < out[j].SnapshotNumber })
+	return out, nil
+}
+
+func cloneAssessmentSnapshot(snapshot *assessmentsnapshot.Snapshot) *assessmentsnapshot.Snapshot {
+	if snapshot == nil {
+		return nil
+	}
+	copySnapshot := *snapshot
+	copySnapshot.RunReferences = append([]assessmentsnapshot.RunReference(nil), snapshot.RunReferences...)
+	for index := range copySnapshot.RunReferences {
+		copySnapshot.RunReferences[index].LaneReferences = append([]assessmentsnapshot.LaneReference(nil), snapshot.RunReferences[index].LaneReferences...)
+	}
+	copySnapshot.Dimensions = append([]assessmentsnapshot.Dimension(nil), snapshot.Dimensions...)
+	for index := range copySnapshot.Dimensions {
+		copySnapshot.Dimensions[index].IncludedScope = append([]string(nil), snapshot.Dimensions[index].IncludedScope...)
+		copySnapshot.Dimensions[index].ExcludedScope = append([]string(nil), snapshot.Dimensions[index].ExcludedScope...)
+		copySnapshot.Dimensions[index].Versions = append([]assessmentsnapshot.Version(nil), snapshot.Dimensions[index].Versions...)
+	}
+	if snapshot.FinalizedAt != nil {
+		value := *snapshot.FinalizedAt
+		copySnapshot.FinalizedAt = &value
+	}
+	if snapshot.SupersededAt != nil {
+		value := *snapshot.SupersededAt
+		copySnapshot.SupersededAt = &value
+	}
+	return &copySnapshot
+}

--- a/internal/infrastructure/persistence/memory/assessment_snapshot_repo.go
+++ b/internal/infrastructure/persistence/memory/assessment_snapshot_repo.go
@@ -31,7 +31,7 @@ func NewAssessmentSnapshotRepository() *AssessmentSnapshotRepository {
 
 var _ ports.AssessmentSnapshotRepository = (*AssessmentSnapshotRepository)(nil)
 
-func (repository *AssessmentSnapshotRepository) CreateFinalizedCAS(_ context.Context, snapshot *assessmentsnapshot.Snapshot, expectedDefaultVersion int64) (*assessmentsnapshot.Snapshot, bool, error) {
+func (repository *AssessmentSnapshotRepository) CreateFinalizedCAS(ctx context.Context, snapshot *assessmentsnapshot.Snapshot, expectedDefaultVersion int64) (*assessmentsnapshot.Snapshot, bool, error) {
 	if snapshot == nil {
 		return nil, false, fmt.Errorf("%w: assessment snapshot is required", shared.ErrValidation)
 	}
@@ -63,6 +63,7 @@ func (repository *AssessmentSnapshotRepository) CreateFinalizedCAS(_ context.Con
 			return nil, false, fmt.Errorf("%w: assessment snapshot %q already exists", shared.ErrConflict, snapshot.ID)
 		}
 	}
+	repository.registerRollback(ctx)
 
 	if repository.counters[tenantID] == nil {
 		repository.counters[tenantID] = map[shared.ID]int{}
@@ -104,7 +105,7 @@ func (repository *AssessmentSnapshotRepository) CreateFinalizedCAS(_ context.Con
 	return cloneAssessmentSnapshot(stored), true, nil
 }
 
-func (repository *AssessmentSnapshotRepository) CreateLegacyProjection(_ context.Context, snapshot *assessmentsnapshot.Snapshot) (*assessmentsnapshot.Snapshot, bool, error) {
+func (repository *AssessmentSnapshotRepository) CreateLegacyProjection(ctx context.Context, snapshot *assessmentsnapshot.Snapshot) (*assessmentsnapshot.Snapshot, bool, error) {
 	if snapshot == nil || snapshot.Provenance != assessmentsnapshot.ProvenanceLegacy {
 		return nil, false, fmt.Errorf("%w: legacy assessment snapshot is required", shared.ErrValidation)
 	}
@@ -131,6 +132,7 @@ func (repository *AssessmentSnapshotRepository) CreateLegacyProjection(_ context
 			return nil, false, fmt.Errorf("%w: assessment snapshot %q already exists", shared.ErrConflict, snapshot.ID)
 		}
 	}
+	repository.registerRollback(ctx)
 	if repository.counters[tenantID] == nil {
 		repository.counters[tenantID] = map[shared.ID]int{}
 	}
@@ -190,17 +192,29 @@ func (repository *AssessmentSnapshotRepository) GetDefault(_ context.Context, te
 }
 
 func (repository *AssessmentSnapshotRepository) ListByAssessment(_ context.Context, tenantID, assessmentID shared.ID) ([]assessmentsnapshot.Snapshot, error) {
-	tenantID = shared.TenantOrDefault(tenantID)
+	page, err := repository.ListAssessmentSnapshots(context.Background(), ports.AssessmentSnapshotListQuery{TenantID: tenantID, AssessmentID: assessmentID, Limit: 100})
+	return page.Items, err
+}
+
+func (repository *AssessmentSnapshotRepository) ListAssessmentSnapshots(_ context.Context, query ports.AssessmentSnapshotListQuery) (ports.AssessmentSnapshotPage, error) {
+	if query.Limit < 1 || query.Limit > 100 || query.AfterSnapshotNumber < 0 {
+		return ports.AssessmentSnapshotPage{}, fmt.Errorf("%w: assessment snapshot page is invalid", shared.ErrValidation)
+	}
+	tenantID, assessmentID := shared.TenantOrDefault(query.TenantID), query.AssessmentID
 	repository.mu.RLock()
 	defer repository.mu.RUnlock()
 	var out []assessmentsnapshot.Snapshot
 	for _, snapshot := range repository.byID[tenantID] {
-		if snapshot.AssessmentID == assessmentID {
+		if snapshot.AssessmentID == assessmentID && snapshot.SnapshotNumber > query.AfterSnapshotNumber {
 			out = append(out, *cloneAssessmentSnapshot(snapshot))
 		}
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].SnapshotNumber < out[j].SnapshotNumber })
-	return out, nil
+	page := ports.AssessmentSnapshotPage{Items: out}
+	if len(page.Items) > query.Limit {
+		page.Items, page.HasMore = page.Items[:query.Limit], true
+	}
+	return page, nil
 }
 
 func cloneAssessmentSnapshot(snapshot *assessmentsnapshot.Snapshot) *assessmentsnapshot.Snapshot {
@@ -214,8 +228,8 @@ func cloneAssessmentSnapshot(snapshot *assessmentsnapshot.Snapshot) *assessments
 	}
 	copySnapshot.Dimensions = append([]assessmentsnapshot.Dimension(nil), snapshot.Dimensions...)
 	for index := range copySnapshot.Dimensions {
-		copySnapshot.Dimensions[index].IncludedScope = append([]string(nil), snapshot.Dimensions[index].IncludedScope...)
-		copySnapshot.Dimensions[index].ExcludedScope = append([]string(nil), snapshot.Dimensions[index].ExcludedScope...)
+		copySnapshot.Dimensions[index].IncludedScope = cloneSnapshotStrings(snapshot.Dimensions[index].IncludedScope)
+		copySnapshot.Dimensions[index].ExcludedScope = cloneSnapshotStrings(snapshot.Dimensions[index].ExcludedScope)
 		copySnapshot.Dimensions[index].Versions = append([]assessmentsnapshot.Version(nil), snapshot.Dimensions[index].Versions...)
 	}
 	if snapshot.FinalizedAt != nil {
@@ -227,4 +241,66 @@ func cloneAssessmentSnapshot(snapshot *assessmentsnapshot.Snapshot) *assessments
 		copySnapshot.SupersededAt = &value
 	}
 	return &copySnapshot
+}
+
+func cloneSnapshotStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	cloned := make([]string, len(values))
+	copy(cloned, values)
+	return cloned
+}
+
+type assessmentSnapshotRepositoryState struct {
+	byID     map[shared.ID]map[shared.ID]*assessmentsnapshot.Snapshot
+	requests map[shared.ID]map[shared.ID]map[string]shared.ID
+	defaults map[shared.ID]map[shared.ID]ports.AssessmentSnapshotDefault
+	counters map[shared.ID]map[shared.ID]int
+}
+
+func (repository *AssessmentSnapshotRepository) registerRollback(ctx context.Context) {
+	state := repository.cloneState()
+	registerTenantRollback(ctx, func() {
+		repository.mu.Lock()
+		defer repository.mu.Unlock()
+		repository.byID, repository.requests, repository.defaults, repository.counters = state.byID, state.requests, state.defaults, state.counters
+	})
+}
+
+func (repository *AssessmentSnapshotRepository) cloneState() assessmentSnapshotRepositoryState {
+	state := assessmentSnapshotRepositoryState{
+		byID:     make(map[shared.ID]map[shared.ID]*assessmentsnapshot.Snapshot, len(repository.byID)),
+		requests: make(map[shared.ID]map[shared.ID]map[string]shared.ID, len(repository.requests)),
+		defaults: make(map[shared.ID]map[shared.ID]ports.AssessmentSnapshotDefault, len(repository.defaults)),
+		counters: make(map[shared.ID]map[shared.ID]int, len(repository.counters)),
+	}
+	for tenantID, snapshots := range repository.byID {
+		state.byID[tenantID] = make(map[shared.ID]*assessmentsnapshot.Snapshot, len(snapshots))
+		for snapshotID, snapshot := range snapshots {
+			state.byID[tenantID][snapshotID] = cloneAssessmentSnapshot(snapshot)
+		}
+	}
+	for tenantID, tenantRequests := range repository.requests {
+		state.requests[tenantID] = make(map[shared.ID]map[string]shared.ID, len(tenantRequests))
+		for assessmentID, assessmentRequests := range tenantRequests {
+			state.requests[tenantID][assessmentID] = make(map[string]shared.ID, len(assessmentRequests))
+			for requestKey, snapshotID := range assessmentRequests {
+				state.requests[tenantID][assessmentID][requestKey] = snapshotID
+			}
+		}
+	}
+	for tenantID, pointers := range repository.defaults {
+		state.defaults[tenantID] = make(map[shared.ID]ports.AssessmentSnapshotDefault, len(pointers))
+		for assessmentID, pointer := range pointers {
+			state.defaults[tenantID][assessmentID] = pointer
+		}
+	}
+	for tenantID, counters := range repository.counters {
+		state.counters[tenantID] = make(map[shared.ID]int, len(counters))
+		for assessmentID, counter := range counters {
+			state.counters[tenantID][assessmentID] = counter
+		}
+	}
+	return state
 }

--- a/internal/infrastructure/persistence/memory/engagement_repo.go
+++ b/internal/infrastructure/persistence/memory/engagement_repo.go
@@ -31,6 +31,7 @@ var _ ports.PromotionReconciliationScopeReader = (*EngagementRepository)(nil)
 var _ ports.VulnerabilityReconciliationTenantStore = (*EngagementRepository)(nil)
 var _ ports.DetectionReconciliationTenantStore = (*EngagementRepository)(nil)
 var _ ports.VulnerabilityReconciliationEngagementStore = (*EngagementRepository)(nil)
+var _ ports.AssessmentCycleBackfillSource = (*EngagementRepository)(nil)
 
 func (r *EngagementRepository) Create(_ context.Context, e *engagement.Engagement) error {
 	r.mu.Lock()
@@ -148,6 +149,35 @@ func (r *EngagementRepository) List(_ context.Context, tenantID shared.ID) ([]*e
 		}
 	}
 	return out, nil
+}
+
+func (r *EngagementRepository) ListAssessmentCycleBackfillEngagements(_ context.Context, tenantID, after shared.ID, snapshotAt time.Time, limit int) ([]*engagement.Engagement, error) {
+	if snapshotAt.IsZero() || limit < 1 || limit > 2000 {
+		return nil, fmt.Errorf("%w: assessment cycle backfill page is invalid", shared.ErrValidation)
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	ids := make([]shared.ID, 0, limit)
+	for id, item := range r.data {
+		if item.TenantID == tenantID && item.ProjectID.IsZero() && id > after && !item.Audit.CreatedAt.After(snapshotAt) {
+			ids = append(ids, id)
+		}
+	}
+	sort.Slice(ids, func(left, right int) bool { return ids[left] < ids[right] })
+	if len(ids) > limit {
+		ids = ids[:limit]
+	}
+	items := make([]*engagement.Engagement, 0, len(ids))
+	for _, id := range ids {
+		copy := *r.data[id]
+		items = append(items, &copy)
+	}
+	return items, nil
+}
+
+func (r *EngagementRepository) ListAssessmentSnapshotBackfillEngagements(ctx context.Context, tenantID, after shared.ID, snapshotAt time.Time, limit int) ([]*engagement.Engagement, error) {
+	return r.ListAssessmentCycleBackfillEngagements(ctx, tenantID, after, snapshotAt, limit)
 }
 
 func (r *EngagementRepository) ListProjectEngagements(_ context.Context, tenantID shared.ID) ([]*engagement.Engagement, error) {

--- a/internal/infrastructure/persistence/memory/engagement_repo.go
+++ b/internal/infrastructure/persistence/memory/engagement_repo.go
@@ -33,10 +33,21 @@ var _ ports.DetectionReconciliationTenantStore = (*EngagementRepository)(nil)
 var _ ports.VulnerabilityReconciliationEngagementStore = (*EngagementRepository)(nil)
 var _ ports.AssessmentCycleBackfillSource = (*EngagementRepository)(nil)
 
-func (r *EngagementRepository) Create(_ context.Context, e *engagement.Engagement) error {
+func (r *EngagementRepository) Create(ctx context.Context, e *engagement.Engagement) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	e.TenantID = shared.TenantOrDefault(e.TenantID)
+	previous, existed := r.data[e.ID]
+	previous = cloneMemoryEngagement(previous)
+	registerTenantRollback(ctx, func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if existed {
+			r.data[e.ID] = previous
+		} else {
+			delete(r.data, e.ID)
+		}
+	})
 	r.data[e.ID] = e
 	return nil
 }
@@ -96,12 +107,19 @@ func (r *EngagementRepository) ProjectContexts(_ context.Context, tenantID share
 	return out, nil
 }
 
-func (r *EngagementRepository) Update(_ context.Context, e *engagement.Engagement) error {
+func (r *EngagementRepository) Update(ctx context.Context, e *engagement.Engagement) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if _, ok := r.data[e.ID]; !ok {
+	previous, ok := r.data[e.ID]
+	if !ok {
 		return shared.ErrNotFound
 	}
+	previous = cloneMemoryEngagement(previous)
+	registerTenantRollback(ctx, func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.data[e.ID] = previous
+	})
 	e.TenantID = shared.TenantOrDefault(e.TenantID)
 	r.data[e.ID] = e
 	return nil
@@ -110,11 +128,41 @@ func (r *EngagementRepository) Update(_ context.Context, e *engagement.Engagemen
 // Delete removes an engagement (idempotent). In Postgres the FK cascade removes
 // children; in memory other stores are independent, but import rollback only needs
 // the engagement gone so a re-import isn't blocked.
-func (r *EngagementRepository) Delete(_ context.Context, id shared.ID) error {
+func (r *EngagementRepository) Delete(ctx context.Context, id shared.ID) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	previous, existed := r.data[id]
+	previous = cloneMemoryEngagement(previous)
+	registerTenantRollback(ctx, func() {
+		if !existed {
+			return
+		}
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.data[id] = previous
+	})
 	delete(r.data, id)
 	return nil
+}
+
+func cloneMemoryEngagement(item *engagement.Engagement) *engagement.Engagement {
+	if item == nil {
+		return nil
+	}
+	cloned := *item
+	cloned.Scope.InScope = append([]engagement.Target(nil), item.Scope.InScope...)
+	cloned.Scope.OutOfScope = append([]engagement.Target(nil), item.Scope.OutOfScope...)
+	cloned.RoE.AllowedToolClasses = append([]engagement.ToolClass(nil), item.RoE.AllowedToolClasses...)
+	cloned.RoE.Blackouts = append([]engagement.Blackout(nil), item.RoE.Blackouts...)
+	if item.AuthorizedFrom != nil {
+		value := *item.AuthorizedFrom
+		cloned.AuthorizedFrom = &value
+	}
+	if item.AuthorizedTo != nil {
+		value := *item.AuthorizedTo
+		cloned.AuthorizedTo = &value
+	}
+	return &cloned
 }
 
 // ListPromotionReconciliationScopes returns every non-project engagement for

--- a/internal/infrastructure/persistence/memory/tenant_tx.go
+++ b/internal/infrastructure/persistence/memory/tenant_tx.go
@@ -14,6 +14,8 @@ type TenantTransactionRunner struct {
 	mu sync.Mutex
 }
 
+type tenantTransactionKey struct{}
+
 // NewTenantTransactionRunner constructs an in-memory TenantTransactionRunner.
 func NewTenantTransactionRunner() *TenantTransactionRunner {
 	return &TenantTransactionRunner{}
@@ -26,7 +28,14 @@ func (r *TenantTransactionRunner) Run(ctx context.Context, tenantID shared.ID, f
 	if tenantID.IsZero() || fn == nil {
 		return fmt.Errorf("%w: tenant transaction identity is required", shared.ErrValidation)
 	}
+	if boundTenant, ok := ctx.Value(tenantTransactionKey{}).(shared.ID); ok {
+		if boundTenant != tenantID {
+			return fmt.Errorf("%w: nested tenant transaction mismatch", shared.ErrValidation)
+		}
+		return fn(ctx)
+	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return fn(shared.WithTenant(ctx, tenantID))
+	txCtx := context.WithValue(ctx, tenantTransactionKey{}, tenantID)
+	return fn(shared.WithTenant(txCtx, tenantID))
 }

--- a/internal/infrastructure/persistence/memory/tenant_tx.go
+++ b/internal/infrastructure/persistence/memory/tenant_tx.go
@@ -16,6 +16,11 @@ type TenantTransactionRunner struct {
 
 type tenantTransactionKey struct{}
 
+type tenantTransaction struct {
+	tenantID  shared.ID
+	rollbacks []func()
+}
+
 // NewTenantTransactionRunner constructs an in-memory TenantTransactionRunner.
 func NewTenantTransactionRunner() *TenantTransactionRunner {
 	return &TenantTransactionRunner{}
@@ -28,14 +33,33 @@ func (r *TenantTransactionRunner) Run(ctx context.Context, tenantID shared.ID, f
 	if tenantID.IsZero() || fn == nil {
 		return fmt.Errorf("%w: tenant transaction identity is required", shared.ErrValidation)
 	}
-	if boundTenant, ok := ctx.Value(tenantTransactionKey{}).(shared.ID); ok {
-		if boundTenant != tenantID {
+	if transaction, ok := ctx.Value(tenantTransactionKey{}).(*tenantTransaction); ok {
+		if transaction.tenantID != tenantID {
 			return fmt.Errorf("%w: nested tenant transaction mismatch", shared.ErrValidation)
 		}
 		return fn(ctx)
 	}
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	txCtx := context.WithValue(ctx, tenantTransactionKey{}, tenantID)
-	return fn(shared.WithTenant(txCtx, tenantID))
+	transaction := &tenantTransaction{tenantID: tenantID}
+	txCtx := shared.WithTenant(context.WithValue(ctx, tenantTransactionKey{}, transaction), tenantID)
+	if err := fn(txCtx); err != nil {
+		for index := len(transaction.rollbacks) - 1; index >= 0; index-- {
+			transaction.rollbacks[index]()
+		}
+		return err
+	}
+	return nil
+}
+
+// registerTenantRollback adds a repository-local compensation to the current
+// in-memory transaction. Repositories call it while holding their own mutex and
+// restore the captured state only after the mutation has returned and unlocked.
+func registerTenantRollback(ctx context.Context, rollback func()) bool {
+	transaction, ok := ctx.Value(tenantTransactionKey{}).(*tenantTransaction)
+	if !ok || rollback == nil {
+		return false
+	}
+	transaction.rollbacks = append(transaction.rollbacks, rollback)
+	return true
 }

--- a/internal/infrastructure/persistence/postgres/assessment_cycle_api_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_cycle_api_test.go
@@ -1,0 +1,190 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type assessmentCycleNoopAudit struct{}
+
+func (assessmentCycleNoopAudit) Record(context.Context, ports.AuditEntry) error { return nil }
+
+func TestPostgresAssessmentCycleAPIReplayConcurrency(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := fmt.Sprintf("cycle-api-%d", time.Now().UnixNano())
+	tenantID := shared.ID("tenant-" + suffix)
+	otherTenantID := shared.ID("other-" + suffix)
+	for _, tenant := range []shared.ID{tenantID, otherTenantID} {
+		if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1,$2)`, tenant.String(), tenant.String()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	engagements := NewEngagementRepository(pool)
+	cycles := NewAssessmentCycleRepository(pool)
+	transactions := NewTenantTransactionRunner(pool)
+	clock := idgen.SystemClock{}
+	ids := idgen.RandomID{}
+	audit := assessmentCycleNoopAudit{}
+	engagementService := enguc.NewService(engagements, clock, ids, audit)
+	cycleService, err := cycleuc.NewService(cycles, engagements, nil, nil, transactions, ids, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api, err := cycleuc.NewAPIService(cycleService, cycles, NewAssessmentCycleRequestRepository(pool), engagementService, transactions, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := cycleuc.CreateInitialAssessmentInput{
+		Request:    cycleuc.RetainedRequest{TenantID: tenantID, Actor: "alice", Route: "/api/v1/engagements", IdempotencyKey: "same-key"},
+		Engagement: enguc.CreateInput{Name: "Concurrent", InScope: []engdom.Target{{Kind: engdom.TargetDomain, Value: "app.example.com"}}},
+	}
+
+	const callers = 8
+	responses := make(chan cycleuc.RetainedResponse, callers)
+	errorsCh := make(chan error, callers)
+	var wait sync.WaitGroup
+	for range callers {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			response, err := api.CreateInitialAssessment(ctx, input)
+			responses <- response
+			errorsCh <- err
+		}()
+	}
+	wait.Wait()
+	close(responses)
+	close(errorsCh)
+	for err := range errorsCh {
+		if err != nil {
+			t.Fatalf("concurrent create: %v", err)
+		}
+	}
+	var body string
+	for response := range responses {
+		if response.StatusCode != 201 {
+			t.Fatalf("status=%d", response.StatusCode)
+		}
+		if body == "" {
+			body = string(response.Body)
+		} else if string(response.Body) != body {
+			t.Fatalf("retained bodies differ: %q != %q", response.Body, body)
+		}
+	}
+	var engagementCount, cycleCount, requestCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM engagements WHERE tenant_id=$1`, tenantID.String()).Scan(&engagementCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM assessment_cycles WHERE tenant_id=$1`, tenantID.String()).Scan(&cycleCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM assessment_cycle_api_requests WHERE tenant_id=$1`, tenantID.String()).Scan(&requestCount); err != nil {
+		t.Fatal(err)
+	}
+	if engagementCount != 1 || cycleCount != 1 || requestCount != 1 {
+		t.Fatalf("counts engagement=%d cycle=%d request=%d", engagementCount, cycleCount, requestCount)
+	}
+
+	mismatch := input
+	mismatch.Engagement.Name = "Mismatch"
+	if _, err := api.CreateInitialAssessment(ctx, mismatch); !errors.Is(err, shared.ErrConflict) || cycleuc.ErrorCode(err) != cycleuc.CodeIdempotencyBodyMismatch {
+		t.Fatalf("body mismatch=%v", err)
+	}
+	engagementList, err := engagementService.List(ctx, tenantID)
+	if err != nil || len(engagementList) != 1 {
+		t.Fatalf("engagement list=%d err=%v", len(engagementList), err)
+	}
+	retest, err := api.CreateRetestAssessment(ctx, cycleuc.CreateRetestAssessmentInput{
+		Request:      cycleuc.RetainedRequest{TenantID: tenantID, Actor: "alice", Route: "/api/v1/engagements/" + engagementList[0].ID.String() + "/retests", IdempotencyKey: "retest-key"},
+		AssessmentID: engagementList[0].ID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var retestBody cycleuc.CreateRetestResponse
+	if err := json.Unmarshal(retest.Body, &retestBody); err != nil {
+		t.Fatal(err)
+	}
+	persistedRetest, err := engagementService.Get(ctx, tenantID, retestBody.Engagement.ID)
+	if err != nil || !persistedRetest.RequiresExplicitExecutionAuthorization || persistedRetest.AllowsExecution() {
+		t.Fatalf("persisted Re-test=%+v err=%v", persistedRetest, err)
+	}
+	if _, err := api.GetLifecycle(ctx, otherTenantID, engagementList[0].ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant lifecycle=%v", err)
+	}
+}
+
+func TestPostgresAssessmentCycleListProjectionFilters(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := fmt.Sprintf("cycle-list-%d", time.Now().UnixNano())
+	tenantID := shared.ID("tenant-" + suffix)
+	freshAssessmentID := shared.ID("fresh-assessment-" + suffix)
+	missingAssessmentID := shared.ID("missing-assessment-" + suffix)
+	for _, assessmentID := range []shared.ID{freshAssessmentID, missingAssessmentID} {
+		ensureTestTenantAndEngagement(t, ctx, pool, tenantID, assessmentID, "", "")
+		if _, err := pool.Exec(ctx, `UPDATE engagements SET status='active' WHERE tenant_id=$1 AND id=$2`, tenantID.String(), assessmentID.String()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	repository := NewAssessmentCycleRepository(pool)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	for _, fixture := range []struct {
+		id           shared.ID
+		name         string
+		assessmentID shared.ID
+	}{
+		{id: shared.ID("fresh-cycle-" + suffix), name: "Fresh Cycle", assessmentID: freshAssessmentID},
+		{id: shared.ID("missing-cycle-" + suffix), name: "Missing Cycle", assessmentID: missingAssessmentID},
+	} {
+		cycle, err := cycledom.NewAssessmentCycle(fixture.id, tenantID, fixture.name, cycledom.BoundaryStandalone, "", "", fixture.assessmentID, "alice", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		member, err := cycledom.NewInitialMember(tenantID, fixture.id, fixture.assessmentID, "alice", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := repository.CreateCycle(ctx, cycle); err != nil {
+			t.Fatal(err)
+		}
+		if err := repository.CreateMember(ctx, member); err != nil {
+			t.Fatal(err)
+		}
+	}
+	run := postgresNativeRun(t, tenantID, freshAssessmentID, shared.ID("fresh-run-"+suffix), strings.Repeat("a", 64))
+	runRepository := NewScanRunStore(pool)
+	sealPostgresNativeRun(t, ctx, runRepository, &run, now)
+
+	records, err := repository.ListCycles(ctx, ports.AssessmentCycleListQuery{
+		TenantID: tenantID, AssessmentStatus: engdom.StatusActive, SelectedHeadID: freshAssessmentID,
+		AssessmentType: cycledom.AssessmentTypeInitial, ScanStaleness: "fresh", ScanStaleBefore: now.Add(-24 * time.Hour), Search: "Fresh", Limit: 10, MemberLimit: 10,
+	})
+	if err != nil || len(records) != 1 || records[0].Cycle.Name != "Fresh Cycle" || records[0].ScanStaleness != "fresh" || records[0].SelectedHeadScanAt == nil {
+		t.Fatalf("fresh projection=%+v err=%v", records, err)
+	}
+	for name, filter := range map[string]ports.AssessmentCycleListQuery{
+		"missing": {TenantID: tenantID, ScanStaleness: "missing", ScanStaleBefore: now.Add(-24 * time.Hour), Limit: 10, MemberLimit: 10},
+	} {
+		filtered, err := repository.ListCycles(ctx, filter)
+		if err != nil {
+			t.Fatalf("%s filter: %v", name, err)
+		}
+		if name == "missing" && (len(filtered) != 1 || filtered[0].Cycle.Name != "Missing Cycle") {
+			t.Fatalf("missing filter=%+v", filtered)
+		}
+	}
+}

--- a/internal/infrastructure/persistence/postgres/assessment_cycle_api_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_cycle_api_test.go
@@ -28,6 +28,9 @@ func TestPostgresAssessmentCycleAPIReplayConcurrency(t *testing.T) {
 	suffix := fmt.Sprintf("cycle-api-%d", time.Now().UnixNano())
 	tenantID := shared.ID("tenant-" + suffix)
 	otherTenantID := shared.ID("other-" + suffix)
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM assessment_cycle_api_requests WHERE tenant_id IN ($1,$2)`, tenantID.String(), otherTenantID.String())
+	})
 	for _, tenant := range []shared.ID{tenantID, otherTenantID} {
 		if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1,$2)`, tenant.String(), tenant.String()); err != nil {
 			t.Fatal(err)

--- a/internal/infrastructure/persistence/postgres/assessment_cycle_backfill_repo.go
+++ b/internal/infrastructure/persistence/postgres/assessment_cycle_backfill_repo.go
@@ -1,0 +1,232 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const assessmentCycleBackfillRunCols = `tenant_id,id,schema_version,dry_run,batch_size,snapshot_at,checkpoint_assessment_id,state,lease_owner,lease_token,lease_expires_at,processed_count,created_count,would_create_count,skipped_count,failed_count,created_by,created_at,updated_at,completed_at`
+
+type AssessmentCycleBackfillRepository struct{ pool *pgxpool.Pool }
+
+func NewAssessmentCycleBackfillRepository(pool *pgxpool.Pool) *AssessmentCycleBackfillRepository {
+	return &AssessmentCycleBackfillRepository{pool: pool}
+}
+
+var _ ports.AssessmentCycleBackfillStore = (*AssessmentCycleBackfillRepository)(nil)
+
+func (repository *AssessmentCycleBackfillRepository) AcquireAssessmentCycleBackfillRun(ctx context.Context, request ports.AssessmentCycleBackfillAcquireRequest) (run ports.AssessmentCycleBackfillRun, resumed bool, err error) {
+	if err := validatePostgresBackfillAcquire(request); err != nil {
+		return ports.AssessmentCycleBackfillRun{}, false, err
+	}
+	err = WithTenant(ctx, repository.pool, request.Run.TenantID.String(), func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `SELECT `+assessmentCycleBackfillRunCols+` FROM assessment_cycle_backfill_runs WHERE tenant_id=$1 AND state='running' FOR UPDATE`, request.Run.TenantID.String())
+		existing, scanErr := scanAssessmentCycleBackfillRun(row)
+		if scanErr == nil {
+			if existing.LeaseOwner != request.Run.LeaseOwner && existing.LeaseExpiresAt.After(request.Run.CreatedAt) {
+				return fmt.Errorf("%w: assessment cycle backfill already running for tenant", shared.ErrConflict)
+			}
+			if existing.SchemaVersion != request.Run.SchemaVersion || existing.DryRun != request.Run.DryRun || existing.BatchSize != request.Run.BatchSize {
+				return fmt.Errorf("%w: requested assessment cycle backfill config (schema=%d dry_run=%t batch_size=%d) differs from persisted config (schema=%d dry_run=%t batch_size=%d)", shared.ErrConflict,
+					request.Run.SchemaVersion, request.Run.DryRun, request.Run.BatchSize, existing.SchemaVersion, existing.DryRun, existing.BatchSize)
+			}
+			row = tx.QueryRow(ctx, `UPDATE assessment_cycle_backfill_runs SET lease_owner=$3,lease_token=$4,lease_expires_at=$5,updated_at=$6 WHERE tenant_id=$1 AND id=$2 AND state='running' RETURNING `+assessmentCycleBackfillRunCols,
+				request.Run.TenantID.String(), existing.ID.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.Run.CreatedAt.Add(request.LeaseDuration), request.Run.CreatedAt)
+			updated, err := scanAssessmentCycleBackfillRun(row)
+			if err != nil {
+				return fmt.Errorf("resume assessment cycle backfill run: %w", err)
+			}
+			run, resumed = updated, true
+			return nil
+		}
+		if !errors.Is(scanErr, pgx.ErrNoRows) {
+			return fmt.Errorf("find active assessment cycle backfill run: %w", scanErr)
+		}
+		row = tx.QueryRow(ctx, `INSERT INTO assessment_cycle_backfill_runs (`+assessmentCycleBackfillRunCols+`) VALUES ($1,$2,$3,$4,$5,$6,$7,'running',$8,$9,$10,0,0,0,0,0,$11,$12,$12,NULL) RETURNING `+assessmentCycleBackfillRunCols,
+			request.Run.TenantID.String(), request.Run.ID.String(), request.Run.SchemaVersion, request.Run.DryRun, request.Run.BatchSize, request.Run.SnapshotAt,
+			request.InitialCheckpoint.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.Run.CreatedAt.Add(request.LeaseDuration), request.Run.CreatedBy, request.Run.CreatedAt)
+		created, err := scanAssessmentCycleBackfillRun(row)
+		if err != nil {
+			return fmt.Errorf("create assessment cycle backfill run: %w", err)
+		}
+		run = created
+		return nil
+	})
+	return run, resumed, err
+}
+
+func (repository *AssessmentCycleBackfillRepository) GetAssessmentCycleBackfillRun(ctx context.Context, tenantID, runID shared.ID) (run ports.AssessmentCycleBackfillRun, err error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		item, err := scanAssessmentCycleBackfillRun(tx.QueryRow(ctx, `SELECT `+assessmentCycleBackfillRunCols+` FROM assessment_cycle_backfill_runs WHERE tenant_id=$1 AND id=$2`, tenantID.String(), runID.String()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("get assessment cycle backfill run: %w", err)
+		}
+		run = item
+		return nil
+	})
+	return run, err
+}
+
+func (repository *AssessmentCycleBackfillRepository) GetAssessmentCycleBackfillItem(ctx context.Context, tenantID, runID, assessmentID shared.ID) (item ports.AssessmentCycleBackfillItem, err error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `SELECT tenant_id,run_id,assessment_id,schema_version,idempotency_key,COALESCE(cycle_id,''),outcome,reason_code,retryable,repair_guidance,processed_at FROM assessment_cycle_backfill_items WHERE tenant_id=$1 AND run_id=$2 AND assessment_id=$3`, tenantID.String(), runID.String(), assessmentID.String())
+		if err := row.Scan(&item.TenantID, &item.RunID, &item.AssessmentID, &item.SchemaVersion, &item.IdempotencyKey, &item.CycleID, &item.Outcome, &item.ReasonCode, &item.Retryable, &item.RepairGuidance, &item.ProcessedAt); errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		} else if err != nil {
+			return fmt.Errorf("get assessment cycle backfill item: %w", err)
+		}
+		return nil
+	})
+	return item, err
+}
+
+func (repository *AssessmentCycleBackfillRepository) CommitAssessmentCycleBackfillItem(ctx context.Context, tenantID, runID, leaseToken shared.ID, now time.Time, build func(context.Context) (ports.AssessmentCycleBackfillItem, error)) (item ports.AssessmentCycleBackfillItem, created bool, err error) {
+	tenantID, now = shared.TenantOrDefault(tenantID), now.UTC()
+	if tenantID.IsZero() || runID.IsZero() || leaseToken.IsZero() || now.IsZero() || build == nil {
+		return item, false, fmt.Errorf("%w: assessment cycle backfill commit identity is invalid", shared.ErrValidation)
+	}
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var active bool
+		if err := tx.QueryRow(ctx, `SELECT state='running' AND lease_token=$3 AND lease_expires_at>$4 FROM assessment_cycle_backfill_runs WHERE tenant_id=$1 AND id=$2 FOR UPDATE`, tenantID.String(), runID.String(), leaseToken.String(), now).Scan(&active); errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		} else if err != nil {
+			return fmt.Errorf("lock assessment cycle backfill lease: %w", err)
+		}
+		if !active {
+			return fmt.Errorf("%w: assessment cycle backfill lease is stale", shared.ErrConflict)
+		}
+		var err error
+		item, err = build(bindTenantTransaction(ctx, tenantID, tx))
+		if err != nil {
+			return err
+		}
+		if item.TenantID != tenantID || item.RunID != runID {
+			return fmt.Errorf("%w: assessment cycle backfill item ownership differs from lease", shared.ErrValidation)
+		}
+		if err := validatePostgresBackfillItem(item); err != nil {
+			return err
+		}
+		var inserted int
+		err = tx.QueryRow(ctx, `INSERT INTO assessment_cycle_backfill_items(tenant_id,run_id,assessment_id,schema_version,idempotency_key,cycle_id,outcome,reason_code,retryable,repair_guidance,processed_at)
+			VALUES($1,$2,$3,$4,$5,NULLIF($6,''),$7,$8,$9,$10,$11) ON CONFLICT (tenant_id,run_id,assessment_id) DO NOTHING RETURNING 1`,
+			item.TenantID.String(), item.RunID.String(), item.AssessmentID.String(), item.SchemaVersion, item.IdempotencyKey, item.CycleID.String(), item.Outcome, item.ReasonCode, item.Retryable, item.RepairGuidance, item.ProcessedAt.UTC()).Scan(&inserted)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("save assessment cycle backfill item: %w", err)
+		}
+		created = inserted == 1
+		return nil
+	})
+	return item, created, err
+}
+
+func (repository *AssessmentCycleBackfillRepository) AdvanceAssessmentCycleBackfillRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken, checkpoint shared.ID, now time.Time, leaseDuration time.Duration) (run ports.AssessmentCycleBackfillRun, err error) {
+	tenantID, leaseOwner, now = shared.TenantOrDefault(tenantID), strings.TrimSpace(leaseOwner), now.UTC()
+	if tenantID.IsZero() || runID.IsZero() || leaseOwner == "" || leaseToken.IsZero() || checkpoint.IsZero() || now.IsZero() || leaseDuration <= 0 {
+		return ports.AssessmentCycleBackfillRun{}, fmt.Errorf("%w: assessment cycle backfill checkpoint is invalid", shared.ErrValidation)
+	}
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `UPDATE assessment_cycle_backfill_runs AS run SET checkpoint_assessment_id=$5,updated_at=$6::timestamptz,lease_expires_at=$6::timestamptz+($7 * interval '1 microsecond'),
+			processed_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id),
+			created_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='created'),
+			would_create_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='would_create'),
+			skipped_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='skipped'),
+			failed_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='failed')
+			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>$6 AND run.checkpoint_assessment_id COLLATE "C"<=$5 RETURNING `+assessmentCycleBackfillRunCols,
+			tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), checkpoint.String(), now, leaseDuration.Microseconds())
+		updated, err := scanAssessmentCycleBackfillRun(row)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: assessment cycle backfill checkpoint rejected", shared.ErrConflict)
+		}
+		if err != nil {
+			return fmt.Errorf("advance assessment cycle backfill run: %w", err)
+		}
+		run = updated
+		return nil
+	})
+	return run, err
+}
+
+func (repository *AssessmentCycleBackfillRepository) FinishAssessmentCycleBackfillRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken shared.ID, state ports.AssessmentCycleBackfillState, now time.Time) (run ports.AssessmentCycleBackfillRun, err error) {
+	if state != ports.AssessmentCycleBackfillCompleted && state != ports.AssessmentCycleBackfillCancelled && state != ports.AssessmentCycleBackfillFailed {
+		return ports.AssessmentCycleBackfillRun{}, fmt.Errorf("%w: invalid assessment cycle backfill terminal state", shared.ErrValidation)
+	}
+	tenantID, leaseOwner, now = shared.TenantOrDefault(tenantID), strings.TrimSpace(leaseOwner), now.UTC()
+	if tenantID.IsZero() || runID.IsZero() || leaseOwner == "" || leaseToken.IsZero() || now.IsZero() {
+		return ports.AssessmentCycleBackfillRun{}, fmt.Errorf("%w: assessment cycle backfill completion identity is invalid", shared.ErrValidation)
+	}
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `UPDATE assessment_cycle_backfill_runs AS run SET state=$5,lease_owner='',lease_token='',lease_expires_at=NULL,updated_at=$6,completed_at=$6,
+			processed_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id),
+			created_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='created'),
+			would_create_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='would_create'),
+			skipped_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='skipped'),
+			failed_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='failed')
+			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>$6 RETURNING `+assessmentCycleBackfillRunCols,
+			tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), string(state), now)
+		finished, err := scanAssessmentCycleBackfillRun(row)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: assessment cycle backfill completion rejected", shared.ErrConflict)
+		}
+		if err != nil {
+			return fmt.Errorf("finish assessment cycle backfill run: %w", err)
+		}
+		run = finished
+		return nil
+	})
+	return run, err
+}
+
+func scanAssessmentCycleBackfillRun(row rowScanner) (ports.AssessmentCycleBackfillRun, error) {
+	var (
+		run                       ports.AssessmentCycleBackfillRun
+		state                     string
+		leaseExpires, completedAt pgtype.Timestamptz
+	)
+	if err := row.Scan(&run.TenantID, &run.ID, &run.SchemaVersion, &run.DryRun, &run.BatchSize, &run.SnapshotAt, &run.CheckpointAssessment, &state, &run.LeaseOwner, &run.LeaseToken, &leaseExpires,
+		&run.ProcessedCount, &run.CreatedCount, &run.WouldCreateCount, &run.SkippedCount, &run.FailedCount, &run.CreatedBy, &run.CreatedAt, &run.UpdatedAt, &completedAt); err != nil {
+		return ports.AssessmentCycleBackfillRun{}, err
+	}
+	run.State = ports.AssessmentCycleBackfillState(state)
+	if leaseExpires.Valid {
+		run.LeaseExpiresAt = leaseExpires.Time
+	}
+	if completedAt.Valid {
+		completed := completedAt.Time
+		run.CompletedAt = &completed
+	}
+	return run, nil
+}
+
+func validatePostgresBackfillAcquire(request ports.AssessmentCycleBackfillAcquireRequest) error {
+	run := request.Run
+	if run.TenantID.IsZero() || run.ID.IsZero() || run.LeaseToken.IsZero() || run.SchemaVersion <= 0 || run.BatchSize < 1 || run.BatchSize > 2000 || run.SnapshotAt.IsZero() || run.State != ports.AssessmentCycleBackfillRunning || strings.TrimSpace(run.LeaseOwner) == "" || len(run.LeaseOwner) > 256 || strings.TrimSpace(run.CreatedBy) == "" || len(run.CreatedBy) > 256 || run.CreatedAt.IsZero() || request.LeaseDuration <= 0 {
+		return fmt.Errorf("%w: assessment cycle backfill run is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validatePostgresBackfillItem(item ports.AssessmentCycleBackfillItem) error {
+	validOutcome := item.Outcome == "created" || item.Outcome == "would_create" || item.Outcome == "skipped" || item.Outcome == "failed"
+	if item.TenantID.IsZero() || item.RunID.IsZero() || item.AssessmentID.IsZero() || item.SchemaVersion <= 0 || strings.TrimSpace(item.IdempotencyKey) == "" || len(item.IdempotencyKey) > 128 || !validOutcome || strings.TrimSpace(item.ReasonCode) == "" || len(item.ReasonCode) > 64 || len(item.RepairGuidance) > 1024 || item.ProcessedAt.IsZero() {
+		return fmt.Errorf("%w: assessment cycle backfill item is invalid", shared.ErrValidation)
+	}
+	return nil
+}

--- a/internal/infrastructure/persistence/postgres/assessment_cycle_backfill_repo.go
+++ b/internal/infrastructure/persistence/postgres/assessment_cycle_backfill_repo.go
@@ -33,16 +33,19 @@ func (repository *AssessmentCycleBackfillRepository) AcquireAssessmentCycleBackf
 		row := tx.QueryRow(ctx, `SELECT `+assessmentCycleBackfillRunCols+` FROM assessment_cycle_backfill_runs WHERE tenant_id=$1 AND state='running' FOR UPDATE`, request.Run.TenantID.String())
 		existing, scanErr := scanAssessmentCycleBackfillRun(row)
 		if scanErr == nil {
-			if existing.LeaseOwner != request.Run.LeaseOwner && existing.LeaseExpiresAt.After(request.Run.CreatedAt) {
-				return fmt.Errorf("%w: assessment cycle backfill already running for tenant", shared.ErrConflict)
-			}
 			if existing.SchemaVersion != request.Run.SchemaVersion || existing.DryRun != request.Run.DryRun || existing.BatchSize != request.Run.BatchSize {
 				return fmt.Errorf("%w: requested assessment cycle backfill config (schema=%d dry_run=%t batch_size=%d) differs from persisted config (schema=%d dry_run=%t batch_size=%d)", shared.ErrConflict,
 					request.Run.SchemaVersion, request.Run.DryRun, request.Run.BatchSize, existing.SchemaVersion, existing.DryRun, existing.BatchSize)
 			}
-			row = tx.QueryRow(ctx, `UPDATE assessment_cycle_backfill_runs SET lease_owner=$3,lease_token=$4,lease_expires_at=$5,updated_at=$6 WHERE tenant_id=$1 AND id=$2 AND state='running' RETURNING `+assessmentCycleBackfillRunCols,
-				request.Run.TenantID.String(), existing.ID.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.Run.CreatedAt.Add(request.LeaseDuration), request.Run.CreatedAt)
+			row = tx.QueryRow(ctx, `UPDATE assessment_cycle_backfill_runs
+				SET lease_owner=$3,lease_token=$4,lease_expires_at=now()+($5 * interval '1 microsecond'),updated_at=$6
+				WHERE tenant_id=$1 AND id=$2 AND state='running' AND (lease_owner=$3 OR lease_expires_at <= now())
+				RETURNING `+assessmentCycleBackfillRunCols,
+				request.Run.TenantID.String(), existing.ID.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.LeaseDuration.Microseconds(), request.Run.CreatedAt)
 			updated, err := scanAssessmentCycleBackfillRun(row)
+			if errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("%w: assessment cycle backfill already running for tenant", shared.ErrConflict)
+			}
 			if err != nil {
 				return fmt.Errorf("resume assessment cycle backfill run: %w", err)
 			}
@@ -52,9 +55,9 @@ func (repository *AssessmentCycleBackfillRepository) AcquireAssessmentCycleBackf
 		if !errors.Is(scanErr, pgx.ErrNoRows) {
 			return fmt.Errorf("find active assessment cycle backfill run: %w", scanErr)
 		}
-		row = tx.QueryRow(ctx, `INSERT INTO assessment_cycle_backfill_runs (`+assessmentCycleBackfillRunCols+`) VALUES ($1,$2,$3,$4,$5,$6,$7,'running',$8,$9,$10,0,0,0,0,0,$11,$12,$12,NULL) RETURNING `+assessmentCycleBackfillRunCols,
+		row = tx.QueryRow(ctx, `INSERT INTO assessment_cycle_backfill_runs (`+assessmentCycleBackfillRunCols+`) VALUES ($1,$2,$3,$4,$5,$6,$7,'running',$8,$9,now()+($10 * interval '1 microsecond'),0,0,0,0,0,$11,$12,$12,NULL) RETURNING `+assessmentCycleBackfillRunCols,
 			request.Run.TenantID.String(), request.Run.ID.String(), request.Run.SchemaVersion, request.Run.DryRun, request.Run.BatchSize, request.Run.SnapshotAt,
-			request.InitialCheckpoint.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.Run.CreatedAt.Add(request.LeaseDuration), request.Run.CreatedBy, request.Run.CreatedAt)
+			request.InitialCheckpoint.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.LeaseDuration.Microseconds(), request.Run.CreatedBy, request.Run.CreatedAt)
 		created, err := scanAssessmentCycleBackfillRun(row)
 		if err != nil {
 			return fmt.Errorf("create assessment cycle backfill run: %w", err)
@@ -102,7 +105,7 @@ func (repository *AssessmentCycleBackfillRepository) CommitAssessmentCycleBackfi
 	}
 	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
 		var active bool
-		if err := tx.QueryRow(ctx, `SELECT state='running' AND lease_token=$3 AND lease_expires_at>$4 FROM assessment_cycle_backfill_runs WHERE tenant_id=$1 AND id=$2 FOR UPDATE`, tenantID.String(), runID.String(), leaseToken.String(), now).Scan(&active); errors.Is(err, pgx.ErrNoRows) {
+		if err := tx.QueryRow(ctx, `SELECT state='running' AND lease_token=$3 AND lease_expires_at>now() FROM assessment_cycle_backfill_runs WHERE tenant_id=$1 AND id=$2 FOR UPDATE`, tenantID.String(), runID.String(), leaseToken.String()).Scan(&active); errors.Is(err, pgx.ErrNoRows) {
 			return shared.ErrNotFound
 		} else if err != nil {
 			return fmt.Errorf("lock assessment cycle backfill lease: %w", err)
@@ -143,13 +146,13 @@ func (repository *AssessmentCycleBackfillRepository) AdvanceAssessmentCycleBackf
 		return ports.AssessmentCycleBackfillRun{}, fmt.Errorf("%w: assessment cycle backfill checkpoint is invalid", shared.ErrValidation)
 	}
 	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
-		row := tx.QueryRow(ctx, `UPDATE assessment_cycle_backfill_runs AS run SET checkpoint_assessment_id=$5,updated_at=$6::timestamptz,lease_expires_at=$6::timestamptz+($7 * interval '1 microsecond'),
+		row := tx.QueryRow(ctx, `UPDATE assessment_cycle_backfill_runs AS run SET checkpoint_assessment_id=$5,updated_at=$6::timestamptz,lease_expires_at=now()+($7 * interval '1 microsecond'),
 			processed_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id),
 			created_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='created'),
 			would_create_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='would_create'),
 			skipped_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='skipped'),
 			failed_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='failed')
-			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>$6 AND run.checkpoint_assessment_id COLLATE "C"<=$5 RETURNING `+assessmentCycleBackfillRunCols,
+			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>now() AND run.checkpoint_assessment_id COLLATE "C"<=$5 RETURNING `+assessmentCycleBackfillRunCols,
 			tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), checkpoint.String(), now, leaseDuration.Microseconds())
 		updated, err := scanAssessmentCycleBackfillRun(row)
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -179,7 +182,7 @@ func (repository *AssessmentCycleBackfillRepository) FinishAssessmentCycleBackfi
 			would_create_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='would_create'),
 			skipped_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='skipped'),
 			failed_count=(SELECT count(*) FROM assessment_cycle_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='failed')
-			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>$6 RETURNING `+assessmentCycleBackfillRunCols,
+			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>now() RETURNING `+assessmentCycleBackfillRunCols,
 			tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), string(state), now)
 		finished, err := scanAssessmentCycleBackfillRun(row)
 		if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/infrastructure/persistence/postgres/assessment_cycle_backfill_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_cycle_backfill_repo_test.go
@@ -1,0 +1,128 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/pressly/goose/v3"
+)
+
+type postgresBackfillClock struct{ now time.Time }
+
+func (clock *postgresBackfillClock) Now() time.Time { return clock.now }
+
+func TestPostgresAssessmentCycleBackfillRunner(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 132); err != nil {
+		t.Fatalf("up to 0132: %v", err)
+	}
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	clock := &postgresBackfillClock{now: now}
+	tenantID, otherTenantID := shared.ID("backfill-pg-tenant"), shared.ID("backfill-pg-other")
+	for _, tenant := range []shared.ID{tenantID, otherTenantID} {
+		if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES($1,$1)`, tenant.String()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	engagements := NewEngagementRepository(pool)
+	for index, status := range []engdom.Status{engdom.StatusActive, engdom.StatusArchived} {
+		assessment, err := engdom.New(shared.ID([]string{"assessment-a", "assessment-b"}[index]), tenantID, "Historical", "Client", now.Add(-time.Duration(index+2)*time.Hour))
+		if err != nil {
+			t.Fatal(err)
+		}
+		assessment.Status = status
+		assessment.Audit.CreatedBy, assessment.Audit.UpdatedBy = "owner", "reviewer"
+		assessment.Audit.UpdatedAt = now.Add(-time.Duration(index+1) * time.Hour)
+		if err := engagements.Create(ctx, assessment); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cycles := NewAssessmentCycleRepository(pool)
+	transactions := NewTenantTransactionRunner(pool)
+	audit := assessmentCycleNoopAudit{}
+	cycleService, err := cycleuc.NewService(cycles, engagements, nil, nil, transactions, idgen.RandomID{}, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewAssessmentCycleBackfillRepository(pool)
+	runner, err := cycleuc.NewBackfillRunner(cycleService, engagements, store, idgen.RandomID{}, clock, audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := runner.Run(ctx, cycleuc.BackfillRequest{TenantID: tenantID, Actor: "operator", LeaseOwner: "postgres-test", BatchSize: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.State != ports.AssessmentCycleBackfillCompleted || run.ProcessedCount != 2 || run.CreatedCount != 2 || run.CheckpointAssessment != "assessment-b" {
+		t.Fatalf("postgres backfill run = %+v", run)
+	}
+	if _, err := store.GetAssessmentCycleBackfillRun(ctx, otherTenantID, run.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant run read = %v", err)
+	}
+	archived, err := cycles.GetCycleByAssessment(ctx, tenantID, "assessment-b")
+	if err != nil || archived.Status != "archived" || archived.CreatedBy != "owner" || archived.UpdatedBy != "reviewer" {
+		t.Fatalf("postgres archived cycle = %+v, err=%v", archived, err)
+	}
+}
+
+func TestPostgresAssessmentCycleBackfillLeaseAndCompositeFK(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 132); err != nil {
+		t.Fatalf("up to 0132: %v", err)
+	}
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	for _, tenant := range []string{"lease-a", "lease-b"} {
+		if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES($1,$1)`, tenant); err != nil {
+			t.Fatal(err)
+		}
+	}
+	assessment, err := engdom.New("assessment-b", "lease-b", "Other tenant", "Client", time.Now().UTC().Add(-time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := NewEngagementRepository(pool).Create(ctx, assessment); err != nil {
+		t.Fatal(err)
+	}
+	repository := NewAssessmentCycleBackfillRepository(pool)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	request := ports.AssessmentCycleBackfillAcquireRequest{Run: ports.AssessmentCycleBackfillRun{
+		TenantID: "lease-a", ID: "run-a", SchemaVersion: 1, BatchSize: 500, SnapshotAt: now, State: ports.AssessmentCycleBackfillRunning,
+		LeaseOwner: "owner-a", LeaseToken: "token-a", LeaseExpiresAt: now.Add(time.Minute), CreatedBy: "operator", CreatedAt: now, UpdatedAt: now,
+	}, LeaseDuration: time.Minute}
+	if _, _, err := repository.AcquireAssessmentCycleBackfillRun(ctx, request); err != nil {
+		t.Fatal(err)
+	}
+	contender := request
+	contender.Run.ID, contender.Run.LeaseOwner, contender.Run.LeaseToken = "run-b", "owner-b", "token-b"
+	if _, _, err := repository.AcquireAssessmentCycleBackfillRun(ctx, contender); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("concurrent backfill lease = %v", err)
+	}
+	if _, _, err := repository.CommitAssessmentCycleBackfillItem(ctx, "lease-a", "run-a", "token-a", now, func(context.Context) (ports.AssessmentCycleBackfillItem, error) {
+		return ports.AssessmentCycleBackfillItem{TenantID: "lease-a", RunID: "run-a", AssessmentID: "assessment-b", SchemaVersion: 1, IdempotencyKey: "source-v1", Outcome: "failed", ReasonCode: "source_not_found", RepairGuidance: "repair", ProcessedAt: now}, nil
+	}); err == nil {
+		t.Fatal("expected composite tenant FK rejection")
+	}
+	contender.Run.CreatedAt, contender.Run.SnapshotAt = now.Add(2*time.Minute), now
+	resumed, wasResumed, err := repository.AcquireAssessmentCycleBackfillRun(ctx, contender)
+	if err != nil || !wasResumed || resumed.ID != "run-a" || resumed.LeaseOwner != "owner-b" {
+		t.Fatalf("expired lease resume = %+v resumed=%v err=%v", resumed, wasResumed, err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/assessment_cycle_backfill_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_cycle_backfill_repo_test.go
@@ -20,7 +20,7 @@ func (clock *postgresBackfillClock) Now() time.Time { return clock.now }
 
 func TestPostgresAssessmentCycleBackfillRunner(t *testing.T) {
 	db, dsn := newAssessmentMigrationDB(t)
-	if err := goose.UpTo(db, ".", 132); err != nil {
+	if err := goose.UpTo(db, ".", 133); err != nil {
 		t.Fatalf("up to 0132: %v", err)
 	}
 	ctx := context.Background()
@@ -80,7 +80,7 @@ func TestPostgresAssessmentCycleBackfillRunner(t *testing.T) {
 
 func TestPostgresAssessmentCycleBackfillLeaseAndCompositeFK(t *testing.T) {
 	db, dsn := newAssessmentMigrationDB(t)
-	if err := goose.UpTo(db, ".", 132); err != nil {
+	if err := goose.UpTo(db, ".", 133); err != nil {
 		t.Fatalf("up to 0132: %v", err)
 	}
 	ctx := context.Background()

--- a/internal/infrastructure/persistence/postgres/assessment_cycle_integrity_repo.go
+++ b/internal/infrastructure/persistence/postgres/assessment_cycle_integrity_repo.go
@@ -1,0 +1,393 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const assessmentCycleIntegrityRunCols = `tenant_id,id,batch_size,snapshot_at,checkpoint_assessment_id,state,lease_owner,lease_token,lease_expires_at,scanned_count,clean_count,finding_count,created_by,created_at,updated_at,completed_at`
+
+type AssessmentCycleIntegrityRepository struct{ pool *pgxpool.Pool }
+
+func NewAssessmentCycleIntegrityRepository(pool *pgxpool.Pool) *AssessmentCycleIntegrityRepository {
+	return &AssessmentCycleIntegrityRepository{pool: pool}
+}
+
+var _ ports.AssessmentCycleIntegritySource = (*AssessmentCycleIntegrityRepository)(nil)
+var _ ports.AssessmentCycleIntegrityStore = (*AssessmentCycleIntegrityRepository)(nil)
+
+func (repository *AssessmentCycleIntegrityRepository) ListAssessmentCycleIntegritySubjects(ctx context.Context, tenantID, after shared.ID, snapshotAt time.Time, limit int) (subjects []ports.AssessmentCycleIntegritySubject, err error) {
+	if snapshotAt.IsZero() || limit < 1 || limit > 2000 {
+		return nil, fmt.Errorf("%w: assessment cycle integrity page is invalid", shared.ErrValidation)
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT id FROM engagements WHERE tenant_id=$1 AND project_id IS NULL AND id COLLATE "C">$2 AND created_at<=$3 ORDER BY id COLLATE "C" LIMIT $4`, tenantID.String(), after.String(), snapshotAt.UTC(), limit)
+		if err != nil {
+			return fmt.Errorf("list assessment cycle integrity subjects: %w", err)
+		}
+		assessmentIDs := make([]shared.ID, 0, limit)
+		for rows.Next() {
+			var assessmentID shared.ID
+			if err := rows.Scan(&assessmentID); err != nil {
+				rows.Close()
+				return fmt.Errorf("scan assessment cycle integrity subject: %w", err)
+			}
+			assessmentIDs = append(assessmentIDs, assessmentID)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return err
+		}
+		rows.Close()
+		if len(assessmentIDs) == 0 {
+			return nil
+		}
+		idStrings := make([]string, len(assessmentIDs))
+		subjectIndex := make(map[shared.ID]int, len(assessmentIDs))
+		for index, assessmentID := range assessmentIDs {
+			idStrings[index] = assessmentID.String()
+			subjects = append(subjects, ports.AssessmentCycleIntegritySubject{TenantID: tenantID, AssessmentID: assessmentID})
+			subjectIndex[assessmentID] = len(subjects) - 1
+		}
+		membershipRows, err := tx.Query(ctx, `SELECT assessment_id,cycle_id,count(*) FROM assessment_cycle_members WHERE tenant_id=$1 AND assessment_id=ANY($2) GROUP BY assessment_id,cycle_id ORDER BY assessment_id,cycle_id`, tenantID.String(), idStrings)
+		if err != nil {
+			return fmt.Errorf("list assessment cycle integrity memberships: %w", err)
+		}
+		membershipCounts := map[shared.ID]map[shared.ID]int{}
+		cycleSet := map[shared.ID]bool{}
+		for membershipRows.Next() {
+			var assessmentID, cycleID shared.ID
+			var count int
+			if err := membershipRows.Scan(&assessmentID, &cycleID, &count); err != nil {
+				membershipRows.Close()
+				return err
+			}
+			if membershipCounts[assessmentID] == nil {
+				membershipCounts[assessmentID] = map[shared.ID]int{}
+			}
+			membershipCounts[assessmentID][cycleID] = count
+			cycleSet[cycleID] = true
+		}
+		if err := membershipRows.Err(); err != nil {
+			membershipRows.Close()
+			return err
+		}
+		membershipRows.Close()
+		if len(cycleSet) == 0 {
+			return nil
+		}
+		cycleIDs := make([]string, 0, len(cycleSet))
+		for cycleID := range cycleSet {
+			cycleIDs = append(cycleIDs, cycleID.String())
+		}
+		cycleRows, err := tx.Query(ctx, `SELECT `+assessmentCycleCols+` FROM assessment_cycles WHERE tenant_id=$1 AND id=ANY($2)`, tenantID.String(), cycleIDs)
+		if err != nil {
+			return fmt.Errorf("load assessment cycles for integrity: %w", err)
+		}
+		cycles := map[shared.ID]cycledom.AssessmentCycle{}
+		for cycleRows.Next() {
+			cycle, err := scanAssessmentCycle(cycleRows)
+			if err != nil {
+				cycleRows.Close()
+				return err
+			}
+			cycles[cycle.ID] = *cycle
+		}
+		if err := cycleRows.Err(); err != nil {
+			cycleRows.Close()
+			return err
+		}
+		cycleRows.Close()
+		memberRows, err := tx.Query(ctx, `SELECT m.tenant_id,m.cycle_id,m.assessment_id,m.assessment_type,COALESCE(m.predecessor_assessment_id,''),m.retest_number,m.relationship_version,m.created_at,m.created_by,m.archived_at,
+			e.id IS NOT NULL,COALESCE(e.status,''),COALESCE(e.business_asset_id,''),COALESCE(e.project_id,'')
+			FROM assessment_cycle_members m LEFT JOIN engagements e ON e.tenant_id=m.tenant_id AND e.id=m.assessment_id
+			WHERE m.tenant_id=$1 AND m.cycle_id=ANY($2) ORDER BY m.cycle_id,m.retest_number,m.assessment_id`, tenantID.String(), cycleIDs)
+		if err != nil {
+			return fmt.Errorf("load assessment cycle integrity members: %w", err)
+		}
+		members := map[shared.ID][]ports.AssessmentCycleIntegrityMember{}
+		for memberRows.Next() {
+			var (
+				wrapped   ports.AssessmentCycleIntegrityMember
+				typeValue string
+				status    string
+				archived  pgtype.Timestamptz
+			)
+			if err := memberRows.Scan(&wrapped.Member.TenantID, &wrapped.Member.CycleID, &wrapped.Member.AssessmentID, &typeValue, &wrapped.Member.PredecessorAssessmentID,
+				&wrapped.Member.RetestNumber, &wrapped.Member.RelationshipVersion, &wrapped.Member.CreatedAt, &wrapped.Member.CreatedBy, &archived,
+				&wrapped.AssessmentExists, &status, &wrapped.BusinessAssetID, &wrapped.ProjectID); err != nil {
+				memberRows.Close()
+				return err
+			}
+			wrapped.Member.AssessmentType, wrapped.AssessmentStatus = cycledom.AssessmentType(typeValue), engdom.Status(status)
+			if archived.Valid {
+				archivedAt := archived.Time
+				wrapped.Member.ArchivedAt = &archivedAt
+			}
+			members[wrapped.Member.CycleID] = append(members[wrapped.Member.CycleID], wrapped)
+		}
+		if err := memberRows.Err(); err != nil {
+			memberRows.Close()
+			return err
+		}
+		memberRows.Close()
+		for assessmentID, cycleMemberships := range membershipCounts {
+			subject := &subjects[subjectIndex[assessmentID]]
+			for cycleID, count := range cycleMemberships {
+				cycle, exists := cycles[cycleID]
+				if !exists {
+					cycle = cycledom.AssessmentCycle{TenantID: tenantID, ID: cycleID}
+				}
+				subject.Cycles = append(subject.Cycles, ports.AssessmentCycleIntegrityCycle{Cycle: cycle, CycleExists: exists, SubjectMembershipCount: count, Members: append([]ports.AssessmentCycleIntegrityMember(nil), members[cycleID]...)})
+			}
+			sort.Slice(subject.Cycles, func(left, right int) bool { return subject.Cycles[left].Cycle.ID < subject.Cycles[right].Cycle.ID })
+		}
+		return nil
+	})
+	return subjects, err
+}
+
+func (repository *AssessmentCycleIntegrityRepository) CountAssessmentCycleIntegritySubjects(ctx context.Context, tenantID shared.ID, snapshotAt time.Time) (eligible int, memberships int, err error) {
+	if snapshotAt.IsZero() {
+		return 0, 0, fmt.Errorf("%w: assessment cycle integrity count snapshot is required", shared.ErrValidation)
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		if err := tx.QueryRow(ctx, `SELECT count(*) FROM engagements WHERE tenant_id=$1 AND project_id IS NULL AND created_at<=$2`, tenantID.String(), snapshotAt.UTC()).Scan(&eligible); err != nil {
+			return err
+		}
+		return tx.QueryRow(ctx, `SELECT count(*) FROM assessment_cycle_members member JOIN engagements assessment ON assessment.tenant_id=member.tenant_id AND assessment.id=member.assessment_id
+			WHERE member.tenant_id=$1 AND assessment.project_id IS NULL AND assessment.created_at<=$2`, tenantID.String(), snapshotAt.UTC()).Scan(&memberships)
+	})
+	return eligible, memberships, err
+}
+
+func (repository *AssessmentCycleIntegrityRepository) AcquireAssessmentCycleIntegrityRun(ctx context.Context, request ports.AssessmentCycleIntegrityAcquireRequest) (run ports.AssessmentCycleIntegrityRun, resumed bool, err error) {
+	if err := validatePostgresIntegrityAcquire(request); err != nil {
+		return ports.AssessmentCycleIntegrityRun{}, false, err
+	}
+	err = WithTenant(ctx, repository.pool, request.Run.TenantID.String(), func(tx pgx.Tx) error {
+		existing, scanErr := scanAssessmentCycleIntegrityRun(tx.QueryRow(ctx, `SELECT `+assessmentCycleIntegrityRunCols+` FROM assessment_cycle_integrity_runs WHERE tenant_id=$1 AND state='running' FOR UPDATE`, request.Run.TenantID.String()))
+		if scanErr == nil {
+			if existing.LeaseOwner != request.Run.LeaseOwner && existing.LeaseExpiresAt.After(request.Run.CreatedAt) {
+				return fmt.Errorf("%w: assessment cycle integrity verifier already running for tenant", shared.ErrConflict)
+			}
+			if existing.BatchSize != request.Run.BatchSize {
+				return fmt.Errorf("%w: requested assessment cycle integrity batch size %d differs from persisted batch size %d", shared.ErrConflict, request.Run.BatchSize, existing.BatchSize)
+			}
+			updated, err := scanAssessmentCycleIntegrityRun(tx.QueryRow(ctx, `UPDATE assessment_cycle_integrity_runs SET lease_owner=$3,lease_token=$4,lease_expires_at=$5,updated_at=$6 WHERE tenant_id=$1 AND id=$2 AND state='running' RETURNING `+assessmentCycleIntegrityRunCols,
+				request.Run.TenantID.String(), existing.ID.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.Run.CreatedAt.Add(request.LeaseDuration), request.Run.CreatedAt))
+			if err != nil {
+				return fmt.Errorf("resume assessment cycle integrity run: %w", err)
+			}
+			run, resumed = updated, true
+			return nil
+		}
+		if !errors.Is(scanErr, pgx.ErrNoRows) {
+			return fmt.Errorf("find active assessment cycle integrity run: %w", scanErr)
+		}
+		created, err := scanAssessmentCycleIntegrityRun(tx.QueryRow(ctx, `INSERT INTO assessment_cycle_integrity_runs (`+assessmentCycleIntegrityRunCols+`) VALUES ($1,$2,$3,$4,'','running',$5,$6,$7,0,0,0,$8,$9,$9,NULL) RETURNING `+assessmentCycleIntegrityRunCols,
+			request.Run.TenantID.String(), request.Run.ID.String(), request.Run.BatchSize, request.Run.SnapshotAt, request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.Run.CreatedAt.Add(request.LeaseDuration), request.Run.CreatedBy, request.Run.CreatedAt))
+		if err != nil {
+			return fmt.Errorf("create assessment cycle integrity run: %w", err)
+		}
+		run = created
+		return nil
+	})
+	return run, resumed, err
+}
+
+func (repository *AssessmentCycleIntegrityRepository) GetAssessmentCycleIntegrityRun(ctx context.Context, tenantID, runID shared.ID) (run ports.AssessmentCycleIntegrityRun, err error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		item, err := scanAssessmentCycleIntegrityRun(tx.QueryRow(ctx, `SELECT `+assessmentCycleIntegrityRunCols+` FROM assessment_cycle_integrity_runs WHERE tenant_id=$1 AND id=$2`, tenantID.String(), runID.String()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return err
+		}
+		run = item
+		return nil
+	})
+	return run, err
+}
+
+func (repository *AssessmentCycleIntegrityRepository) GetAssessmentCycleIntegritySubject(ctx context.Context, tenantID, runID, assessmentID shared.ID) (result ports.AssessmentCycleIntegritySubjectResult, err error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		err := tx.QueryRow(ctx, `SELECT tenant_id,run_id,assessment_id,clean,finding_count,processed_at FROM assessment_cycle_integrity_subjects WHERE tenant_id=$1 AND run_id=$2 AND assessment_id=$3`, tenantID.String(), runID.String(), assessmentID.String()).Scan(
+			&result.TenantID, &result.RunID, &result.AssessmentID, &result.Clean, &result.FindingCount, &result.ProcessedAt)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		return err
+	})
+	return result, err
+}
+
+func (repository *AssessmentCycleIntegrityRepository) ListAssessmentCycleIntegrityFindings(ctx context.Context, tenantID, runID shared.ID) (findings []ports.AssessmentCycleIntegrityFinding, err error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT tenant_id,run_id,occurrence_id,assessment_id,COALESCE(cycle_id,''),COALESCE(member_id,''),reason_code,severity,repair_plan,detected_at FROM assessment_cycle_integrity_findings WHERE tenant_id=$1 AND run_id=$2 ORDER BY occurrence_id`, tenantID.String(), runID.String())
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var finding ports.AssessmentCycleIntegrityFinding
+			if err := rows.Scan(&finding.TenantID, &finding.RunID, &finding.OccurrenceID, &finding.AssessmentID, &finding.CycleID, &finding.MemberID, &finding.ReasonCode, &finding.Severity, &finding.RepairPlan, &finding.DetectedAt); err != nil {
+				return err
+			}
+			findings = append(findings, finding)
+		}
+		return rows.Err()
+	})
+	return findings, err
+}
+
+func (repository *AssessmentCycleIntegrityRepository) SaveAssessmentCycleIntegritySubject(ctx context.Context, leaseToken shared.ID, now time.Time, result ports.AssessmentCycleIntegritySubjectResult, findings []ports.AssessmentCycleIntegrityFinding) (created bool, err error) {
+	if err := validatePostgresIntegritySubject(result, findings); err != nil {
+		return false, err
+	}
+	if leaseToken.IsZero() || now.IsZero() {
+		return false, fmt.Errorf("%w: assessment cycle integrity lease identity is invalid", shared.ErrValidation)
+	}
+	err = WithTenant(ctx, repository.pool, result.TenantID.String(), func(tx pgx.Tx) error {
+		var active bool
+		if err := tx.QueryRow(ctx, `SELECT state='running' AND lease_token=$3 AND lease_expires_at>$4 FROM assessment_cycle_integrity_runs WHERE tenant_id=$1 AND id=$2 FOR UPDATE`, result.TenantID.String(), result.RunID.String(), leaseToken.String(), now.UTC()).Scan(&active); errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		} else if err != nil {
+			return fmt.Errorf("lock assessment cycle integrity lease: %w", err)
+		}
+		if !active {
+			return fmt.Errorf("%w: assessment cycle integrity lease is stale", shared.ErrConflict)
+		}
+		var inserted int
+		err := tx.QueryRow(ctx, `INSERT INTO assessment_cycle_integrity_subjects(tenant_id,run_id,assessment_id,clean,finding_count,processed_at) VALUES($1,$2,$3,$4,$5,$6)
+			ON CONFLICT (tenant_id,run_id,assessment_id) DO NOTHING RETURNING 1`, result.TenantID.String(), result.RunID.String(), result.AssessmentID.String(), result.Clean, result.FindingCount, result.ProcessedAt.UTC()).Scan(&inserted)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("save assessment cycle integrity subject: %w", err)
+		}
+		for _, finding := range findings {
+			if _, err := tx.Exec(ctx, `INSERT INTO assessment_cycle_integrity_findings(tenant_id,run_id,occurrence_id,assessment_id,cycle_id,member_id,reason_code,severity,repair_plan,detected_at)
+				VALUES($1,$2,$3,$4,NULLIF($5,''),NULLIF($6,''),$7,$8,$9,$10)`, finding.TenantID.String(), finding.RunID.String(), finding.OccurrenceID, finding.AssessmentID.String(), finding.CycleID.String(), finding.MemberID.String(), finding.ReasonCode, finding.Severity, finding.RepairPlan, finding.DetectedAt.UTC()); err != nil {
+				return fmt.Errorf("save assessment cycle integrity finding: %w", err)
+			}
+		}
+		created = inserted == 1
+		return nil
+	})
+	return created, err
+}
+
+func (repository *AssessmentCycleIntegrityRepository) AdvanceAssessmentCycleIntegrityRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken, checkpoint shared.ID, now time.Time, leaseDuration time.Duration) (run ports.AssessmentCycleIntegrityRun, err error) {
+	tenantID, leaseOwner, now = shared.TenantOrDefault(tenantID), strings.TrimSpace(leaseOwner), now.UTC()
+	if tenantID.IsZero() || runID.IsZero() || leaseOwner == "" || leaseToken.IsZero() || checkpoint.IsZero() || now.IsZero() || leaseDuration <= 0 {
+		return ports.AssessmentCycleIntegrityRun{}, fmt.Errorf("%w: assessment cycle integrity checkpoint is invalid", shared.ErrValidation)
+	}
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		updated, err := scanAssessmentCycleIntegrityRun(tx.QueryRow(ctx, `UPDATE assessment_cycle_integrity_runs AS run SET checkpoint_assessment_id=$5,updated_at=$6::timestamptz,lease_expires_at=$6::timestamptz+($7 * interval '1 microsecond'),
+			scanned_count=(SELECT count(*) FROM assessment_cycle_integrity_subjects subject WHERE subject.tenant_id=run.tenant_id AND subject.run_id=run.id),
+			clean_count=(SELECT count(*) FROM assessment_cycle_integrity_subjects subject WHERE subject.tenant_id=run.tenant_id AND subject.run_id=run.id AND subject.clean),
+			finding_count=(SELECT COALESCE(sum(subject.finding_count),0) FROM assessment_cycle_integrity_subjects subject WHERE subject.tenant_id=run.tenant_id AND subject.run_id=run.id)
+			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>$6 AND run.checkpoint_assessment_id COLLATE "C"<=$5 RETURNING `+assessmentCycleIntegrityRunCols,
+			tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), checkpoint.String(), now, leaseDuration.Microseconds()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: assessment cycle integrity checkpoint rejected", shared.ErrConflict)
+		}
+		if err != nil {
+			return err
+		}
+		run = updated
+		return nil
+	})
+	return run, err
+}
+
+func (repository *AssessmentCycleIntegrityRepository) FinishAssessmentCycleIntegrityRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken shared.ID, state ports.AssessmentCycleIntegrityState, now time.Time) (run ports.AssessmentCycleIntegrityRun, err error) {
+	if state != ports.AssessmentCycleIntegrityCompleted && state != ports.AssessmentCycleIntegrityCancelled && state != ports.AssessmentCycleIntegrityFailed {
+		return ports.AssessmentCycleIntegrityRun{}, fmt.Errorf("%w: invalid assessment cycle integrity terminal state", shared.ErrValidation)
+	}
+	tenantID, leaseOwner, now = shared.TenantOrDefault(tenantID), strings.TrimSpace(leaseOwner), now.UTC()
+	if tenantID.IsZero() || runID.IsZero() || leaseOwner == "" || leaseToken.IsZero() || now.IsZero() {
+		return ports.AssessmentCycleIntegrityRun{}, fmt.Errorf("%w: assessment cycle integrity completion identity is invalid", shared.ErrValidation)
+	}
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		finished, err := scanAssessmentCycleIntegrityRun(tx.QueryRow(ctx, `UPDATE assessment_cycle_integrity_runs AS run SET state=$5,lease_owner='',lease_token='',lease_expires_at=NULL,updated_at=$6,completed_at=$6,
+			scanned_count=(SELECT count(*) FROM assessment_cycle_integrity_subjects subject WHERE subject.tenant_id=run.tenant_id AND subject.run_id=run.id),
+			clean_count=(SELECT count(*) FROM assessment_cycle_integrity_subjects subject WHERE subject.tenant_id=run.tenant_id AND subject.run_id=run.id AND subject.clean),
+			finding_count=(SELECT COALESCE(sum(subject.finding_count),0) FROM assessment_cycle_integrity_subjects subject WHERE subject.tenant_id=run.tenant_id AND subject.run_id=run.id)
+			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>$6 RETURNING `+assessmentCycleIntegrityRunCols,
+			tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), string(state), now))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: assessment cycle integrity completion rejected", shared.ErrConflict)
+		}
+		if err != nil {
+			return err
+		}
+		run = finished
+		return nil
+	})
+	return run, err
+}
+
+func scanAssessmentCycleIntegrityRun(row rowScanner) (ports.AssessmentCycleIntegrityRun, error) {
+	var (
+		run                       ports.AssessmentCycleIntegrityRun
+		state                     string
+		leaseExpires, completedAt pgtype.Timestamptz
+	)
+	if err := row.Scan(&run.TenantID, &run.ID, &run.BatchSize, &run.SnapshotAt, &run.CheckpointAssessment, &state, &run.LeaseOwner, &run.LeaseToken, &leaseExpires,
+		&run.ScannedCount, &run.CleanCount, &run.FindingCount, &run.CreatedBy, &run.CreatedAt, &run.UpdatedAt, &completedAt); err != nil {
+		return ports.AssessmentCycleIntegrityRun{}, err
+	}
+	run.State = ports.AssessmentCycleIntegrityState(state)
+	if leaseExpires.Valid {
+		run.LeaseExpiresAt = leaseExpires.Time
+	}
+	if completedAt.Valid {
+		completed := completedAt.Time
+		run.CompletedAt = &completed
+	}
+	return run, nil
+}
+
+func validatePostgresIntegrityAcquire(request ports.AssessmentCycleIntegrityAcquireRequest) error {
+	run := request.Run
+	if run.TenantID.IsZero() || run.ID.IsZero() || run.LeaseToken.IsZero() || run.BatchSize < 1 || run.BatchSize > 2000 || run.SnapshotAt.IsZero() || run.State != ports.AssessmentCycleIntegrityRunning || strings.TrimSpace(run.LeaseOwner) == "" || len(run.LeaseOwner) > 256 || strings.TrimSpace(run.CreatedBy) == "" || len(run.CreatedBy) > 256 || run.CreatedAt.IsZero() || request.LeaseDuration <= 0 {
+		return fmt.Errorf("%w: assessment cycle integrity run is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validatePostgresIntegritySubject(result ports.AssessmentCycleIntegritySubjectResult, findings []ports.AssessmentCycleIntegrityFinding) error {
+	if result.TenantID.IsZero() || result.RunID.IsZero() || result.AssessmentID.IsZero() || result.FindingCount != len(findings) || result.Clean != (len(findings) == 0) || result.ProcessedAt.IsZero() {
+		return fmt.Errorf("%w: assessment cycle integrity subject result is invalid", shared.ErrValidation)
+	}
+	for _, finding := range findings {
+		validSeverity := finding.Severity == "medium" || finding.Severity == "high" || finding.Severity == "critical"
+		if finding.TenantID != result.TenantID || finding.RunID != result.RunID || finding.AssessmentID != result.AssessmentID || len(finding.OccurrenceID) != 32 || strings.TrimSpace(finding.ReasonCode) == "" || len(finding.ReasonCode) > 64 || !validSeverity || !json.Valid(finding.RepairPlan) || len(finding.RepairPlan) > 8192 || finding.DetectedAt.IsZero() {
+			return fmt.Errorf("%w: assessment cycle integrity finding is invalid", shared.ErrValidation)
+		}
+	}
+	return nil
+}

--- a/internal/infrastructure/persistence/postgres/assessment_cycle_integrity_repo.go
+++ b/internal/infrastructure/persistence/postgres/assessment_cycle_integrity_repo.go
@@ -19,7 +19,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
-const assessmentCycleIntegrityRunCols = `tenant_id,id,batch_size,snapshot_at,checkpoint_assessment_id,state,lease_owner,lease_token,lease_expires_at,scanned_count,clean_count,finding_count,created_by,created_at,updated_at,completed_at`
+const assessmentCycleIntegrityRunCols = `tenant_id,id,batch_size,snapshot_at,source_generation,checkpoint_assessment_id,state,lease_owner,lease_token,lease_expires_at,scanned_count,clean_count,finding_count,created_by,created_at,updated_at,completed_at`
 
 type AssessmentCycleIntegrityRepository struct{ pool *pgxpool.Pool }
 
@@ -29,6 +29,14 @@ func NewAssessmentCycleIntegrityRepository(pool *pgxpool.Pool) *AssessmentCycleI
 
 var _ ports.AssessmentCycleIntegritySource = (*AssessmentCycleIntegrityRepository)(nil)
 var _ ports.AssessmentCycleIntegrityStore = (*AssessmentCycleIntegrityRepository)(nil)
+
+func (repository *AssessmentCycleIntegrityRepository) AssessmentCycleIntegrityGeneration(ctx context.Context, tenantID shared.ID) (generation int64, err error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT COALESCE((SELECT generation FROM assessment_cycle_integrity_generations WHERE tenant_id=$1),0)`, tenantID.String()).Scan(&generation)
+	})
+	return generation, err
+}
 
 func (repository *AssessmentCycleIntegrityRepository) ListAssessmentCycleIntegritySubjects(ctx context.Context, tenantID, after shared.ID, snapshotAt time.Time, limit int) (subjects []ports.AssessmentCycleIntegritySubject, err error) {
 	if snapshotAt.IsZero() || limit < 1 || limit > 2000 {
@@ -184,14 +192,17 @@ func (repository *AssessmentCycleIntegrityRepository) AcquireAssessmentCycleInte
 	err = WithTenant(ctx, repository.pool, request.Run.TenantID.String(), func(tx pgx.Tx) error {
 		existing, scanErr := scanAssessmentCycleIntegrityRun(tx.QueryRow(ctx, `SELECT `+assessmentCycleIntegrityRunCols+` FROM assessment_cycle_integrity_runs WHERE tenant_id=$1 AND state='running' FOR UPDATE`, request.Run.TenantID.String()))
 		if scanErr == nil {
-			if existing.LeaseOwner != request.Run.LeaseOwner && existing.LeaseExpiresAt.After(request.Run.CreatedAt) {
-				return fmt.Errorf("%w: assessment cycle integrity verifier already running for tenant", shared.ErrConflict)
-			}
 			if existing.BatchSize != request.Run.BatchSize {
 				return fmt.Errorf("%w: requested assessment cycle integrity batch size %d differs from persisted batch size %d", shared.ErrConflict, request.Run.BatchSize, existing.BatchSize)
 			}
-			updated, err := scanAssessmentCycleIntegrityRun(tx.QueryRow(ctx, `UPDATE assessment_cycle_integrity_runs SET lease_owner=$3,lease_token=$4,lease_expires_at=$5,updated_at=$6 WHERE tenant_id=$1 AND id=$2 AND state='running' RETURNING `+assessmentCycleIntegrityRunCols,
-				request.Run.TenantID.String(), existing.ID.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.Run.CreatedAt.Add(request.LeaseDuration), request.Run.CreatedAt))
+			updated, err := scanAssessmentCycleIntegrityRun(tx.QueryRow(ctx, `UPDATE assessment_cycle_integrity_runs
+				SET lease_owner=$3,lease_token=$4,lease_expires_at=now()+($5 * interval '1 microsecond'),updated_at=$6
+				WHERE tenant_id=$1 AND id=$2 AND state='running' AND (lease_owner=$3 OR lease_expires_at <= now())
+				RETURNING `+assessmentCycleIntegrityRunCols,
+				request.Run.TenantID.String(), existing.ID.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.LeaseDuration.Microseconds(), request.Run.CreatedAt))
+			if errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("%w: assessment cycle integrity verifier already running for tenant", shared.ErrConflict)
+			}
 			if err != nil {
 				return fmt.Errorf("resume assessment cycle integrity run: %w", err)
 			}
@@ -201,8 +212,8 @@ func (repository *AssessmentCycleIntegrityRepository) AcquireAssessmentCycleInte
 		if !errors.Is(scanErr, pgx.ErrNoRows) {
 			return fmt.Errorf("find active assessment cycle integrity run: %w", scanErr)
 		}
-		created, err := scanAssessmentCycleIntegrityRun(tx.QueryRow(ctx, `INSERT INTO assessment_cycle_integrity_runs (`+assessmentCycleIntegrityRunCols+`) VALUES ($1,$2,$3,$4,'','running',$5,$6,$7,0,0,0,$8,$9,$9,NULL) RETURNING `+assessmentCycleIntegrityRunCols,
-			request.Run.TenantID.String(), request.Run.ID.String(), request.Run.BatchSize, request.Run.SnapshotAt, request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.Run.CreatedAt.Add(request.LeaseDuration), request.Run.CreatedBy, request.Run.CreatedAt))
+		created, err := scanAssessmentCycleIntegrityRun(tx.QueryRow(ctx, `INSERT INTO assessment_cycle_integrity_runs (`+assessmentCycleIntegrityRunCols+`) VALUES ($1,$2,$3,$4,$5,'','running',$6,$7,now()+($8 * interval '1 microsecond'),0,0,0,$9,$10,$10,NULL) RETURNING `+assessmentCycleIntegrityRunCols,
+			request.Run.TenantID.String(), request.Run.ID.String(), request.Run.BatchSize, request.Run.SnapshotAt, request.Run.SourceGeneration, request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.LeaseDuration.Microseconds(), request.Run.CreatedBy, request.Run.CreatedAt))
 		if err != nil {
 			return fmt.Errorf("create assessment cycle integrity run: %w", err)
 		}
@@ -270,7 +281,7 @@ func (repository *AssessmentCycleIntegrityRepository) SaveAssessmentCycleIntegri
 	}
 	err = WithTenant(ctx, repository.pool, result.TenantID.String(), func(tx pgx.Tx) error {
 		var active bool
-		if err := tx.QueryRow(ctx, `SELECT state='running' AND lease_token=$3 AND lease_expires_at>$4 FROM assessment_cycle_integrity_runs WHERE tenant_id=$1 AND id=$2 FOR UPDATE`, result.TenantID.String(), result.RunID.String(), leaseToken.String(), now.UTC()).Scan(&active); errors.Is(err, pgx.ErrNoRows) {
+		if err := tx.QueryRow(ctx, `SELECT state='running' AND lease_token=$3 AND lease_expires_at>now() FROM assessment_cycle_integrity_runs WHERE tenant_id=$1 AND id=$2 FOR UPDATE`, result.TenantID.String(), result.RunID.String(), leaseToken.String()).Scan(&active); errors.Is(err, pgx.ErrNoRows) {
 			return shared.ErrNotFound
 		} else if err != nil {
 			return fmt.Errorf("lock assessment cycle integrity lease: %w", err)
@@ -305,11 +316,11 @@ func (repository *AssessmentCycleIntegrityRepository) AdvanceAssessmentCycleInte
 		return ports.AssessmentCycleIntegrityRun{}, fmt.Errorf("%w: assessment cycle integrity checkpoint is invalid", shared.ErrValidation)
 	}
 	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
-		updated, err := scanAssessmentCycleIntegrityRun(tx.QueryRow(ctx, `UPDATE assessment_cycle_integrity_runs AS run SET checkpoint_assessment_id=$5,updated_at=$6::timestamptz,lease_expires_at=$6::timestamptz+($7 * interval '1 microsecond'),
+		updated, err := scanAssessmentCycleIntegrityRun(tx.QueryRow(ctx, `UPDATE assessment_cycle_integrity_runs AS run SET checkpoint_assessment_id=$5,updated_at=$6::timestamptz,lease_expires_at=now()+($7 * interval '1 microsecond'),
 			scanned_count=(SELECT count(*) FROM assessment_cycle_integrity_subjects subject WHERE subject.tenant_id=run.tenant_id AND subject.run_id=run.id),
 			clean_count=(SELECT count(*) FROM assessment_cycle_integrity_subjects subject WHERE subject.tenant_id=run.tenant_id AND subject.run_id=run.id AND subject.clean),
 			finding_count=(SELECT COALESCE(sum(subject.finding_count),0) FROM assessment_cycle_integrity_subjects subject WHERE subject.tenant_id=run.tenant_id AND subject.run_id=run.id)
-			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>$6 AND run.checkpoint_assessment_id COLLATE "C"<=$5 RETURNING `+assessmentCycleIntegrityRunCols,
+			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>now() AND run.checkpoint_assessment_id COLLATE "C"<=$5 RETURNING `+assessmentCycleIntegrityRunCols,
 			tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), checkpoint.String(), now, leaseDuration.Microseconds()))
 		if errors.Is(err, pgx.ErrNoRows) {
 			return fmt.Errorf("%w: assessment cycle integrity checkpoint rejected", shared.ErrConflict)
@@ -332,11 +343,15 @@ func (repository *AssessmentCycleIntegrityRepository) FinishAssessmentCycleInteg
 		return ports.AssessmentCycleIntegrityRun{}, fmt.Errorf("%w: assessment cycle integrity completion identity is invalid", shared.ErrValidation)
 	}
 	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended('assessment-cycle-integrity:' || $1, 0))`, tenantID.String()); err != nil {
+			return fmt.Errorf("lock assessment cycle integrity source generation: %w", err)
+		}
 		finished, err := scanAssessmentCycleIntegrityRun(tx.QueryRow(ctx, `UPDATE assessment_cycle_integrity_runs AS run SET state=$5,lease_owner='',lease_token='',lease_expires_at=NULL,updated_at=$6,completed_at=$6,
 			scanned_count=(SELECT count(*) FROM assessment_cycle_integrity_subjects subject WHERE subject.tenant_id=run.tenant_id AND subject.run_id=run.id),
 			clean_count=(SELECT count(*) FROM assessment_cycle_integrity_subjects subject WHERE subject.tenant_id=run.tenant_id AND subject.run_id=run.id AND subject.clean),
 			finding_count=(SELECT COALESCE(sum(subject.finding_count),0) FROM assessment_cycle_integrity_subjects subject WHERE subject.tenant_id=run.tenant_id AND subject.run_id=run.id)
-			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>$6 RETURNING `+assessmentCycleIntegrityRunCols,
+			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>now()
+			AND ($5 <> 'completed' OR run.source_generation=COALESCE((SELECT generation FROM assessment_cycle_integrity_generations WHERE tenant_id=$1),0)) RETURNING `+assessmentCycleIntegrityRunCols,
 			tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), string(state), now))
 		if errors.Is(err, pgx.ErrNoRows) {
 			return fmt.Errorf("%w: assessment cycle integrity completion rejected", shared.ErrConflict)
@@ -356,7 +371,7 @@ func scanAssessmentCycleIntegrityRun(row rowScanner) (ports.AssessmentCycleInteg
 		state                     string
 		leaseExpires, completedAt pgtype.Timestamptz
 	)
-	if err := row.Scan(&run.TenantID, &run.ID, &run.BatchSize, &run.SnapshotAt, &run.CheckpointAssessment, &state, &run.LeaseOwner, &run.LeaseToken, &leaseExpires,
+	if err := row.Scan(&run.TenantID, &run.ID, &run.BatchSize, &run.SnapshotAt, &run.SourceGeneration, &run.CheckpointAssessment, &state, &run.LeaseOwner, &run.LeaseToken, &leaseExpires,
 		&run.ScannedCount, &run.CleanCount, &run.FindingCount, &run.CreatedBy, &run.CreatedAt, &run.UpdatedAt, &completedAt); err != nil {
 		return ports.AssessmentCycleIntegrityRun{}, err
 	}

--- a/internal/infrastructure/persistence/postgres/assessment_cycle_integrity_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_cycle_integrity_repo_test.go
@@ -1,0 +1,121 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/pressly/goose/v3"
+)
+
+func TestPostgresAssessmentCycleIntegrityVerifierFindsCorruption(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 133); err != nil {
+		t.Fatalf("up to 0133: %v", err)
+	}
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	clock := &postgresBackfillClock{now: now}
+	tenantID, otherTenantID := shared.ID("integrity-pg-tenant"), shared.ID("integrity-pg-other")
+	for _, tenant := range []shared.ID{tenantID, otherTenantID} {
+		if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES($1,$1)`, tenant.String()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	engagements := NewEngagementRepository(pool)
+	for _, assessmentID := range []shared.ID{"assessment-a", "assessment-b"} {
+		assessment, err := engdom.New(assessmentID, tenantID, assessmentID.String(), "Client", now.Add(-time.Hour))
+		if err != nil {
+			t.Fatal(err)
+		}
+		assessment.Audit.CreatedBy, assessment.Audit.UpdatedBy = "owner", "owner"
+		if err := engagements.Create(ctx, assessment); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cycles := NewAssessmentCycleRepository(pool)
+	cycleService, err := cycleuc.NewService(cycles, engagements, nil, nil, NewTenantTransactionRunner(pool), idgen.RandomID{}, clock, assessmentCycleNoopAudit{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cycle, _, err := cycleService.CreateInitialCycle(ctx, cycleuc.CreateInitialCycleInput{TenantID: tenantID, Name: "Cycle", BoundaryKind: cycledom.BoundaryStandalone, RootAssessmentID: "assessment-a", Actor: "owner"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE assessment_cycles SET selected_head_assessment_id='assessment-b' WHERE tenant_id=$1 AND id=$2`, tenantID.String(), cycle.ID.String()); err != nil {
+		t.Fatal(err)
+	}
+	repository := NewAssessmentCycleIntegrityRepository(pool)
+	verifier, err := cycleuc.NewIntegrityVerifier(repository, repository, idgen.RandomID{}, clock, assessmentCycleNoopAudit{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := verifier.Run(ctx, cycleuc.IntegrityRequest{TenantID: tenantID, Actor: "operator", LeaseOwner: "postgres-integrity", BatchSize: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.State != ports.AssessmentCycleIntegrityCompleted || run.ScannedCount != 2 || run.CleanCount != 0 || run.FindingCount < 2 {
+		t.Fatalf("integrity run = %+v", run)
+	}
+	findings, err := repository.ListAssessmentCycleIntegrityFindings(ctx, tenantID, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reasons := map[string]bool{}
+	for _, finding := range findings {
+		reasons[finding.ReasonCode] = true
+	}
+	if !reasons[cycleuc.IntegrityCoverageMissing] || !reasons[cycleuc.IntegritySelectedHeadMissing] {
+		t.Fatalf("integrity reasons = %v", reasons)
+	}
+	if _, err := repository.GetAssessmentCycleIntegrityRun(ctx, otherTenantID, run.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant integrity run read = %v", err)
+	}
+}
+
+func TestPostgresAssessmentCycleIntegrityLease(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 133); err != nil {
+		t.Fatalf("up to 0133: %v", err)
+	}
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES('integrity-lease','integrity-lease')`); err != nil {
+		t.Fatal(err)
+	}
+	repository := NewAssessmentCycleIntegrityRepository(pool)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	request := ports.AssessmentCycleIntegrityAcquireRequest{Run: ports.AssessmentCycleIntegrityRun{
+		TenantID: "integrity-lease", ID: "run-a", BatchSize: 500, SnapshotAt: now, State: ports.AssessmentCycleIntegrityRunning,
+		LeaseOwner: "owner-a", LeaseToken: "token-a", LeaseExpiresAt: now.Add(time.Minute), CreatedBy: "operator", CreatedAt: now, UpdatedAt: now,
+	}, LeaseDuration: time.Minute}
+	if _, _, err := repository.AcquireAssessmentCycleIntegrityRun(ctx, request); err != nil {
+		t.Fatal(err)
+	}
+	contender := request
+	contender.Run.ID, contender.Run.LeaseOwner, contender.Run.LeaseToken = "run-b", "owner-b", "token-b"
+	if _, _, err := repository.AcquireAssessmentCycleIntegrityRun(ctx, contender); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("concurrent integrity lease = %v", err)
+	}
+	contender.Run.CreatedAt, contender.Run.SnapshotAt = now.Add(2*time.Minute), now
+	resumed, wasResumed, err := repository.AcquireAssessmentCycleIntegrityRun(ctx, contender)
+	if err != nil || !wasResumed || resumed.ID != "run-a" || resumed.LeaseOwner != "owner-b" {
+		t.Fatalf("expired integrity lease resume = %+v resumed=%v err=%v", resumed, wasResumed, err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/assessment_cycle_integrity_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_cycle_integrity_repo_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestPostgresAssessmentCycleIntegrityVerifierFindsCorruption(t *testing.T) {
 	db, dsn := newAssessmentMigrationDB(t)
-	if err := goose.UpTo(db, ".", 133); err != nil {
+	if err := goose.UpTo(db, ".", 134); err != nil {
 		t.Fatalf("up to 0133: %v", err)
 	}
 	ctx := context.Background()
@@ -87,7 +87,7 @@ func TestPostgresAssessmentCycleIntegrityVerifierFindsCorruption(t *testing.T) {
 
 func TestPostgresAssessmentCycleIntegrityLease(t *testing.T) {
 	db, dsn := newAssessmentMigrationDB(t)
-	if err := goose.UpTo(db, ".", 133); err != nil {
+	if err := goose.UpTo(db, ".", 134); err != nil {
 		t.Fatalf("up to 0133: %v", err)
 	}
 	ctx := context.Background()

--- a/internal/infrastructure/persistence/postgres/assessment_cycle_repo.go
+++ b/internal/infrastructure/persistence/postgres/assessment_cycle_repo.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -30,6 +31,8 @@ func NewAssessmentCycleRepository(pool *pgxpool.Pool) *AssessmentCycleRepository
 }
 
 var _ ports.AssessmentCycleRepository = (*AssessmentCycleRepository)(nil)
+var _ ports.AssessmentCycleListRepository = (*AssessmentCycleRepository)(nil)
+var _ ports.AssessmentCycleCompensationRepository = (*AssessmentCycleRepository)(nil)
 
 func (r *AssessmentCycleRepository) CreateCycle(ctx context.Context, cycle *assessmentcycle.AssessmentCycle) error {
 	if cycle == nil {
@@ -119,6 +122,171 @@ func (r *AssessmentCycleRepository) GetCycleByAssessment(ctx context.Context, te
 		return nil
 	})
 	return cycle, err
+}
+
+func (r *AssessmentCycleRepository) ListCycles(ctx context.Context, query ports.AssessmentCycleListQuery) ([]ports.AssessmentCycleListRecord, error) {
+	tenantID := shared.TenantOrDefault(query.TenantID)
+	if tenantID.IsZero() || query.Limit <= 0 {
+		return nil, fmt.Errorf("%w: tenant and positive cycle list limit are required", shared.ErrValidation)
+	}
+	if query.MemberLimit <= 0 {
+		query.MemberLimit = 10
+	}
+	records := make([]ports.AssessmentCycleListRecord, 0, query.Limit)
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT c.tenant_id, c.id, c.name, c.boundary_kind, c.business_asset_id, c.project_id, c.status,
+			       c.root_assessment_id, c.selected_head_assessment_id, c.next_retest_number, c.version,
+			       c.created_at, c.updated_at, c.created_by, c.updated_by,
+			       COALESCE(stats.member_count, 0), COALESCE(stats.branch_count, 0),
+			       COALESCE(latest.assessment_id, ''), COALESCE(latest.retest_number, -1),
+			       COALESCE(member_page.members, '[]'::jsonb),
+			       COALESCE(root_default.snapshot_id, ''), COALESCE(current_default.snapshot_id, ''),
+			       latest_scan.last_scan_at,
+			       CASE WHEN latest_scan.last_scan_at IS NULL THEN 'missing'
+			            WHEN latest_scan.last_scan_at >= $12::timestamptz THEN 'fresh' ELSE 'stale' END
+			FROM assessment_cycles c
+			JOIN engagements selected_head
+			  ON selected_head.tenant_id = c.tenant_id AND selected_head.id = c.selected_head_assessment_id
+			LEFT JOIN LATERAL (
+				SELECT COUNT(*)::int AS member_count,
+				       COUNT(*) FILTER (WHERE member.archived_at IS NULL AND NOT EXISTS (
+					       SELECT 1 FROM assessment_cycle_members child
+					       WHERE child.tenant_id = member.tenant_id AND child.cycle_id = member.cycle_id
+					         AND child.predecessor_assessment_id = member.assessment_id AND child.archived_at IS NULL
+				       ))::int AS branch_count
+				FROM assessment_cycle_members member
+				WHERE member.tenant_id = c.tenant_id AND member.cycle_id = c.id
+			) stats ON true
+			LEFT JOIN LATERAL (
+				SELECT member.assessment_id, member.retest_number
+				FROM assessment_cycle_members member
+				WHERE member.tenant_id = c.tenant_id AND member.cycle_id = c.id AND member.archived_at IS NULL
+				ORDER BY member.retest_number DESC, member.assessment_id DESC
+				LIMIT 1
+			) latest ON true
+			LEFT JOIN LATERAL (
+				SELECT jsonb_agg(jsonb_build_object(
+					'assessment_id', member.assessment_id,
+					'assessment_type', member.assessment_type,
+					'predecessor_assessment_id', COALESCE(member.predecessor_assessment_id, ''),
+					'retest_number', member.retest_number,
+					'relationship_version', member.relationship_version,
+					'created_at', member.created_at,
+					'created_by', member.created_by,
+					'archived_at', member.archived_at
+				) ORDER BY member.retest_number, member.assessment_id) AS members
+				FROM (
+					SELECT member.* FROM assessment_cycle_members member
+					WHERE member.tenant_id = c.tenant_id AND member.cycle_id = c.id
+					ORDER BY member.retest_number, member.assessment_id
+					LIMIT $7
+				) member
+			) member_page ON true
+			LEFT JOIN assessment_snapshot_defaults root_default
+			  ON root_default.tenant_id = c.tenant_id AND root_default.assessment_id = c.root_assessment_id
+			LEFT JOIN assessment_snapshot_defaults current_default
+			  ON current_default.tenant_id = c.tenant_id AND current_default.assessment_id = c.selected_head_assessment_id
+			LEFT JOIN LATERAL (
+				SELECT MAX(run.sealed_at) AS last_scan_at
+				FROM scan_runs run
+				WHERE run.tenant_id = c.tenant_id AND run.engagement_id = c.selected_head_assessment_id
+				  AND run.provenance = 'native' AND run.terminal_status IN ('succeeded','partial') AND run.sealed_at IS NOT NULL
+			) latest_scan ON true
+			WHERE c.tenant_id = $1
+			  AND ($2 = '' OR c.status = $2)
+			  AND ($3 = '' OR c.boundary_kind = $3)
+			  AND ($4::timestamptz IS NULL OR c.updated_at < $4 OR (c.updated_at = $4 AND c.id < $5))
+			  AND ($8 = '' OR selected_head.status = $8)
+			  AND ($9 = '' OR c.selected_head_assessment_id = $9)
+			  AND ($10 = '' OR EXISTS (
+				  SELECT 1 FROM assessment_cycle_members filtered_member
+				  WHERE filtered_member.tenant_id = c.tenant_id AND filtered_member.cycle_id = c.id AND filtered_member.assessment_type = $10
+			  ))
+			  AND ($11 = '' OR CASE WHEN latest_scan.last_scan_at IS NULL THEN 'missing'
+			      WHEN latest_scan.last_scan_at >= $12::timestamptz THEN 'fresh' ELSE 'stale' END = $11)
+			  AND ($13 = '' OR position(lower($13) in lower(c.name)) > 0 OR position(lower($13) in lower(c.id)) > 0
+			      OR position(lower($13) in lower(c.root_assessment_id)) > 0 OR position(lower($13) in lower(c.selected_head_assessment_id)) > 0)
+			ORDER BY c.updated_at DESC, c.id DESC
+			LIMIT $6`, tenantID.String(), string(query.Status), string(query.BoundaryKind), nullableCycleCursorTime(query.AfterUpdatedAt), query.AfterCycleID.String(), query.Limit, query.MemberLimit+1,
+			string(query.AssessmentStatus), query.SelectedHeadID.String(), string(query.AssessmentType), query.ScanStaleness, query.ScanStaleBefore, query.Search)
+		if err != nil {
+			return fmt.Errorf("list assessment cycles: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			cycle, record, err := scanAssessmentCycleListRecord(rows, query.MemberLimit)
+			if err != nil {
+				return err
+			}
+			record.Cycle = *cycle
+			records = append(records, record)
+		}
+		return rows.Err()
+	})
+	return records, err
+}
+
+func (r *AssessmentCycleRepository) ListMigrationPendingAssessments(ctx context.Context, query ports.AssessmentCycleListQuery) ([]ports.AssessmentCycleMigrationPendingRecord, int, error) {
+	tenantID := shared.TenantOrDefault(query.TenantID)
+	if tenantID.IsZero() || query.Limit < 1 || query.Limit > 100 {
+		return nil, 0, fmt.Errorf("%w: tenant and bounded migration-pending limit are required", shared.ErrValidation)
+	}
+	records := make([]ports.AssessmentCycleMigrationPendingRecord, 0, query.Limit)
+	total := 0
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		predicate := `e.tenant_id=$1 AND e.project_id IS NULL AND NOT EXISTS (
+			SELECT 1 FROM assessment_cycle_members member WHERE member.tenant_id=e.tenant_id AND member.assessment_id=e.id)`
+		if err := tx.QueryRow(ctx, `SELECT count(*) FROM engagements e WHERE `+predicate, tenantID.String()).Scan(&total); err != nil {
+			return fmt.Errorf("count migration-pending assessments: %w", err)
+		}
+		if query.Status != "" || !query.SelectedHeadID.IsZero() || query.AssessmentType != "" || query.ScanStaleness != "" {
+			return nil
+		}
+		rows, err := tx.Query(ctx, `SELECT e.id,e.name,e.status,
+			CASE WHEN e.business_asset_id IS NULL THEN 'standalone' ELSE 'asset' END,
+			COALESCE(e.business_asset_id,''),e.updated_at
+			FROM engagements e WHERE `+predicate+`
+			AND ($2 = '' OR e.status = $2)
+			AND ($3 = '' OR CASE WHEN e.business_asset_id IS NULL THEN 'standalone' ELSE 'asset' END = $3)
+			AND ($4 = '' OR position(lower($4) in lower(e.name)) > 0 OR position(lower($4) in lower(e.id)) > 0)
+			ORDER BY e.updated_at DESC,e.id DESC LIMIT $5`, tenantID.String(), string(query.AssessmentStatus), string(query.BoundaryKind), query.Search, query.Limit)
+		if err != nil {
+			return fmt.Errorf("list migration-pending assessments: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var record ports.AssessmentCycleMigrationPendingRecord
+			if err := rows.Scan(&record.AssessmentID, &record.Name, &record.Status, &record.BoundaryKind, &record.BusinessAssetID, &record.UpdatedAt); err != nil {
+				return fmt.Errorf("scan migration-pending assessment: %w", err)
+			}
+			records = append(records, record)
+		}
+		return rows.Err()
+	})
+	return records, total, err
+}
+
+func (r *AssessmentCycleRepository) DeleteCycle(ctx context.Context, tenantID, cycleID shared.ID) error {
+	tenantID = shared.TenantOrDefault(tenantID)
+	if tenantID.IsZero() || cycleID.IsZero() {
+		return fmt.Errorf("%w: tenant and cycle ids are required", shared.ErrValidation)
+	}
+	return WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `DELETE FROM assessment_cycles WHERE tenant_id=$1 AND id=$2`, tenantID.String(), cycleID.String())
+		return err
+	})
+}
+
+func (r *AssessmentCycleRepository) DeleteMember(ctx context.Context, tenantID, cycleID, assessmentID shared.ID) error {
+	tenantID = shared.TenantOrDefault(tenantID)
+	if tenantID.IsZero() || cycleID.IsZero() || assessmentID.IsZero() {
+		return fmt.Errorf("%w: tenant, cycle, and assessment ids are required", shared.ErrValidation)
+	}
+	return WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `DELETE FROM assessment_cycle_members WHERE tenant_id=$1 AND cycle_id=$2 AND assessment_id=$3`, tenantID.String(), cycleID.String(), assessmentID.String())
+		return err
+	})
 }
 
 func (r *AssessmentCycleRepository) UpdateCycleCAS(ctx context.Context, cycle *assessmentcycle.AssessmentCycle, expectedVersion int64) error {
@@ -410,6 +578,81 @@ func scanAssessmentCycle(row rowScanner) (*assessmentcycle.AssessmentCycle, erro
 		CreatedBy:                createdBy,
 		UpdatedBy:                updatedBy,
 	}, nil
+}
+
+func scanAssessmentCycleListRecord(row rowScanner, memberLimit int) (*assessmentcycle.AssessmentCycle, ports.AssessmentCycleListRecord, error) {
+	var (
+		cycle              assessmentcycle.AssessmentCycle
+		kind               string
+		status             string
+		businessAssetID    pgtype.Text
+		projectID          pgtype.Text
+		latestAssessmentID string
+		membersJSON        []byte
+		rootSnapshotID     string
+		currentSnapshotID  string
+		selectedHeadScanAt pgtype.Timestamptz
+		scanStaleness      string
+		record             ports.AssessmentCycleListRecord
+	)
+	err := row.Scan(
+		&cycle.TenantID, &cycle.ID, &cycle.Name, &kind, &businessAssetID, &projectID, &status,
+		&cycle.RootAssessmentID, &cycle.SelectedHeadAssessmentID, &cycle.NextRetestNumber, &cycle.Version,
+		&cycle.CreatedAt, &cycle.UpdatedAt, &cycle.CreatedBy, &cycle.UpdatedBy,
+		&record.MemberCount, &record.ActiveBranchCount, &latestAssessmentID, &record.LatestRetestNumber,
+		&membersJSON, &rootSnapshotID, &currentSnapshotID,
+		&selectedHeadScanAt, &scanStaleness,
+	)
+	if err != nil {
+		return nil, ports.AssessmentCycleListRecord{}, fmt.Errorf("scan assessment cycle list record: %w", err)
+	}
+	cycle.BoundaryKind, cycle.Status = assessmentcycle.BoundaryKind(kind), assessmentcycle.Status(status)
+	if businessAssetID.Valid {
+		cycle.BusinessAssetID = shared.ID(businessAssetID.String)
+	}
+	if projectID.Valid {
+		cycle.ProjectID = shared.ID(projectID.String)
+	}
+	record.LatestAssessmentID = shared.ID(latestAssessmentID)
+	var members []assessmentCycleListMemberJSON
+	if err := json.Unmarshal(membersJSON, &members); err != nil {
+		return nil, ports.AssessmentCycleListRecord{}, fmt.Errorf("decode assessment cycle list members: %w", err)
+	}
+	record.MembersHaveMore = len(members) > memberLimit
+	for _, member := range members[:min(len(members), memberLimit)] {
+		record.Members = append(record.Members, assessmentcycle.Member{
+			TenantID: cycle.TenantID, CycleID: cycle.ID, AssessmentID: shared.ID(member.AssessmentID), AssessmentType: assessmentcycle.AssessmentType(member.AssessmentType),
+			PredecessorAssessmentID: shared.ID(member.PredecessorAssessmentID), RetestNumber: member.RetestNumber, RelationshipVersion: member.RelationshipVersion,
+			CreatedAt: member.CreatedAt, CreatedBy: member.CreatedBy, ArchivedAt: member.ArchivedAt,
+		})
+	}
+	record.RootSnapshotID, record.CurrentSnapshotID, record.ScanStaleness = shared.ID(rootSnapshotID), shared.ID(currentSnapshotID), scanStaleness
+	if selectedHeadScanAt.Valid {
+		scanAt := selectedHeadScanAt.Time.UTC()
+		record.SelectedHeadScanAt = &scanAt
+	}
+	if err := cycle.Validate(); err != nil {
+		return nil, ports.AssessmentCycleListRecord{}, err
+	}
+	return &cycle, record, nil
+}
+
+type assessmentCycleListMemberJSON struct {
+	AssessmentID            string     `json:"assessment_id"`
+	AssessmentType          string     `json:"assessment_type"`
+	PredecessorAssessmentID string     `json:"predecessor_assessment_id"`
+	RetestNumber            int        `json:"retest_number"`
+	RelationshipVersion     int64      `json:"relationship_version"`
+	CreatedAt               time.Time  `json:"created_at"`
+	CreatedBy               string     `json:"created_by"`
+	ArchivedAt              *time.Time `json:"archived_at"`
+}
+
+func nullableCycleCursorTime(value time.Time) any {
+	if value.IsZero() {
+		return nil
+	}
+	return value.UTC()
 }
 
 func scanAssessmentCycleMember(row rowScanner) (*assessmentcycle.Member, error) {

--- a/internal/infrastructure/persistence/postgres/assessment_cycle_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_cycle_repo_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
@@ -89,6 +90,15 @@ func TestPostgresAssessmentCycleRepository_LifecycleAndCAS(t *testing.T) {
 	}
 	if err := repo.CreateMember(ctx, rootMember); err != nil {
 		t.Fatalf("create initial member: %v", err)
+	}
+	assetID := "asset-" + tenantID.String()
+	if _, err := pool.Exec(ctx, `INSERT INTO fleet_business_services(id,tenant_id,"key",name,owner) VALUES($1,$2,$1,'Frozen boundary','team')`, assetID, tenantID.String()); err != nil {
+		t.Fatalf("create boundary-change probe asset: %v", err)
+	}
+	_, err = pool.Exec(ctx, `UPDATE engagements SET business_asset_id=$1 WHERE tenant_id=$2 AND id=$3`, assetID, tenantID.String(), rootID.String())
+	var boundaryErr *pgconn.PgError
+	if !errors.As(err, &boundaryErr) || boundaryErr.Code != "23514" || boundaryErr.ConstraintName != "assessment_cycle_frozen_business_asset" {
+		t.Fatalf("database boundary invariant error=%v", err)
 	}
 
 	// 3. Duplicate Cycle Create -> ErrConflict

--- a/internal/infrastructure/persistence/postgres/assessment_cycle_request_repo.go
+++ b/internal/infrastructure/persistence/postgres/assessment_cycle_request_repo.go
@@ -1,0 +1,124 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const maxAssessmentCycleResponseBytes = 2 << 20
+
+type AssessmentCycleRequestRepository struct{ pool *pgxpool.Pool }
+
+func NewAssessmentCycleRequestRepository(pool *pgxpool.Pool) *AssessmentCycleRequestRepository {
+	return &AssessmentCycleRequestRepository{pool: pool}
+}
+
+var _ ports.AssessmentCycleRequestStore = (*AssessmentCycleRequestRepository)(nil)
+
+func (repository *AssessmentCycleRequestRepository) BeginAssessmentCycleRequest(ctx context.Context, request ports.AssessmentCycleRequest) (ports.AssessmentCycleRequest, bool, error) {
+	if err := validatePostgresAssessmentCycleRequest(request); err != nil {
+		return ports.AssessmentCycleRequest{}, false, err
+	}
+	tenantID := shared.TenantOrDefault(request.Scope.TenantID)
+	var stored ports.AssessmentCycleRequest
+	created := false
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `INSERT INTO assessment_cycle_api_requests
+			(tenant_id, actor, route, idempotency_key, request_hash, created_at)
+			VALUES ($1,$2,$3,$4,$5,$6)
+			ON CONFLICT (tenant_id, actor, route, idempotency_key) DO NOTHING`,
+			tenantID.String(), request.Scope.Actor, request.Scope.Route, request.Scope.IdempotencyKey, request.RequestHash, request.CreatedAt.UTC())
+		if err != nil {
+			return fmt.Errorf("reserve assessment cycle request: %w", err)
+		}
+		if tag.RowsAffected() == 1 {
+			stored, created = clonePostgresAssessmentCycleRequest(request), true
+			return nil
+		}
+		loaded, err := scanAssessmentCycleRequest(tx.QueryRow(ctx, `SELECT tenant_id, actor, route, idempotency_key, request_hash,
+			status_code, response_body, created_at, completed_at
+			FROM assessment_cycle_api_requests
+			WHERE tenant_id=$1 AND actor=$2 AND route=$3 AND idempotency_key=$4`,
+			tenantID.String(), request.Scope.Actor, request.Scope.Route, request.Scope.IdempotencyKey))
+		if err != nil {
+			return err
+		}
+		stored = loaded
+		return nil
+	})
+	return stored, created, err
+}
+
+func (repository *AssessmentCycleRequestRepository) CompleteAssessmentCycleRequest(ctx context.Context, scope ports.AssessmentCycleRequestScope, requestHash string, statusCode int, responseBody []byte, completedAt time.Time) error {
+	if err := validatePostgresAssessmentCycleRequest(ports.AssessmentCycleRequest{Scope: scope, RequestHash: requestHash, CreatedAt: completedAt}); err != nil || statusCode < 200 || statusCode > 599 || len(responseBody) == 0 || len(responseBody) > maxAssessmentCycleResponseBytes {
+		return fmt.Errorf("%w: assessment cycle request completion is invalid", shared.ErrValidation)
+	}
+	tenantID := shared.TenantOrDefault(scope.TenantID)
+	return WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `UPDATE assessment_cycle_api_requests
+			SET status_code=$6, response_body=$7, completed_at=$8
+			WHERE tenant_id=$1 AND actor=$2 AND route=$3 AND idempotency_key=$4
+			  AND request_hash=$5 AND completed_at IS NULL`, tenantID.String(), scope.Actor, scope.Route, scope.IdempotencyKey, requestHash, statusCode, responseBody, completedAt.UTC())
+		if err != nil {
+			return fmt.Errorf("complete assessment cycle request: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("%w: assessment cycle request completion conflict", shared.ErrConflict)
+		}
+		return nil
+	})
+}
+
+func (repository *AssessmentCycleRequestRepository) AbortAssessmentCycleRequest(ctx context.Context, scope ports.AssessmentCycleRequestScope, requestHash string) error {
+	tenantID := shared.TenantOrDefault(scope.TenantID)
+	if tenantID.IsZero() || strings.TrimSpace(scope.Actor) == "" || strings.TrimSpace(scope.Route) == "" || strings.TrimSpace(scope.IdempotencyKey) == "" || len(requestHash) != 64 {
+		return fmt.Errorf("%w: assessment cycle request abort is invalid", shared.ErrValidation)
+	}
+	return WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `DELETE FROM assessment_cycle_api_requests
+			WHERE tenant_id=$1 AND actor=$2 AND route=$3 AND idempotency_key=$4
+			  AND request_hash=$5 AND completed_at IS NULL`, tenantID.String(), scope.Actor, scope.Route, scope.IdempotencyKey, requestHash)
+		return err
+	})
+}
+
+func scanAssessmentCycleRequest(row rowScanner) (ports.AssessmentCycleRequest, error) {
+	var (
+		request     ports.AssessmentCycleRequest
+		statusCode  pgtype.Int4
+		completedAt pgtype.Timestamptz
+	)
+	if err := row.Scan(&request.Scope.TenantID, &request.Scope.Actor, &request.Scope.Route, &request.Scope.IdempotencyKey,
+		&request.RequestHash, &statusCode, &request.ResponseBody, &request.CreatedAt, &completedAt); err != nil {
+		return ports.AssessmentCycleRequest{}, fmt.Errorf("scan assessment cycle request: %w", err)
+	}
+	if statusCode.Valid {
+		request.StatusCode = int(statusCode.Int32)
+	}
+	if completedAt.Valid {
+		value := completedAt.Time.UTC()
+		request.CompletedAt = &value
+	}
+	return request, nil
+}
+
+func validatePostgresAssessmentCycleRequest(request ports.AssessmentCycleRequest) error {
+	if shared.TenantOrDefault(request.Scope.TenantID).IsZero() || strings.TrimSpace(request.Scope.Actor) == "" || len(request.Scope.Actor) > 256 || strings.TrimSpace(request.Scope.Route) == "" || len(request.Scope.Route) > 256 || strings.TrimSpace(request.Scope.IdempotencyKey) == "" || len(request.Scope.IdempotencyKey) > 128 || len(request.RequestHash) != 64 || request.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: assessment cycle idempotency request is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func clonePostgresAssessmentCycleRequest(request ports.AssessmentCycleRequest) ports.AssessmentCycleRequest {
+	request.ResponseBody = append([]byte(nil), request.ResponseBody...)
+	return request
+}

--- a/internal/infrastructure/persistence/postgres/assessment_cycle_request_repo.go
+++ b/internal/infrastructure/persistence/postgres/assessment_cycle_request_repo.go
@@ -25,6 +25,9 @@ func NewAssessmentCycleRequestRepository(pool *pgxpool.Pool) *AssessmentCycleReq
 var _ ports.AssessmentCycleRequestStore = (*AssessmentCycleRequestRepository)(nil)
 
 func (repository *AssessmentCycleRequestRepository) BeginAssessmentCycleRequest(ctx context.Context, request ports.AssessmentCycleRequest) (ports.AssessmentCycleRequest, bool, error) {
+	if request.ExpiresAt.IsZero() {
+		request.ExpiresAt = request.CreatedAt.Add(24 * time.Hour)
+	}
 	if err := validatePostgresAssessmentCycleRequest(request); err != nil {
 		return ports.AssessmentCycleRequest{}, false, err
 	}
@@ -32,11 +35,14 @@ func (repository *AssessmentCycleRequestRepository) BeginAssessmentCycleRequest(
 	var stored ports.AssessmentCycleRequest
 	created := false
 	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `DELETE FROM assessment_cycle_api_requests WHERE tenant_id=$1 AND expires_at <= $2`, tenantID.String(), request.CreatedAt.UTC()); err != nil {
+			return fmt.Errorf("prune expired assessment cycle requests: %w", err)
+		}
 		tag, err := tx.Exec(ctx, `INSERT INTO assessment_cycle_api_requests
-			(tenant_id, actor, route, idempotency_key, request_hash, created_at)
-			VALUES ($1,$2,$3,$4,$5,$6)
+			(tenant_id, actor, route, idempotency_key, request_hash, created_at, expires_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7)
 			ON CONFLICT (tenant_id, actor, route, idempotency_key) DO NOTHING`,
-			tenantID.String(), request.Scope.Actor, request.Scope.Route, request.Scope.IdempotencyKey, request.RequestHash, request.CreatedAt.UTC())
+			tenantID.String(), request.Scope.Actor, request.Scope.Route, request.Scope.IdempotencyKey, request.RequestHash, request.CreatedAt.UTC(), request.ExpiresAt.UTC())
 		if err != nil {
 			return fmt.Errorf("reserve assessment cycle request: %w", err)
 		}
@@ -45,7 +51,7 @@ func (repository *AssessmentCycleRequestRepository) BeginAssessmentCycleRequest(
 			return nil
 		}
 		loaded, err := scanAssessmentCycleRequest(tx.QueryRow(ctx, `SELECT tenant_id, actor, route, idempotency_key, request_hash,
-			status_code, response_body, created_at, completed_at
+			status_code, response_body, created_at, expires_at, completed_at
 			FROM assessment_cycle_api_requests
 			WHERE tenant_id=$1 AND actor=$2 AND route=$3 AND idempotency_key=$4`,
 			tenantID.String(), request.Scope.Actor, request.Scope.Route, request.Scope.IdempotencyKey))
@@ -59,7 +65,7 @@ func (repository *AssessmentCycleRequestRepository) BeginAssessmentCycleRequest(
 }
 
 func (repository *AssessmentCycleRequestRepository) CompleteAssessmentCycleRequest(ctx context.Context, scope ports.AssessmentCycleRequestScope, requestHash string, statusCode int, responseBody []byte, completedAt time.Time) error {
-	if err := validatePostgresAssessmentCycleRequest(ports.AssessmentCycleRequest{Scope: scope, RequestHash: requestHash, CreatedAt: completedAt}); err != nil || statusCode < 200 || statusCode > 599 || len(responseBody) == 0 || len(responseBody) > maxAssessmentCycleResponseBytes {
+	if err := validatePostgresAssessmentCycleRequest(ports.AssessmentCycleRequest{Scope: scope, RequestHash: requestHash, CreatedAt: completedAt, ExpiresAt: completedAt.Add(24 * time.Hour)}); err != nil || statusCode < 200 || statusCode > 599 || len(responseBody) == 0 || len(responseBody) > maxAssessmentCycleResponseBytes {
 		return fmt.Errorf("%w: assessment cycle request completion is invalid", shared.ErrValidation)
 	}
 	tenantID := shared.TenantOrDefault(scope.TenantID)
@@ -98,7 +104,7 @@ func scanAssessmentCycleRequest(row rowScanner) (ports.AssessmentCycleRequest, e
 		completedAt pgtype.Timestamptz
 	)
 	if err := row.Scan(&request.Scope.TenantID, &request.Scope.Actor, &request.Scope.Route, &request.Scope.IdempotencyKey,
-		&request.RequestHash, &statusCode, &request.ResponseBody, &request.CreatedAt, &completedAt); err != nil {
+		&request.RequestHash, &statusCode, &request.ResponseBody, &request.CreatedAt, &request.ExpiresAt, &completedAt); err != nil {
 		return ports.AssessmentCycleRequest{}, fmt.Errorf("scan assessment cycle request: %w", err)
 	}
 	if statusCode.Valid {
@@ -112,7 +118,7 @@ func scanAssessmentCycleRequest(row rowScanner) (ports.AssessmentCycleRequest, e
 }
 
 func validatePostgresAssessmentCycleRequest(request ports.AssessmentCycleRequest) error {
-	if shared.TenantOrDefault(request.Scope.TenantID).IsZero() || strings.TrimSpace(request.Scope.Actor) == "" || len(request.Scope.Actor) > 256 || strings.TrimSpace(request.Scope.Route) == "" || len(request.Scope.Route) > 256 || strings.TrimSpace(request.Scope.IdempotencyKey) == "" || len(request.Scope.IdempotencyKey) > 128 || len(request.RequestHash) != 64 || request.CreatedAt.IsZero() {
+	if shared.TenantOrDefault(request.Scope.TenantID).IsZero() || strings.TrimSpace(request.Scope.Actor) == "" || len(request.Scope.Actor) > 256 || strings.TrimSpace(request.Scope.Route) == "" || len(request.Scope.Route) > 256 || strings.TrimSpace(request.Scope.IdempotencyKey) == "" || len(request.Scope.IdempotencyKey) > 128 || len(request.RequestHash) != 64 || request.CreatedAt.IsZero() || !request.ExpiresAt.After(request.CreatedAt) {
 		return fmt.Errorf("%w: assessment cycle idempotency request is invalid", shared.ErrValidation)
 	}
 	return nil

--- a/internal/infrastructure/persistence/postgres/assessment_migration_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_migration_test.go
@@ -1,0 +1,66 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/migrations"
+)
+
+func newAssessmentMigrationDB(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	sharedDSN := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if sharedDSN == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	dsn := isolatedAssessmentMigrationDSN(t, sharedDSN)
+	db, err := goose.OpenDBWithDriver("pgx", dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	goose.SetBaseFS(migrations.FS)
+	if err := goose.SetDialect("postgres"); err != nil {
+		t.Fatal(err)
+	}
+	return db, dsn
+}
+
+func isolatedAssessmentMigrationDSN(t *testing.T, sharedDSN string) string {
+	t.Helper()
+	u, err := url.Parse(sharedDSN)
+	if err != nil || (u.Scheme != "postgres" && u.Scheme != "postgresql") {
+		t.Fatalf("parse PostgreSQL test DSN: %v", err)
+	}
+	name := fmt.Sprintf("synapse_assessment_migration_%d", time.Now().UnixNano())
+	isolated := *u
+	isolated.Path = "/" + name
+	isolated.RawPath = ""
+	admin, err := Connect(context.Background(), sharedDSN)
+	if err != nil {
+		t.Fatalf("connect PostgreSQL admin database: %v", err)
+	}
+	quotedName := pgx.Identifier{name}.Sanitize()
+	if _, err := admin.Exec(context.Background(), "CREATE DATABASE "+quotedName); err != nil {
+		admin.Close()
+		t.Fatalf("create isolated migration database: %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_, _ = admin.Exec(ctx, `SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname=$1`, name)
+		if _, err := admin.Exec(ctx, "DROP DATABASE "+quotedName); err != nil {
+			t.Errorf("drop isolated migration database: %v", err)
+		}
+		admin.Close()
+	})
+	return isolated.String()
+}

--- a/internal/infrastructure/persistence/postgres/assessment_snapshot_backfill_repo.go
+++ b/internal/infrastructure/persistence/postgres/assessment_snapshot_backfill_repo.go
@@ -1,0 +1,244 @@
+package postgres
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const assessmentSnapshotBackfillRunColumns = `tenant_id,id,schema_version,dry_run,batch_size,snapshot_at,checkpoint_assessment_id,state,lease_owner,lease_token,lease_expires_at,processed_count,created_count,would_create_count,skipped_count,failed_count,created_by,created_at,updated_at,completed_at`
+
+type AssessmentSnapshotBackfillRepository struct{ pool *pgxpool.Pool }
+
+func NewAssessmentSnapshotBackfillRepository(pool *pgxpool.Pool) *AssessmentSnapshotBackfillRepository {
+	return &AssessmentSnapshotBackfillRepository{pool: pool}
+}
+
+var _ ports.AssessmentSnapshotBackfillStore = (*AssessmentSnapshotBackfillRepository)(nil)
+
+func (repository *AssessmentSnapshotBackfillRepository) AcquireAssessmentSnapshotBackfillRun(ctx context.Context, request ports.AssessmentSnapshotBackfillAcquireRequest) (run ports.AssessmentSnapshotBackfillRun, resumed bool, err error) {
+	if err := validatePostgresAssessmentSnapshotBackfillAcquire(request); err != nil {
+		return ports.AssessmentSnapshotBackfillRun{}, false, err
+	}
+	err = WithTenant(ctx, repository.pool, request.Run.TenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `SELECT id FROM tenants WHERE id=$1 FOR UPDATE`, request.Run.TenantID.String()); err != nil {
+			return fmt.Errorf("lock assessment snapshot backfill tenant: %w", err)
+		}
+		row := tx.QueryRow(ctx, `SELECT `+assessmentSnapshotBackfillRunColumns+` FROM assessment_snapshot_backfill_runs WHERE tenant_id=$1 AND state='running' FOR UPDATE`, request.Run.TenantID.String())
+		existing, scanErr := scanAssessmentSnapshotBackfillRun(row)
+		if scanErr == nil {
+			if existing.LeaseOwner != request.Run.LeaseOwner && existing.LeaseExpiresAt.After(request.Run.CreatedAt) {
+				return fmt.Errorf("%w: assessment snapshot backfill already running for tenant", shared.ErrConflict)
+			}
+			if existing.SchemaVersion != request.Run.SchemaVersion || existing.DryRun != request.Run.DryRun || existing.BatchSize != request.Run.BatchSize {
+				return fmt.Errorf("%w: requested assessment snapshot backfill config (schema=%d dry_run=%t batch_size=%d) differs from persisted config (schema=%d dry_run=%t batch_size=%d)", shared.ErrConflict,
+					request.Run.SchemaVersion, request.Run.DryRun, request.Run.BatchSize, existing.SchemaVersion, existing.DryRun, existing.BatchSize)
+			}
+			updated, err := scanAssessmentSnapshotBackfillRun(tx.QueryRow(ctx, `UPDATE assessment_snapshot_backfill_runs SET lease_owner=$3,lease_token=$4,lease_expires_at=$5,updated_at=$6 WHERE tenant_id=$1 AND id=$2 AND state='running' RETURNING `+assessmentSnapshotBackfillRunColumns,
+				request.Run.TenantID.String(), existing.ID.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.Run.CreatedAt.Add(request.LeaseDuration), request.Run.CreatedAt))
+			if err != nil {
+				return fmt.Errorf("resume assessment snapshot backfill run: %w", err)
+			}
+			run, resumed = updated, true
+			return nil
+		}
+		if !errors.Is(scanErr, pgx.ErrNoRows) {
+			return fmt.Errorf("find active assessment snapshot backfill run: %w", scanErr)
+		}
+		created, err := scanAssessmentSnapshotBackfillRun(tx.QueryRow(ctx, `INSERT INTO assessment_snapshot_backfill_runs (`+assessmentSnapshotBackfillRunColumns+`) VALUES ($1,$2,$3,$4,$5,$6,$7,'running',$8,$9,$10,0,0,0,0,0,$11,$12,$12,NULL) RETURNING `+assessmentSnapshotBackfillRunColumns,
+			request.Run.TenantID.String(), request.Run.ID.String(), request.Run.SchemaVersion, request.Run.DryRun, request.Run.BatchSize, request.Run.SnapshotAt,
+			request.InitialCheckpoint.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.Run.CreatedAt.Add(request.LeaseDuration), request.Run.CreatedBy, request.Run.CreatedAt))
+		if err != nil {
+			return fmt.Errorf("create assessment snapshot backfill run: %w", err)
+		}
+		run = created
+		return nil
+	})
+	return run, resumed, err
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) GetAssessmentSnapshotBackfillRun(ctx context.Context, tenantID, runID shared.ID) (run ports.AssessmentSnapshotBackfillRun, err error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		item, err := scanAssessmentSnapshotBackfillRun(tx.QueryRow(ctx, `SELECT `+assessmentSnapshotBackfillRunColumns+` FROM assessment_snapshot_backfill_runs WHERE tenant_id=$1 AND id=$2`, tenantID.String(), runID.String()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("get assessment snapshot backfill run: %w", err)
+		}
+		run = item
+		return nil
+	})
+	return run, err
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) GetAssessmentSnapshotBackfillItem(ctx context.Context, tenantID, runID, assessmentID shared.ID) (item ports.AssessmentSnapshotBackfillItem, err error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `SELECT tenant_id,run_id,assessment_id,schema_version,idempotency_key,source_hash,COALESCE(snapshot_id,''),outcome,reason_code,retryable,repair_guidance,processed_at FROM assessment_snapshot_backfill_items WHERE tenant_id=$1 AND run_id=$2 AND assessment_id=$3`, tenantID.String(), runID.String(), assessmentID.String())
+		if err := row.Scan(&item.TenantID, &item.RunID, &item.AssessmentID, &item.SchemaVersion, &item.IdempotencyKey, &item.SourceHash, &item.SnapshotID, &item.Outcome, &item.ReasonCode, &item.Retryable, &item.RepairGuidance, &item.ProcessedAt); errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		} else if err != nil {
+			return fmt.Errorf("get assessment snapshot backfill item: %w", err)
+		}
+		return nil
+	})
+	return item, err
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) CommitAssessmentSnapshotBackfillItem(ctx context.Context, tenantID, runID, leaseToken shared.ID, now time.Time, build func(context.Context) (ports.AssessmentSnapshotBackfillItem, error)) (item ports.AssessmentSnapshotBackfillItem, created bool, err error) {
+	tenantID, now = shared.TenantOrDefault(tenantID), now.UTC()
+	if tenantID.IsZero() || runID.IsZero() || leaseToken.IsZero() || now.IsZero() || build == nil {
+		return item, false, fmt.Errorf("%w: assessment snapshot backfill commit identity is invalid", shared.ErrValidation)
+	}
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var active bool
+		if err := tx.QueryRow(ctx, `SELECT state='running' AND lease_token=$3 AND lease_expires_at>$4 FROM assessment_snapshot_backfill_runs WHERE tenant_id=$1 AND id=$2 FOR UPDATE`, tenantID.String(), runID.String(), leaseToken.String(), now).Scan(&active); errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		} else if err != nil {
+			return fmt.Errorf("lock assessment snapshot backfill lease: %w", err)
+		}
+		if !active {
+			return fmt.Errorf("%w: assessment snapshot backfill lease is stale", shared.ErrConflict)
+		}
+		var err error
+		item, err = build(bindTenantTransaction(ctx, tenantID, tx))
+		if err != nil {
+			return err
+		}
+		if item.TenantID != tenantID || item.RunID != runID {
+			return fmt.Errorf("%w: assessment snapshot backfill item ownership differs from lease", shared.ErrValidation)
+		}
+		if err := validatePostgresAssessmentSnapshotBackfillItem(item); err != nil {
+			return err
+		}
+		result, err := tx.Exec(ctx, `INSERT INTO assessment_snapshot_backfill_items(
+			tenant_id,run_id,assessment_id,schema_version,idempotency_key,source_hash,snapshot_id,outcome,reason_code,retryable,repair_guidance,processed_at)
+			SELECT $1,$2,$3,$4,$5,$6,NULLIF($7,''),$8,$9,$10,$11,$12
+			WHERE EXISTS (SELECT 1 FROM assessment_snapshot_backfill_runs WHERE tenant_id=$1 AND id=$2 AND state='running')
+			ON CONFLICT DO NOTHING`, item.TenantID.String(), item.RunID.String(), item.AssessmentID.String(), item.SchemaVersion,
+			item.IdempotencyKey, item.SourceHash, item.SnapshotID.String(), item.Outcome, item.ReasonCode, item.Retryable, item.RepairGuidance, item.ProcessedAt)
+		if err != nil {
+			return mapPostgresError(err, "save assessment snapshot backfill item")
+		}
+		created = result.RowsAffected() == 1
+		if !created {
+			var exists bool
+			if err := tx.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM assessment_snapshot_backfill_items WHERE tenant_id=$1 AND run_id=$2 AND assessment_id=$3)`, item.TenantID.String(), item.RunID.String(), item.AssessmentID.String()).Scan(&exists); err != nil {
+				return err
+			}
+			if !exists {
+				return fmt.Errorf("%w: assessment snapshot backfill run is not active", shared.ErrConflict)
+			}
+		}
+		return nil
+	})
+	return item, created, err
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) AdvanceAssessmentSnapshotBackfillRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken, checkpoint shared.ID, now time.Time, leaseDuration time.Duration) (run ports.AssessmentSnapshotBackfillRun, err error) {
+	tenantID, leaseOwner, now = shared.TenantOrDefault(tenantID), strings.TrimSpace(leaseOwner), now.UTC()
+	if leaseToken.IsZero() || leaseDuration <= 0 {
+		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: assessment snapshot backfill lease duration is invalid", shared.ErrValidation)
+	}
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		updated, err := scanAssessmentSnapshotBackfillRun(tx.QueryRow(ctx, `UPDATE assessment_snapshot_backfill_runs AS run SET checkpoint_assessment_id=$5,lease_expires_at=$7,updated_at=$6,
+			processed_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id),
+			created_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='created'),
+			would_create_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='would_create'),
+			skipped_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='skipped'),
+			failed_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='failed')
+			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>$6 AND run.checkpoint_assessment_id COLLATE "C" <= $5
+			RETURNING `+assessmentSnapshotBackfillRunColumns, tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), checkpoint.String(), now, now.Add(leaseDuration)))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: assessment snapshot backfill checkpoint rejected", shared.ErrConflict)
+		}
+		if err != nil {
+			return fmt.Errorf("advance assessment snapshot backfill run: %w", err)
+		}
+		run = updated
+		return nil
+	})
+	return run, err
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) FinishAssessmentSnapshotBackfillRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken shared.ID, state ports.AssessmentSnapshotBackfillState, now time.Time) (run ports.AssessmentSnapshotBackfillRun, err error) {
+	if state != ports.AssessmentSnapshotBackfillCompleted && state != ports.AssessmentSnapshotBackfillCancelled && state != ports.AssessmentSnapshotBackfillFailed {
+		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: invalid assessment snapshot backfill terminal state", shared.ErrValidation)
+	}
+	tenantID, leaseOwner, now = shared.TenantOrDefault(tenantID), strings.TrimSpace(leaseOwner), now.UTC()
+	if tenantID.IsZero() || runID.IsZero() || leaseOwner == "" || leaseToken.IsZero() || now.IsZero() {
+		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: assessment snapshot backfill completion identity is invalid", shared.ErrValidation)
+	}
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		finished, err := scanAssessmentSnapshotBackfillRun(tx.QueryRow(ctx, `UPDATE assessment_snapshot_backfill_runs AS run SET state=$5,lease_owner='',lease_token='',lease_expires_at=NULL,updated_at=$6,completed_at=$6,
+			processed_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id),
+			created_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='created'),
+			would_create_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='would_create'),
+			skipped_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='skipped'),
+			failed_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='failed')
+			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>$6 RETURNING `+assessmentSnapshotBackfillRunColumns,
+			tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), string(state), now))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: assessment snapshot backfill completion rejected", shared.ErrConflict)
+		}
+		if err != nil {
+			return fmt.Errorf("finish assessment snapshot backfill run: %w", err)
+		}
+		run = finished
+		return nil
+	})
+	return run, err
+}
+
+func scanAssessmentSnapshotBackfillRun(row rowScanner) (ports.AssessmentSnapshotBackfillRun, error) {
+	var (
+		run                       ports.AssessmentSnapshotBackfillRun
+		state                     string
+		leaseExpires, completedAt pgtype.Timestamptz
+	)
+	if err := row.Scan(&run.TenantID, &run.ID, &run.SchemaVersion, &run.DryRun, &run.BatchSize, &run.SnapshotAt, &run.CheckpointAssessment, &state, &run.LeaseOwner, &run.LeaseToken, &leaseExpires,
+		&run.ProcessedCount, &run.CreatedCount, &run.WouldCreateCount, &run.SkippedCount, &run.FailedCount, &run.CreatedBy, &run.CreatedAt, &run.UpdatedAt, &completedAt); err != nil {
+		return ports.AssessmentSnapshotBackfillRun{}, err
+	}
+	run.State = ports.AssessmentSnapshotBackfillState(state)
+	if leaseExpires.Valid {
+		run.LeaseExpiresAt = leaseExpires.Time
+	}
+	if completedAt.Valid {
+		completed := completedAt.Time
+		run.CompletedAt = &completed
+	}
+	return run, nil
+}
+
+func validatePostgresAssessmentSnapshotBackfillAcquire(request ports.AssessmentSnapshotBackfillAcquireRequest) error {
+	run := request.Run
+	if run.TenantID.IsZero() || run.ID.IsZero() || run.LeaseToken.IsZero() || run.SchemaVersion <= 0 || run.BatchSize < 1 || run.BatchSize > 2000 || run.SnapshotAt.IsZero() || run.State != ports.AssessmentSnapshotBackfillRunning || strings.TrimSpace(run.LeaseOwner) == "" || len(run.LeaseOwner) > 256 || strings.TrimSpace(run.CreatedBy) == "" || len(run.CreatedBy) > 256 || run.CreatedAt.IsZero() || request.LeaseDuration <= 0 {
+		return fmt.Errorf("%w: assessment snapshot backfill run is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validatePostgresAssessmentSnapshotBackfillItem(item ports.AssessmentSnapshotBackfillItem) error {
+	validOutcome := item.Outcome == "created" || item.Outcome == "would_create" || item.Outcome == "skipped" || item.Outcome == "failed"
+	_, hashErr := hex.DecodeString(item.SourceHash)
+	if item.TenantID.IsZero() || item.RunID.IsZero() || item.AssessmentID.IsZero() || item.SchemaVersion <= 0 || strings.TrimSpace(item.IdempotencyKey) == "" || len(item.IdempotencyKey) > 128 || len(item.SourceHash) != 64 || strings.ToLower(item.SourceHash) != item.SourceHash || hashErr != nil || !validOutcome || strings.TrimSpace(item.ReasonCode) == "" || len(item.ReasonCode) > 64 || len(item.RepairGuidance) > 1024 || item.ProcessedAt.IsZero() {
+		return fmt.Errorf("%w: assessment snapshot backfill item is invalid", shared.ErrValidation)
+	}
+	if item.Outcome == "created" && item.SnapshotID.IsZero() {
+		return fmt.Errorf("%w: created assessment snapshot backfill item requires a snapshot", shared.ErrValidation)
+	}
+	return nil
+}

--- a/internal/infrastructure/persistence/postgres/assessment_snapshot_backfill_repo.go
+++ b/internal/infrastructure/persistence/postgres/assessment_snapshot_backfill_repo.go
@@ -37,15 +37,18 @@ func (repository *AssessmentSnapshotBackfillRepository) AcquireAssessmentSnapsho
 		row := tx.QueryRow(ctx, `SELECT `+assessmentSnapshotBackfillRunColumns+` FROM assessment_snapshot_backfill_runs WHERE tenant_id=$1 AND state='running' FOR UPDATE`, request.Run.TenantID.String())
 		existing, scanErr := scanAssessmentSnapshotBackfillRun(row)
 		if scanErr == nil {
-			if existing.LeaseOwner != request.Run.LeaseOwner && existing.LeaseExpiresAt.After(request.Run.CreatedAt) {
-				return fmt.Errorf("%w: assessment snapshot backfill already running for tenant", shared.ErrConflict)
-			}
 			if existing.SchemaVersion != request.Run.SchemaVersion || existing.DryRun != request.Run.DryRun || existing.BatchSize != request.Run.BatchSize {
 				return fmt.Errorf("%w: requested assessment snapshot backfill config (schema=%d dry_run=%t batch_size=%d) differs from persisted config (schema=%d dry_run=%t batch_size=%d)", shared.ErrConflict,
 					request.Run.SchemaVersion, request.Run.DryRun, request.Run.BatchSize, existing.SchemaVersion, existing.DryRun, existing.BatchSize)
 			}
-			updated, err := scanAssessmentSnapshotBackfillRun(tx.QueryRow(ctx, `UPDATE assessment_snapshot_backfill_runs SET lease_owner=$3,lease_token=$4,lease_expires_at=$5,updated_at=$6 WHERE tenant_id=$1 AND id=$2 AND state='running' RETURNING `+assessmentSnapshotBackfillRunColumns,
-				request.Run.TenantID.String(), existing.ID.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.Run.CreatedAt.Add(request.LeaseDuration), request.Run.CreatedAt))
+			updated, err := scanAssessmentSnapshotBackfillRun(tx.QueryRow(ctx, `UPDATE assessment_snapshot_backfill_runs
+				SET lease_owner=$3,lease_token=$4,lease_expires_at=now()+($5 * interval '1 microsecond'),updated_at=$6
+				WHERE tenant_id=$1 AND id=$2 AND state='running' AND (lease_owner=$3 OR lease_expires_at <= now())
+				RETURNING `+assessmentSnapshotBackfillRunColumns,
+				request.Run.TenantID.String(), existing.ID.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.LeaseDuration.Microseconds(), request.Run.CreatedAt))
+			if errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("%w: assessment snapshot backfill already running for tenant", shared.ErrConflict)
+			}
 			if err != nil {
 				return fmt.Errorf("resume assessment snapshot backfill run: %w", err)
 			}
@@ -55,9 +58,9 @@ func (repository *AssessmentSnapshotBackfillRepository) AcquireAssessmentSnapsho
 		if !errors.Is(scanErr, pgx.ErrNoRows) {
 			return fmt.Errorf("find active assessment snapshot backfill run: %w", scanErr)
 		}
-		created, err := scanAssessmentSnapshotBackfillRun(tx.QueryRow(ctx, `INSERT INTO assessment_snapshot_backfill_runs (`+assessmentSnapshotBackfillRunColumns+`) VALUES ($1,$2,$3,$4,$5,$6,$7,'running',$8,$9,$10,0,0,0,0,0,$11,$12,$12,NULL) RETURNING `+assessmentSnapshotBackfillRunColumns,
+		created, err := scanAssessmentSnapshotBackfillRun(tx.QueryRow(ctx, `INSERT INTO assessment_snapshot_backfill_runs (`+assessmentSnapshotBackfillRunColumns+`) VALUES ($1,$2,$3,$4,$5,$6,$7,'running',$8,$9,now()+($10 * interval '1 microsecond'),0,0,0,0,0,$11,$12,$12,NULL) RETURNING `+assessmentSnapshotBackfillRunColumns,
 			request.Run.TenantID.String(), request.Run.ID.String(), request.Run.SchemaVersion, request.Run.DryRun, request.Run.BatchSize, request.Run.SnapshotAt,
-			request.InitialCheckpoint.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.Run.CreatedAt.Add(request.LeaseDuration), request.Run.CreatedBy, request.Run.CreatedAt))
+			request.InitialCheckpoint.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.LeaseDuration.Microseconds(), request.Run.CreatedBy, request.Run.CreatedAt))
 		if err != nil {
 			return fmt.Errorf("create assessment snapshot backfill run: %w", err)
 		}
@@ -104,7 +107,7 @@ func (repository *AssessmentSnapshotBackfillRepository) CommitAssessmentSnapshot
 	}
 	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
 		var active bool
-		if err := tx.QueryRow(ctx, `SELECT state='running' AND lease_token=$3 AND lease_expires_at>$4 FROM assessment_snapshot_backfill_runs WHERE tenant_id=$1 AND id=$2 FOR UPDATE`, tenantID.String(), runID.String(), leaseToken.String(), now).Scan(&active); errors.Is(err, pgx.ErrNoRows) {
+		if err := tx.QueryRow(ctx, `SELECT state='running' AND lease_token=$3 AND lease_expires_at>now() FROM assessment_snapshot_backfill_runs WHERE tenant_id=$1 AND id=$2 FOR UPDATE`, tenantID.String(), runID.String(), leaseToken.String()).Scan(&active); errors.Is(err, pgx.ErrNoRows) {
 			return shared.ErrNotFound
 		} else if err != nil {
 			return fmt.Errorf("lock assessment snapshot backfill lease: %w", err)
@@ -153,14 +156,14 @@ func (repository *AssessmentSnapshotBackfillRepository) AdvanceAssessmentSnapsho
 		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: assessment snapshot backfill lease duration is invalid", shared.ErrValidation)
 	}
 	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
-		updated, err := scanAssessmentSnapshotBackfillRun(tx.QueryRow(ctx, `UPDATE assessment_snapshot_backfill_runs AS run SET checkpoint_assessment_id=$5,lease_expires_at=$7,updated_at=$6,
+		updated, err := scanAssessmentSnapshotBackfillRun(tx.QueryRow(ctx, `UPDATE assessment_snapshot_backfill_runs AS run SET checkpoint_assessment_id=$5,lease_expires_at=now()+($7 * interval '1 microsecond'),updated_at=$6,
 			processed_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id),
 			created_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='created'),
 			would_create_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='would_create'),
 			skipped_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='skipped'),
 			failed_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='failed')
-			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>$6 AND run.checkpoint_assessment_id COLLATE "C" <= $5
-			RETURNING `+assessmentSnapshotBackfillRunColumns, tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), checkpoint.String(), now, now.Add(leaseDuration)))
+			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>now() AND run.checkpoint_assessment_id COLLATE "C" <= $5
+			RETURNING `+assessmentSnapshotBackfillRunColumns, tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), checkpoint.String(), now, leaseDuration.Microseconds()))
 		if errors.Is(err, pgx.ErrNoRows) {
 			return fmt.Errorf("%w: assessment snapshot backfill checkpoint rejected", shared.ErrConflict)
 		}
@@ -188,7 +191,7 @@ func (repository *AssessmentSnapshotBackfillRepository) FinishAssessmentSnapshot
 			would_create_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='would_create'),
 			skipped_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='skipped'),
 			failed_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='failed')
-			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>$6 RETURNING `+assessmentSnapshotBackfillRunColumns,
+			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>now() RETURNING `+assessmentSnapshotBackfillRunColumns,
 			tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), string(state), now))
 		if errors.Is(err, pgx.ErrNoRows) {
 			return fmt.Errorf("%w: assessment snapshot backfill completion rejected", shared.ErrConflict)

--- a/internal/infrastructure/persistence/postgres/assessment_snapshot_backfill_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_snapshot_backfill_repo_test.go
@@ -1,0 +1,247 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestPostgresAssessmentSnapshotBackfillRunnerAndRLS(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 134); err != nil {
+		t.Fatalf("up to 0134: %v", err)
+	}
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	now := time.Now().UTC().Add(time.Hour)
+	clock := &postgresBackfillClock{now: now}
+	tenantID, otherTenantID := shared.ID("snapshot-backfill-pg"), shared.ID("snapshot-backfill-other")
+	assessmentID, otherAssessmentID := shared.ID("snapshot-backfill-assessment"), shared.ID("snapshot-backfill-other-assessment")
+	ensureTestTenantAndEngagement(t, ctx, pool, tenantID, assessmentID, "", "")
+	ensureTestTenantAndEngagement(t, ctx, pool, otherTenantID, otherAssessmentID, "", "")
+	cycles := NewAssessmentCycleRepository(pool)
+	cycle, err := assessmentcycle.NewAssessmentCycle("snapshot-backfill-cycle", tenantID, "Cycle", assessmentcycle.BoundaryStandalone, "", "", assessmentID, "operator", now.Add(-time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember(tenantID, cycle.ID, assessmentID, "operator", now.Add(-time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+	run := postgresNativeRun(t, tenantID, assessmentID, "snapshot-backfill-run", strings.Repeat("a", 64))
+	runRepository := NewScanRunStore(pool)
+	sealPostgresNativeRun(t, ctx, runRepository, &run, now)
+	storedRuns, err := runRepository.ListScanRuns(ctx, tenantID, assessmentID)
+	if err != nil || len(storedRuns) != 1 {
+		t.Fatalf("stored runs=%+v err=%v", storedRuns, err)
+	}
+	if !storedRuns[0].IsSealed() {
+		t.Fatalf("stored scan run is not sealed: %+v", storedRuns[0])
+	}
+	results := NewScanResultStore(pool)
+	if err := results.SaveResult(ctx, assessmentID, []byte(`{"source":"legacy-cache"}`)); err != nil {
+		t.Fatal(err)
+	}
+	snapshots := NewAssessmentSnapshotRepository(pool)
+	audit := NewAuditLog(pool)
+	projector, err := snapshotuc.NewLegacyProjector(snapshots, cycles, NewTenantTransactionRunner(pool), idgen.RandomID{}, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewAssessmentSnapshotBackfillRepository(pool)
+	runner, err := snapshotuc.NewBackfillRunner(projector, NewEngagementRepository(pool), store, runRepository, results, idgen.RandomID{}, clock, audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backfillRun, err := runner.Run(ctx, snapshotuc.BackfillRequest{TenantID: tenantID, Actor: "operator", LeaseOwner: "postgres", BatchSize: 1})
+	if err != nil || backfillRun.State != ports.AssessmentSnapshotBackfillCompleted || backfillRun.CreatedCount != 1 || backfillRun.FailedCount != 0 {
+		item, itemErr := store.GetAssessmentSnapshotBackfillItem(ctx, tenantID, backfillRun.ID, assessmentID)
+		t.Fatalf("postgres snapshot backfill=%+v item=%+v item_err=%v err=%v", backfillRun, item, itemErr, err)
+	}
+	projected, err := snapshots.ListByAssessment(ctx, tenantID, assessmentID)
+	if err != nil || len(projected) != 1 || projected[0].Provenance != assessmentsnapshot.ProvenanceLegacy || len(projected[0].Dimensions) != 1 || projected[0].Dimensions[0].State != assessmentsnapshot.CoverageUnknown {
+		t.Fatalf("postgres projected snapshots=%+v err=%v", projected, err)
+	}
+	if _, _, err := snapshots.GetDefault(ctx, tenantID, assessmentID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("legacy projection changed default: %v", err)
+	}
+	if _, err := store.GetAssessmentSnapshotBackfillRun(ctx, otherTenantID, backfillRun.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant run read=%v", err)
+	}
+	if _, err := store.GetAssessmentSnapshotBackfillItem(ctx, otherTenantID, backfillRun.ID, assessmentID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant item read=%v", err)
+	}
+}
+
+func TestPostgresAssessmentSnapshotBackfillLeaseAndCompositeOwnership(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 134); err != nil {
+		t.Fatalf("up to 0134: %v", err)
+	}
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	ensureTestTenantAndEngagement(t, ctx, pool, "snapshot-lease-a", "snapshot-assessment-a", "", "")
+	ensureTestTenantAndEngagement(t, ctx, pool, "snapshot-lease-b", "snapshot-assessment-b", "", "")
+	repository := NewAssessmentSnapshotBackfillRepository(pool)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	request := ports.AssessmentSnapshotBackfillAcquireRequest{Run: ports.AssessmentSnapshotBackfillRun{
+		TenantID: "snapshot-lease-a", ID: "run-a", SchemaVersion: 1, BatchSize: 500, SnapshotAt: now,
+		State: ports.AssessmentSnapshotBackfillRunning, LeaseOwner: "owner-a", LeaseToken: "token-a", LeaseExpiresAt: now.Add(time.Minute), CreatedBy: "operator", CreatedAt: now, UpdatedAt: now,
+	}, LeaseDuration: time.Minute}
+	if _, _, err := repository.AcquireAssessmentSnapshotBackfillRun(ctx, request); err != nil {
+		t.Fatal(err)
+	}
+	contender := request
+	contender.Run.ID, contender.Run.LeaseOwner, contender.Run.LeaseToken = "run-b", "owner-b", "token-b"
+	if _, _, err := repository.AcquireAssessmentSnapshotBackfillRun(ctx, contender); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("concurrent lease=%v", err)
+	}
+	if _, _, err := repository.CommitAssessmentSnapshotBackfillItem(ctx, "snapshot-lease-a", "run-a", "token-a", now, func(context.Context) (ports.AssessmentSnapshotBackfillItem, error) {
+		return ports.AssessmentSnapshotBackfillItem{TenantID: "snapshot-lease-a", RunID: "run-a", AssessmentID: "snapshot-assessment-b", SchemaVersion: 1,
+			IdempotencyKey: "source-v1", SourceHash: strings.Repeat("a", 64), Outcome: "failed", ReasonCode: "source_read_failed", ProcessedAt: now}, nil
+	}); err == nil {
+		t.Fatal("expected cross-tenant Assessment ownership rejection")
+	}
+	contender.Run.CreatedAt, contender.Run.SnapshotAt = now.Add(2*time.Minute), now
+	resumed, wasResumed, err := repository.AcquireAssessmentSnapshotBackfillRun(ctx, contender)
+	if err != nil || !wasResumed || resumed.ID != "run-a" || resumed.LeaseOwner != "owner-b" {
+		t.Fatalf("expired lease resume=%+v resumed=%v err=%v", resumed, wasResumed, err)
+	}
+}
+
+func TestPostgresAssessmentSnapshotBackfillConcurrentStart(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 134); err != nil {
+		t.Fatalf("up to 0134: %v", err)
+	}
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES('snapshot-concurrent','Snapshot concurrent')`); err != nil {
+		t.Fatal(err)
+	}
+	repository := NewAssessmentSnapshotBackfillRepository(pool)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	start := make(chan struct{})
+	errorsCh := make(chan error, 2)
+	var wait sync.WaitGroup
+	for _, identity := range []string{"a", "b"} {
+		wait.Add(1)
+		go func(identity string) {
+			defer wait.Done()
+			<-start
+			_, _, err := repository.AcquireAssessmentSnapshotBackfillRun(ctx, ports.AssessmentSnapshotBackfillAcquireRequest{Run: ports.AssessmentSnapshotBackfillRun{
+				TenantID: "snapshot-concurrent", ID: shared.ID("run-" + identity), SchemaVersion: 1, BatchSize: 500, SnapshotAt: now,
+				State: ports.AssessmentSnapshotBackfillRunning, LeaseOwner: "owner-" + identity, LeaseToken: shared.ID("token-" + identity), LeaseExpiresAt: now.Add(time.Minute), CreatedBy: "operator", CreatedAt: now, UpdatedAt: now,
+			}, LeaseDuration: time.Minute})
+			errorsCh <- err
+		}(identity)
+	}
+	close(start)
+	wait.Wait()
+	close(errorsCh)
+	succeeded, conflicted := 0, 0
+	for err := range errorsCh {
+		switch {
+		case err == nil:
+			succeeded++
+		case errors.Is(err, shared.ErrConflict):
+			conflicted++
+		default:
+			t.Fatalf("concurrent start error=%v", err)
+		}
+	}
+	if succeeded != 1 || conflicted != 1 {
+		t.Fatalf("concurrent starts succeeded=%d conflicted=%d", succeeded, conflicted)
+	}
+}
+
+func TestPostgresAssessmentSnapshotBackfillProjectsUpgradedLegacyRun(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 128); err != nil {
+		t.Fatalf("up to 0128: %v", err)
+	}
+	for _, statement := range []string{
+		`INSERT INTO tenants(id,name) VALUES('snapshot-upgrade-tenant','Snapshot upgrade')`,
+		`INSERT INTO engagements(id,tenant_id,name,created_at,updated_at) VALUES('snapshot-upgrade-assessment','snapshot-upgrade-tenant','Historical',now()-interval '2 hours',now()-interval '1 hour')`,
+		`INSERT INTO scan_runs(id,engagement_id,created_at,manifest,finding_keys) VALUES('snapshot-upgrade-run','snapshot-upgrade-assessment',now()-interval '1 hour','{}'::jsonb,'["legacy-key"]'::jsonb)`,
+	} {
+		if _, err := db.ExecContext(context.Background(), statement); err != nil {
+			t.Fatalf("seed upgraded legacy fixture: %v", err)
+		}
+	}
+	if err := goose.UpTo(db, ".", 134); err != nil {
+		t.Fatalf("upgrade fixture to 0134: %v", err)
+	}
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	tenantID, assessmentID := shared.ID("snapshot-upgrade-tenant"), shared.ID("snapshot-upgrade-assessment")
+	cycles := NewAssessmentCycleRepository(pool)
+	now := time.Now().UTC()
+	cycle, err := assessmentcycle.NewAssessmentCycle("snapshot-upgrade-cycle", tenantID, "Cycle", assessmentcycle.BoundaryStandalone, "", "", assessmentID, "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember(tenantID, cycle.ID, assessmentID, "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+	clock := &postgresBackfillClock{now: now.Add(time.Minute)}
+	snapshots := NewAssessmentSnapshotRepository(pool)
+	audit := NewAuditLog(pool)
+	projector, err := snapshotuc.NewLegacyProjector(snapshots, cycles, NewTenantTransactionRunner(pool), idgen.RandomID{}, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner, err := snapshotuc.NewBackfillRunner(projector, NewEngagementRepository(pool), NewAssessmentSnapshotBackfillRepository(pool), NewScanRunStore(pool), NewScanResultStore(pool), idgen.RandomID{}, clock, audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := runner.Run(ctx, snapshotuc.BackfillRequest{TenantID: tenantID, Actor: "operator", LeaseOwner: "upgrade", BatchSize: 1})
+	if err != nil || run.CreatedCount != 1 {
+		t.Fatalf("upgraded legacy projection run=%+v err=%v", run, err)
+	}
+	projected, err := snapshots.ListByAssessment(ctx, tenantID, assessmentID)
+	if err != nil || len(projected) != 1 || projected[0].Provenance != assessmentsnapshot.ProvenanceLegacy || len(projected[0].RunReferences) != 1 || len(projected[0].Dimensions) != 0 {
+		t.Fatalf("upgraded legacy projection=%+v err=%v", projected, err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/assessment_snapshot_backfill_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_snapshot_backfill_repo_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestPostgresAssessmentSnapshotBackfillRunnerAndRLS(t *testing.T) {
 	db, dsn := newAssessmentMigrationDB(t)
-	if err := goose.UpTo(db, ".", 134); err != nil {
+	if err := goose.UpTo(db, ".", 135); err != nil {
 		t.Fatalf("up to 0134: %v", err)
 	}
 	ctx := context.Background()
@@ -97,7 +97,7 @@ func TestPostgresAssessmentSnapshotBackfillRunnerAndRLS(t *testing.T) {
 
 func TestPostgresAssessmentSnapshotBackfillLeaseAndCompositeOwnership(t *testing.T) {
 	db, dsn := newAssessmentMigrationDB(t)
-	if err := goose.UpTo(db, ".", 134); err != nil {
+	if err := goose.UpTo(db, ".", 135); err != nil {
 		t.Fatalf("up to 0134: %v", err)
 	}
 	ctx := context.Background()
@@ -137,7 +137,7 @@ func TestPostgresAssessmentSnapshotBackfillLeaseAndCompositeOwnership(t *testing
 
 func TestPostgresAssessmentSnapshotBackfillConcurrentStart(t *testing.T) {
 	db, dsn := newAssessmentMigrationDB(t)
-	if err := goose.UpTo(db, ".", 134); err != nil {
+	if err := goose.UpTo(db, ".", 135); err != nil {
 		t.Fatalf("up to 0134: %v", err)
 	}
 	ctx := context.Background()
@@ -199,7 +199,7 @@ func TestPostgresAssessmentSnapshotBackfillProjectsUpgradedLegacyRun(t *testing.
 			t.Fatalf("seed upgraded legacy fixture: %v", err)
 		}
 	}
-	if err := goose.UpTo(db, ".", 134); err != nil {
+	if err := goose.UpTo(db, ".", 135); err != nil {
 		t.Fatalf("upgrade fixture to 0134: %v", err)
 	}
 	ctx := context.Background()

--- a/internal/infrastructure/persistence/postgres/assessment_snapshot_repo.go
+++ b/internal/infrastructure/persistence/postgres/assessment_snapshot_repo.go
@@ -1,0 +1,425 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const assessmentSnapshotColumns = `tenant_id,id,cycle_id,assessment_id,snapshot_number,default_version,lifecycle,provenance,boundary_kind,
+	COALESCE(business_asset_id,''),COALESCE(project_id,''),schema_version,content_hash,request_key,request_hash,
+	created_at,created_by,finalized_at,finalized_by,superseded_at,superseded_by`
+
+type AssessmentSnapshotRepository struct{ pool *pgxpool.Pool }
+
+func NewAssessmentSnapshotRepository(pool *pgxpool.Pool) *AssessmentSnapshotRepository {
+	return &AssessmentSnapshotRepository{pool: pool}
+}
+
+var _ ports.AssessmentSnapshotRepository = (*AssessmentSnapshotRepository)(nil)
+
+func (repository *AssessmentSnapshotRepository) CreateFinalizedCAS(ctx context.Context, snapshot *assessmentsnapshot.Snapshot, expectedDefaultVersion int64) (*assessmentsnapshot.Snapshot, bool, error) {
+	if snapshot == nil {
+		return nil, false, fmt.Errorf("%w: assessment snapshot is required", shared.ErrValidation)
+	}
+	if err := snapshot.Validate(); err != nil {
+		return nil, false, err
+	}
+	tenantID := shared.TenantOrDefault(snapshot.TenantID)
+	var stored *assessmentsnapshot.Snapshot
+	created := false
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO assessment_snapshot_counters(tenant_id,assessment_id,next_snapshot_number)
+			VALUES($1,$2,1) ON CONFLICT (tenant_id,assessment_id) DO NOTHING`, tenantID.String(), snapshot.AssessmentID.String()); err != nil {
+			return fmt.Errorf("initialize assessment snapshot counter: %w", err)
+		}
+		var snapshotNumber int
+		if err := tx.QueryRow(ctx, `SELECT next_snapshot_number FROM assessment_snapshot_counters
+			WHERE tenant_id=$1 AND assessment_id=$2 FOR UPDATE`, tenantID.String(), snapshot.AssessmentID.String()).Scan(&snapshotNumber); err != nil {
+			return fmt.Errorf("lock assessment snapshot counter: %w", err)
+		}
+		existing, err := loadAssessmentSnapshotByRequest(ctx, tx, tenantID, snapshot.AssessmentID, snapshot.RequestKey)
+		if err == nil {
+			if existing.RequestHash != snapshot.RequestHash {
+				return fmt.Errorf("%w: snapshot request key was reused with different content", shared.ErrConflict)
+			}
+			stored = existing
+			return nil
+		}
+		if !errors.Is(err, shared.ErrNotFound) {
+			return err
+		}
+
+		var currentSnapshotID string
+		var currentVersion int64
+		err = tx.QueryRow(ctx, `SELECT snapshot_id,version FROM assessment_snapshot_defaults
+			WHERE tenant_id=$1 AND assessment_id=$2 FOR UPDATE`, tenantID.String(), snapshot.AssessmentID.String()).Scan(&currentSnapshotID, &currentVersion)
+		if errors.Is(err, pgx.ErrNoRows) {
+			if expectedDefaultVersion != 0 {
+				return fmt.Errorf("%w: assessment snapshot default version mismatch", shared.ErrConflict)
+			}
+			currentSnapshotID, currentVersion = "", 0
+		} else if err != nil {
+			return fmt.Errorf("lock assessment snapshot default: %w", err)
+		} else if currentVersion != expectedDefaultVersion {
+			return fmt.Errorf("%w: assessment snapshot default version mismatch", shared.ErrConflict)
+		}
+
+		if _, err := tx.Exec(ctx, `UPDATE assessment_snapshot_counters SET next_snapshot_number=next_snapshot_number+1
+			WHERE tenant_id=$1 AND assessment_id=$2`, tenantID.String(), snapshot.AssessmentID.String()); err != nil {
+			return fmt.Errorf("allocate assessment snapshot number: %w", err)
+		}
+
+		defaultVersion := currentVersion + 1
+		if err := insertAndFinalizeAssessmentSnapshot(ctx, tx, tenantID, snapshot, snapshotNumber, defaultVersion); err != nil {
+			return err
+		}
+		var result pgconn.CommandTag
+		if currentSnapshotID != "" {
+			result, err = tx.Exec(ctx, `UPDATE assessment_snapshots SET lifecycle='superseded',superseded_at=$1,superseded_by=$2
+				WHERE tenant_id=$3 AND id=$4 AND lifecycle='finalized'`, snapshot.FinalizedAt, snapshot.FinalizedBy, tenantID.String(), currentSnapshotID)
+			if err != nil {
+				return fmt.Errorf("supersede assessment snapshot: %w", err)
+			}
+			if result.RowsAffected() != 1 {
+				return fmt.Errorf("%w: current assessment snapshot changed", shared.ErrConflict)
+			}
+		}
+		if currentVersion == 0 {
+			result, err = tx.Exec(ctx, `INSERT INTO assessment_snapshot_defaults(tenant_id,assessment_id,snapshot_id,version,updated_at,updated_by)
+				VALUES($1,$2,$3,1,$4,$5)`, tenantID.String(), snapshot.AssessmentID.String(), snapshot.ID.String(), snapshot.FinalizedAt, snapshot.FinalizedBy)
+		} else {
+			result, err = tx.Exec(ctx, `UPDATE assessment_snapshot_defaults SET snapshot_id=$1,version=version+1,updated_at=$2,updated_by=$3
+				WHERE tenant_id=$4 AND assessment_id=$5 AND version=$6`, snapshot.ID.String(), snapshot.FinalizedAt, snapshot.FinalizedBy,
+				tenantID.String(), snapshot.AssessmentID.String(), expectedDefaultVersion)
+		}
+		if err != nil {
+			return mapPostgresError(err, "update assessment snapshot default")
+		}
+		if result.RowsAffected() != 1 {
+			return fmt.Errorf("%w: assessment snapshot default changed", shared.ErrConflict)
+		}
+		stored = cloneFinalizedSnapshot(snapshot, snapshotNumber, defaultVersion)
+		created = true
+		return nil
+	})
+	return stored, created, err
+}
+
+func (repository *AssessmentSnapshotRepository) CreateLegacyProjection(ctx context.Context, snapshot *assessmentsnapshot.Snapshot) (*assessmentsnapshot.Snapshot, bool, error) {
+	if snapshot == nil || snapshot.Provenance != assessmentsnapshot.ProvenanceLegacy {
+		return nil, false, fmt.Errorf("%w: legacy assessment snapshot is required", shared.ErrValidation)
+	}
+	if err := snapshot.Validate(); err != nil {
+		return nil, false, err
+	}
+	tenantID := shared.TenantOrDefault(snapshot.TenantID)
+	var stored *assessmentsnapshot.Snapshot
+	created := false
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO assessment_snapshot_counters(tenant_id,assessment_id,next_snapshot_number)
+			VALUES($1,$2,1) ON CONFLICT (tenant_id,assessment_id) DO NOTHING`, tenantID.String(), snapshot.AssessmentID.String()); err != nil {
+			return fmt.Errorf("initialize assessment snapshot counter: %w", err)
+		}
+		var snapshotNumber int
+		if err := tx.QueryRow(ctx, `SELECT next_snapshot_number FROM assessment_snapshot_counters
+			WHERE tenant_id=$1 AND assessment_id=$2 FOR UPDATE`, tenantID.String(), snapshot.AssessmentID.String()).Scan(&snapshotNumber); err != nil {
+			return fmt.Errorf("lock assessment snapshot counter: %w", err)
+		}
+		existing, err := loadAssessmentSnapshotByRequest(ctx, tx, tenantID, snapshot.AssessmentID, snapshot.RequestKey)
+		if err == nil {
+			if existing.RequestHash != snapshot.RequestHash {
+				return fmt.Errorf("%w: snapshot request key was reused with different content", shared.ErrConflict)
+			}
+			stored = existing
+			return nil
+		}
+		if !errors.Is(err, shared.ErrNotFound) {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `UPDATE assessment_snapshot_counters SET next_snapshot_number=next_snapshot_number+1
+			WHERE tenant_id=$1 AND assessment_id=$2`, tenantID.String(), snapshot.AssessmentID.String()); err != nil {
+			return fmt.Errorf("allocate assessment snapshot number: %w", err)
+		}
+		if err := insertAndFinalizeAssessmentSnapshot(ctx, tx, tenantID, snapshot, snapshotNumber, 0); err != nil {
+			return err
+		}
+		stored, created = cloneFinalizedSnapshot(snapshot, snapshotNumber, 0), true
+		return nil
+	})
+	return stored, created, err
+}
+
+func insertAndFinalizeAssessmentSnapshot(ctx context.Context, tx pgx.Tx, tenantID shared.ID, snapshot *assessmentsnapshot.Snapshot, snapshotNumber int, defaultVersion int64) error {
+	_, err := tx.Exec(ctx, `INSERT INTO assessment_snapshots(
+		tenant_id,id,cycle_id,assessment_id,snapshot_number,default_version,lifecycle,provenance,boundary_kind,business_asset_id,project_id,
+		schema_version,content_hash,request_key,request_hash,created_at,created_by)
+		VALUES($1,$2,$3,$4,$5,$6,'building',$7,$8,NULLIF($9,''),NULLIF($10,''),$11,$12,$13,$14,$15,$16)`,
+		tenantID.String(), snapshot.ID.String(), snapshot.CycleID.String(), snapshot.AssessmentID.String(), snapshotNumber, defaultVersion,
+		string(snapshot.Provenance), string(snapshot.Boundary.Kind), snapshot.Boundary.BusinessAssetID.String(), snapshot.Boundary.ProjectID.String(),
+		snapshot.SchemaVersion, snapshot.ContentHash, snapshot.RequestKey, snapshot.RequestHash, snapshot.CreatedAt, snapshot.CreatedBy)
+	if err != nil {
+		return mapPostgresError(err, "create assessment snapshot")
+	}
+	for runPosition, run := range snapshot.RunReferences {
+		if _, err := tx.Exec(ctx, `INSERT INTO assessment_snapshot_run_refs(tenant_id,snapshot_id,position,scan_run_id,manifest_hash)
+			VALUES($1,$2,$3,$4,$5)`, tenantID.String(), snapshot.ID.String(), runPosition, run.RunID, run.ManifestHash); err != nil {
+			return mapPostgresError(err, "create assessment snapshot run reference")
+		}
+		for _, lane := range run.LaneReferences {
+			if _, err := tx.Exec(ctx, `INSERT INTO assessment_snapshot_lane_refs(tenant_id,snapshot_id,run_position,scan_run_id,lane_key,manifest_hash)
+				VALUES($1,$2,$3,$4,$5,$6)`, tenantID.String(), snapshot.ID.String(), runPosition, run.RunID, lane.LaneKey, lane.ManifestHash); err != nil {
+				return mapPostgresError(err, "create assessment snapshot lane reference")
+			}
+		}
+	}
+	for position, dimension := range snapshot.Dimensions {
+		includedScope, err := json.Marshal(dimension.IncludedScope)
+		if err != nil {
+			return fmt.Errorf("marshal snapshot included scope: %w", err)
+		}
+		excludedScope, err := json.Marshal(dimension.ExcludedScope)
+		if err != nil {
+			return fmt.Errorf("marshal snapshot excluded scope: %w", err)
+		}
+		versions, err := json.Marshal(dimension.Versions)
+		if err != nil {
+			return fmt.Errorf("marshal snapshot versions: %w", err)
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO assessment_snapshot_dimensions(
+			tenant_id,snapshot_id,position,run_id,lane_key,lane_manifest_hash,producer,finding_kind,target_kind,target_schema_version,
+			target_canonical,evaluated_revision,coverage_state,reason_code,included_scope,excluded_scope,versions)
+			VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)`,
+			tenantID.String(), snapshot.ID.String(), position, dimension.RunID, dimension.LaneKey, dimension.LaneManifestHash,
+			dimension.Producer, dimension.FindingKind, string(dimension.Target.Kind), dimension.Target.SchemaVersion,
+			dimension.Target.Canonical, dimension.Target.EvaluatedRevision, string(dimension.State), dimension.ReasonCode,
+			includedScope, excludedScope, versions); err != nil {
+			return mapPostgresError(err, "create assessment snapshot dimension")
+		}
+	}
+	result, err := tx.Exec(ctx, `UPDATE assessment_snapshots SET lifecycle='finalized',finalized_at=$1,finalized_by=$2
+		WHERE tenant_id=$3 AND id=$4 AND lifecycle='building'`, snapshot.FinalizedAt, snapshot.FinalizedBy, tenantID.String(), snapshot.ID.String())
+	if err != nil {
+		return fmt.Errorf("finalize assessment snapshot: %w", err)
+	}
+	if result.RowsAffected() != 1 {
+		return fmt.Errorf("%w: assessment snapshot finalization lost", shared.ErrConflict)
+	}
+	return nil
+}
+
+func (repository *AssessmentSnapshotRepository) Get(ctx context.Context, tenantID, snapshotID shared.ID) (*assessmentsnapshot.Snapshot, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var snapshot *assessmentsnapshot.Snapshot
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var err error
+		snapshot, err = loadAssessmentSnapshot(ctx, tx, tenantID, snapshotID)
+		return err
+	})
+	return snapshot, err
+}
+
+func (repository *AssessmentSnapshotRepository) GetByRequestKey(ctx context.Context, tenantID, assessmentID shared.ID, requestKey string) (*assessmentsnapshot.Snapshot, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var snapshot *assessmentsnapshot.Snapshot
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var err error
+		snapshot, err = loadAssessmentSnapshotByRequest(ctx, tx, tenantID, assessmentID, requestKey)
+		return err
+	})
+	return snapshot, err
+}
+
+func (repository *AssessmentSnapshotRepository) GetDefault(ctx context.Context, tenantID, assessmentID shared.ID) (*assessmentsnapshot.Snapshot, ports.AssessmentSnapshotDefault, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var snapshot *assessmentsnapshot.Snapshot
+	var pointer ports.AssessmentSnapshotDefault
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var snapshotID string
+		if err := tx.QueryRow(ctx, `SELECT snapshot_id,version,updated_at,updated_by FROM assessment_snapshot_defaults
+			WHERE tenant_id=$1 AND assessment_id=$2`, tenantID.String(), assessmentID.String()).Scan(&snapshotID, &pointer.Version, &pointer.UpdatedAt, &pointer.UpdatedBy); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return shared.ErrNotFound
+			}
+			return fmt.Errorf("load default assessment snapshot: %w", err)
+		}
+		pointer.TenantID, pointer.AssessmentID, pointer.SnapshotID = tenantID, assessmentID, shared.ID(snapshotID)
+		var err error
+		snapshot, err = loadAssessmentSnapshot(ctx, tx, tenantID, pointer.SnapshotID)
+		return err
+	})
+	return snapshot, pointer, err
+}
+
+func (repository *AssessmentSnapshotRepository) ListByAssessment(ctx context.Context, tenantID, assessmentID shared.ID) ([]assessmentsnapshot.Snapshot, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var out []assessmentsnapshot.Snapshot
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT id FROM assessment_snapshots WHERE tenant_id=$1 AND assessment_id=$2 ORDER BY snapshot_number`, tenantID.String(), assessmentID.String())
+		if err != nil {
+			return fmt.Errorf("list assessment snapshots: %w", err)
+		}
+		defer rows.Close()
+		var ids []shared.ID
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				return err
+			}
+			ids = append(ids, shared.ID(id))
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		for _, id := range ids {
+			snapshot, err := loadAssessmentSnapshot(ctx, tx, tenantID, id)
+			if err != nil {
+				return err
+			}
+			out = append(out, *snapshot)
+		}
+		return nil
+	})
+	return out, err
+}
+
+func loadAssessmentSnapshotByRequest(ctx context.Context, tx pgx.Tx, tenantID, assessmentID shared.ID, requestKey string) (*assessmentsnapshot.Snapshot, error) {
+	var id string
+	if err := tx.QueryRow(ctx, `SELECT id FROM assessment_snapshots WHERE tenant_id=$1 AND assessment_id=$2 AND request_key=$3`,
+		tenantID.String(), assessmentID.String(), requestKey).Scan(&id); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, shared.ErrNotFound
+		}
+		return nil, fmt.Errorf("load assessment snapshot request: %w", err)
+	}
+	return loadAssessmentSnapshot(ctx, tx, tenantID, shared.ID(id))
+}
+
+func loadAssessmentSnapshot(ctx context.Context, tx pgx.Tx, tenantID, snapshotID shared.ID) (*assessmentsnapshot.Snapshot, error) {
+	row := tx.QueryRow(ctx, `SELECT `+assessmentSnapshotColumns+` FROM assessment_snapshots WHERE tenant_id=$1 AND id=$2`, tenantID.String(), snapshotID.String())
+	snapshot, err := scanAssessmentSnapshot(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, shared.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan assessment snapshot: %w", err)
+	}
+	runRows, err := tx.Query(ctx, `SELECT position,scan_run_id,manifest_hash FROM assessment_snapshot_run_refs
+		WHERE tenant_id=$1 AND snapshot_id=$2 ORDER BY position`, tenantID.String(), snapshotID.String())
+	if err != nil {
+		return nil, err
+	}
+	type persistedRunReference struct {
+		position  int
+		reference assessmentsnapshot.RunReference
+	}
+	var persistedRuns []persistedRunReference
+	for runRows.Next() {
+		var position int
+		var reference assessmentsnapshot.RunReference
+		if err := runRows.Scan(&position, &reference.RunID, &reference.ManifestHash); err != nil {
+			runRows.Close()
+			return nil, err
+		}
+		persistedRuns = append(persistedRuns, persistedRunReference{position: position, reference: reference})
+	}
+	if err := runRows.Err(); err != nil {
+		runRows.Close()
+		return nil, err
+	}
+	runRows.Close()
+	for _, persisted := range persistedRuns {
+		reference := persisted.reference
+		laneRows, err := tx.Query(ctx, `SELECT lane_key,manifest_hash FROM assessment_snapshot_lane_refs
+			WHERE tenant_id=$1 AND snapshot_id=$2 AND run_position=$3 ORDER BY lane_key`, tenantID.String(), snapshotID.String(), persisted.position)
+		if err != nil {
+			return nil, err
+		}
+		for laneRows.Next() {
+			var lane assessmentsnapshot.LaneReference
+			if err := laneRows.Scan(&lane.LaneKey, &lane.ManifestHash); err != nil {
+				laneRows.Close()
+				return nil, err
+			}
+			reference.LaneReferences = append(reference.LaneReferences, lane)
+		}
+		if err := laneRows.Err(); err != nil {
+			laneRows.Close()
+			return nil, err
+		}
+		laneRows.Close()
+		snapshot.RunReferences = append(snapshot.RunReferences, reference)
+	}
+
+	dimensionRows, err := tx.Query(ctx, `SELECT run_id,lane_key,lane_manifest_hash,producer,finding_kind,target_kind,target_schema_version,
+		target_canonical,evaluated_revision,coverage_state,reason_code,included_scope,excluded_scope,versions
+		FROM assessment_snapshot_dimensions WHERE tenant_id=$1 AND snapshot_id=$2 ORDER BY position`, tenantID.String(), snapshotID.String())
+	if err != nil {
+		return nil, err
+	}
+	defer dimensionRows.Close()
+	for dimensionRows.Next() {
+		var dimension assessmentsnapshot.Dimension
+		var targetKind, coverageState string
+		var includedScope, excludedScope, versions []byte
+		if err := dimensionRows.Scan(&dimension.RunID, &dimension.LaneKey, &dimension.LaneManifestHash, &dimension.Producer, &dimension.FindingKind,
+			&targetKind, &dimension.Target.SchemaVersion, &dimension.Target.Canonical, &dimension.Target.EvaluatedRevision,
+			&coverageState, &dimension.ReasonCode, &includedScope, &excludedScope, &versions); err != nil {
+			return nil, err
+		}
+		dimension.Target.Kind = scanrun.TargetKind(targetKind)
+		dimension.State = assessmentsnapshot.CoverageState(coverageState)
+		if err := json.Unmarshal(includedScope, &dimension.IncludedScope); err != nil {
+			return nil, fmt.Errorf("decode snapshot included scope: %w", err)
+		}
+		if err := json.Unmarshal(excludedScope, &dimension.ExcludedScope); err != nil {
+			return nil, fmt.Errorf("decode snapshot excluded scope: %w", err)
+		}
+		if err := json.Unmarshal(versions, &dimension.Versions); err != nil {
+			return nil, fmt.Errorf("decode snapshot versions: %w", err)
+		}
+		snapshot.Dimensions = append(snapshot.Dimensions, dimension)
+	}
+	if err := dimensionRows.Err(); err != nil {
+		return nil, err
+	}
+	if err := snapshot.Validate(); err != nil {
+		return nil, fmt.Errorf("validate persisted assessment snapshot: %w", err)
+	}
+	return snapshot, nil
+}
+
+func scanAssessmentSnapshot(row rowScanner) (*assessmentsnapshot.Snapshot, error) {
+	var snapshot assessmentsnapshot.Snapshot
+	var tenantID, id, cycleID, assessmentID, lifecycle, provenance, boundaryKind, businessAssetID, projectID string
+	var finalizedAt, supersededAt *time.Time
+	if err := row.Scan(&tenantID, &id, &cycleID, &assessmentID, &snapshot.SnapshotNumber, &snapshot.DefaultVersion, &lifecycle, &provenance, &boundaryKind,
+		&businessAssetID, &projectID, &snapshot.SchemaVersion, &snapshot.ContentHash, &snapshot.RequestKey, &snapshot.RequestHash,
+		&snapshot.CreatedAt, &snapshot.CreatedBy, &finalizedAt, &snapshot.FinalizedBy, &supersededAt, &snapshot.SupersededBy); err != nil {
+		return nil, err
+	}
+	snapshot.TenantID, snapshot.ID, snapshot.CycleID, snapshot.AssessmentID = shared.ID(tenantID), shared.ID(id), shared.ID(cycleID), shared.ID(assessmentID)
+	snapshot.Lifecycle, snapshot.Provenance = assessmentsnapshot.Lifecycle(lifecycle), assessmentsnapshot.Provenance(provenance)
+	snapshot.Boundary = assessmentsnapshot.Boundary{Kind: assessmentcycle.BoundaryKind(boundaryKind), BusinessAssetID: shared.ID(businessAssetID), ProjectID: shared.ID(projectID)}
+	snapshot.FinalizedAt, snapshot.SupersededAt = finalizedAt, supersededAt
+	return &snapshot, nil
+}
+
+func cloneFinalizedSnapshot(snapshot *assessmentsnapshot.Snapshot, snapshotNumber int, defaultVersion int64) *assessmentsnapshot.Snapshot {
+	copySnapshot := *snapshot
+	copySnapshot.SnapshotNumber = snapshotNumber
+	copySnapshot.DefaultVersion = defaultVersion
+	return &copySnapshot
+}

--- a/internal/infrastructure/persistence/postgres/assessment_snapshot_repo.go
+++ b/internal/infrastructure/persistence/postgres/assessment_snapshot_repo.go
@@ -264,10 +264,18 @@ func (repository *AssessmentSnapshotRepository) GetDefault(ctx context.Context, 
 }
 
 func (repository *AssessmentSnapshotRepository) ListByAssessment(ctx context.Context, tenantID, assessmentID shared.ID) ([]assessmentsnapshot.Snapshot, error) {
-	tenantID = shared.TenantOrDefault(tenantID)
-	var out []assessmentsnapshot.Snapshot
+	page, err := repository.ListAssessmentSnapshots(ctx, ports.AssessmentSnapshotListQuery{TenantID: tenantID, AssessmentID: assessmentID, Limit: 100})
+	return page.Items, err
+}
+
+func (repository *AssessmentSnapshotRepository) ListAssessmentSnapshots(ctx context.Context, query ports.AssessmentSnapshotListQuery) (ports.AssessmentSnapshotPage, error) {
+	if query.Limit < 1 || query.Limit > 100 || query.AfterSnapshotNumber < 0 {
+		return ports.AssessmentSnapshotPage{}, fmt.Errorf("%w: assessment snapshot page is invalid", shared.ErrValidation)
+	}
+	tenantID, assessmentID := shared.TenantOrDefault(query.TenantID), query.AssessmentID
+	page := ports.AssessmentSnapshotPage{}
 	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
-		rows, err := tx.Query(ctx, `SELECT id FROM assessment_snapshots WHERE tenant_id=$1 AND assessment_id=$2 ORDER BY snapshot_number`, tenantID.String(), assessmentID.String())
+		rows, err := tx.Query(ctx, `SELECT id FROM assessment_snapshots WHERE tenant_id=$1 AND assessment_id=$2 AND snapshot_number>$3 ORDER BY snapshot_number LIMIT $4`, tenantID.String(), assessmentID.String(), query.AfterSnapshotNumber, query.Limit+1)
 		if err != nil {
 			return fmt.Errorf("list assessment snapshots: %w", err)
 		}
@@ -283,16 +291,19 @@ func (repository *AssessmentSnapshotRepository) ListByAssessment(ctx context.Con
 		if err := rows.Err(); err != nil {
 			return err
 		}
+		if len(ids) > query.Limit {
+			ids, page.HasMore = ids[:query.Limit], true
+		}
 		for _, id := range ids {
 			snapshot, err := loadAssessmentSnapshot(ctx, tx, tenantID, id)
 			if err != nil {
 				return err
 			}
-			out = append(out, *snapshot)
+			page.Items = append(page.Items, *snapshot)
 		}
 		return nil
 	})
-	return out, err
+	return page, err
 }
 
 func loadAssessmentSnapshotByRequest(ctx context.Context, tx pgx.Tx, tenantID, assessmentID shared.ID, requestKey string) (*assessmentsnapshot.Snapshot, error) {

--- a/internal/infrastructure/persistence/postgres/assessment_snapshot_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_snapshot_repo_test.go
@@ -1,0 +1,358 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestPostgresAssessmentSnapshotRepositoryRLSCASReplayAndImmutability(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := time.Now().UnixNano()
+	tenantA := shared.ID(fmt.Sprintf("snapshot-tenant-a-%d", suffix))
+	tenantB := shared.ID(fmt.Sprintf("snapshot-tenant-b-%d", suffix))
+	assessmentID := shared.ID(fmt.Sprintf("snapshot-assessment-%d", suffix))
+	cycleID := shared.ID(fmt.Sprintf("snapshot-cycle-%d", suffix))
+	ensureTestTenantAndEngagement(t, ctx, pool, tenantA, assessmentID, "", "")
+	ensureTestTenantAndEngagement(t, ctx, pool, tenantB, shared.ID(fmt.Sprintf("snapshot-other-%d", suffix)), "", "")
+
+	cycleRepository := NewAssessmentCycleRepository(pool)
+	cycle, err := assessmentcycle.NewAssessmentCycle(cycleID, tenantA, "Snapshot cycle", assessmentcycle.BoundaryStandalone, "", "", assessmentID, "operator", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember(tenantA, cycleID, assessmentID, "operator", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycleRepository.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycleRepository.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+
+	runRepository := NewScanRunStore(pool)
+	runOne := postgresNativeRun(t, tenantA, assessmentID, shared.ID(fmt.Sprintf("snapshot-run-1-%d", suffix)), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	sealPostgresNativeRun(t, ctx, runRepository, &runOne, time.Now().UTC())
+
+	repository := NewAssessmentSnapshotRepository(pool)
+	first := postgresAssessmentSnapshot(t, tenantA, cycleID, assessmentID, "snapshot-first", "request-first", runOne)
+	stored, created, err := repository.CreateFinalizedCAS(ctx, first, 0)
+	if err != nil || !created || stored.SnapshotNumber != 1 {
+		t.Fatalf("create first snapshot=%+v created=%v err=%v", stored, created, err)
+	}
+	replayed, created, err := repository.CreateFinalizedCAS(ctx, postgresAssessmentSnapshot(t, tenantA, cycleID, assessmentID, "snapshot-replay", "request-first", runOne), 0)
+	if err != nil || created || replayed.ID != stored.ID {
+		t.Fatalf("replay snapshot=%+v created=%v err=%v", replayed, created, err)
+	}
+	if _, err := repository.Get(ctx, tenantB, stored.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant get=%v", err)
+	}
+
+	runTwo := postgresNativeRun(t, tenantA, assessmentID, shared.ID(fmt.Sprintf("snapshot-run-2-%d", suffix)), "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	sealPostgresNativeRun(t, ctx, runRepository, &runTwo, time.Now().UTC())
+	second := postgresAssessmentSnapshot(t, tenantA, cycleID, assessmentID, "snapshot-second", "request-second", runTwo)
+	storedSecond, created, err := repository.CreateFinalizedCAS(ctx, second, 1)
+	if err != nil || !created || storedSecond.SnapshotNumber != 2 {
+		t.Fatalf("create second snapshot=%+v created=%v err=%v", storedSecond, created, err)
+	}
+	old, err := repository.Get(ctx, tenantA, stored.ID)
+	if err != nil || old.Lifecycle != assessmentsnapshot.LifecycleSuperseded {
+		t.Fatalf("superseded snapshot=%+v err=%v", old, err)
+	}
+	if _, _, err := repository.CreateFinalizedCAS(ctx, postgresAssessmentSnapshot(t, tenantA, cycleID, assessmentID, "snapshot-stale", "request-stale", runOne), 1); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale default CAS=%v", err)
+	}
+
+	if err := WithTenant(ctx, pool, tenantA.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `UPDATE assessment_snapshots SET content_hash=$1 WHERE tenant_id=$2 AND id=$3`,
+			"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", tenantA.String(), storedSecond.ID.String())
+		return err
+	}); err == nil {
+		t.Fatal("finalized snapshot accepted content mutation")
+	}
+
+	for _, table := range []string{"assessment_snapshots", "assessment_snapshot_run_refs", "assessment_snapshot_lane_refs", "assessment_snapshot_dimensions", "assessment_snapshot_counters", "assessment_snapshot_defaults"} {
+		var forced bool
+		if err := pool.QueryRow(ctx, `SELECT relforcerowsecurity FROM pg_class WHERE oid=$1::regclass`, table).Scan(&forced); err != nil || !forced {
+			t.Fatalf("FORCE RLS %s=%v err=%v", table, forced, err)
+		}
+	}
+}
+
+func TestPostgresAssessmentSnapshotRepositoryConcurrentInitialCASHasNoNumberGap(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := time.Now().UnixNano()
+	tenantID := shared.ID(fmt.Sprintf("snapshot-concurrent-tenant-%d", suffix))
+	assessmentID := shared.ID(fmt.Sprintf("snapshot-concurrent-assessment-%d", suffix))
+	cycleID := shared.ID(fmt.Sprintf("snapshot-concurrent-cycle-%d", suffix))
+	ensureTestTenantAndEngagement(t, ctx, pool, tenantID, assessmentID, "", "")
+
+	cycleRepository := NewAssessmentCycleRepository(pool)
+	cycle, err := assessmentcycle.NewAssessmentCycle(cycleID, tenantID, "Concurrent snapshot cycle", assessmentcycle.BoundaryStandalone, "", "", assessmentID, "operator", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember(tenantID, cycleID, assessmentID, "operator", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycleRepository.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycleRepository.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+
+	runRepository := NewScanRunStore(pool)
+	run := postgresNativeRun(t, tenantID, assessmentID, shared.ID(fmt.Sprintf("snapshot-concurrent-run-%d", suffix)), "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
+	sealPostgresNativeRun(t, ctx, runRepository, &run, time.Now().UTC())
+
+	repository := NewAssessmentSnapshotRepository(pool)
+	candidates := []*assessmentsnapshot.Snapshot{
+		postgresAssessmentSnapshot(t, tenantID, cycleID, assessmentID, fmt.Sprintf("snapshot-concurrent-a-%d", suffix), "request-a", run),
+		postgresAssessmentSnapshot(t, tenantID, cycleID, assessmentID, fmt.Sprintf("snapshot-concurrent-b-%d", suffix), "request-b", run),
+	}
+	type result struct {
+		snapshot *assessmentsnapshot.Snapshot
+		created  bool
+		err      error
+	}
+	start := make(chan struct{})
+	results := make(chan result, len(candidates))
+	var wait sync.WaitGroup
+	for _, candidate := range candidates {
+		wait.Add(1)
+		go func(candidate *assessmentsnapshot.Snapshot) {
+			defer wait.Done()
+			<-start
+			stored, created, err := repository.CreateFinalizedCAS(ctx, candidate, 0)
+			results <- result{snapshot: stored, created: created, err: err}
+		}(candidate)
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+
+	var winner *assessmentsnapshot.Snapshot
+	var successes, conflicts int
+	for result := range results {
+		switch {
+		case result.err == nil && result.created:
+			successes++
+			winner = result.snapshot
+		case errors.Is(result.err, shared.ErrConflict):
+			conflicts++
+		default:
+			t.Fatalf("concurrent initial CAS result=%+v", result)
+		}
+	}
+	if successes != 1 || conflicts != 1 || winner == nil || winner.SnapshotNumber != 1 {
+		t.Fatalf("concurrent initial CAS successes=%d conflicts=%d winner=%+v", successes, conflicts, winner)
+	}
+	defaultSnapshot, pointer, err := repository.GetDefault(ctx, tenantID, assessmentID)
+	if err != nil || pointer.Version != 1 || defaultSnapshot.ID != winner.ID {
+		t.Fatalf("default snapshot=%+v pointer=%+v err=%v", defaultSnapshot, pointer, err)
+	}
+	snapshots, err := repository.ListByAssessment(ctx, tenantID, assessmentID)
+	if err != nil || len(snapshots) != 1 || snapshots[0].SnapshotNumber != 1 {
+		t.Fatalf("snapshots=%+v err=%v", snapshots, err)
+	}
+}
+
+func TestPostgresAssessmentSnapshotConcurrentReplayAndAuditRollback(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := time.Now().UnixNano()
+	tenantID, assessmentID, cycleID, run := createPostgresSnapshotFixture(t, ctx, pool, fmt.Sprintf("replay-%d", suffix))
+	repository := NewAssessmentSnapshotRepository(pool)
+	candidate := postgresAssessmentSnapshot(t, tenantID, cycleID, assessmentID, fmt.Sprintf("snapshot-replay-%d", suffix), "request-replay", run)
+
+	type result struct {
+		snapshot *assessmentsnapshot.Snapshot
+		created  bool
+		err      error
+	}
+	start := make(chan struct{})
+	results := make(chan result, 2)
+	var wait sync.WaitGroup
+	for index := 0; index < 2; index++ {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			stored, created, err := repository.CreateFinalizedCAS(context.Background(), candidate, 0)
+			results <- result{snapshot: stored, created: created, err: err}
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	var createdCount, replayCount int
+	for result := range results {
+		if result.err != nil || result.snapshot == nil || result.snapshot.ID != candidate.ID {
+			t.Fatalf("concurrent replay result=%+v", result)
+		}
+		if result.created {
+			createdCount++
+		} else {
+			replayCount++
+		}
+	}
+	if createdCount != 1 || replayCount != 1 {
+		t.Fatalf("concurrent replay created=%d replayed=%d", createdCount, replayCount)
+	}
+
+	failureTenant, failureAssessment, _, failureRun := createPostgresSnapshotFixture(t, ctx, pool, fmt.Sprintf("rollback-%d", suffix))
+	failureRepository := NewAssessmentSnapshotRepository(pool)
+	service, err := snapshotuc.NewService(
+		failureRepository, NewAssessmentCycleRepository(pool), NewEngagementRepository(pool), NewScanRunStore(pool), NewTenantTransactionRunner(pool),
+		&snapshotPostgresIDs{prefix: fmt.Sprintf("snapshot-rollback-%d", suffix)},
+		snapshotPostgresClock{now: time.Date(2026, time.September, 1, 15, 0, 0, 0, time.UTC)}, snapshotFailureAudit{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := service.Finalize(ctx, snapshotuc.FinalizeInput{
+		TenantID: failureTenant, AssessmentID: failureAssessment, SelectedRunIDs: []string{failureRun.ID},
+		RequestKey: "request-audit-failure", ExpectedDefaultVersion: 0, Actor: "operator",
+	}); err == nil || !strings.Contains(err.Error(), "forced snapshot audit failure") {
+		t.Fatalf("audit failure=%v", err)
+	}
+	if _, err := failureRepository.GetByRequestKey(ctx, failureTenant, failureAssessment, "request-audit-failure"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("audit failure retained snapshot=%v", err)
+	}
+	if snapshots, err := failureRepository.ListByAssessment(ctx, failureTenant, failureAssessment); err != nil || len(snapshots) != 0 {
+		t.Fatalf("audit rollback snapshots=%+v err=%v", snapshots, err)
+	}
+}
+
+func createPostgresSnapshotFixture(t *testing.T, ctx context.Context, pool *pgxpool.Pool, suffix string) (shared.ID, shared.ID, shared.ID, scanrun.ScanRun) {
+	t.Helper()
+	tenantID := shared.ID("snapshot-service-tenant-" + suffix)
+	assessmentID := shared.ID("snapshot-service-assessment-" + suffix)
+	cycleID := shared.ID("snapshot-service-cycle-" + suffix)
+	ensureTestTenantAndEngagement(t, ctx, pool, tenantID, assessmentID, "", "")
+	cycle, err := assessmentcycle.NewAssessmentCycle(cycleID, tenantID, "Snapshot service cycle", assessmentcycle.BoundaryStandalone, "", "", assessmentID, "operator", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember(tenantID, cycleID, assessmentID, "operator", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cycles := NewAssessmentCycleRepository(pool)
+	if err := cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+	run := postgresNativeRun(t, tenantID, assessmentID, shared.ID("snapshot-service-run-"+suffix), strings.Repeat("e", 64))
+	runs := NewScanRunStore(pool)
+	sealPostgresNativeRun(t, ctx, runs, &run, time.Now().UTC())
+	return tenantID, assessmentID, cycleID, run
+}
+
+type snapshotFailureAudit struct{}
+
+func (snapshotFailureAudit) Record(context.Context, ports.AuditEntry) error {
+	return errors.New("forced snapshot audit failure")
+}
+
+type snapshotPostgresClock struct{ now time.Time }
+
+func (clock snapshotPostgresClock) Now() time.Time { return clock.now }
+
+type snapshotPostgresIDs struct {
+	prefix string
+	next   int
+}
+
+func (ids *snapshotPostgresIDs) NewID() shared.ID {
+	ids.next++
+	return shared.ID(fmt.Sprintf("%s-%d", ids.prefix, ids.next))
+}
+
+func postgresAssessmentSnapshot(t *testing.T, tenantID, cycleID, assessmentID shared.ID, snapshotID, requestKey string, run scanrun.ScanRun) *assessmentsnapshot.Snapshot {
+	t.Helper()
+	if !run.IsSealed() {
+		t.Fatal("expected sealed scan run")
+	}
+	snapshot, err := assessmentsnapshot.NewFinalized(tenantID, shared.ID(snapshotID), cycleID, assessmentID,
+		assessmentsnapshot.Boundary{Kind: assessmentcycle.BoundaryStandalone}, requestKey, "operator", time.Now().UTC(),
+		[]assessmentsnapshot.SelectedRun{{
+			ID: run.ID, ManifestHash: run.ManifestHash, Provenance: run.Provenance,
+			TerminalStatus: run.TerminalStatus, Trusted: true, Lanes: run.Lanes,
+		}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snapshot
+}
+
+func postgresNativeRun(t *testing.T, tenantID, assessmentID shared.ID, runID shared.ID, revision string) scanrun.ScanRun {
+	t.Helper()
+	started := time.Now().UTC().Add(-2 * time.Minute)
+	finished := started.Add(time.Minute)
+	target, err := scanrun.CanonicalizeRepositoryTarget("https://example.com/synapse/repo.git", revision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return scanrun.ScanRun{
+		TenantID: tenantID, EngagementID: assessmentID, ID: runID.String(), Provenance: scanrun.ProvenanceNative,
+		TerminalStatus: scanrun.StatusBuilding, ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion, CreatedAt: started, UpdatedAt: started,
+		Lanes: []scanrun.Lane{{
+			TenantID: tenantID, EngagementID: assessmentID, ScanRunID: runID.String(), LaneKey: "sca", Producer: "sca",
+			TerminalStatus: scanrun.StatusSucceeded, Target: target, AuthoritativeFindingKinds: []string{"vulnerability"},
+			IncludedScope: []string{"src/**"}, ExcludedScope: []string{"vendor/**"}, StartedAt: started, FinishedAt: &finished,
+			ResultSHA256: strings.Repeat("a", 64), ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion,
+			Versions: []scanrun.LaneVersion{{VersionKind: scanrun.VersionScanner, Name: "sca", Version: "1"}},
+			Stages:   []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSucceeded, StartedAt: started, FinishedAt: &finished}},
+		}},
+	}
+}
+
+func sealPostgresNativeRun(t *testing.T, ctx context.Context, repository *ScanRunStore, run *scanrun.ScanRun, sealedAt time.Time) {
+	t.Helper()
+	building := *run
+	building.Lanes = nil
+	if err := repository.SaveScanRun(ctx, building); err != nil {
+		t.Fatal(err)
+	}
+	lanes := append([]scanrun.Lane(nil), run.Lanes...)
+	for index := range lanes {
+		lanes[index].SealedAt = &sealedAt
+		hash, err := scanrun.ComputeManifestHash(lanes[index])
+		if err != nil {
+			t.Fatal(err)
+		}
+		lanes[index].ManifestHash = hash
+	}
+	manifestHash, err := scanrun.ComputeRunManifestHash(lanes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.SealScanRun(ctx, run.TenantID, run.ID, scanrun.StatusSucceeded, lanes, scanrun.CurrentManifestSchemaVersion, manifestHash, sealedAt); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := repository.GetScanRun(ctx, run.TenantID, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	*run = stored
+}

--- a/internal/infrastructure/persistence/postgres/asset_repo.go
+++ b/internal/infrastructure/persistence/postgres/asset_repo.go
@@ -289,6 +289,23 @@ func (r *AssetRepository) listBusinessAssetLinks(ctx context.Context, tenantID, 
 
 func (r *AssetRepository) AssignEngagementBusinessAsset(ctx context.Context, tenantID, engagementID, assetID shared.ID) error {
 	return WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var currentAssetID string
+		if err := tx.QueryRow(ctx, `SELECT COALESCE(business_asset_id,'') FROM engagements
+			WHERE tenant_id=$1 AND id=$2 AND project_id IS NULL FOR UPDATE`, tenantID.String(), engagementID.String()).Scan(&currentAssetID); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return shared.ErrNotFound
+			}
+			return err
+		}
+		if currentAssetID != assetID.String() {
+			var frozen bool
+			if err := tx.QueryRow(ctx, `SELECT EXISTS(SELECT 1 FROM assessment_cycle_members WHERE tenant_id=$1 AND assessment_id=$2)`, tenantID.String(), engagementID.String()).Scan(&frozen); err != nil {
+				return err
+			}
+			if frozen {
+				return fmt.Errorf("%w: an Assessment Cycle freezes its Business Asset boundary", shared.ErrConflict)
+			}
+		}
 		ct, err := tx.Exec(ctx, `UPDATE engagements SET business_asset_id=NULLIF($3,''), updated_at=now() WHERE tenant_id=$1 AND id=$2 AND project_id IS NULL`, tenantID.String(), engagementID.String(), assetID.String())
 		if err != nil {
 			return err

--- a/internal/infrastructure/persistence/postgres/aup_audit.go
+++ b/internal/infrastructure/persistence/postgres/aup_audit.go
@@ -225,6 +225,9 @@ func (l *AuditLog) RecordOnce(ctx context.Context, e ports.AuditEntry) error {
 	if e.Metadata["idempotency_key"] == "" {
 		return l.Record(ctx, e)
 	}
+	if handled, err := l.recordInBoundTenantTransaction(ctx, e); handled {
+		return err
+	}
 	const maxAttempts = 8
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		err := l.recordOnce(ctx, e)
@@ -241,6 +244,9 @@ func (l *AuditLog) RecordOnce(ctx context.Context, e ports.AuditEntry) error {
 }
 
 func (l *AuditLog) Record(ctx context.Context, e ports.AuditEntry) error {
+	if handled, err := l.recordInBoundTenantTransaction(ctx, e); handled {
+		return err
+	}
 	const maxAttempts = 8
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		err := l.recordOnce(ctx, e)
@@ -254,6 +260,18 @@ func (l *AuditLog) Record(ctx context.Context, e ports.AuditEntry) error {
 		return err
 	}
 	return fmt.Errorf("append audit entry: %w after %d attempts", shared.ErrConflict, maxAttempts)
+}
+
+func (l *AuditLog) recordInBoundTenantTransaction(ctx context.Context, e ports.AuditEntry) (bool, error) {
+	tenantID, tenantBound := shared.TenantFrom(ctx)
+	if !tenantBound {
+		return false, nil
+	}
+	tx, bound, err := contextTenantTx(ctx, tenantID)
+	if err != nil || !bound {
+		return bound, err
+	}
+	return true, appendTenantAudit(ctx, tx, tenantID.String(), e)
 }
 
 // recordOnce performs one locked read-head → chain → insert attempt. A 23505 unique violation

--- a/internal/infrastructure/persistence/postgres/engagement_repo.go
+++ b/internal/infrastructure/persistence/postgres/engagement_repo.go
@@ -17,7 +17,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
-const engagementCols = `id, tenant_id, project_id, business_asset_id, name, client, status, authorized_from, authorized_to, created_at, updated_at, timezone, roe, live_recon, created_by, updated_by`
+const engagementCols = `id, tenant_id, project_id, business_asset_id, name, client, status, authorized_from, authorized_to, created_at, updated_at, timezone, roe, live_recon, requires_explicit_execution_authorization, created_by, updated_by`
 
 // EngagementRepository persists engagements and their scope to PostgreSQL.
 type EngagementRepository struct{ pool *pgxpool.Pool }
@@ -31,6 +31,7 @@ var _ ports.EngagementRepository = (*EngagementRepository)(nil)
 var _ ports.PromotionReconciliationScopeReader = (*EngagementRepository)(nil)
 var _ ports.VulnerabilityReconciliationTenantStore = (*EngagementRepository)(nil)
 var _ ports.DetectionReconciliationTenantStore = (*EngagementRepository)(nil)
+var _ ports.AssessmentCycleBackfillSource = (*EngagementRepository)(nil)
 
 // Create inserts the engagement and its scope targets in one transaction.
 func (r *EngagementRepository) Create(ctx context.Context, e *engagement.Engagement) error {
@@ -42,9 +43,9 @@ func (r *EngagementRepository) Create(ctx context.Context, e *engagement.Engagem
 			return fmt.Errorf("marshal roe: %w", err)
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO engagements (`+engagementCols+`) VALUES ($1,$2,NULLIF($3,''),NULLIF($4,''),$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16)`,
+			`INSERT INTO engagements (`+engagementCols+`) VALUES ($1,$2,NULLIF($3,''),NULLIF($4,''),$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)`,
 			e.ID.String(), tenantID.String(), e.ProjectID.String(), e.BusinessAssetID.String(), e.Name, e.Client, string(e.Status),
-			e.AuthorizedFrom, e.AuthorizedTo, e.Audit.CreatedAt, e.Audit.UpdatedAt, e.Timezone, roeJSON, e.LiveReconEnabled,
+			e.AuthorizedFrom, e.AuthorizedTo, e.Audit.CreatedAt, e.Audit.UpdatedAt, e.Timezone, roeJSON, e.LiveReconEnabled, e.RequiresExplicitExecutionAuthorization,
 			e.Audit.CreatedBy, e.Audit.UpdatedBy); err != nil {
 			return fmt.Errorf("insert engagement: %w", err)
 		}
@@ -110,9 +111,9 @@ func (r *EngagementRepository) Update(ctx context.Context, e *engagement.Engagem
 			return fmt.Errorf("marshal roe: %w", err)
 		}
 		ct, err := tx.Exec(ctx,
-			`UPDATE engagements SET name=$2, client=$3, status=$4, authorized_from=$5, authorized_to=$6, timezone=$7, updated_at=$8, roe=$9, live_recon=$10, updated_by=$11, business_asset_id=NULLIF($12,'') WHERE id=$1`,
+			`UPDATE engagements SET name=$2, client=$3, status=$4, authorized_from=$5, authorized_to=$6, timezone=$7, updated_at=$8, roe=$9, live_recon=$10, updated_by=$11, business_asset_id=NULLIF($12,''), requires_explicit_execution_authorization=$13 WHERE id=$1`,
 			e.ID.String(), e.Name, e.Client, string(e.Status),
-			e.AuthorizedFrom, e.AuthorizedTo, e.Timezone, e.Audit.UpdatedAt, roeJSON, e.LiveReconEnabled, e.Audit.UpdatedBy, e.BusinessAssetID.String())
+			e.AuthorizedFrom, e.AuthorizedTo, e.Timezone, e.Audit.UpdatedAt, roeJSON, e.LiveReconEnabled, e.Audit.UpdatedBy, e.BusinessAssetID.String(), e.RequiresExplicitExecutionAuthorization)
 		if err != nil {
 			return fmt.Errorf("update engagement: %w", err)
 		}
@@ -264,6 +265,33 @@ func (r *EngagementRepository) List(ctx context.Context, tenantID shared.ID) (ou
 	return out, err
 }
 
+func (r *EngagementRepository) ListAssessmentCycleBackfillEngagements(ctx context.Context, tenantID, after shared.ID, snapshotAt time.Time, limit int) (out []*engagement.Engagement, err error) {
+	if snapshotAt.IsZero() || limit < 1 || limit > 2000 {
+		return nil, fmt.Errorf("%w: assessment cycle backfill page is invalid", shared.ErrValidation)
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	err = WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT `+engagementCols+` FROM engagements WHERE tenant_id=$1 AND project_id IS NULL AND id COLLATE "C">$2 AND created_at<=$3 ORDER BY id COLLATE "C" LIMIT $4`, tenantID.String(), after.String(), snapshotAt.UTC(), limit)
+		if err != nil {
+			return fmt.Errorf("list assessment cycle backfill engagements: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			item, err := scanEngagement(rows)
+			if err != nil {
+				return fmt.Errorf("scan assessment cycle backfill engagement: %w", err)
+			}
+			out = append(out, item)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+func (r *EngagementRepository) ListAssessmentSnapshotBackfillEngagements(ctx context.Context, tenantID, after shared.ID, snapshotAt time.Time, limit int) ([]*engagement.Engagement, error) {
+	return r.ListAssessmentCycleBackfillEngagements(ctx, tenantID, after, snapshotAt, limit)
+}
+
 // ListProjectEngagements returns the tenant's hidden Project analysis contexts for operational
 // aggregation. Normal engagement lists remain unchanged and continue to hide these rows.
 func (r *EngagementRepository) ListProjectEngagements(ctx context.Context, tenantID shared.ID) (out []*engagement.Engagement, err error) {
@@ -408,7 +436,7 @@ func scanEngagement(row rowScanner) (*engagement.Engagement, error) {
 		af, at                     pgtype.Timestamptz
 		roeJSON                    []byte
 	)
-	if err := row.Scan(&idStr, &ten, &projectID, &businessAssetID, &e.Name, &e.Client, &st, &af, &at, &e.Audit.CreatedAt, &e.Audit.UpdatedAt, &e.Timezone, &roeJSON, &e.LiveReconEnabled, &e.Audit.CreatedBy, &e.Audit.UpdatedBy); err != nil {
+	if err := row.Scan(&idStr, &ten, &projectID, &businessAssetID, &e.Name, &e.Client, &st, &af, &at, &e.Audit.CreatedAt, &e.Audit.UpdatedAt, &e.Timezone, &roeJSON, &e.LiveReconEnabled, &e.RequiresExplicitExecutionAuthorization, &e.Audit.CreatedBy, &e.Audit.UpdatedBy); err != nil {
 		return nil, err
 	}
 	if len(roeJSON) > 0 {

--- a/internal/infrastructure/persistence/postgres/tenant.go
+++ b/internal/infrastructure/persistence/postgres/tenant.go
@@ -126,6 +126,13 @@ func contextTenantTx(ctx context.Context, tenantID shared.ID) (pgx.Tx, bool, err
 	return bound.tx, true, nil
 }
 
+// bindTenantTransaction exposes an already-open tenant transaction to nested
+// repositories. It is used by fenced backfill commits so the projected business
+// artifact and its accounting item share one database commit.
+func bindTenantTransaction(ctx context.Context, tenantID shared.ID, tx pgx.Tx) context.Context {
+	return shared.WithTenant(context.WithValue(ctx, tenantTransactionKey{}, tenantTransaction{tenantID: tenantID.String(), tx: tx}), tenantID)
+}
+
 // CheckRLSRuntimeRole reports whether the role the pool connects as can actually be constrained by
 // Row Level Security. RLS is bypassed entirely by SUPERUSER and BYPASSRLS roles regardless of
 // FORCE ROW LEVEL SECURITY, so if the runtime role holds either attribute the whole tenant

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -378,6 +378,15 @@ type Config struct {
 	// SLAEnabled turns on durable risk-based remediation deadlines, versioned tenant policy, and
 	// human lifecycle APIs. Default false until an operator explicitly opts into the new schema/path.
 	SLAEnabled bool
+	// Assessment lifecycle gates default off and use explicit tenant allowlists for staged rollout.
+	AssessmentCycleAPIEnabled       bool
+	AssessmentCycleDualWriteEnabled bool
+	AssessmentCycleDualWriteTenants []string
+	AssessmentSnapshotEnabled       bool
+	AssessmentLifecycleReadEnabled  bool
+	AssessmentLifecycleReadTenants  []string
+	AssessmentLifecycleUIDefault    bool
+	AssessmentLifecycleUITenants    []string
 	// SASTEnabled turns on the deterministic pattern-SAST analyzer in the scan pipeline; off by default.
 	SASTEnabled bool
 	// SecretScanEnabled turns on the deterministic secret scanner in the scan pipeline; off by default.
@@ -776,6 +785,14 @@ func Load() Config {
 		VulnerabilityDryRunEnabled:            getbool("SYNAPSE_VULNERABILITY_DRY_RUN_ENABLED", true),
 		VulnerabilityTenantAllowlist:          splitList(getenv("SYNAPSE_VULNERABILITY_TENANT_ALLOWLIST", "")),
 		SLAEnabled:                            getbool("SYNAPSE_SLA_ENABLED", false),
+		AssessmentCycleAPIEnabled:             getbool("SYNAPSE_ASSESSMENT_CYCLE_API_ENABLED", false),
+		AssessmentCycleDualWriteEnabled:       getbool("SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_ENABLED", false),
+		AssessmentCycleDualWriteTenants:       splitList(getenv("SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_TENANTS", "")),
+		AssessmentSnapshotEnabled:             getbool("SYNAPSE_ASSESSMENT_SNAPSHOT_ENABLED", false),
+		AssessmentLifecycleReadEnabled:        getbool("SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED", false),
+		AssessmentLifecycleReadTenants:        splitList(getenv("SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS", "")),
+		AssessmentLifecycleUIDefault:          getbool("SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_ENABLED", false),
+		AssessmentLifecycleUITenants:          splitList(getenv("SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_TENANTS", "")),
 		GovulncheckBin:                        getenv("SYNAPSE_GOVULNCHECK_BIN", "govulncheck"),
 		GoModGraphEnabled:                     getbool("SYNAPSE_GOMODGRAPH_ENABLED", true),
 		GoBin:                                 getenv("SYNAPSE_GO_BIN", "go"),
@@ -1129,6 +1146,75 @@ func (c Config) ValidateWorkerConcurrency() error {
 		return fmt.Errorf("SYNAPSE_WORKER_CONCURRENCY must be between 1 and %d (got %d)", maxWorkerConcurrency, c.WorkerConcurrency)
 	}
 	return nil
+}
+
+// ValidateAssessmentLifecycleRollout rejects partial feature combinations that
+// would expose lifecycle UI without its tenant-scoped read path.
+func (c Config) ValidateAssessmentLifecycleRollout() error {
+	if c.AssessmentCycleDualWriteEnabled && len(c.AssessmentCycleDualWriteTenants) == 0 {
+		return errors.New("SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_ENABLED requires SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_TENANTS")
+	}
+	if c.AssessmentLifecycleReadEnabled && len(c.AssessmentLifecycleReadTenants) == 0 {
+		return errors.New("SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED requires SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS")
+	}
+	if c.AssessmentLifecycleUIDefault && !c.AssessmentLifecycleReadEnabled {
+		return errors.New("SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_ENABLED requires SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED=true")
+	}
+	if c.AssessmentLifecycleUIDefault && len(c.AssessmentLifecycleUITenants) == 0 {
+		return errors.New("SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_ENABLED requires SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_TENANTS")
+	}
+	if !tenantAllowlistCovers(c.AssessmentLifecycleReadTenants, c.AssessmentLifecycleUITenants) {
+		return errors.New("SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_TENANTS must be a subset of SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS")
+	}
+	return nil
+}
+
+func (c Config) AssessmentCycleDualWriteForTenant(tenantID string) bool {
+	if c.AssessmentCycleAPIEnabled {
+		return true
+	}
+	return tenantFeatureEnabled(c.AssessmentCycleDualWriteEnabled, c.AssessmentCycleDualWriteTenants, tenantID)
+}
+
+func (c Config) AssessmentLifecycleReadForTenant(tenantID string) bool {
+	return tenantFeatureEnabled(c.AssessmentLifecycleReadEnabled, c.AssessmentLifecycleReadTenants, tenantID)
+}
+
+func (c Config) AssessmentLifecycleUIForTenant(tenantID string) bool {
+	return tenantFeatureEnabled(c.AssessmentLifecycleUIDefault, c.AssessmentLifecycleUITenants, tenantID)
+}
+
+func tenantFeatureEnabled(enabled bool, allowlist []string, tenantID string) bool {
+	if !enabled {
+		return false
+	}
+	tenantID = strings.TrimSpace(tenantID)
+	for _, allowed := range allowlist {
+		if allowed == "*" || strings.TrimSpace(allowed) == tenantID {
+			return true
+		}
+	}
+	return false
+}
+
+func tenantAllowlistCovers(superset, subset []string) bool {
+	if len(subset) == 0 {
+		return true
+	}
+	allowed := make(map[string]struct{}, len(superset))
+	for _, tenantID := range superset {
+		tenantID = strings.TrimSpace(tenantID)
+		if tenantID == "*" {
+			return true
+		}
+		allowed[tenantID] = struct{}{}
+	}
+	for _, tenantID := range subset {
+		if _, ok := allowed[strings.TrimSpace(tenantID)]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // ValidateOIDCPosture fails closed when the browser OIDC BFF cannot bind identity/session state to a fixed tenant.

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -379,14 +379,16 @@ type Config struct {
 	// human lifecycle APIs. Default false until an operator explicitly opts into the new schema/path.
 	SLAEnabled bool
 	// Assessment lifecycle gates default off and use explicit tenant allowlists for staged rollout.
-	AssessmentCycleAPIEnabled       bool
-	AssessmentCycleDualWriteEnabled bool
-	AssessmentCycleDualWriteTenants []string
-	AssessmentSnapshotEnabled       bool
-	AssessmentLifecycleReadEnabled  bool
-	AssessmentLifecycleReadTenants  []string
-	AssessmentLifecycleUIDefault    bool
-	AssessmentLifecycleUITenants    []string
+	AssessmentCycleAPIEnabled           bool
+	AssessmentCycleDualWriteEnabled     bool
+	AssessmentCycleDualWriteTenants     []string
+	AssessmentSnapshotEnabled           bool
+	AssessmentSnapshotCompletionEnabled bool
+	AssessmentSnapshotCompletionTenants []string
+	AssessmentLifecycleReadEnabled      bool
+	AssessmentLifecycleReadTenants      []string
+	AssessmentLifecycleUIDefault        bool
+	AssessmentLifecycleUITenants        []string
 	// SASTEnabled turns on the deterministic pattern-SAST analyzer in the scan pipeline; off by default.
 	SASTEnabled bool
 	// SecretScanEnabled turns on the deterministic secret scanner in the scan pipeline; off by default.
@@ -789,6 +791,8 @@ func Load() Config {
 		AssessmentCycleDualWriteEnabled:       getbool("SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_ENABLED", false),
 		AssessmentCycleDualWriteTenants:       splitList(getenv("SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_TENANTS", "")),
 		AssessmentSnapshotEnabled:             getbool("SYNAPSE_ASSESSMENT_SNAPSHOT_ENABLED", false),
+		AssessmentSnapshotCompletionEnabled:   getbool("SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_ENABLED", false),
+		AssessmentSnapshotCompletionTenants:   splitList(getenv("SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_TENANTS", "")),
 		AssessmentLifecycleReadEnabled:        getbool("SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED", false),
 		AssessmentLifecycleReadTenants:        splitList(getenv("SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS", "")),
 		AssessmentLifecycleUIDefault:          getbool("SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_ENABLED", false),
@@ -1157,6 +1161,18 @@ func (c Config) ValidateAssessmentLifecycleRollout() error {
 	if c.AssessmentLifecycleReadEnabled && len(c.AssessmentLifecycleReadTenants) == 0 {
 		return errors.New("SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED requires SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS")
 	}
+	if c.AssessmentSnapshotCompletionEnabled && !c.AssessmentSnapshotEnabled {
+		return errors.New("SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_ENABLED requires SYNAPSE_ASSESSMENT_SNAPSHOT_ENABLED=true")
+	}
+	if c.AssessmentSnapshotCompletionEnabled && len(c.AssessmentSnapshotCompletionTenants) == 0 {
+		return errors.New("SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_ENABLED requires SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_TENANTS")
+	}
+	if c.AssessmentSnapshotCompletionEnabled && !c.AssessmentLifecycleReadEnabled {
+		return errors.New("SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_ENABLED requires SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED=true")
+	}
+	if !tenantAllowlistCovers(c.AssessmentLifecycleReadTenants, c.AssessmentSnapshotCompletionTenants) {
+		return errors.New("SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_TENANTS must be a subset of SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS")
+	}
 	if c.AssessmentLifecycleUIDefault && !c.AssessmentLifecycleReadEnabled {
 		return errors.New("SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_ENABLED requires SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED=true")
 	}
@@ -1170,14 +1186,15 @@ func (c Config) ValidateAssessmentLifecycleRollout() error {
 }
 
 func (c Config) AssessmentCycleDualWriteForTenant(tenantID string) bool {
-	if c.AssessmentCycleAPIEnabled {
-		return true
-	}
 	return tenantFeatureEnabled(c.AssessmentCycleDualWriteEnabled, c.AssessmentCycleDualWriteTenants, tenantID)
 }
 
 func (c Config) AssessmentLifecycleReadForTenant(tenantID string) bool {
 	return tenantFeatureEnabled(c.AssessmentLifecycleReadEnabled, c.AssessmentLifecycleReadTenants, tenantID)
+}
+
+func (c Config) AssessmentSnapshotCompletionForTenant(tenantID string) bool {
+	return tenantFeatureEnabled(c.AssessmentSnapshotCompletionEnabled, c.AssessmentSnapshotCompletionTenants, tenantID)
 }
 
 func (c Config) AssessmentLifecycleUIForTenant(tenantID string) bool {

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -746,3 +746,62 @@ func TestProductionOIDCRequiresPostgres(t *testing.T) {
 		t.Fatalf("production OIDC with database: %v", err)
 	}
 }
+
+func TestLoadAssessmentLifecycleDefaultsFailClosed(t *testing.T) {
+	for _, key := range []string{
+		"SYNAPSE_ASSESSMENT_CYCLE_API_ENABLED",
+		"SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_ENABLED",
+		"SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_TENANTS",
+		"SYNAPSE_ASSESSMENT_SNAPSHOT_ENABLED",
+		"SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED",
+		"SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS",
+		"SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_ENABLED",
+		"SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_TENANTS",
+	} {
+		t.Setenv(key, "")
+	}
+	cfg := Load()
+	if cfg.AssessmentCycleAPIEnabled || cfg.AssessmentCycleDualWriteEnabled || cfg.AssessmentSnapshotEnabled || cfg.AssessmentLifecycleReadEnabled || cfg.AssessmentLifecycleUIDefault {
+		t.Fatal("assessment lifecycle flags must remain disabled by default")
+	}
+}
+
+func TestValidateAssessmentLifecycleRollout(t *testing.T) {
+	valid := Config{
+		AssessmentCycleDualWriteEnabled: true,
+		AssessmentCycleDualWriteTenants: []string{"tenant-a"},
+		AssessmentLifecycleReadEnabled:  true,
+		AssessmentLifecycleReadTenants:  []string{"tenant-a", "tenant-b"},
+		AssessmentLifecycleUIDefault:    true,
+		AssessmentLifecycleUITenants:    []string{"tenant-a"},
+	}
+	if err := valid.ValidateAssessmentLifecycleRollout(); err != nil {
+		t.Fatalf("valid assessment lifecycle rollout: %v", err)
+	}
+
+	invalid := valid
+	invalid.AssessmentCycleDualWriteTenants = nil
+	if err := invalid.ValidateAssessmentLifecycleRollout(); err == nil {
+		t.Fatal("dual-write without a tenant allowlist must fail")
+	}
+	invalid = valid
+	invalid.AssessmentLifecycleUITenants = []string{"tenant-c"}
+	if err := invalid.ValidateAssessmentLifecycleRollout(); err == nil {
+		t.Fatal("UI tenant outside read allowlist must fail")
+	}
+}
+
+func TestAssessmentLifecycleTenantGates(t *testing.T) {
+	cfg := Config{
+		AssessmentCycleDualWriteEnabled: true,
+		AssessmentCycleDualWriteTenants: []string{"tenant-a"},
+		AssessmentLifecycleReadEnabled:  true,
+		AssessmentLifecycleReadTenants:  []string{"*"},
+	}
+	if !cfg.AssessmentCycleDualWriteForTenant("tenant-a") || cfg.AssessmentCycleDualWriteForTenant("tenant-b") {
+		t.Fatal("tenant-scoped cycle dual-write allowlist mismatch")
+	}
+	if !cfg.AssessmentLifecycleReadForTenant("tenant-b") || cfg.AssessmentLifecycleUIForTenant("tenant-b") {
+		t.Fatal("read wildcard or fail-closed UI gate mismatch")
+	}
+}

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -753,6 +753,8 @@ func TestLoadAssessmentLifecycleDefaultsFailClosed(t *testing.T) {
 		"SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_ENABLED",
 		"SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_TENANTS",
 		"SYNAPSE_ASSESSMENT_SNAPSHOT_ENABLED",
+		"SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_ENABLED",
+		"SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_TENANTS",
 		"SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED",
 		"SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS",
 		"SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_ENABLED",
@@ -761,19 +763,22 @@ func TestLoadAssessmentLifecycleDefaultsFailClosed(t *testing.T) {
 		t.Setenv(key, "")
 	}
 	cfg := Load()
-	if cfg.AssessmentCycleAPIEnabled || cfg.AssessmentCycleDualWriteEnabled || cfg.AssessmentSnapshotEnabled || cfg.AssessmentLifecycleReadEnabled || cfg.AssessmentLifecycleUIDefault {
+	if cfg.AssessmentCycleAPIEnabled || cfg.AssessmentCycleDualWriteEnabled || cfg.AssessmentSnapshotEnabled || cfg.AssessmentSnapshotCompletionEnabled || cfg.AssessmentLifecycleReadEnabled || cfg.AssessmentLifecycleUIDefault {
 		t.Fatal("assessment lifecycle flags must remain disabled by default")
 	}
 }
 
 func TestValidateAssessmentLifecycleRollout(t *testing.T) {
 	valid := Config{
-		AssessmentCycleDualWriteEnabled: true,
-		AssessmentCycleDualWriteTenants: []string{"tenant-a"},
-		AssessmentLifecycleReadEnabled:  true,
-		AssessmentLifecycleReadTenants:  []string{"tenant-a", "tenant-b"},
-		AssessmentLifecycleUIDefault:    true,
-		AssessmentLifecycleUITenants:    []string{"tenant-a"},
+		AssessmentCycleDualWriteEnabled:     true,
+		AssessmentCycleDualWriteTenants:     []string{"tenant-a"},
+		AssessmentLifecycleReadEnabled:      true,
+		AssessmentLifecycleReadTenants:      []string{"tenant-a", "tenant-b"},
+		AssessmentLifecycleUIDefault:        true,
+		AssessmentLifecycleUITenants:        []string{"tenant-a"},
+		AssessmentSnapshotEnabled:           true,
+		AssessmentSnapshotCompletionEnabled: true,
+		AssessmentSnapshotCompletionTenants: []string{"tenant-a"},
 	}
 	if err := valid.ValidateAssessmentLifecycleRollout(); err != nil {
 		t.Fatalf("valid assessment lifecycle rollout: %v", err)
@@ -789,19 +794,29 @@ func TestValidateAssessmentLifecycleRollout(t *testing.T) {
 	if err := invalid.ValidateAssessmentLifecycleRollout(); err == nil {
 		t.Fatal("UI tenant outside read allowlist must fail")
 	}
+	invalid = valid
+	invalid.AssessmentSnapshotCompletionTenants = []string{"tenant-c"}
+	if err := invalid.ValidateAssessmentLifecycleRollout(); err == nil {
+		t.Fatal("Snapshot completion tenant outside read allowlist must fail")
+	}
 }
 
 func TestAssessmentLifecycleTenantGates(t *testing.T) {
 	cfg := Config{
-		AssessmentCycleDualWriteEnabled: true,
-		AssessmentCycleDualWriteTenants: []string{"tenant-a"},
-		AssessmentLifecycleReadEnabled:  true,
-		AssessmentLifecycleReadTenants:  []string{"*"},
+		AssessmentCycleDualWriteEnabled:     true,
+		AssessmentCycleDualWriteTenants:     []string{"tenant-a"},
+		AssessmentLifecycleReadEnabled:      true,
+		AssessmentLifecycleReadTenants:      []string{"*"},
+		AssessmentSnapshotCompletionEnabled: true,
+		AssessmentSnapshotCompletionTenants: []string{"tenant-a"},
 	}
 	if !cfg.AssessmentCycleDualWriteForTenant("tenant-a") || cfg.AssessmentCycleDualWriteForTenant("tenant-b") {
 		t.Fatal("tenant-scoped cycle dual-write allowlist mismatch")
 	}
 	if !cfg.AssessmentLifecycleReadForTenant("tenant-b") || cfg.AssessmentLifecycleUIForTenant("tenant-b") {
 		t.Fatal("read wildcard or fail-closed UI gate mismatch")
+	}
+	if !cfg.AssessmentSnapshotCompletionForTenant("tenant-a") || cfg.AssessmentSnapshotCompletionForTenant("tenant-b") {
+		t.Fatal("Snapshot completion tenant gate mismatch")
 	}
 }

--- a/internal/usecase/assessmentcycle/api_service.go
+++ b/internal/usecase/assessmentcycle/api_service.go
@@ -1,0 +1,786 @@
+package assessmentcycle
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	CodeIdempotencyKeyRequired     = "idempotency_key_required"
+	CodeIdempotencyBodyMismatch    = "idempotency_body_mismatch"
+	CodeIdempotencyRequestPending  = "idempotency_request_in_progress"
+	CodeCycleReopenRequired        = "cycle_reopen_required"
+	CodeCycleArchived              = "cycle_archived"
+	CodeHiddenProjectContext       = "hidden_project_context_ineligible"
+	CodeInvalidCursor              = "invalid_cursor"
+	CodeInvalidFilter              = "invalid_filter"
+	CodeInvalidPageSize            = "invalid_page_size"
+	CodeInvalidScopeStrategy       = "invalid_scope_strategy"
+	CodeInvalidProfileStrategy     = "invalid_profile_strategy"
+	WarningAuthorizationNotCopied  = "authorization_not_inherited"
+	WarningRoENotCopied            = "roe_not_inherited"
+	WarningScannerProfileNotCopied = "scanner_profile_not_inherited"
+)
+
+type APIError struct {
+	Code  string
+	Cause error
+}
+
+func (err *APIError) Error() string { return err.Code }
+func (err *APIError) Unwrap() error { return err.Cause }
+
+func ErrorCode(err error) string {
+	var coded *APIError
+	if errors.As(err, &coded) {
+		return coded.Code
+	}
+	return ""
+}
+
+type APIService struct {
+	cycles      *Service
+	cycleList   ports.AssessmentCycleListRepository
+	requests    ports.AssessmentCycleRequestStore
+	engagements *enguc.Service
+	tx          ports.TenantTransactionRunner
+	clock       ports.Clock
+	audit       ports.AuditLogger
+}
+
+func NewAPIService(cycles *Service, cycleList ports.AssessmentCycleListRepository, requests ports.AssessmentCycleRequestStore, engagements *enguc.Service, tx ports.TenantTransactionRunner, clock ports.Clock, audit ports.AuditLogger) (*APIService, error) {
+	if cycles == nil || cycleList == nil || requests == nil || engagements == nil || tx == nil || clock == nil {
+		return nil, fmt.Errorf("%w: assessment cycle API dependencies are required", shared.ErrValidation)
+	}
+	return &APIService{cycles: cycles, cycleList: cycleList, requests: requests, engagements: engagements, tx: tx, clock: clock, audit: audit}, nil
+}
+
+type RetainedRequest struct {
+	TenantID       shared.ID
+	Actor          string
+	Route          string
+	IdempotencyKey string
+}
+
+type RetainedResponse struct {
+	StatusCode int
+	Body       []byte
+	Replayed   bool
+}
+
+type SourceUpload struct {
+	Filename string
+	Size     int64
+	SHA256   string
+	Reader   io.Reader
+}
+
+type CreateInitialAssessmentInput struct {
+	Request    RetainedRequest
+	Engagement enguc.CreateInput
+	Source     *SourceUpload
+}
+
+func (service *APIService) CreateInitialAssessment(ctx context.Context, input CreateInitialAssessmentInput) (RetainedResponse, error) {
+	var compensate func(context.Context) error
+	canonical := struct {
+		Engagement enguc.CreateInput `json:"engagement"`
+		Source     *struct {
+			Filename string `json:"filename"`
+			Size     int64  `json:"size"`
+			SHA256   string `json:"sha256"`
+		} `json:"source,omitempty"`
+	}{Engagement: input.Engagement}
+	if input.Source != nil {
+		canonical.Source = &struct {
+			Filename string `json:"filename"`
+			Size     int64  `json:"size"`
+			SHA256   string `json:"sha256"`
+		}{Filename: input.Source.Filename, Size: input.Source.Size, SHA256: input.Source.SHA256}
+	}
+	return service.executeRetained(ctx, input.Request, canonical, func(txCtx context.Context) (int, any, error) {
+		engagementInput := input.Engagement
+		engagementInput.TenantID = shared.TenantOrDefault(input.Request.TenantID)
+		engagementInput.CreatedBy = strings.TrimSpace(input.Request.Actor)
+		var (
+			assessment *engdom.Engagement
+			err        error
+		)
+		if input.Source == nil {
+			assessment, err = service.engagements.Create(txCtx, engagementInput)
+		} else {
+			if input.Source.Reader == nil {
+				return 0, nil, &APIError{Code: "source_upload_required", Cause: shared.ErrValidation}
+			}
+			assessment, _, err = service.engagements.CreateFromSourcePackage(txCtx, engagementInput, input.Source.Filename, input.Source.Size, input.Source.SHA256, input.Source.Reader)
+		}
+		if err != nil {
+			return 0, nil, err
+		}
+		boundary := cycledom.BoundaryStandalone
+		if !assessment.BusinessAssetID.IsZero() {
+			boundary = cycledom.BoundaryAsset
+		}
+		cycle, _, err := service.cycles.CreateInitialCycle(txCtx, CreateInitialCycleInput{
+			TenantID: assessment.TenantID, Name: assessment.Name, BoundaryKind: boundary,
+			BusinessAssetID: assessment.BusinessAssetID, RootAssessmentID: assessment.ID, Actor: input.Request.Actor,
+		})
+		if err != nil {
+			return 0, nil, errors.Join(err, service.engagements.CompensateCreate(context.WithoutCancel(txCtx), assessment.TenantID, assessment.ID))
+		}
+		compensate = func(cleanupCtx context.Context) error {
+			return errors.Join(
+				service.cycles.compensateInitialCreate(cleanupCtx, assessment.TenantID, cycle.ID),
+				service.engagements.CompensateCreate(cleanupCtx, assessment.TenantID, assessment.ID),
+			)
+		}
+		service.record(txCtx, input.Request, "assessment_cycle.api_initial_created", cycle.ID, map[string]string{
+			"assessment_id": assessment.ID.String(), "cycle_version": strconv.FormatInt(cycle.Version, 10),
+		})
+		return 201, assessment, nil
+	}, func(cleanupCtx context.Context) error {
+		if compensate == nil {
+			return nil
+		}
+		return compensate(cleanupCtx)
+	})
+}
+
+type CreateRetestAssessmentInput struct {
+	Request                 RetainedRequest
+	AssessmentID            shared.ID
+	Name                    string
+	PredecessorAssessmentID shared.ID
+	ScopeStrategy           string
+	ProfileStrategy         string
+	AuthorizedFrom          *time.Time
+	AuthorizedTo            *time.Time
+	Timezone                string
+	RoE                     *engdom.RoE
+}
+
+type InheritanceDiff struct {
+	Scope          string `json:"scope"`
+	Authorization  string `json:"authorization"`
+	RoE            string `json:"roe"`
+	ScannerProfile string `json:"scanner_profile"`
+}
+
+type CreateRetestResponse struct {
+	Engagement      *engdom.Engagement `json:"engagement"`
+	Cycle           CycleView          `json:"cycle"`
+	Member          MemberView         `json:"member"`
+	InheritanceDiff InheritanceDiff    `json:"inheritance_diff"`
+	Warnings        []string           `json:"warnings"`
+}
+
+func (service *APIService) CreateRetestAssessment(ctx context.Context, input CreateRetestAssessmentInput) (RetainedResponse, error) {
+	var compensate func(context.Context) error
+	canonical := struct {
+		AssessmentID            shared.ID   `json:"assessment_id"`
+		Name                    string      `json:"name,omitempty"`
+		PredecessorAssessmentID shared.ID   `json:"predecessor_assessment_id,omitempty"`
+		ScopeStrategy           string      `json:"scope_strategy,omitempty"`
+		ProfileStrategy         string      `json:"profile_strategy,omitempty"`
+		AuthorizedFrom          *time.Time  `json:"authorized_from,omitempty"`
+		AuthorizedTo            *time.Time  `json:"authorized_to,omitempty"`
+		Timezone                string      `json:"timezone,omitempty"`
+		RoE                     *engdom.RoE `json:"roe,omitempty"`
+	}{input.AssessmentID, input.Name, input.PredecessorAssessmentID, input.ScopeStrategy, input.ProfileStrategy, input.AuthorizedFrom, input.AuthorizedTo, input.Timezone, input.RoE}
+	return service.executeRetained(ctx, input.Request, canonical, func(txCtx context.Context) (int, any, error) {
+		tenantID := shared.TenantOrDefault(input.Request.TenantID)
+		cycle, err := service.cycles.GetCycleByAssessment(txCtx, tenantID, input.AssessmentID)
+		if err != nil {
+			return 0, nil, err
+		}
+		if cycle.Status == cycledom.StatusCompleted {
+			return 0, nil, &APIError{Code: CodeCycleReopenRequired, Cause: cycledom.ErrCycleReopenRequired}
+		}
+		if cycle.Status == cycledom.StatusArchived {
+			return 0, nil, &APIError{Code: CodeCycleArchived, Cause: cycledom.ErrCycleArchived}
+		}
+		originalCycle := *cycle
+		if !cycle.ProjectID.IsZero() || cycle.BoundaryKind == cycledom.BoundaryProject || cycle.BoundaryKind == cycledom.BoundaryAssetProject {
+			return 0, nil, &APIError{Code: CodeHiddenProjectContext, Cause: cycledom.ErrHiddenProjectContext}
+		}
+		source, err := service.engagements.Get(txCtx, tenantID, input.AssessmentID)
+		if err != nil {
+			return 0, nil, err
+		}
+		scopeStrategy := strings.TrimSpace(input.ScopeStrategy)
+		if scopeStrategy == "" {
+			scopeStrategy = "copy"
+		}
+		var inScope, outOfScope []engdom.Target
+		switch scopeStrategy {
+		case "copy":
+			inScope = append([]engdom.Target(nil), source.Scope.InScope...)
+			outOfScope = append([]engdom.Target(nil), source.Scope.OutOfScope...)
+		case "empty":
+		default:
+			return 0, nil, &APIError{Code: CodeInvalidScopeStrategy, Cause: shared.ErrValidation}
+		}
+		profileStrategy := strings.TrimSpace(input.ProfileStrategy)
+		if profileStrategy == "" {
+			profileStrategy = "none"
+		}
+		if profileStrategy != "none" {
+			return 0, nil, &APIError{Code: CodeInvalidProfileStrategy, Cause: shared.ErrValidation}
+		}
+		name := strings.TrimSpace(input.Name)
+		if name == "" {
+			name = source.Name + " Re-test"
+		}
+		assessment, err := service.engagements.Create(txCtx, enguc.CreateInput{
+			TenantID: tenantID, BusinessAssetID: cycle.BusinessAssetID, CreatedBy: input.Request.Actor,
+			Name: name, Client: source.Client, InScope: inScope, OutOfScope: outOfScope,
+			AuthorizedFrom: input.AuthorizedFrom, AuthorizedTo: input.AuthorizedTo, Timezone: input.Timezone,
+			RoE: input.RoE, RequiresExplicitExecutionAuthorization: true,
+		})
+		if err != nil {
+			return 0, nil, err
+		}
+		member, err := service.cycles.CreateRetest(txCtx, CreateRetestInput{
+			TenantID: tenantID, CycleID: cycle.ID, PredecessorAssessmentID: input.PredecessorAssessmentID,
+			NewAssessmentID: assessment.ID, Actor: input.Request.Actor,
+		})
+		if err != nil {
+			return 0, nil, errors.Join(mapRetestError(err), service.engagements.CompensateCreate(context.WithoutCancel(txCtx), tenantID, assessment.ID))
+		}
+		compensate = func(cleanupCtx context.Context) error {
+			return errors.Join(
+				service.cycles.compensateCycleMutation(cleanupCtx, &originalCycle, assessment.ID),
+				service.engagements.CompensateCreate(cleanupCtx, tenantID, assessment.ID),
+			)
+		}
+		updatedCycle, err := service.cycles.GetCycle(txCtx, tenantID, cycle.ID)
+		if err != nil {
+			return 0, nil, err
+		}
+		warnings := []string{WarningAuthorizationNotCopied, WarningRoENotCopied, WarningScannerProfileNotCopied}
+		if input.AuthorizedFrom != nil || input.AuthorizedTo != nil {
+			warnings = removeWarning(warnings, WarningAuthorizationNotCopied)
+		}
+		if input.RoE != nil {
+			warnings = removeWarning(warnings, WarningRoENotCopied)
+		}
+		service.record(txCtx, input.Request, "assessment_cycle.api_retest_created", cycle.ID, map[string]string{
+			"assessment_id": assessment.ID.String(), "predecessor_id": member.PredecessorAssessmentID.String(),
+			"retest_number": strconv.Itoa(member.RetestNumber), "cycle_version": strconv.FormatInt(updatedCycle.Version, 10),
+		})
+		return 201, CreateRetestResponse{
+			Engagement: assessment, Cycle: projectCycle(updatedCycle), Member: projectMember(*member),
+			InheritanceDiff: InheritanceDiff{Scope: scopeStrategy, Authorization: "explicit_only", RoE: "explicit_only", ScannerProfile: profileStrategy},
+			Warnings:        warnings,
+		}, nil
+	}, func(cleanupCtx context.Context) error {
+		if compensate == nil {
+			return nil
+		}
+		return compensate(cleanupCtx)
+	})
+}
+
+type MemberView struct {
+	AssessmentID            string     `json:"assessment_id"`
+	AssessmentType          string     `json:"assessment_type"`
+	PredecessorAssessmentID string     `json:"predecessor_assessment_id,omitempty"`
+	RetestNumber            int        `json:"retest_number"`
+	RelationshipVersion     int64      `json:"relationship_version"`
+	CreatedAt               time.Time  `json:"created_at"`
+	CreatedBy               string     `json:"created_by"`
+	ArchivedAt              *time.Time `json:"archived_at,omitempty"`
+}
+
+type CycleView struct {
+	ID                       string                `json:"id"`
+	Name                     string                `json:"name"`
+	BoundaryKind             cycledom.BoundaryKind `json:"boundary_kind"`
+	BusinessAssetID          string                `json:"business_asset_id,omitempty"`
+	ProjectID                string                `json:"project_id,omitempty"`
+	Status                   cycledom.Status       `json:"status"`
+	RootAssessmentID         string                `json:"root_assessment_id"`
+	SelectedHeadAssessmentID string                `json:"selected_head_assessment_id"`
+	NextRetestNumber         int                   `json:"next_retest_number"`
+	Version                  int64                 `json:"version"`
+	CreatedAt                time.Time             `json:"created_at"`
+	UpdatedAt                time.Time             `json:"updated_at"`
+	CreatedBy                string                `json:"created_by"`
+	UpdatedBy                string                `json:"updated_by"`
+}
+
+type CycleDetail struct {
+	Cycle       CycleView    `json:"cycle"`
+	Members     []MemberView `json:"members"`
+	BranchHeads []MemberView `json:"branch_heads"`
+}
+
+type LifecycleView struct {
+	AssessmentID string `json:"assessment_id"`
+	CycleDetail
+}
+
+func (service *APIService) GetLifecycle(ctx context.Context, tenantID, assessmentID shared.ID) (LifecycleView, error) {
+	cycle, err := service.cycles.GetCycleByAssessment(ctx, tenantID, assessmentID)
+	if err != nil {
+		return LifecycleView{}, err
+	}
+	detail, err := service.cycleDetail(ctx, tenantID, cycle)
+	return LifecycleView{AssessmentID: assessmentID.String(), CycleDetail: detail}, err
+}
+
+func (service *APIService) GetCycle(ctx context.Context, tenantID, cycleID shared.ID) (CycleDetail, error) {
+	cycle, err := service.cycles.GetCycle(ctx, tenantID, cycleID)
+	if err != nil {
+		return CycleDetail{}, err
+	}
+	return service.cycleDetail(ctx, tenantID, cycle)
+}
+
+type ListCyclesInput struct {
+	TenantID         shared.ID
+	Status           cycledom.Status
+	BoundaryKind     cycledom.BoundaryKind
+	AssessmentStatus engdom.Status
+	SelectedHeadID   shared.ID
+	AssessmentType   cycledom.AssessmentType
+	ScanStaleness    string
+	Search           string
+	Cursor           string
+	Limit            int
+}
+
+type CycleSummary struct {
+	CycleView
+	MemberCount            int          `json:"member_count"`
+	ActiveBranchCount      int          `json:"active_branch_count"`
+	LatestAssessmentID     string       `json:"latest_assessment_id,omitempty"`
+	LatestRetestNumber     int          `json:"latest_retest_number"`
+	Members                []MemberView `json:"members"`
+	MembersNextCursor      string       `json:"members_next_cursor,omitempty"`
+	RootSnapshotID         string       `json:"root_snapshot_id,omitempty"`
+	CurrentSnapshotID      string       `json:"current_snapshot_id,omitempty"`
+	SelectedHeadLastScanAt *time.Time   `json:"selected_head_last_scan_at,omitempty"`
+	ScanStaleness          string       `json:"scan_staleness"`
+}
+
+type CyclePage struct {
+	Items                 []CycleSummary               `json:"items"`
+	NextCursor            string                       `json:"next_cursor,omitempty"`
+	MigrationPending      []MigrationPendingAssessment `json:"migration_pending"`
+	MigrationPendingTotal int                          `json:"migration_pending_total"`
+}
+
+type MigrationPendingAssessment struct {
+	AssessmentID    string                `json:"assessment_id"`
+	Name            string                `json:"name"`
+	Status          string                `json:"status"`
+	BoundaryKind    cycledom.BoundaryKind `json:"boundary_kind"`
+	BusinessAssetID string                `json:"business_asset_id,omitempty"`
+	UpdatedAt       time.Time             `json:"updated_at"`
+}
+
+type ListCycleMembersInput struct {
+	TenantID shared.ID
+	CycleID  shared.ID
+	Cursor   string
+	Limit    int
+}
+
+type CycleMemberPage struct {
+	Items      []MemberView `json:"items"`
+	NextCursor string       `json:"next_cursor,omitempty"`
+}
+
+func (service *APIService) ListCycles(ctx context.Context, input ListCyclesInput) (CyclePage, error) {
+	limit := input.Limit
+	if limit == 0 {
+		limit = 50
+	}
+	if limit < 1 || limit > 100 {
+		return CyclePage{}, &APIError{Code: CodeInvalidPageSize, Cause: shared.ErrValidation}
+	}
+	if input.Status != "" && !input.Status.Valid() {
+		return CyclePage{}, fmt.Errorf("%w: invalid assessment cycle status", shared.ErrValidation)
+	}
+	if input.BoundaryKind != "" && !input.BoundaryKind.Valid() {
+		return CyclePage{}, fmt.Errorf("%w: invalid assessment cycle boundary", shared.ErrValidation)
+	}
+	if err := normalizeCycleListFilters(&input); err != nil {
+		return CyclePage{}, err
+	}
+	updatedAt, cycleID, err := decodeCycleCursor(input.Cursor)
+	if err != nil {
+		return CyclePage{}, &APIError{Code: CodeInvalidCursor, Cause: shared.ErrValidation}
+	}
+	query := ports.AssessmentCycleListQuery{
+		TenantID: input.TenantID, Status: input.Status, BoundaryKind: input.BoundaryKind, AssessmentStatus: input.AssessmentStatus,
+		SelectedHeadID: input.SelectedHeadID, AssessmentType: input.AssessmentType,
+		ScanStaleness: input.ScanStaleness, ScanStaleBefore: service.clock.Now().UTC().Add(-24 * time.Hour), Search: input.Search,
+		AfterUpdatedAt: updatedAt, AfterCycleID: cycleID, Limit: limit + 1, MemberLimit: 10,
+	}
+	records, err := service.cycleList.ListCycles(ctx, query)
+	if err != nil {
+		return CyclePage{}, err
+	}
+	page := CyclePage{Items: make([]CycleSummary, 0, min(limit, len(records))), MigrationPending: make([]MigrationPendingAssessment, 0)}
+	for _, record := range records[:min(limit, len(records))] {
+		summary := CycleSummary{
+			CycleView: projectCycle(&record.Cycle), MemberCount: record.MemberCount, ActiveBranchCount: record.ActiveBranchCount,
+			LatestAssessmentID: record.LatestAssessmentID.String(), LatestRetestNumber: record.LatestRetestNumber,
+			Members: make([]MemberView, 0, len(record.Members)), RootSnapshotID: record.RootSnapshotID.String(), CurrentSnapshotID: record.CurrentSnapshotID.String(),
+			SelectedHeadLastScanAt: record.SelectedHeadScanAt, ScanStaleness: record.ScanStaleness,
+		}
+		for _, member := range record.Members {
+			summary.Members = append(summary.Members, projectMember(member))
+		}
+		if record.MembersHaveMore && len(record.Members) > 0 {
+			last := record.Members[len(record.Members)-1]
+			summary.MembersNextCursor = encodeCycleMemberCursor(last.RetestNumber, last.AssessmentID)
+		}
+		page.Items = append(page.Items, summary)
+	}
+	if len(records) > limit {
+		last := records[limit-1].Cycle
+		page.NextCursor = encodeCycleCursor(last.UpdatedAt, last.ID)
+	}
+	query.Limit = min(limit, 100)
+	pending, pendingTotal, err := service.cycleList.ListMigrationPendingAssessments(ctx, query)
+	if err != nil {
+		return CyclePage{}, err
+	}
+	page.MigrationPendingTotal = pendingTotal
+	for _, record := range pending {
+		page.MigrationPending = append(page.MigrationPending, MigrationPendingAssessment{
+			AssessmentID: record.AssessmentID.String(), Name: record.Name, Status: record.Status, BoundaryKind: record.BoundaryKind,
+			BusinessAssetID: record.BusinessAssetID.String(), UpdatedAt: record.UpdatedAt,
+		})
+	}
+	return page, nil
+}
+
+func normalizeCycleListFilters(input *ListCyclesInput) error {
+	if input.AssessmentStatus != "" && !input.AssessmentStatus.Valid() {
+		return invalidCycleListFilter("assessment_status")
+	}
+	if input.AssessmentType != "" && !input.AssessmentType.Valid() {
+		return invalidCycleListFilter("assessment_type")
+	}
+	if input.ScanStaleness != "" && input.ScanStaleness != "fresh" && input.ScanStaleness != "stale" && input.ScanStaleness != "missing" {
+		return invalidCycleListFilter("scan_staleness")
+	}
+	for name, value := range map[string]*string{"q": &input.Search} {
+		*value = strings.TrimSpace(*value)
+		if len(*value) > 256 || strings.ContainsFunc(*value, unicode.IsControl) {
+			return invalidCycleListFilter(name)
+		}
+	}
+	input.SelectedHeadID = shared.ID(strings.TrimSpace(input.SelectedHeadID.String()))
+	if len(input.SelectedHeadID) > 256 || strings.ContainsFunc(input.SelectedHeadID.String(), unicode.IsControl) {
+		return invalidCycleListFilter("selected_head_assessment_id")
+	}
+	return nil
+}
+
+func invalidCycleListFilter(name string) error {
+	return &APIError{Code: CodeInvalidFilter, Cause: fmt.Errorf("%w: invalid %s filter", shared.ErrValidation, name)}
+}
+
+func (service *APIService) ListCycleMembers(ctx context.Context, input ListCycleMembersInput) (CycleMemberPage, error) {
+	limit := input.Limit
+	if limit == 0 {
+		limit = 25
+	}
+	if limit < 1 || limit > 100 {
+		return CycleMemberPage{}, &APIError{Code: CodeInvalidPageSize, Cause: shared.ErrValidation}
+	}
+	afterNumber, afterID, err := decodeCycleMemberCursor(input.Cursor)
+	if err != nil {
+		return CycleMemberPage{}, &APIError{Code: CodeInvalidCursor, Cause: shared.ErrValidation}
+	}
+	if _, err := service.cycles.GetCycle(ctx, input.TenantID, input.CycleID); err != nil {
+		return CycleMemberPage{}, err
+	}
+	members, err := service.cycles.ListMembers(ctx, input.TenantID, input.CycleID)
+	if err != nil {
+		return CycleMemberPage{}, err
+	}
+	filtered := make([]cycledom.Member, 0, min(len(members), limit+1))
+	for _, member := range members {
+		if input.Cursor != "" && (member.RetestNumber < afterNumber || member.RetestNumber == afterNumber && member.AssessmentID <= afterID) {
+			continue
+		}
+		filtered = append(filtered, member)
+		if len(filtered) == limit+1 {
+			break
+		}
+	}
+	page := CycleMemberPage{Items: make([]MemberView, 0, min(limit, len(filtered)))}
+	for _, member := range filtered[:min(limit, len(filtered))] {
+		page.Items = append(page.Items, projectMember(member))
+	}
+	if len(filtered) > limit {
+		last := filtered[limit-1]
+		page.NextCursor = encodeCycleMemberCursor(last.RetestNumber, last.AssessmentID)
+	}
+	return page, nil
+}
+
+type ArchiveCycleRequest struct {
+	Request         RetainedRequest
+	CycleID         shared.ID
+	ExpectedVersion int64
+}
+
+func (service *APIService) ArchiveCycle(ctx context.Context, input ArchiveCycleRequest) (RetainedResponse, error) {
+	var compensate func(context.Context) error
+	canonical := struct {
+		CycleID         shared.ID `json:"cycle_id"`
+		ExpectedVersion int64     `json:"expected_version"`
+	}{input.CycleID, input.ExpectedVersion}
+	return service.executeRetained(ctx, input.Request, canonical, func(txCtx context.Context) (int, any, error) {
+		if input.ExpectedVersion < 1 {
+			return 0, nil, &APIError{Code: "precondition_required", Cause: shared.ErrValidation}
+		}
+		originalCycle, err := service.cycles.GetCycle(txCtx, input.Request.TenantID, input.CycleID)
+		if err != nil {
+			return 0, nil, err
+		}
+		if err := service.cycles.ArchiveCycle(txCtx, ArchiveCycleInput{
+			TenantID: input.Request.TenantID, CycleID: input.CycleID,
+			ExpectedCycleVersion: input.ExpectedVersion, Actor: input.Request.Actor,
+		}); err != nil {
+			return 0, nil, err
+		}
+		compensate = func(cleanupCtx context.Context) error {
+			return service.cycles.compensateCycleMutation(cleanupCtx, originalCycle, "")
+		}
+		detail, err := service.GetCycle(txCtx, input.Request.TenantID, input.CycleID)
+		if err != nil {
+			return 0, nil, err
+		}
+		service.record(txCtx, input.Request, "assessment_cycle.api_archived", input.CycleID, map[string]string{
+			"previous_version": strconv.FormatInt(input.ExpectedVersion, 10), "cycle_version": strconv.FormatInt(detail.Cycle.Version, 10),
+		})
+		return 200, detail, nil
+	}, func(cleanupCtx context.Context) error {
+		if compensate == nil {
+			return nil
+		}
+		return compensate(cleanupCtx)
+	})
+}
+
+func (service *APIService) executeRetained(ctx context.Context, request RetainedRequest, canonical any, operation func(context.Context) (int, any, error), compensate func(context.Context) error) (RetainedResponse, error) {
+	scope := ports.AssessmentCycleRequestScope{
+		TenantID: shared.TenantOrDefault(request.TenantID), Actor: strings.TrimSpace(request.Actor),
+		Route: strings.TrimSpace(request.Route), IdempotencyKey: strings.TrimSpace(request.IdempotencyKey),
+	}
+	if scope.Actor == "" || scope.Route == "" {
+		return RetainedResponse{}, fmt.Errorf("%w: actor and route are required", shared.ErrValidation)
+	}
+	if scope.IdempotencyKey == "" || len(scope.IdempotencyKey) > 128 {
+		return RetainedResponse{}, &APIError{Code: CodeIdempotencyKeyRequired, Cause: shared.ErrValidation}
+	}
+	requestHash, err := canonicalHash(canonical)
+	if err != nil {
+		return RetainedResponse{}, err
+	}
+	var response RetainedResponse
+	createdReservation := false
+	err = service.tx.Run(ctx, scope.TenantID, func(txCtx context.Context) error {
+		stored, created, err := service.requests.BeginAssessmentCycleRequest(txCtx, ports.AssessmentCycleRequest{
+			Scope: scope, RequestHash: requestHash, CreatedAt: service.clock.Now().UTC(),
+		})
+		if err != nil {
+			return err
+		}
+		createdReservation = created
+		if !created {
+			if stored.RequestHash != requestHash {
+				return &APIError{Code: CodeIdempotencyBodyMismatch, Cause: shared.ErrConflict}
+			}
+			if stored.CompletedAt == nil || stored.StatusCode == 0 || len(stored.ResponseBody) == 0 {
+				return &APIError{Code: CodeIdempotencyRequestPending, Cause: shared.ErrConflict}
+			}
+			response = RetainedResponse{StatusCode: stored.StatusCode, Body: append([]byte(nil), stored.ResponseBody...), Replayed: true}
+			return nil
+		}
+		statusCode, value, err := operation(txCtx)
+		if err != nil {
+			return errors.Join(err, compensate(context.WithoutCancel(txCtx)))
+		}
+		body, err := json.Marshal(value)
+		if err != nil {
+			return errors.Join(fmt.Errorf("marshal assessment cycle response: %w", err), compensate(context.WithoutCancel(txCtx)))
+		}
+		if err := service.requests.CompleteAssessmentCycleRequest(txCtx, scope, requestHash, statusCode, body, service.clock.Now().UTC()); err != nil {
+			return errors.Join(err, compensate(context.WithoutCancel(txCtx)))
+		}
+		response = RetainedResponse{StatusCode: statusCode, Body: body}
+		return nil
+	})
+	if err != nil && createdReservation {
+		_ = service.requests.AbortAssessmentCycleRequest(context.WithoutCancel(ctx), scope, requestHash)
+	}
+	return response, err
+}
+
+func (service *APIService) cycleDetail(ctx context.Context, tenantID shared.ID, cycle *cycledom.AssessmentCycle) (CycleDetail, error) {
+	members, err := service.cycles.ListMembers(ctx, tenantID, cycle.ID)
+	if err != nil {
+		return CycleDetail{}, err
+	}
+	detail := CycleDetail{Cycle: projectCycle(cycle), Members: make([]MemberView, 0, len(members))}
+	for _, member := range members {
+		detail.Members = append(detail.Members, projectMember(member))
+	}
+	for _, member := range cycledom.DeriveBranchHeads(members) {
+		detail.BranchHeads = append(detail.BranchHeads, projectMember(member))
+	}
+	return detail, nil
+}
+
+func (service *APIService) record(ctx context.Context, request RetainedRequest, action string, target shared.ID, metadata map[string]string) {
+	if service.audit == nil {
+		return
+	}
+	metadata["tenant_id"] = shared.TenantOrDefault(request.TenantID).String()
+	metadata["idempotency_key"] = strings.TrimSpace(request.IdempotencyKey)
+	_ = service.audit.Record(ctx, ports.AuditEntry{Actor: strings.TrimSpace(request.Actor), Action: action, Target: target.String(), Metadata: metadata, At: service.clock.Now().UTC()})
+}
+
+func projectCycle(cycle *cycledom.AssessmentCycle) CycleView {
+	return CycleView{
+		ID: cycle.ID.String(), Name: cycle.Name, BoundaryKind: cycle.BoundaryKind,
+		BusinessAssetID: cycle.BusinessAssetID.String(), ProjectID: cycle.ProjectID.String(), Status: cycle.Status,
+		RootAssessmentID: cycle.RootAssessmentID.String(), SelectedHeadAssessmentID: cycle.SelectedHeadAssessmentID.String(),
+		NextRetestNumber: cycle.NextRetestNumber, Version: cycle.Version, CreatedAt: cycle.CreatedAt, UpdatedAt: cycle.UpdatedAt,
+		CreatedBy: cycle.CreatedBy, UpdatedBy: cycle.UpdatedBy,
+	}
+}
+
+func projectMember(member cycledom.Member) MemberView {
+	return MemberView{
+		AssessmentID: member.AssessmentID.String(), AssessmentType: string(member.AssessmentType),
+		PredecessorAssessmentID: member.PredecessorAssessmentID.String(), RetestNumber: member.RetestNumber,
+		RelationshipVersion: member.RelationshipVersion, CreatedAt: member.CreatedAt, CreatedBy: member.CreatedBy, ArchivedAt: member.ArchivedAt,
+	}
+}
+
+func mapRetestError(err error) error {
+	switch {
+	case errors.Is(err, cycledom.ErrCycleReopenRequired):
+		return &APIError{Code: CodeCycleReopenRequired, Cause: err}
+	case errors.Is(err, cycledom.ErrCycleArchived):
+		return &APIError{Code: CodeCycleArchived, Cause: err}
+	case errors.Is(err, cycledom.ErrHiddenProjectContext):
+		return &APIError{Code: CodeHiddenProjectContext, Cause: err}
+	default:
+		return err
+	}
+}
+
+func removeWarning(warnings []string, value string) []string {
+	for index, warning := range warnings {
+		if warning == value {
+			return append(warnings[:index], warnings[index+1:]...)
+		}
+	}
+	return warnings
+}
+
+func canonicalHash(value any) (string, error) {
+	// ponytail: request schemas contain no maps or floats; use a full RFC 8785 encoder if either is added.
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return "", fmt.Errorf("canonicalize assessment cycle request: %w", err)
+	}
+	sum := sha256.Sum256(bytes.TrimSuffix(buffer.Bytes(), []byte("\n")))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+type cycleCursor struct {
+	UpdatedAt time.Time `json:"updated_at"`
+	CycleID   shared.ID `json:"cycle_id"`
+}
+
+type cycleMemberCursor struct {
+	RetestNumber int       `json:"retest_number"`
+	AssessmentID shared.ID `json:"assessment_id"`
+}
+
+func encodeCycleCursor(updatedAt time.Time, cycleID shared.ID) string {
+	encoded, _ := json.Marshal(cycleCursor{UpdatedAt: updatedAt.UTC(), CycleID: cycleID})
+	return base64.RawURLEncoding.EncodeToString(encoded)
+}
+
+func decodeCycleCursor(cursor string) (time.Time, shared.ID, error) {
+	if strings.TrimSpace(cursor) == "" {
+		return time.Time{}, "", nil
+	}
+	if len(cursor) > 684 {
+		return time.Time{}, "", fmt.Errorf("invalid cursor")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil || len(raw) > 512 {
+		return time.Time{}, "", fmt.Errorf("invalid cursor")
+	}
+	var decoded cycleCursor
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&decoded); err != nil || decoded.UpdatedAt.IsZero() || decoded.CycleID.IsZero() {
+		return time.Time{}, "", fmt.Errorf("invalid cursor")
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return time.Time{}, "", fmt.Errorf("invalid cursor")
+	}
+	return decoded.UpdatedAt.UTC(), decoded.CycleID, nil
+}
+
+func encodeCycleMemberCursor(retestNumber int, assessmentID shared.ID) string {
+	encoded, _ := json.Marshal(cycleMemberCursor{RetestNumber: retestNumber, AssessmentID: assessmentID})
+	return base64.RawURLEncoding.EncodeToString(encoded)
+}
+
+func decodeCycleMemberCursor(cursor string) (int, shared.ID, error) {
+	if strings.TrimSpace(cursor) == "" {
+		return -1, "", nil
+	}
+	if len(cursor) > 684 {
+		return 0, "", fmt.Errorf("invalid cursor")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil || len(raw) > 512 {
+		return 0, "", fmt.Errorf("invalid cursor")
+	}
+	var decoded cycleMemberCursor
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&decoded); err != nil || decoded.RetestNumber < 0 || decoded.AssessmentID.IsZero() {
+		return 0, "", fmt.Errorf("invalid cursor")
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return 0, "", fmt.Errorf("invalid cursor")
+	}
+	return decoded.RetestNumber, decoded.AssessmentID, nil
+}

--- a/internal/usecase/assessmentcycle/api_service.go
+++ b/internal/usecase/assessmentcycle/api_service.go
@@ -34,10 +34,13 @@ const (
 	CodeInvalidPageSize            = "invalid_page_size"
 	CodeInvalidScopeStrategy       = "invalid_scope_strategy"
 	CodeInvalidProfileStrategy     = "invalid_profile_strategy"
+	CodeInvalidPredecessor         = "invalid_predecessor_assessment"
 	WarningAuthorizationNotCopied  = "authorization_not_inherited"
 	WarningRoENotCopied            = "roe_not_inherited"
 	WarningScannerProfileNotCopied = "scanner_profile_not_inherited"
 )
+
+const assessmentCycleRequestRetention = 24 * time.Hour
 
 type APIError struct {
 	Code  string
@@ -151,9 +154,11 @@ func (service *APIService) CreateInitialAssessment(ctx context.Context, input Cr
 				service.engagements.CompensateCreate(cleanupCtx, assessment.TenantID, assessment.ID),
 			)
 		}
-		service.record(txCtx, input.Request, "assessment_cycle.api_initial_created", cycle.ID, map[string]string{
+		if err := service.record(txCtx, input.Request, "assessment_cycle.api_initial_created", cycle.ID, map[string]string{
 			"assessment_id": assessment.ID.String(), "cycle_version": strconv.FormatInt(cycle.Version, 10),
-		})
+		}); err != nil {
+			return 0, nil, err
+		}
 		return 201, assessment, nil
 	}, func(cleanupCtx context.Context) error {
 		if compensate == nil {
@@ -206,6 +211,9 @@ func (service *APIService) CreateRetestAssessment(ctx context.Context, input Cre
 	}{input.AssessmentID, input.Name, input.PredecessorAssessmentID, input.ScopeStrategy, input.ProfileStrategy, input.AuthorizedFrom, input.AuthorizedTo, input.Timezone, input.RoE}
 	return service.executeRetained(ctx, input.Request, canonical, func(txCtx context.Context) (int, any, error) {
 		tenantID := shared.TenantOrDefault(input.Request.TenantID)
+		if !input.PredecessorAssessmentID.IsZero() && input.PredecessorAssessmentID != input.AssessmentID {
+			return 0, nil, &APIError{Code: CodeInvalidPredecessor, Cause: shared.ErrValidation}
+		}
 		cycle, err := service.cycles.GetCycleByAssessment(txCtx, tenantID, input.AssessmentID)
 		if err != nil {
 			return 0, nil, err
@@ -281,10 +289,12 @@ func (service *APIService) CreateRetestAssessment(ctx context.Context, input Cre
 		if input.RoE != nil {
 			warnings = removeWarning(warnings, WarningRoENotCopied)
 		}
-		service.record(txCtx, input.Request, "assessment_cycle.api_retest_created", cycle.ID, map[string]string{
+		if err := service.record(txCtx, input.Request, "assessment_cycle.api_retest_created", cycle.ID, map[string]string{
 			"assessment_id": assessment.ID.String(), "predecessor_id": member.PredecessorAssessmentID.String(),
 			"retest_number": strconv.Itoa(member.RetestNumber), "cycle_version": strconv.FormatInt(updatedCycle.Version, 10),
-		})
+		}); err != nil {
+			return 0, nil, err
+		}
 		return 201, CreateRetestResponse{
 			Engagement: assessment, Cycle: projectCycle(updatedCycle), Member: projectMember(*member),
 			InheritanceDiff: InheritanceDiff{Scope: scopeStrategy, Authorization: "explicit_only", RoE: "explicit_only", ScannerProfile: profileStrategy},
@@ -549,6 +559,59 @@ type ArchiveCycleRequest struct {
 	ExpectedVersion int64
 }
 
+type ReopenCycleRequest struct {
+	Request         RetainedRequest
+	CycleID         shared.ID
+	ExpectedVersion int64
+	Reason          string
+}
+
+func (service *APIService) ReopenCycle(ctx context.Context, input ReopenCycleRequest) (RetainedResponse, error) {
+	var compensate func(context.Context) error
+	reason := strings.TrimSpace(input.Reason)
+	canonical := struct {
+		CycleID         shared.ID `json:"cycle_id"`
+		ExpectedVersion int64     `json:"expected_version"`
+		Reason          string    `json:"reason"`
+	}{input.CycleID, input.ExpectedVersion, reason}
+	return service.executeRetained(ctx, input.Request, canonical, func(txCtx context.Context) (int, any, error) {
+		if input.ExpectedVersion < 1 {
+			return 0, nil, &APIError{Code: "precondition_required", Cause: shared.ErrValidation}
+		}
+		if reason == "" || len(reason) > 1024 {
+			return 0, nil, &APIError{Code: "reopen_reason_required", Cause: shared.ErrValidation}
+		}
+		originalCycle, err := service.cycles.GetCycle(txCtx, input.Request.TenantID, input.CycleID)
+		if err != nil {
+			return 0, nil, err
+		}
+		if err := service.cycles.ReopenCycle(txCtx, ReopenCycleInput{
+			TenantID: input.Request.TenantID, CycleID: input.CycleID, ExpectedCycleVersion: input.ExpectedVersion,
+			Actor: input.Request.Actor, Reason: reason,
+		}); err != nil {
+			return 0, nil, err
+		}
+		compensate = func(cleanupCtx context.Context) error {
+			return service.cycles.compensateCycleMutation(cleanupCtx, originalCycle, "")
+		}
+		detail, err := service.GetCycle(txCtx, input.Request.TenantID, input.CycleID)
+		if err != nil {
+			return 0, nil, err
+		}
+		if err := service.record(txCtx, input.Request, "assessment_cycle.api_reopened", input.CycleID, map[string]string{
+			"previous_version": strconv.FormatInt(input.ExpectedVersion, 10), "cycle_version": strconv.FormatInt(detail.Cycle.Version, 10), "reason": reason,
+		}); err != nil {
+			return 0, nil, err
+		}
+		return 200, detail, nil
+	}, func(cleanupCtx context.Context) error {
+		if compensate == nil {
+			return nil
+		}
+		return compensate(cleanupCtx)
+	})
+}
+
 func (service *APIService) ArchiveCycle(ctx context.Context, input ArchiveCycleRequest) (RetainedResponse, error) {
 	var compensate func(context.Context) error
 	canonical := struct {
@@ -576,9 +639,11 @@ func (service *APIService) ArchiveCycle(ctx context.Context, input ArchiveCycleR
 		if err != nil {
 			return 0, nil, err
 		}
-		service.record(txCtx, input.Request, "assessment_cycle.api_archived", input.CycleID, map[string]string{
+		if err := service.record(txCtx, input.Request, "assessment_cycle.api_archived", input.CycleID, map[string]string{
 			"previous_version": strconv.FormatInt(input.ExpectedVersion, 10), "cycle_version": strconv.FormatInt(detail.Cycle.Version, 10),
-		})
+		}); err != nil {
+			return 0, nil, err
+		}
 		return 200, detail, nil
 	}, func(cleanupCtx context.Context) error {
 		if compensate == nil {
@@ -606,8 +671,9 @@ func (service *APIService) executeRetained(ctx context.Context, request Retained
 	var response RetainedResponse
 	createdReservation := false
 	err = service.tx.Run(ctx, scope.TenantID, func(txCtx context.Context) error {
+		createdAt := service.clock.Now().UTC()
 		stored, created, err := service.requests.BeginAssessmentCycleRequest(txCtx, ports.AssessmentCycleRequest{
-			Scope: scope, RequestHash: requestHash, CreatedAt: service.clock.Now().UTC(),
+			Scope: scope, RequestHash: requestHash, CreatedAt: createdAt, ExpiresAt: createdAt.Add(assessmentCycleRequestRetention),
 		})
 		if err != nil {
 			return err
@@ -658,13 +724,15 @@ func (service *APIService) cycleDetail(ctx context.Context, tenantID shared.ID, 
 	return detail, nil
 }
 
-func (service *APIService) record(ctx context.Context, request RetainedRequest, action string, target shared.ID, metadata map[string]string) {
+func (service *APIService) record(ctx context.Context, request RetainedRequest, action string, target shared.ID, metadata map[string]string) error {
 	if service.audit == nil {
-		return
+		return nil
 	}
 	metadata["tenant_id"] = shared.TenantOrDefault(request.TenantID).String()
-	metadata["idempotency_key"] = strings.TrimSpace(request.IdempotencyKey)
-	_ = service.audit.Record(ctx, ports.AuditEntry{Actor: strings.TrimSpace(request.Actor), Action: action, Target: target.String(), Metadata: metadata, At: service.clock.Now().UTC()})
+	if err := service.audit.Record(ctx, ports.AuditEntry{Actor: strings.TrimSpace(request.Actor), Action: action, Target: target.String(), Metadata: metadata, At: service.clock.Now().UTC()}); err != nil {
+		return fmt.Errorf("audit retained assessment cycle mutation: %w", err)
+	}
+	return nil
 }
 
 func projectCycle(cycle *cycledom.AssessmentCycle) CycleView {

--- a/internal/usecase/assessmentcycle/api_service_test.go
+++ b/internal/usecase/assessmentcycle/api_service_test.go
@@ -1,0 +1,311 @@
+package assessmentcycle_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type failCompleteRequestStore struct {
+	inner ports.AssessmentCycleRequestStore
+	mu    sync.Mutex
+	fail  bool
+}
+
+func (store *failCompleteRequestStore) failNext() {
+	store.mu.Lock()
+	store.fail = true
+	store.mu.Unlock()
+}
+
+func (store *failCompleteRequestStore) BeginAssessmentCycleRequest(ctx context.Context, request ports.AssessmentCycleRequest) (ports.AssessmentCycleRequest, bool, error) {
+	return store.inner.BeginAssessmentCycleRequest(ctx, request)
+}
+
+func (store *failCompleteRequestStore) CompleteAssessmentCycleRequest(ctx context.Context, scope ports.AssessmentCycleRequestScope, requestHash string, statusCode int, responseBody []byte, completedAt time.Time) error {
+	store.mu.Lock()
+	fail := store.fail
+	store.fail = false
+	store.mu.Unlock()
+	if fail {
+		return errors.New("injected retained-response failure")
+	}
+	return store.inner.CompleteAssessmentCycleRequest(ctx, scope, requestHash, statusCode, responseBody, completedAt)
+}
+
+func (store *failCompleteRequestStore) AbortAssessmentCycleRequest(ctx context.Context, scope ports.AssessmentCycleRequestScope, requestHash string) error {
+	return store.inner.AbortAssessmentCycleRequest(ctx, scope, requestHash)
+}
+
+func TestAPIServiceRetainedLifecycle(t *testing.T) {
+	ctx := context.Background()
+	tenantID := shared.ID("tenant-1")
+	clock := fixedClock{t: time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)}
+	ids := &seqIDGen{}
+	audit := &recordAudit{}
+	engagements := memory.NewEngagementRepository()
+	cycles := memory.NewAssessmentCycleRepository()
+	requests := memory.NewAssessmentCycleRequestRepository()
+	transactions := memory.NewTenantTransactionRunner()
+	engagementService := enguc.NewService(engagements, clock, ids, audit)
+	cycleService, err := cycleuc.NewService(cycles, engagements, nil, nil, transactions, ids, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api, err := cycleuc.NewAPIService(cycleService, cycles, requests, engagementService, transactions, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createRequest := cycleuc.CreateInitialAssessmentInput{
+		Request:    cycleuc.RetainedRequest{TenantID: tenantID, Actor: "alice", Route: "/api/v1/engagements", IdempotencyKey: "create-1"},
+		Engagement: enguc.CreateInput{Name: "External API", Client: "Acme", InScope: []engdom.Target{{Kind: engdom.TargetDomain, Value: "api.example.com"}}},
+	}
+	created, err := api.CreateInitialAssessment(ctx, createRequest)
+	if err != nil || created.StatusCode != 201 || created.Replayed {
+		t.Fatalf("create initial response = %+v, err=%v", created, err)
+	}
+	var root engdom.Engagement
+	if err := json.Unmarshal(created.Body, &root); err != nil {
+		t.Fatal(err)
+	}
+	replayed, err := api.CreateInitialAssessment(ctx, createRequest)
+	if err != nil || !replayed.Replayed || string(replayed.Body) != string(created.Body) {
+		t.Fatalf("replay response = %+v, err=%v", replayed, err)
+	}
+	mismatch := createRequest
+	mismatch.Engagement.Name = "Different"
+	if _, err := api.CreateInitialAssessment(ctx, mismatch); !errors.Is(err, shared.ErrConflict) || cycleuc.ErrorCode(err) != cycleuc.CodeIdempotencyBodyMismatch {
+		t.Fatalf("body mismatch = %v", err)
+	}
+
+	retest, err := api.CreateRetestAssessment(ctx, cycleuc.CreateRetestAssessmentInput{
+		Request:      cycleuc.RetainedRequest{TenantID: tenantID, Actor: "alice", Route: "/api/v1/engagements/" + root.ID.String() + "/retests", IdempotencyKey: "retest-1"},
+		AssessmentID: root.ID,
+	})
+	if err != nil || retest.StatusCode != 201 {
+		t.Fatalf("create retest response = %+v, err=%v", retest, err)
+	}
+	var retestBody cycleuc.CreateRetestResponse
+	if err := json.Unmarshal(retest.Body, &retestBody); err != nil {
+		t.Fatal(err)
+	}
+	if !retestBody.Engagement.RequiresExplicitExecutionAuthorization || retestBody.Engagement.AllowsExecution() {
+		t.Fatalf("Re-test execution guard missing: %+v", retestBody.Engagement)
+	}
+	if len(retestBody.Engagement.Scope.InScope) != 1 || retestBody.Member.RetestNumber != 1 {
+		t.Fatalf("Re-test inheritance/member mismatch: %+v", retestBody)
+	}
+
+	lifecycle, err := api.GetLifecycle(ctx, tenantID, root.ID)
+	if err != nil || len(lifecycle.Members) != 2 || lifecycle.Cycle.Version != 2 {
+		t.Fatalf("lifecycle = %+v, err=%v", lifecycle, err)
+	}
+	page, err := api.ListCycles(ctx, cycleuc.ListCyclesInput{TenantID: tenantID, Limit: 1})
+	if err != nil || len(page.Items) != 1 {
+		t.Fatalf("list cycles = %+v, err=%v", page, err)
+	}
+	if _, err := api.ListCycles(ctx, cycleuc.ListCyclesInput{TenantID: tenantID, Cursor: strings.Repeat("A", 685)}); cycleuc.ErrorCode(err) != cycleuc.CodeInvalidCursor {
+		t.Fatalf("oversized cursor error = %v", err)
+	}
+
+	archived, err := api.ArchiveCycle(ctx, cycleuc.ArchiveCycleRequest{
+		Request: cycleuc.RetainedRequest{TenantID: tenantID, Actor: "reviewer", Route: "/api/v1/assessment-cycles/" + lifecycle.Cycle.ID + "/archive", IdempotencyKey: "archive-1"},
+		CycleID: shared.ID(lifecycle.Cycle.ID), ExpectedVersion: lifecycle.Cycle.Version,
+	})
+	if err != nil || archived.StatusCode != 200 {
+		t.Fatalf("archive response = %+v, err=%v", archived, err)
+	}
+	detail, err := api.GetCycle(ctx, tenantID, shared.ID(lifecycle.Cycle.ID))
+	if err != nil || detail.Cycle.Status != "archived" {
+		t.Fatalf("archived detail = %+v, err=%v", detail, err)
+	}
+	apiAuditCount := 0
+	for _, entry := range audit.entries {
+		serialized := fmt.Sprintf("%v", entry.Metadata)
+		for _, sensitive := range []string{"Acme", "api.example.com", `\"name\"`} {
+			if strings.Contains(serialized, sensitive) {
+				t.Fatalf("audit metadata leaked %q: %+v", sensitive, entry)
+			}
+		}
+		if strings.HasPrefix(entry.Action, "assessment_cycle.api_") {
+			apiAuditCount++
+			if entry.Actor == "" || entry.Target == "" || entry.Metadata["tenant_id"] != tenantID.String() || entry.Metadata["idempotency_key"] == "" || entry.Metadata["cycle_version"] == "" {
+				t.Fatalf("incomplete assessment cycle API audit entry: %+v", entry)
+			}
+		}
+	}
+	if apiAuditCount != 3 {
+		t.Fatalf("assessment cycle API audit count = %d, want 3", apiAuditCount)
+	}
+}
+
+func TestAPIServiceCompensatesRetainedResponseFailures(t *testing.T) {
+	ctx := context.Background()
+	tenantID := shared.ID("tenant-compensation")
+	clock := fixedClock{t: time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)}
+	ids := &seqIDGen{}
+	audit := &recordAudit{}
+	engagements := memory.NewEngagementRepository()
+	cycles := memory.NewAssessmentCycleRepository()
+	requests := &failCompleteRequestStore{inner: memory.NewAssessmentCycleRequestRepository()}
+	transactions := memory.NewTenantTransactionRunner()
+	engagementService := enguc.NewService(engagements, clock, ids, audit)
+	cycleService, err := cycleuc.NewService(cycles, engagements, nil, nil, transactions, ids, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api, err := cycleuc.NewAPIService(cycleService, cycles, requests, engagementService, transactions, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	create := cycleuc.CreateInitialAssessmentInput{
+		Request:    cycleuc.RetainedRequest{TenantID: tenantID, Actor: "alice", Route: "/api/v1/engagements", IdempotencyKey: "create-failure"},
+		Engagement: enguc.CreateInput{Name: "Compensated", InScope: []engdom.Target{{Kind: engdom.TargetDomain, Value: "app.example.com"}}},
+	}
+	requests.failNext()
+	if _, err := api.CreateInitialAssessment(ctx, create); err == nil {
+		t.Fatal("expected retained-response failure")
+	}
+	assertAssessmentCycleCounts(t, ctx, engagementService, cycles, tenantID, 0, 0)
+
+	created, err := api.CreateInitialAssessment(ctx, create)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root engdom.Engagement
+	if err := json.Unmarshal(created.Body, &root); err != nil {
+		t.Fatal(err)
+	}
+	lifecycle, err := api.GetLifecycle(ctx, tenantID, root.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	retest := cycleuc.CreateRetestAssessmentInput{
+		Request:      cycleuc.RetainedRequest{TenantID: tenantID, Actor: "alice", Route: "/api/v1/engagements/" + root.ID.String() + "/retests", IdempotencyKey: "retest-failure"},
+		AssessmentID: root.ID,
+	}
+	requests.failNext()
+	if _, err := api.CreateRetestAssessment(ctx, retest); err == nil {
+		t.Fatal("expected Re-test retained-response failure")
+	}
+	assertAssessmentCycleCounts(t, ctx, engagementService, cycles, tenantID, 1, 1)
+	unchanged, err := api.GetLifecycle(ctx, tenantID, root.ID)
+	if err != nil || unchanged.Cycle.Version != lifecycle.Cycle.Version || len(unchanged.Members) != 1 {
+		t.Fatalf("Re-test compensation lifecycle = %+v, err=%v", unchanged, err)
+	}
+	if _, err := api.CreateRetestAssessment(ctx, retest); err != nil {
+		t.Fatal(err)
+	}
+	lifecycle, err = api.GetLifecycle(ctx, tenantID, root.ID)
+	if err != nil || len(lifecycle.Members) != 2 {
+		t.Fatalf("Re-test retry lifecycle = %+v, err=%v", lifecycle, err)
+	}
+
+	archive := cycleuc.ArchiveCycleRequest{
+		Request:         cycleuc.RetainedRequest{TenantID: tenantID, Actor: "reviewer", Route: "/api/v1/assessment-cycles/" + lifecycle.Cycle.ID + "/archive", IdempotencyKey: "archive-failure"},
+		CycleID:         shared.ID(lifecycle.Cycle.ID),
+		ExpectedVersion: lifecycle.Cycle.Version,
+	}
+	requests.failNext()
+	if _, err := api.ArchiveCycle(ctx, archive); err == nil {
+		t.Fatal("expected archive retained-response failure")
+	}
+	unchanged, err = api.GetLifecycle(ctx, tenantID, root.ID)
+	if err != nil || unchanged.Cycle.Status != "open" || unchanged.Cycle.Version != lifecycle.Cycle.Version {
+		t.Fatalf("archive compensation lifecycle = %+v, err=%v", unchanged, err)
+	}
+	if _, err := api.ArchiveCycle(ctx, archive); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAPIServiceListCyclesCursorAndFilterValidation(t *testing.T) {
+	ctx := context.Background()
+	tenantID := shared.ID("tenant-cycle-list")
+	clock := fixedClock{t: time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)}
+	ids := &seqIDGen{}
+	audit := &recordAudit{}
+	engagements := memory.NewEngagementRepository()
+	cycles := memory.NewAssessmentCycleRepository()
+	transactions := memory.NewTenantTransactionRunner()
+	engagementService := enguc.NewService(engagements, clock, ids, audit)
+	cycleService, err := cycleuc.NewService(cycles, engagements, nil, nil, transactions, ids, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api, err := cycleuc.NewAPIService(cycleService, cycles, memory.NewAssessmentCycleRequestRepository(), engagementService, transactions, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index, name := range []string{"Alpha", "Beta", "Gamma"} {
+		_, err := api.CreateInitialAssessment(ctx, cycleuc.CreateInitialAssessmentInput{
+			Request:    cycleuc.RetainedRequest{TenantID: tenantID, Actor: "alice", Route: "/api/v1/engagements", IdempotencyKey: fmt.Sprintf("list-%d", index)},
+			Engagement: enguc.CreateInput{Name: name, InScope: []engdom.Target{{Kind: engdom.TargetDomain, Value: strings.ToLower(name) + ".example.com"}}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	seen := map[string]bool{}
+	cursor := ""
+	for {
+		page, err := api.ListCycles(ctx, cycleuc.ListCyclesInput{TenantID: tenantID, Cursor: cursor, Limit: 1})
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, cycle := range page.Items {
+			if seen[cycle.ID] {
+				t.Fatalf("duplicate cycle across cursor pages: %s", cycle.ID)
+			}
+			seen[cycle.ID] = true
+		}
+		if page.NextCursor == "" {
+			break
+		}
+		cursor = page.NextCursor
+	}
+	if len(seen) != 3 {
+		t.Fatalf("cursor pages returned %d cycles, want 3", len(seen))
+	}
+	filtered, err := api.ListCycles(ctx, cycleuc.ListCyclesInput{TenantID: tenantID, Search: " beta ", Limit: 10})
+	if err != nil || len(filtered.Items) != 1 || filtered.Items[0].Name != "Beta" {
+		t.Fatalf("search result=%+v err=%v", filtered, err)
+	}
+	for name, input := range map[string]cycleuc.ListCyclesInput{
+		"oversized search":  {TenantID: tenantID, Search: strings.Repeat("x", 257)},
+		"control search":    {TenantID: tenantID, Search: "bad\nquery"},
+		"invalid staleness": {TenantID: tenantID, ScanStaleness: "ancient"},
+	} {
+		if _, err := api.ListCycles(ctx, input); cycleuc.ErrorCode(err) != cycleuc.CodeInvalidFilter {
+			t.Fatalf("%s error=%v code=%s", name, err, cycleuc.ErrorCode(err))
+		}
+	}
+}
+
+func assertAssessmentCycleCounts(t *testing.T, ctx context.Context, engagements *enguc.Service, cycles *memory.AssessmentCycleRepository, tenantID shared.ID, wantEngagements, wantCycles int) {
+	t.Helper()
+	items, err := engagements.List(ctx, tenantID)
+	if err != nil || len(items) != wantEngagements {
+		t.Fatalf("engagement count = %d, want %d, err=%v", len(items), wantEngagements, err)
+	}
+	records, err := cycles.ListCycles(ctx, ports.AssessmentCycleListQuery{TenantID: tenantID, Limit: 10})
+	if err != nil || len(records) != wantCycles {
+		t.Fatalf("cycle count = %d, want %d, err=%v", len(records), wantCycles, err)
+	}
+}

--- a/internal/usecase/assessmentcycle/api_service_test.go
+++ b/internal/usecase/assessmentcycle/api_service_test.go
@@ -24,6 +24,38 @@ type failCompleteRequestStore struct {
 	fail  bool
 }
 
+type rejectingAudit struct{ err error }
+
+func (audit rejectingAudit) Record(context.Context, ports.AuditEntry) error { return audit.err }
+
+func TestHistoricalCycleBackfillRollsBackWhenAuditFails(t *testing.T) {
+	ctx := context.Background()
+	tenantID := shared.ID("tenant-audit-rollback")
+	clock := fixedClock{t: time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)}
+	engagements := memory.NewEngagementRepository()
+	assessment, err := engdom.New("assessment-audit-rollback", tenantID, "Historical", "", clock.t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(ctx, assessment); err != nil {
+		t.Fatal(err)
+	}
+	cycles := memory.NewAssessmentCycleRepository()
+	auditErr := errors.New("audit unavailable")
+	service, err := cycleuc.NewService(cycles, engagements, nil, nil, memory.NewTenantTransactionRunner(), &seqIDGen{}, clock, rejectingAudit{err: auditErr})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.BackfillHistoricalSingleton(ctx, cycleuc.BackfillHistoricalSingletonInput{
+		TenantID: tenantID, AssessmentID: assessment.ID, SchemaVersion: 1, Actor: "operator",
+	}); !errors.Is(err, auditErr) {
+		t.Fatalf("backfill audit failure=%v", err)
+	}
+	if _, err := cycles.GetCycleByAssessment(ctx, tenantID, assessment.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cycle survived failed audit: %v", err)
+	}
+}
+
 func (store *failCompleteRequestStore) failNext() {
 	store.mu.Lock()
 	store.fail = true
@@ -90,6 +122,12 @@ func TestAPIServiceRetainedLifecycle(t *testing.T) {
 	if _, err := api.CreateInitialAssessment(ctx, mismatch); !errors.Is(err, shared.ErrConflict) || cycleuc.ErrorCode(err) != cycleuc.CodeIdempotencyBodyMismatch {
 		t.Fatalf("body mismatch = %v", err)
 	}
+	if _, err := api.CreateRetestAssessment(ctx, cycleuc.CreateRetestAssessmentInput{
+		Request:      cycleuc.RetainedRequest{TenantID: tenantID, Actor: "alice", Route: "/api/v1/engagements/" + root.ID.String() + "/retests", IdempotencyKey: "cross-lineage"},
+		AssessmentID: root.ID, PredecessorAssessmentID: "another-assessment",
+	}); !errors.Is(err, shared.ErrValidation) || cycleuc.ErrorCode(err) != cycleuc.CodeInvalidPredecessor {
+		t.Fatalf("cross-assessment predecessor = %v", err)
+	}
 
 	retest, err := api.CreateRetestAssessment(ctx, cycleuc.CreateRetestAssessmentInput{
 		Request:      cycleuc.RetainedRequest{TenantID: tenantID, Actor: "alice", Route: "/api/v1/engagements/" + root.ID.String() + "/retests", IdempotencyKey: "retest-1"},
@@ -142,8 +180,11 @@ func TestAPIServiceRetainedLifecycle(t *testing.T) {
 		}
 		if strings.HasPrefix(entry.Action, "assessment_cycle.api_") {
 			apiAuditCount++
-			if entry.Actor == "" || entry.Target == "" || entry.Metadata["tenant_id"] != tenantID.String() || entry.Metadata["idempotency_key"] == "" || entry.Metadata["cycle_version"] == "" {
+			if entry.Actor == "" || entry.Target == "" || entry.Metadata["tenant_id"] != tenantID.String() || entry.Metadata["cycle_version"] == "" {
 				t.Fatalf("incomplete assessment cycle API audit entry: %+v", entry)
+			}
+			if _, leaked := entry.Metadata["idempotency_key"]; leaked {
+				t.Fatalf("assessment cycle API audit leaked idempotency key: %+v", entry)
 			}
 		}
 	}

--- a/internal/usecase/assessmentcycle/backfill.go
+++ b/internal/usecase/assessmentcycle/backfill.go
@@ -1,0 +1,238 @@
+package assessmentcycle
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	AssessmentCycleBackfillSchemaVersion = 1
+	DefaultAssessmentCycleBackfillBatch  = 500
+	MaxAssessmentCycleBackfillBatch      = 2000
+	assessmentCycleBackfillRetries       = 3
+	defaultAssessmentCycleBackfillLease  = 10 * time.Minute
+)
+
+const (
+	BackfillOutcomeCreated     = "created"
+	BackfillOutcomeWouldCreate = "would_create"
+	BackfillOutcomeSkipped     = "skipped"
+	BackfillOutcomeFailed      = "failed"
+
+	BackfillReasonCreated        = "created"
+	BackfillReasonWouldCreate    = "would_create"
+	BackfillReasonAlreadyInCycle = "already_in_cycle"
+	BackfillReasonHiddenContext  = "hidden_project_context"
+	BackfillReasonSourceMissing  = "source_not_found"
+	BackfillReasonInvalidSource  = "invalid_source"
+	BackfillReasonWriteFailed    = "write_failed"
+)
+
+type historicalSingletonBackfiller interface {
+	BackfillHistoricalSingleton(context.Context, BackfillHistoricalSingletonInput) (BackfillHistoricalSingletonResult, error)
+}
+
+type AssessmentCycleBackfillObserver interface {
+	ObserveAssessmentCycleBackfillItem(outcome string)
+	ObserveAssessmentCycleBackfillRun(state string)
+}
+
+type BackfillRunner struct {
+	backfiller historicalSingletonBackfiller
+	source     ports.AssessmentCycleBackfillSource
+	store      ports.AssessmentCycleBackfillStore
+	ids        ports.IDGenerator
+	clock      ports.Clock
+	audit      ports.AuditLogger
+	observer   AssessmentCycleBackfillObserver
+}
+
+func NewBackfillRunner(backfiller historicalSingletonBackfiller, source ports.AssessmentCycleBackfillSource, store ports.AssessmentCycleBackfillStore, ids ports.IDGenerator, clock ports.Clock, audit ports.AuditLogger, observer AssessmentCycleBackfillObserver) (*BackfillRunner, error) {
+	if backfiller == nil || source == nil || store == nil || ids == nil || clock == nil {
+		return nil, fmt.Errorf("%w: assessment cycle backfill dependencies are required", shared.ErrValidation)
+	}
+	return &BackfillRunner{backfiller: backfiller, source: source, store: store, ids: ids, clock: clock, audit: audit, observer: observer}, nil
+}
+
+type BackfillRequest struct {
+	TenantID      shared.ID
+	Actor         string
+	LeaseOwner    string
+	DryRun        bool
+	BatchSize     int
+	ResumeAfter   shared.ID
+	LeaseDuration time.Duration
+}
+
+func (runner *BackfillRunner) Run(ctx context.Context, request BackfillRequest) (ports.AssessmentCycleBackfillRun, error) {
+	tenantID := shared.TenantOrDefault(request.TenantID)
+	actor, leaseOwner := strings.TrimSpace(request.Actor), strings.TrimSpace(request.LeaseOwner)
+	if tenantID.IsZero() || actor == "" || len(actor) > 256 || leaseOwner == "" || len(leaseOwner) > 256 {
+		return ports.AssessmentCycleBackfillRun{}, fmt.Errorf("%w: tenant, actor, and lease owner are required", shared.ErrValidation)
+	}
+	batchSize := request.BatchSize
+	if batchSize == 0 {
+		batchSize = DefaultAssessmentCycleBackfillBatch
+	}
+	if batchSize < 1 || batchSize > MaxAssessmentCycleBackfillBatch {
+		return ports.AssessmentCycleBackfillRun{}, fmt.Errorf("%w: batch size must be between 1 and %d", shared.ErrValidation, MaxAssessmentCycleBackfillBatch)
+	}
+	leaseDuration := request.LeaseDuration
+	if leaseDuration <= 0 {
+		leaseDuration = defaultAssessmentCycleBackfillLease
+	}
+	now := runner.clock.Now().UTC()
+	acquisitionID := runner.ids.NewID()
+	run, resumed, err := runner.store.AcquireAssessmentCycleBackfillRun(ctx, ports.AssessmentCycleBackfillAcquireRequest{
+		Run: ports.AssessmentCycleBackfillRun{
+			TenantID: tenantID, ID: acquisitionID, SchemaVersion: AssessmentCycleBackfillSchemaVersion,
+			DryRun: request.DryRun, BatchSize: batchSize, SnapshotAt: now, State: ports.AssessmentCycleBackfillRunning,
+			LeaseOwner: leaseOwner, LeaseToken: acquisitionID, LeaseExpiresAt: now.Add(leaseDuration), CreatedBy: actor, CreatedAt: now, UpdatedAt: now,
+		},
+		InitialCheckpoint: request.ResumeAfter,
+		LeaseDuration:     leaseDuration,
+	})
+	if err != nil {
+		return ports.AssessmentCycleBackfillRun{}, err
+	}
+	runner.record(ctx, actor, "assessment_cycle.backfill_started", run.ID, map[string]string{
+		"tenant_id": tenantID.String(), "dry_run": strconv.FormatBool(run.DryRun), "resumed": strconv.FormatBool(resumed), "batch_size": strconv.Itoa(run.BatchSize),
+	})
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return runner.finish(ctx, run, leaseOwner, ports.AssessmentCycleBackfillCancelled, actor, err)
+		}
+		assessments, err := runner.source.ListAssessmentCycleBackfillEngagements(ctx, tenantID, run.CheckpointAssessment, run.SnapshotAt, run.BatchSize)
+		if err != nil {
+			return runner.finish(ctx, run, leaseOwner, ports.AssessmentCycleBackfillFailed, actor, err)
+		}
+		if len(assessments) == 0 {
+			return runner.finish(ctx, run, leaseOwner, ports.AssessmentCycleBackfillCompleted, actor, nil)
+		}
+		if len(assessments) > run.BatchSize {
+			return runner.finish(ctx, run, leaseOwner, ports.AssessmentCycleBackfillFailed, actor, fmt.Errorf("backfill source returned %d rows for limit %d", len(assessments), run.BatchSize))
+		}
+		for _, assessment := range assessments {
+			if err := ctx.Err(); err != nil {
+				return runner.finish(ctx, run, leaseOwner, ports.AssessmentCycleBackfillCancelled, actor, err)
+			}
+			if _, err := runner.store.GetAssessmentCycleBackfillItem(ctx, tenantID, run.ID, assessment.ID); err == nil {
+				continue
+			} else if !errors.Is(err, shared.ErrNotFound) {
+				return runner.finish(ctx, run, leaseOwner, ports.AssessmentCycleBackfillFailed, actor, err)
+			}
+			item, created, err := runner.store.CommitAssessmentCycleBackfillItem(ctx, tenantID, run.ID, run.LeaseToken, runner.clock.Now().UTC(), func(txCtx context.Context) (ports.AssessmentCycleBackfillItem, error) {
+				return runner.processItem(txCtx, run, assessment.ID, actor), nil
+			})
+			if err != nil {
+				return runner.finish(ctx, run, leaseOwner, ports.AssessmentCycleBackfillFailed, actor, err)
+			}
+			if created && runner.observer != nil {
+				runner.observer.ObserveAssessmentCycleBackfillItem(item.Outcome)
+			}
+		}
+		checkpoint := assessments[len(assessments)-1].ID
+		run, err = runner.store.AdvanceAssessmentCycleBackfillRun(ctx, tenantID, run.ID, leaseOwner, run.LeaseToken, checkpoint, runner.clock.Now().UTC(), leaseDuration)
+		if err != nil {
+			return runner.finish(ctx, run, leaseOwner, ports.AssessmentCycleBackfillFailed, actor, err)
+		}
+		runner.record(ctx, actor, "assessment_cycle.backfill_batch_committed", run.ID, map[string]string{
+			"tenant_id": tenantID.String(), "checkpoint_assessment_id": checkpoint.String(), "processed_count": strconv.Itoa(run.ProcessedCount),
+		})
+	}
+}
+
+func (runner *BackfillRunner) processItem(ctx context.Context, run ports.AssessmentCycleBackfillRun, assessmentID shared.ID, actor string) ports.AssessmentCycleBackfillItem {
+	item := ports.AssessmentCycleBackfillItem{
+		TenantID: run.TenantID, RunID: run.ID, AssessmentID: assessmentID, SchemaVersion: run.SchemaVersion,
+		IdempotencyKey: backfillIdempotencyKey(assessmentID, run.SchemaVersion), ProcessedAt: runner.clock.Now().UTC(),
+	}
+	var (
+		result BackfillHistoricalSingletonResult
+		err    error
+	)
+	for attempt := 0; attempt < assessmentCycleBackfillRetries; attempt++ {
+		result, err = runner.backfiller.BackfillHistoricalSingleton(ctx, BackfillHistoricalSingletonInput{
+			TenantID: run.TenantID, AssessmentID: assessmentID, SchemaVersion: run.SchemaVersion, Actor: actor, DryRun: run.DryRun,
+		})
+		if err == nil || !retryableBackfillError(err) {
+			break
+		}
+	}
+	if err != nil {
+		item.Outcome, item.ReasonCode, item.Retryable, item.RepairGuidance = backfillFailure(err)
+		return item
+	}
+	item.CycleID = result.CycleID
+	switch {
+	case result.Created:
+		item.Outcome, item.ReasonCode = BackfillOutcomeCreated, BackfillReasonCreated
+	case result.WouldCreate:
+		item.Outcome, item.ReasonCode = BackfillOutcomeWouldCreate, BackfillReasonWouldCreate
+	default:
+		item.Outcome, item.ReasonCode = BackfillOutcomeSkipped, result.ReasonCode
+	}
+	return item
+}
+
+func (runner *BackfillRunner) finish(ctx context.Context, run ports.AssessmentCycleBackfillRun, leaseOwner string, state ports.AssessmentCycleBackfillState, actor string, cause error) (ports.AssessmentCycleBackfillRun, error) {
+	finishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	finished, err := runner.store.FinishAssessmentCycleBackfillRun(finishCtx, run.TenantID, run.ID, leaseOwner, run.LeaseToken, state, runner.clock.Now().UTC())
+	if err != nil {
+		if cause != nil {
+			return run, errors.Join(cause, err)
+		}
+		return run, err
+	}
+	if runner.observer != nil {
+		runner.observer.ObserveAssessmentCycleBackfillRun(string(state))
+	}
+	runner.record(finishCtx, actor, "assessment_cycle.backfill_"+string(state), run.ID, map[string]string{
+		"tenant_id": run.TenantID.String(), "processed_count": strconv.Itoa(finished.ProcessedCount), "created_count": strconv.Itoa(finished.CreatedCount),
+		"would_create_count": strconv.Itoa(finished.WouldCreateCount), "skipped_count": strconv.Itoa(finished.SkippedCount), "failed_count": strconv.Itoa(finished.FailedCount),
+	})
+	if cause != nil {
+		return finished, cause
+	}
+	return finished, nil
+}
+
+func (runner *BackfillRunner) record(ctx context.Context, actor, action string, target shared.ID, metadata map[string]string) {
+	if runner.audit != nil {
+		_ = runner.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: action, Target: target.String(), Metadata: metadata, At: runner.clock.Now().UTC()})
+	}
+}
+
+func retryableBackfillError(err error) bool {
+	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, shared.ErrValidation) && !errors.Is(err, shared.ErrNotFound) && !errors.Is(err, cycledom.ErrHiddenProjectContext)
+}
+
+func backfillFailure(err error) (outcome, reason string, retryable bool, guidance string) {
+	switch {
+	case errors.Is(err, cycledom.ErrHiddenProjectContext):
+		return BackfillOutcomeSkipped, BackfillReasonHiddenContext, false, "No repair is required; hidden Project analysis contexts are ineligible."
+	case errors.Is(err, shared.ErrNotFound):
+		return BackfillOutcomeFailed, BackfillReasonSourceMissing, false, "Verify the source Assessment still exists in the tenant before rerunning."
+	case errors.Is(err, shared.ErrValidation):
+		return BackfillOutcomeFailed, BackfillReasonInvalidSource, false, "Correct the source Assessment boundary or lifecycle data before rerunning."
+	default:
+		return BackfillOutcomeFailed, BackfillReasonWriteFailed, true, "Retry after restoring database availability; run the integrity verifier before cutover."
+	}
+}
+
+func backfillIdempotencyKey(assessmentID shared.ID, schemaVersion int) string {
+	sum := sha256.Sum256([]byte(assessmentID.String() + "\x00" + strconv.Itoa(schemaVersion)))
+	return "assessment-cycle-backfill-v" + strconv.Itoa(schemaVersion) + "-" + hex.EncodeToString(sum[:])
+}

--- a/internal/usecase/assessmentcycle/backfill.go
+++ b/internal/usecase/assessmentcycle/backfill.go
@@ -105,9 +105,11 @@ func (runner *BackfillRunner) Run(ctx context.Context, request BackfillRequest) 
 	if err != nil {
 		return ports.AssessmentCycleBackfillRun{}, err
 	}
-	runner.record(ctx, actor, "assessment_cycle.backfill_started", run.ID, map[string]string{
+	if err := runner.record(ctx, actor, "assessment_cycle.backfill_started", run.ID, map[string]string{
 		"tenant_id": tenantID.String(), "dry_run": strconv.FormatBool(run.DryRun), "resumed": strconv.FormatBool(resumed), "batch_size": strconv.Itoa(run.BatchSize),
-	})
+	}); err != nil {
+		return runner.finish(ctx, run, leaseOwner, ports.AssessmentCycleBackfillFailed, actor, fmt.Errorf("audit assessment Cycle backfill start: %w", err))
+	}
 
 	for {
 		if err := ctx.Err(); err != nil {
@@ -147,9 +149,11 @@ func (runner *BackfillRunner) Run(ctx context.Context, request BackfillRequest) 
 		if err != nil {
 			return runner.finish(ctx, run, leaseOwner, ports.AssessmentCycleBackfillFailed, actor, err)
 		}
-		runner.record(ctx, actor, "assessment_cycle.backfill_batch_committed", run.ID, map[string]string{
+		if err := runner.record(ctx, actor, "assessment_cycle.backfill_batch_committed", run.ID, map[string]string{
 			"tenant_id": tenantID.String(), "checkpoint_assessment_id": checkpoint.String(), "processed_count": strconv.Itoa(run.ProcessedCount),
-		})
+		}); err != nil {
+			return runner.finish(ctx, run, leaseOwner, ports.AssessmentCycleBackfillFailed, actor, fmt.Errorf("audit assessment Cycle backfill batch: %w", err))
+		}
 	}
 }
 
@@ -199,20 +203,27 @@ func (runner *BackfillRunner) finish(ctx context.Context, run ports.AssessmentCy
 	if runner.observer != nil {
 		runner.observer.ObserveAssessmentCycleBackfillRun(string(state))
 	}
-	runner.record(finishCtx, actor, "assessment_cycle.backfill_"+string(state), run.ID, map[string]string{
+	auditErr := runner.record(finishCtx, actor, "assessment_cycle.backfill_"+string(state), run.ID, map[string]string{
 		"tenant_id": run.TenantID.String(), "processed_count": strconv.Itoa(finished.ProcessedCount), "created_count": strconv.Itoa(finished.CreatedCount),
 		"would_create_count": strconv.Itoa(finished.WouldCreateCount), "skipped_count": strconv.Itoa(finished.SkippedCount), "failed_count": strconv.Itoa(finished.FailedCount),
 	})
 	if cause != nil {
+		if auditErr != nil {
+			return finished, errors.Join(cause, fmt.Errorf("audit assessment Cycle backfill finish: %w", auditErr))
+		}
 		return finished, cause
+	}
+	if auditErr != nil {
+		return finished, fmt.Errorf("audit assessment Cycle backfill finish: %w", auditErr)
 	}
 	return finished, nil
 }
 
-func (runner *BackfillRunner) record(ctx context.Context, actor, action string, target shared.ID, metadata map[string]string) {
+func (runner *BackfillRunner) record(ctx context.Context, actor, action string, target shared.ID, metadata map[string]string) error {
 	if runner.audit != nil {
-		_ = runner.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: action, Target: target.String(), Metadata: metadata, At: runner.clock.Now().UTC()})
+		return runner.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: action, Target: target.String(), Metadata: metadata, At: runner.clock.Now().UTC()})
 	}
+	return nil
 }
 
 func retryableBackfillError(err error) bool {

--- a/internal/usecase/assessmentcycle/backfill_test.go
+++ b/internal/usecase/assessmentcycle/backfill_test.go
@@ -1,0 +1,213 @@
+package assessmentcycle_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type mutableBackfillClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (clock *mutableBackfillClock) Now() time.Time {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	return clock.now
+}
+
+func (clock *mutableBackfillClock) Advance(duration time.Duration) {
+	clock.mu.Lock()
+	clock.now = clock.now.Add(duration)
+	clock.mu.Unlock()
+}
+
+type retryBackfiller struct {
+	calls int
+	fail  int
+	err   error
+}
+
+func (backfiller *retryBackfiller) BackfillHistoricalSingleton(context.Context, cycleuc.BackfillHistoricalSingletonInput) (cycleuc.BackfillHistoricalSingletonResult, error) {
+	backfiller.calls++
+	if backfiller.calls <= backfiller.fail {
+		return cycleuc.BackfillHistoricalSingletonResult{}, backfiller.err
+	}
+	return cycleuc.BackfillHistoricalSingletonResult{Created: true, CycleID: "cycle-retried", ReasonCode: cycleuc.BackfillReasonCreated}, nil
+}
+
+type backfillObserver struct {
+	items []string
+	runs  []string
+}
+
+func (observer *backfillObserver) ObserveAssessmentCycleBackfillItem(outcome string) {
+	observer.items = append(observer.items, outcome)
+}
+
+func (observer *backfillObserver) ObserveAssessmentCycleBackfillRun(state string) {
+	observer.runs = append(observer.runs, state)
+}
+
+func TestBackfillRunnerPreservesHistoryAndRerunsWithoutDuplicates(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	clock := &mutableBackfillClock{now: now}
+	ids := &seqIDGen{}
+	audit := &recordAudit{}
+	engagements := memory.NewEngagementRepository()
+	cycles := memory.NewAssessmentCycleRepository()
+	transactions := memory.NewTenantTransactionRunner()
+	cycleService, err := cycleuc.NewService(cycles, engagements, nil, nil, transactions, ids, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenantID := shared.ID("tenant-backfill")
+	existing := addHistoricalAssessment(t, ctx, engagements, tenantID, "assessment-a", engdom.StatusCompleted, "", now.Add(-72*time.Hour), now.Add(-48*time.Hour), "owner-a", "reviewer-a")
+	archived := addHistoricalAssessment(t, ctx, engagements, tenantID, "assessment-b", engdom.StatusArchived, "", now.Add(-48*time.Hour), now.Add(-24*time.Hour), "owner-b", "reviewer-b")
+	asset := addHistoricalAssessment(t, ctx, engagements, tenantID, "assessment-c", engdom.StatusActive, "asset-1", now.Add(-24*time.Hour), now.Add(-12*time.Hour), "owner-c", "owner-c")
+	hidden := addHistoricalAssessment(t, ctx, engagements, tenantID, "assessment-hidden", engdom.StatusActive, "", now.Add(-time.Hour), now.Add(-time.Hour), "owner-hidden", "owner-hidden")
+	hidden.ProjectID = "project-1"
+	if err := engagements.Update(ctx, hidden); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := cycleService.CreateInitialCycle(ctx, cycleuc.CreateInitialCycleInput{TenantID: tenantID, Name: existing.Name, BoundaryKind: cycledom.BoundaryStandalone, RootAssessmentID: existing.ID, Actor: "owner-a"}); err != nil {
+		t.Fatal(err)
+	}
+
+	store := memory.NewAssessmentCycleBackfillRepository()
+	observer := &backfillObserver{}
+	runner, err := cycleuc.NewBackfillRunner(cycleService, engagements, store, ids, clock, audit, observer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := runner.Run(ctx, cycleuc.BackfillRequest{TenantID: tenantID, Actor: "operator", LeaseOwner: "process-1", BatchSize: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.State != ports.AssessmentCycleBackfillCompleted || first.ProcessedCount != 3 || first.CreatedCount != 2 || first.SkippedCount != 1 || first.FailedCount != 0 {
+		t.Fatalf("first backfill = %+v", first)
+	}
+	archivedCycle, err := cycles.GetCycleByAssessment(ctx, tenantID, archived.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if archivedCycle.Status != cycledom.StatusArchived || !archivedCycle.CreatedAt.Equal(archived.Audit.CreatedAt) || !archivedCycle.UpdatedAt.Equal(archived.Audit.UpdatedAt) || archivedCycle.CreatedBy != "owner-b" || archivedCycle.UpdatedBy != "reviewer-b" {
+		t.Fatalf("archived history was not preserved: %+v", archivedCycle)
+	}
+	assetCycle, err := cycles.GetCycleByAssessment(ctx, tenantID, asset.ID)
+	if err != nil || assetCycle.BoundaryKind != cycledom.BoundaryAsset || assetCycle.BusinessAssetID != "asset-1" {
+		t.Fatalf("asset boundary backfill = %+v, err=%v", assetCycle, err)
+	}
+	if _, err := cycles.GetCycleByAssessment(ctx, tenantID, hidden.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("hidden Project context entered a Cycle: %v", err)
+	}
+
+	second, err := runner.Run(ctx, cycleuc.BackfillRequest{TenantID: tenantID, Actor: "operator", LeaseOwner: "process-2", BatchSize: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.CreatedCount != 0 || second.SkippedCount != 3 || len(observer.runs) != 2 {
+		t.Fatalf("rerun = %+v observer=%+v", second, observer)
+	}
+	records, err := cycles.ListCycles(ctx, ports.AssessmentCycleListQuery{TenantID: tenantID, Limit: 10})
+	if err != nil || len(records) != 3 {
+		t.Fatalf("cycle count after rerun = %d, err=%v", len(records), err)
+	}
+}
+
+func TestBackfillRunnerDryRunLeaseAndCrashResume(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	clock := &mutableBackfillClock{now: now}
+	ids := &seqIDGen{}
+	audit := &recordAudit{}
+	engagements := memory.NewEngagementRepository()
+	cycles := memory.NewAssessmentCycleRepository()
+	transactions := memory.NewTenantTransactionRunner()
+	cycleService, err := cycleuc.NewService(cycles, engagements, nil, nil, transactions, ids, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenantID := shared.ID("tenant-resume")
+	assessment := addHistoricalAssessment(t, ctx, engagements, tenantID, "assessment-a", engdom.StatusActive, "", now.Add(-time.Hour), now.Add(-time.Hour), "owner", "owner")
+	store := memory.NewAssessmentCycleBackfillRepository()
+	runner, err := cycleuc.NewBackfillRunner(cycleService, engagements, store, ids, clock, audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dryRun, err := runner.Run(ctx, cycleuc.BackfillRequest{TenantID: tenantID, Actor: "operator", LeaseOwner: "dry-run", DryRun: true, BatchSize: 1})
+	if err != nil || dryRun.WouldCreateCount != 1 {
+		t.Fatalf("dry run = %+v, err=%v", dryRun, err)
+	}
+	if _, err := cycles.GetCycleByAssessment(ctx, tenantID, assessment.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("dry run created a Cycle: %v", err)
+	}
+
+	lease := time.Minute
+	crashed, _, err := store.AcquireAssessmentCycleBackfillRun(ctx, ports.AssessmentCycleBackfillAcquireRequest{Run: ports.AssessmentCycleBackfillRun{
+		TenantID: tenantID, ID: "crashed-run", SchemaVersion: cycleuc.AssessmentCycleBackfillSchemaVersion, BatchSize: 1,
+		SnapshotAt: now, State: ports.AssessmentCycleBackfillRunning, LeaseOwner: "dead-process", LeaseToken: "dead-token", LeaseExpiresAt: now.Add(lease), CreatedBy: "operator", CreatedAt: now, UpdatedAt: now,
+	}, LeaseDuration: lease})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runner.Run(ctx, cycleuc.BackfillRequest{TenantID: tenantID, Actor: "operator", LeaseOwner: "live-process", BatchSize: 1, LeaseDuration: lease}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("concurrent lease = %v", err)
+	}
+	clock.Advance(lease + time.Second)
+	resumed, err := runner.Run(ctx, cycleuc.BackfillRequest{TenantID: tenantID, Actor: "operator", LeaseOwner: "live-process", BatchSize: 1, LeaseDuration: lease})
+	if err != nil || resumed.ID != crashed.ID || resumed.CreatedCount != 1 {
+		t.Fatalf("crash resume = %+v, err=%v", resumed, err)
+	}
+}
+
+func TestBackfillRunnerBoundsRetriesAndRedactsFailures(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	clock := &mutableBackfillClock{now: now}
+	ids := &seqIDGen{}
+	engagements := memory.NewEngagementRepository()
+	tenantID := shared.ID("tenant-retry")
+	assessment := addHistoricalAssessment(t, ctx, engagements, tenantID, "assessment-a", engdom.StatusActive, "", now.Add(-time.Hour), now.Add(-time.Hour), "owner", "owner")
+	store := memory.NewAssessmentCycleBackfillRepository()
+	backfiller := &retryBackfiller{fail: 3, err: errors.New("database unavailable: secret-token")}
+	runner, err := cycleuc.NewBackfillRunner(backfiller, engagements, store, ids, clock, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := runner.Run(ctx, cycleuc.BackfillRequest{TenantID: tenantID, Actor: "operator", LeaseOwner: "process", BatchSize: 1})
+	if err != nil || run.FailedCount != 1 || backfiller.calls != 3 {
+		t.Fatalf("bounded retry run = %+v calls=%d err=%v", run, backfiller.calls, err)
+	}
+	item, err := store.GetAssessmentCycleBackfillItem(ctx, tenantID, run.ID, assessment.ID)
+	if err != nil || item.ReasonCode != cycleuc.BackfillReasonWriteFailed || !item.Retryable || strings.Contains(item.RepairGuidance, "secret-token") {
+		t.Fatalf("failure item = %+v, err=%v", item, err)
+	}
+}
+
+func addHistoricalAssessment(t *testing.T, ctx context.Context, repository *memory.EngagementRepository, tenantID, assessmentID shared.ID, status engdom.Status, assetID shared.ID, createdAt, updatedAt time.Time, createdBy, updatedBy string) *engdom.Engagement {
+	t.Helper()
+	assessment, err := engdom.New(assessmentID, tenantID, assessmentID.String(), "Client", createdAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assessment.Status, assessment.BusinessAssetID = status, assetID
+	assessment.Audit.CreatedAt, assessment.Audit.UpdatedAt = createdAt, updatedAt
+	assessment.Audit.CreatedBy, assessment.Audit.UpdatedBy = createdBy, updatedBy
+	if err := repository.Create(ctx, assessment); err != nil {
+		t.Fatal(err)
+	}
+	return assessment
+}

--- a/internal/usecase/assessmentcycle/integrity.go
+++ b/internal/usecase/assessmentcycle/integrity.go
@@ -1,0 +1,376 @@
+package assessmentcycle
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	DefaultAssessmentCycleIntegrityBatch = 500
+	MaxAssessmentCycleIntegrityBatch     = 2000
+	defaultAssessmentCycleIntegrityLease = 10 * time.Minute
+	assessmentCycleIntegrityRetries      = 3
+)
+
+const (
+	IntegrityCoverageMissing        = "coverage_missing"
+	IntegrityCoverageMultiple       = "coverage_multiple"
+	IntegrityCycleMissing           = "cycle_missing"
+	IntegrityMemberSourceMissing    = "member_source_missing"
+	IntegrityRootCardinality        = "root_cardinality"
+	IntegrityRootMismatch           = "root_mismatch"
+	IntegrityMemberTenantMismatch   = "member_tenant_mismatch"
+	IntegrityMemberCycleMismatch    = "member_cycle_mismatch"
+	IntegrityBoundaryMismatch       = "frozen_boundary_mismatch"
+	IntegrityHiddenContextMember    = "hidden_project_context_member"
+	IntegritySelectedHeadMissing    = "selected_head_missing"
+	IntegritySelectedHeadArchived   = "selected_head_archived"
+	IntegritySelectedHeadNotLeaf    = "selected_head_not_leaf"
+	IntegritySelectedHeadIneligible = "selected_head_ineligible"
+	IntegrityRetestNumberDuplicate  = "retest_number_duplicate"
+	IntegrityRetestNumberGap        = "retest_number_gap"
+	IntegrityNextRetestNotMonotonic = "next_retest_not_monotonic"
+	IntegrityPredecessorMissing     = "predecessor_missing"
+	IntegrityGraphCycle             = "graph_cycle"
+	IntegritySourceTargetCountDrift = "source_target_count_mismatch"
+)
+
+type AssessmentCycleIntegrityObserver interface {
+	ObserveAssessmentCycleIntegritySubject(outcome string)
+	ObserveAssessmentCycleIntegrityRun(state string)
+}
+
+type IntegrityVerifier struct {
+	source   ports.AssessmentCycleIntegritySource
+	store    ports.AssessmentCycleIntegrityStore
+	ids      ports.IDGenerator
+	clock    ports.Clock
+	audit    ports.AuditLogger
+	observer AssessmentCycleIntegrityObserver
+}
+
+func NewIntegrityVerifier(source ports.AssessmentCycleIntegritySource, store ports.AssessmentCycleIntegrityStore, ids ports.IDGenerator, clock ports.Clock, audit ports.AuditLogger, observer AssessmentCycleIntegrityObserver) (*IntegrityVerifier, error) {
+	if source == nil || store == nil || ids == nil || clock == nil {
+		return nil, fmt.Errorf("%w: assessment cycle integrity dependencies are required", shared.ErrValidation)
+	}
+	return &IntegrityVerifier{source: source, store: store, ids: ids, clock: clock, audit: audit, observer: observer}, nil
+}
+
+type IntegrityRequest struct {
+	TenantID      shared.ID
+	Actor         string
+	LeaseOwner    string
+	BatchSize     int
+	LeaseDuration time.Duration
+}
+
+func (verifier *IntegrityVerifier) Run(ctx context.Context, request IntegrityRequest) (ports.AssessmentCycleIntegrityRun, error) {
+	tenantID := shared.TenantOrDefault(request.TenantID)
+	actor, leaseOwner := strings.TrimSpace(request.Actor), strings.TrimSpace(request.LeaseOwner)
+	if tenantID.IsZero() || actor == "" || len(actor) > 256 || leaseOwner == "" || len(leaseOwner) > 256 {
+		return ports.AssessmentCycleIntegrityRun{}, fmt.Errorf("%w: tenant, actor, and lease owner are required", shared.ErrValidation)
+	}
+	batchSize := request.BatchSize
+	if batchSize == 0 {
+		batchSize = DefaultAssessmentCycleIntegrityBatch
+	}
+	if batchSize < 1 || batchSize > MaxAssessmentCycleIntegrityBatch {
+		return ports.AssessmentCycleIntegrityRun{}, fmt.Errorf("%w: batch size must be between 1 and %d", shared.ErrValidation, MaxAssessmentCycleIntegrityBatch)
+	}
+	leaseDuration := request.LeaseDuration
+	if leaseDuration <= 0 {
+		leaseDuration = defaultAssessmentCycleIntegrityLease
+	}
+	now := verifier.clock.Now().UTC()
+	acquisitionID := verifier.ids.NewID()
+	run, resumed, err := verifier.store.AcquireAssessmentCycleIntegrityRun(ctx, ports.AssessmentCycleIntegrityAcquireRequest{Run: ports.AssessmentCycleIntegrityRun{
+		TenantID: tenantID, ID: acquisitionID, BatchSize: batchSize, SnapshotAt: now, State: ports.AssessmentCycleIntegrityRunning,
+		LeaseOwner: leaseOwner, LeaseToken: acquisitionID, LeaseExpiresAt: now.Add(leaseDuration), CreatedBy: actor, CreatedAt: now, UpdatedAt: now,
+	}, LeaseDuration: leaseDuration})
+	if err != nil {
+		return ports.AssessmentCycleIntegrityRun{}, err
+	}
+	verifier.record(ctx, actor, "assessment_cycle.integrity_started", run.ID, map[string]string{
+		"tenant_id": tenantID.String(), "resumed": strconv.FormatBool(resumed), "batch_size": strconv.Itoa(run.BatchSize),
+	})
+	for {
+		if err := ctx.Err(); err != nil {
+			return verifier.finish(ctx, run, leaseOwner, ports.AssessmentCycleIntegrityCancelled, actor, err)
+		}
+		subjects, err := retryIntegrity(ctx, func() ([]ports.AssessmentCycleIntegritySubject, error) {
+			return verifier.source.ListAssessmentCycleIntegritySubjects(ctx, tenantID, run.CheckpointAssessment, run.SnapshotAt, run.BatchSize)
+		})
+		if err != nil {
+			return verifier.finish(ctx, run, leaseOwner, ports.AssessmentCycleIntegrityFailed, actor, err)
+		}
+		if len(subjects) == 0 {
+			counts, err := retryIntegrity(ctx, func() ([2]int, error) {
+				eligible, memberships, err := verifier.source.CountAssessmentCycleIntegritySubjects(ctx, tenantID, run.SnapshotAt)
+				return [2]int{eligible, memberships}, err
+			})
+			if err != nil {
+				return verifier.finish(ctx, run, leaseOwner, ports.AssessmentCycleIntegrityFailed, actor, err)
+			}
+			eligible, memberships := counts[0], counts[1]
+			if run.ScannedCount != eligible || (memberships != eligible && run.FindingCount == 0) {
+				return verifier.finish(ctx, run, leaseOwner, ports.AssessmentCycleIntegrityFailed, actor, fmt.Errorf("%s: scanned=%d eligible=%d memberships=%d", IntegritySourceTargetCountDrift, run.ScannedCount, eligible, memberships))
+			}
+			return verifier.finish(ctx, run, leaseOwner, ports.AssessmentCycleIntegrityCompleted, actor, nil)
+		}
+		if len(subjects) > run.BatchSize {
+			return verifier.finish(ctx, run, leaseOwner, ports.AssessmentCycleIntegrityFailed, actor, fmt.Errorf("integrity source returned %d rows for limit %d", len(subjects), run.BatchSize))
+		}
+		for _, subject := range subjects {
+			if err := ctx.Err(); err != nil {
+				return verifier.finish(ctx, run, leaseOwner, ports.AssessmentCycleIntegrityCancelled, actor, err)
+			}
+			if _, err := verifier.store.GetAssessmentCycleIntegritySubject(ctx, tenantID, run.ID, subject.AssessmentID); err == nil {
+				continue
+			} else if !errors.Is(err, shared.ErrNotFound) {
+				return verifier.finish(ctx, run, leaseOwner, ports.AssessmentCycleIntegrityFailed, actor, err)
+			}
+			findings := verifyIntegritySubject(run.ID, subject, verifier.clock.Now().UTC())
+			result := ports.AssessmentCycleIntegritySubjectResult{TenantID: tenantID, RunID: run.ID, AssessmentID: subject.AssessmentID, Clean: len(findings) == 0, FindingCount: len(findings), ProcessedAt: verifier.clock.Now().UTC()}
+			created, err := retryIntegrity(ctx, func() (bool, error) {
+				return verifier.store.SaveAssessmentCycleIntegritySubject(ctx, run.LeaseToken, verifier.clock.Now().UTC(), result, findings)
+			})
+			if err != nil {
+				return verifier.finish(ctx, run, leaseOwner, ports.AssessmentCycleIntegrityFailed, actor, err)
+			}
+			if created && verifier.observer != nil {
+				outcome := "clean"
+				if len(findings) > 0 {
+					outcome = "finding"
+				}
+				verifier.observer.ObserveAssessmentCycleIntegritySubject(outcome)
+			}
+		}
+		checkpoint := subjects[len(subjects)-1].AssessmentID
+		run, err = retryIntegrity(ctx, func() (ports.AssessmentCycleIntegrityRun, error) {
+			return verifier.store.AdvanceAssessmentCycleIntegrityRun(ctx, tenantID, run.ID, leaseOwner, run.LeaseToken, checkpoint, verifier.clock.Now().UTC(), leaseDuration)
+		})
+		if err != nil {
+			return verifier.finish(ctx, run, leaseOwner, ports.AssessmentCycleIntegrityFailed, actor, err)
+		}
+		verifier.record(ctx, actor, "assessment_cycle.integrity_batch_committed", run.ID, map[string]string{
+			"tenant_id": tenantID.String(), "checkpoint_assessment_id": checkpoint.String(), "scanned_count": strconv.Itoa(run.ScannedCount), "finding_count": strconv.Itoa(run.FindingCount),
+		})
+	}
+}
+
+func verifyIntegritySubject(runID shared.ID, subject ports.AssessmentCycleIntegritySubject, detectedAt time.Time) []ports.AssessmentCycleIntegrityFinding {
+	var findings []ports.AssessmentCycleIntegrityFinding
+	add := func(reason, severity string, cycleID, memberID shared.ID) {
+		findings = append(findings, newIntegrityFinding(runID, subject.TenantID, subject.AssessmentID, cycleID, memberID, reason, severity, detectedAt))
+	}
+	membershipCount := 0
+	for _, cycle := range subject.Cycles {
+		membershipCount += cycle.SubjectMembershipCount
+	}
+	if membershipCount == 0 {
+		add(IntegrityCoverageMissing, "high", "", "")
+		return findings
+	}
+	if membershipCount != 1 {
+		add(IntegrityCoverageMultiple, "critical", "", "")
+	}
+	for _, record := range subject.Cycles {
+		cycle := record.Cycle
+		if !record.CycleExists {
+			add(IntegrityCycleMissing, "critical", cycle.ID, "")
+			continue
+		}
+		membersByID := make(map[shared.ID]ports.AssessmentCycleIntegrityMember, len(record.Members))
+		activeChildren := map[shared.ID]bool{}
+		rootCount, maxRetest := 0, 0
+		retestNumbers := map[int]bool{}
+		for _, wrapped := range record.Members {
+			member := wrapped.Member
+			membersByID[member.AssessmentID] = wrapped
+			if !wrapped.AssessmentExists {
+				add(IntegrityMemberSourceMissing, "critical", cycle.ID, member.AssessmentID)
+			}
+			if member.IsRoot() {
+				rootCount++
+			}
+			if member.TenantID != subject.TenantID || member.TenantID != cycle.TenantID {
+				add(IntegrityMemberTenantMismatch, "critical", cycle.ID, member.AssessmentID)
+			}
+			if member.CycleID != cycle.ID {
+				add(IntegrityMemberCycleMismatch, "critical", cycle.ID, member.AssessmentID)
+			}
+			if !wrapped.ProjectID.IsZero() {
+				add(IntegrityHiddenContextMember, "critical", cycle.ID, member.AssessmentID)
+			}
+			boundaryValid := (cycle.BoundaryKind == cycledom.BoundaryStandalone && wrapped.BusinessAssetID.IsZero()) ||
+				(cycle.BoundaryKind == cycledom.BoundaryAsset && wrapped.BusinessAssetID == cycle.BusinessAssetID)
+			if !boundaryValid {
+				add(IntegrityBoundaryMismatch, "high", cycle.ID, member.AssessmentID)
+			}
+			if !member.PredecessorAssessmentID.IsZero() && !member.IsArchived() {
+				activeChildren[member.PredecessorAssessmentID] = true
+			}
+			if member.RetestNumber > 0 {
+				if retestNumbers[member.RetestNumber] {
+					add(IntegrityRetestNumberDuplicate, "high", cycle.ID, member.AssessmentID)
+				}
+				retestNumbers[member.RetestNumber] = true
+				if member.RetestNumber > maxRetest {
+					maxRetest = member.RetestNumber
+				}
+			}
+		}
+		if rootCount != 1 {
+			add(IntegrityRootCardinality, "critical", cycle.ID, "")
+		}
+		root, rootExists := membersByID[cycle.RootAssessmentID]
+		if !rootExists || !root.Member.IsRoot() {
+			add(IntegrityRootMismatch, "critical", cycle.ID, cycle.RootAssessmentID)
+		}
+		for number := 1; number <= maxRetest; number++ {
+			if !retestNumbers[number] {
+				add(IntegrityRetestNumberGap, "medium", cycle.ID, "")
+				break
+			}
+		}
+		if cycle.NextRetestNumber <= maxRetest {
+			add(IntegrityNextRetestNotMonotonic, "high", cycle.ID, "")
+		}
+		for _, wrapped := range record.Members {
+			member := wrapped.Member
+			if !member.PredecessorAssessmentID.IsZero() {
+				if _, ok := membersByID[member.PredecessorAssessmentID]; !ok {
+					add(IntegrityPredecessorMissing, "critical", cycle.ID, member.AssessmentID)
+				}
+			}
+		}
+		if hasIntegrityGraphCycle(record.Members) {
+			add(IntegrityGraphCycle, "critical", cycle.ID, "")
+		}
+		head, headExists := membersByID[cycle.SelectedHeadAssessmentID]
+		switch {
+		case !headExists:
+			add(IntegritySelectedHeadMissing, "critical", cycle.ID, cycle.SelectedHeadAssessmentID)
+		case head.Member.IsArchived():
+			add(IntegritySelectedHeadArchived, "high", cycle.ID, head.Member.AssessmentID)
+		case activeChildren[head.Member.AssessmentID]:
+			add(IntegritySelectedHeadNotLeaf, "high", cycle.ID, head.Member.AssessmentID)
+		case cycle.Status != cycledom.StatusArchived && head.AssessmentStatus == engdom.StatusArchived:
+			add(IntegritySelectedHeadIneligible, "high", cycle.ID, head.Member.AssessmentID)
+		}
+	}
+	sort.Slice(findings, func(left, right int) bool { return findings[left].OccurrenceID < findings[right].OccurrenceID })
+	return findings
+}
+
+func hasIntegrityGraphCycle(members []ports.AssessmentCycleIntegrityMember) bool {
+	predecessors := make(map[shared.ID]shared.ID, len(members))
+	for _, member := range members {
+		predecessors[member.Member.AssessmentID] = member.Member.PredecessorAssessmentID
+	}
+	for start := range predecessors {
+		seen := map[shared.ID]bool{}
+		for current := start; !current.IsZero(); current = predecessors[current] {
+			if seen[current] {
+				return true
+			}
+			seen[current] = true
+			if _, exists := predecessors[current]; !exists {
+				break
+			}
+		}
+	}
+	return false
+}
+
+type integrityRepairPlan struct {
+	Action        string   `json:"action"`
+	TargetID      string   `json:"target_id"`
+	Preconditions []string `json:"preconditions"`
+}
+
+func newIntegrityFinding(runID, tenantID, assessmentID, cycleID, memberID shared.ID, reason, severity string, detectedAt time.Time) ports.AssessmentCycleIntegrityFinding {
+	targetID := assessmentID.String()
+	if !cycleID.IsZero() {
+		targetID = cycleID.String()
+	}
+	plan, _ := json.Marshal(integrityRepairPlan{Action: integrityRepairAction(reason), TargetID: targetID, Preconditions: []string{"dual_write_disabled_for_repair", "operator_review_required", "backup_verified"}})
+	sum := sha256.Sum256([]byte(strings.Join([]string{tenantID.String(), assessmentID.String(), cycleID.String(), memberID.String(), reason}, "\x00")))
+	return ports.AssessmentCycleIntegrityFinding{
+		TenantID: tenantID, RunID: runID, OccurrenceID: hex.EncodeToString(sum[:16]), AssessmentID: assessmentID, CycleID: cycleID, MemberID: memberID,
+		ReasonCode: reason, Severity: severity, RepairPlan: plan, DetectedAt: detectedAt.UTC(),
+	}
+}
+
+func integrityRepairAction(reason string) string {
+	switch reason {
+	case IntegrityCoverageMissing:
+		return "create_singleton_cycle"
+	case IntegrityCoverageMultiple, IntegrityGraphCycle, IntegrityRootCardinality, IntegrityRootMismatch:
+		return "manual_relationship_repair"
+	case IntegritySelectedHeadMissing, IntegritySelectedHeadArchived, IntegritySelectedHeadNotLeaf, IntegritySelectedHeadIneligible:
+		return "select_eligible_leaf"
+	case IntegrityNextRetestNotMonotonic, IntegrityRetestNumberDuplicate, IntegrityRetestNumberGap:
+		return "rebuild_retest_allocation"
+	default:
+		return "review_and_repair_cycle"
+	}
+}
+
+func (verifier *IntegrityVerifier) finish(ctx context.Context, run ports.AssessmentCycleIntegrityRun, leaseOwner string, state ports.AssessmentCycleIntegrityState, actor string, cause error) (ports.AssessmentCycleIntegrityRun, error) {
+	finishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	finished, err := verifier.store.FinishAssessmentCycleIntegrityRun(finishCtx, run.TenantID, run.ID, leaseOwner, run.LeaseToken, state, verifier.clock.Now().UTC())
+	if err != nil {
+		if cause != nil {
+			return run, errors.Join(cause, err)
+		}
+		return run, err
+	}
+	if verifier.observer != nil {
+		verifier.observer.ObserveAssessmentCycleIntegrityRun(string(state))
+	}
+	verifier.record(finishCtx, actor, "assessment_cycle.integrity_"+string(state), run.ID, map[string]string{
+		"tenant_id": run.TenantID.String(), "scanned_count": strconv.Itoa(finished.ScannedCount), "clean_count": strconv.Itoa(finished.CleanCount), "finding_count": strconv.Itoa(finished.FindingCount),
+	})
+	if cause != nil {
+		return finished, cause
+	}
+	return finished, nil
+}
+
+func (verifier *IntegrityVerifier) record(ctx context.Context, actor, action string, target shared.ID, metadata map[string]string) {
+	if verifier.audit != nil {
+		_ = verifier.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: action, Target: target.String(), Metadata: metadata, At: verifier.clock.Now().UTC()})
+	}
+}
+
+func retryIntegrity[T any](ctx context.Context, operation func() (T, error)) (T, error) {
+	var zero T
+	for attempt := 0; attempt < assessmentCycleIntegrityRetries; attempt++ {
+		value, err := operation()
+		if err == nil {
+			return value, nil
+		}
+		if ctx.Err() != nil || errors.Is(err, shared.ErrValidation) || errors.Is(err, shared.ErrNotFound) || errors.Is(err, shared.ErrConflict) {
+			return zero, err
+		}
+		if attempt == assessmentCycleIntegrityRetries-1 {
+			return zero, err
+		}
+	}
+	return zero, nil
+}

--- a/internal/usecase/assessmentcycle/integrity.go
+++ b/internal/usecase/assessmentcycle/integrity.go
@@ -95,17 +95,27 @@ func (verifier *IntegrityVerifier) Run(ctx context.Context, request IntegrityReq
 		leaseDuration = defaultAssessmentCycleIntegrityLease
 	}
 	now := verifier.clock.Now().UTC()
+	sourceGeneration, err := verifier.source.AssessmentCycleIntegrityGeneration(ctx, tenantID)
+	if err != nil {
+		return ports.AssessmentCycleIntegrityRun{}, fmt.Errorf("load assessment cycle integrity source generation: %w", err)
+	}
 	acquisitionID := verifier.ids.NewID()
 	run, resumed, err := verifier.store.AcquireAssessmentCycleIntegrityRun(ctx, ports.AssessmentCycleIntegrityAcquireRequest{Run: ports.AssessmentCycleIntegrityRun{
 		TenantID: tenantID, ID: acquisitionID, BatchSize: batchSize, SnapshotAt: now, State: ports.AssessmentCycleIntegrityRunning,
-		LeaseOwner: leaseOwner, LeaseToken: acquisitionID, LeaseExpiresAt: now.Add(leaseDuration), CreatedBy: actor, CreatedAt: now, UpdatedAt: now,
+		SourceGeneration: sourceGeneration,
+		LeaseOwner:       leaseOwner, LeaseToken: acquisitionID, LeaseExpiresAt: now.Add(leaseDuration), CreatedBy: actor, CreatedAt: now, UpdatedAt: now,
 	}, LeaseDuration: leaseDuration})
 	if err != nil {
 		return ports.AssessmentCycleIntegrityRun{}, err
 	}
-	verifier.record(ctx, actor, "assessment_cycle.integrity_started", run.ID, map[string]string{
+	if resumed && run.SourceGeneration != sourceGeneration {
+		return verifier.finish(ctx, run, leaseOwner, ports.AssessmentCycleIntegrityFailed, actor, fmt.Errorf("%w: assessment cycle integrity source changed while the run was interrupted", shared.ErrConflict))
+	}
+	if err := verifier.record(ctx, actor, "assessment_cycle.integrity_started", run.ID, map[string]string{
 		"tenant_id": tenantID.String(), "resumed": strconv.FormatBool(resumed), "batch_size": strconv.Itoa(run.BatchSize),
-	})
+	}); err != nil {
+		return verifier.finish(ctx, run, leaseOwner, ports.AssessmentCycleIntegrityFailed, actor, fmt.Errorf("audit assessment Cycle integrity start: %w", err))
+	}
 	for {
 		if err := ctx.Err(); err != nil {
 			return verifier.finish(ctx, run, leaseOwner, ports.AssessmentCycleIntegrityCancelled, actor, err)
@@ -165,9 +175,11 @@ func (verifier *IntegrityVerifier) Run(ctx context.Context, request IntegrityReq
 		if err != nil {
 			return verifier.finish(ctx, run, leaseOwner, ports.AssessmentCycleIntegrityFailed, actor, err)
 		}
-		verifier.record(ctx, actor, "assessment_cycle.integrity_batch_committed", run.ID, map[string]string{
+		if err := verifier.record(ctx, actor, "assessment_cycle.integrity_batch_committed", run.ID, map[string]string{
 			"tenant_id": tenantID.String(), "checkpoint_assessment_id": checkpoint.String(), "scanned_count": strconv.Itoa(run.ScannedCount), "finding_count": strconv.Itoa(run.FindingCount),
-		})
+		}); err != nil {
+			return verifier.finish(ctx, run, leaseOwner, ports.AssessmentCycleIntegrityFailed, actor, fmt.Errorf("audit assessment Cycle integrity batch: %w", err))
+		}
 	}
 }
 
@@ -343,19 +355,26 @@ func (verifier *IntegrityVerifier) finish(ctx context.Context, run ports.Assessm
 	if verifier.observer != nil {
 		verifier.observer.ObserveAssessmentCycleIntegrityRun(string(state))
 	}
-	verifier.record(finishCtx, actor, "assessment_cycle.integrity_"+string(state), run.ID, map[string]string{
+	auditErr := verifier.record(finishCtx, actor, "assessment_cycle.integrity_"+string(state), run.ID, map[string]string{
 		"tenant_id": run.TenantID.String(), "scanned_count": strconv.Itoa(finished.ScannedCount), "clean_count": strconv.Itoa(finished.CleanCount), "finding_count": strconv.Itoa(finished.FindingCount),
 	})
 	if cause != nil {
+		if auditErr != nil {
+			return finished, errors.Join(cause, fmt.Errorf("audit assessment Cycle integrity finish: %w", auditErr))
+		}
 		return finished, cause
+	}
+	if auditErr != nil {
+		return finished, fmt.Errorf("audit assessment Cycle integrity finish: %w", auditErr)
 	}
 	return finished, nil
 }
 
-func (verifier *IntegrityVerifier) record(ctx context.Context, actor, action string, target shared.ID, metadata map[string]string) {
+func (verifier *IntegrityVerifier) record(ctx context.Context, actor, action string, target shared.ID, metadata map[string]string) error {
 	if verifier.audit != nil {
-		_ = verifier.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: action, Target: target.String(), Metadata: metadata, At: verifier.clock.Now().UTC()})
+		return verifier.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: action, Target: target.String(), Metadata: metadata, At: verifier.clock.Now().UTC()})
 	}
+	return nil
 }
 
 func retryIntegrity[T any](ctx context.Context, operation func() (T, error)) (T, error) {

--- a/internal/usecase/assessmentcycle/integrity_internal_test.go
+++ b/internal/usecase/assessmentcycle/integrity_internal_test.go
@@ -1,0 +1,90 @@
+package assessmentcycle
+
+import (
+	"testing"
+	"time"
+
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestVerifyIntegritySubjectCorruptionFixtures(t *testing.T) {
+	clean := integritySubjectFixture(t)
+	if findings := verifyIntegritySubject("run", clean, time.Now().UTC()); len(findings) != 0 {
+		t.Fatalf("clean fixture findings = %+v", findings)
+	}
+	tests := []struct {
+		name   string
+		mutate func(*ports.AssessmentCycleIntegritySubject)
+		want   string
+	}{
+		{name: "missing coverage", mutate: func(subject *ports.AssessmentCycleIntegritySubject) { subject.Cycles = nil }, want: IntegrityCoverageMissing},
+		{name: "multiple coverage", mutate: func(subject *ports.AssessmentCycleIntegritySubject) {
+			subject.Cycles = append(subject.Cycles, subject.Cycles[0])
+		}, want: IntegrityCoverageMultiple},
+		{name: "root cardinality", mutate: func(subject *ports.AssessmentCycleIntegritySubject) {
+			subject.Cycles[0].Members = subject.Cycles[0].Members[1:]
+		}, want: IntegrityRootCardinality},
+		{name: "boundary mismatch", mutate: func(subject *ports.AssessmentCycleIntegritySubject) {
+			subject.Cycles[0].Members[0].BusinessAssetID = "asset-1"
+		}, want: IntegrityBoundaryMismatch},
+		{name: "selected head not leaf", mutate: func(subject *ports.AssessmentCycleIntegritySubject) {
+			subject.Cycles[0].Cycle.SelectedHeadAssessmentID = "root"
+		}, want: IntegritySelectedHeadNotLeaf},
+		{name: "selected head archived", mutate: func(subject *ports.AssessmentCycleIntegritySubject) {
+			archived := time.Now().UTC()
+			subject.Cycles[0].Members[1].Member.ArchivedAt = &archived
+		}, want: IntegritySelectedHeadArchived},
+		{name: "predecessor missing", mutate: func(subject *ports.AssessmentCycleIntegritySubject) {
+			subject.Cycles[0].Members[1].Member.PredecessorAssessmentID = "missing"
+		}, want: IntegrityPredecessorMissing},
+		{name: "graph cycle", mutate: func(subject *ports.AssessmentCycleIntegritySubject) {
+			subject.Cycles[0].Members[0].Member.AssessmentType = cycledom.AssessmentTypeRetest
+			subject.Cycles[0].Members[0].Member.RetestNumber = 2
+			subject.Cycles[0].Members[0].Member.PredecessorAssessmentID = "retest"
+		}, want: IntegrityGraphCycle},
+		{name: "next retest not monotonic", mutate: func(subject *ports.AssessmentCycleIntegritySubject) { subject.Cycles[0].Cycle.NextRetestNumber = 1 }, want: IntegrityNextRetestNotMonotonic},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			subject := integritySubjectFixture(t)
+			test.mutate(&subject)
+			findings := verifyIntegritySubject("run", subject, time.Now().UTC())
+			found := false
+			for _, finding := range findings {
+				if finding.ReasonCode == test.want {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("findings = %+v, want %s", findings, test.want)
+			}
+		})
+	}
+}
+
+func integritySubjectFixture(t *testing.T) ports.AssessmentCycleIntegritySubject {
+	t.Helper()
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	cycle, err := cycledom.NewAssessmentCycle("cycle", "tenant", "Cycle", cycledom.BoundaryStandalone, "", "", "root", "owner", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cycle.SelectedHeadAssessmentID, cycle.NextRetestNumber = "retest", 2
+	root, err := cycledom.NewInitialMember("tenant", "cycle", "root", "owner", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	retest, err := cycledom.NewRetestMember("tenant", "cycle", "retest", "root", 1, "owner", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ports.AssessmentCycleIntegritySubject{
+		TenantID: "tenant", AssessmentID: "root",
+		Cycles: []ports.AssessmentCycleIntegrityCycle{{Cycle: *cycle, CycleExists: true, SubjectMembershipCount: 1, Members: []ports.AssessmentCycleIntegrityMember{
+			{Member: *root, AssessmentExists: true, AssessmentStatus: engdom.StatusActive},
+			{Member: *retest, AssessmentExists: true, AssessmentStatus: engdom.StatusActive},
+		}}},
+	}
+}

--- a/internal/usecase/assessmentcycle/integrity_runner_test.go
+++ b/internal/usecase/assessmentcycle/integrity_runner_test.go
@@ -1,0 +1,82 @@
+package assessmentcycle_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestIntegrityVerifierPersistsFindingsAndResumesExpiredRun(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	clock := &mutableBackfillClock{now: now}
+	ids := &seqIDGen{}
+	audit := &recordAudit{}
+	engagements := memory.NewEngagementRepository()
+	cycles := memory.NewAssessmentCycleRepository()
+	transactions := memory.NewTenantTransactionRunner()
+	cycleService, err := cycleuc.NewService(cycles, engagements, nil, nil, transactions, ids, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenantID := shared.ID("tenant-integrity")
+	covered := addHistoricalAssessment(t, ctx, engagements, tenantID, "assessment-a", engdom.StatusActive, "", now.Add(-2*time.Hour), now.Add(-time.Hour), "owner", "owner")
+	missing := addHistoricalAssessment(t, ctx, engagements, tenantID, "assessment-b", engdom.StatusActive, "", now.Add(-time.Hour), now.Add(-time.Hour), "owner", "owner")
+	if _, _, err := cycleService.CreateInitialCycle(ctx, cycleuc.CreateInitialCycleInput{TenantID: tenantID, Name: covered.Name, BoundaryKind: cycledom.BoundaryStandalone, RootAssessmentID: covered.ID, Actor: "owner"}); err != nil {
+		t.Fatal(err)
+	}
+	repository := memory.NewAssessmentCycleIntegrityRepository(engagements, cycles)
+	verifier, err := cycleuc.NewIntegrityVerifier(repository, repository, ids, clock, audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := verifier.Run(ctx, cycleuc.IntegrityRequest{TenantID: tenantID, Actor: "operator", LeaseOwner: "process-1", BatchSize: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.State != ports.AssessmentCycleIntegrityCompleted || run.ScannedCount != 2 || run.CleanCount != 1 || run.FindingCount != 1 {
+		t.Fatalf("integrity run = %+v", run)
+	}
+	findings, err := repository.ListAssessmentCycleIntegrityFindings(ctx, tenantID, run.ID)
+	if err != nil || len(findings) != 1 || findings[0].AssessmentID != missing.ID || findings[0].ReasonCode != cycleuc.IntegrityCoverageMissing || !strings.Contains(string(findings[0].RepairPlan), "create_singleton_cycle") {
+		t.Fatalf("integrity findings = %+v, err=%v", findings, err)
+	}
+
+	lease := time.Minute
+	crashed, _, err := repository.AcquireAssessmentCycleIntegrityRun(ctx, ports.AssessmentCycleIntegrityAcquireRequest{Run: ports.AssessmentCycleIntegrityRun{
+		TenantID: tenantID, ID: "integrity-crashed", BatchSize: 1, SnapshotAt: now, State: ports.AssessmentCycleIntegrityRunning,
+		LeaseOwner: "dead", LeaseToken: "dead-token", LeaseExpiresAt: now.Add(lease), CreatedBy: "operator", CreatedAt: now, UpdatedAt: now,
+	}, LeaseDuration: lease})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifier.Run(ctx, cycleuc.IntegrityRequest{TenantID: tenantID, Actor: "operator", LeaseOwner: "live", BatchSize: 1, LeaseDuration: lease}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("concurrent verifier = %v", err)
+	}
+	clock.Advance(lease + time.Second)
+	resumed, err := verifier.Run(ctx, cycleuc.IntegrityRequest{TenantID: tenantID, Actor: "operator", LeaseOwner: "live", BatchSize: 1, LeaseDuration: lease})
+	if err != nil || resumed.ID != crashed.ID || resumed.ScannedCount != 2 || resumed.FindingCount != 1 {
+		t.Fatalf("resumed verifier = %+v, err=%v", resumed, err)
+	}
+}
+
+func TestIntegrityVerifierRejectsOversizedBatch(t *testing.T) {
+	clock := &mutableBackfillClock{now: time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)}
+	repository := memory.NewAssessmentCycleIntegrityRepository(memory.NewEngagementRepository(), memory.NewAssessmentCycleRepository())
+	verifier, err := cycleuc.NewIntegrityVerifier(repository, repository, &seqIDGen{}, clock, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := verifier.Run(context.Background(), cycleuc.IntegrityRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "process", BatchSize: 2001}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("oversized batch = %v", err)
+	}
+}

--- a/internal/usecase/assessmentcycle/integrity_runner_test.go
+++ b/internal/usecase/assessmentcycle/integrity_runner_test.go
@@ -52,9 +52,14 @@ func TestIntegrityVerifierPersistsFindingsAndResumesExpiredRun(t *testing.T) {
 	}
 
 	lease := time.Minute
+	sourceGeneration, err := repository.AssessmentCycleIntegrityGeneration(ctx, tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
 	crashed, _, err := repository.AcquireAssessmentCycleIntegrityRun(ctx, ports.AssessmentCycleIntegrityAcquireRequest{Run: ports.AssessmentCycleIntegrityRun{
 		TenantID: tenantID, ID: "integrity-crashed", BatchSize: 1, SnapshotAt: now, State: ports.AssessmentCycleIntegrityRunning,
-		LeaseOwner: "dead", LeaseToken: "dead-token", LeaseExpiresAt: now.Add(lease), CreatedBy: "operator", CreatedAt: now, UpdatedAt: now,
+		SourceGeneration: sourceGeneration,
+		LeaseOwner:       "dead", LeaseToken: "dead-token", LeaseExpiresAt: now.Add(lease), CreatedBy: "operator", CreatedAt: now, UpdatedAt: now,
 	}, LeaseDuration: lease})
 	if err != nil {
 		t.Fatal(err)
@@ -78,5 +83,41 @@ func TestIntegrityVerifierRejectsOversizedBatch(t *testing.T) {
 	}
 	if _, err := verifier.Run(context.Background(), cycleuc.IntegrityRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "process", BatchSize: 2001}); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("oversized batch = %v", err)
+	}
+}
+
+func TestIntegrityCompletionRejectsConcurrentSourceGeneration(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	tenantID := shared.ID("tenant-generation-fence")
+	engagements := memory.NewEngagementRepository()
+	assessment, err := engdom.New("assessment-generation", tenantID, "Before", "", now.Add(-time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(ctx, assessment); err != nil {
+		t.Fatal(err)
+	}
+	repository := memory.NewAssessmentCycleIntegrityRepository(engagements, memory.NewAssessmentCycleRepository())
+	generation, err := repository.AssessmentCycleIntegrityGeneration(ctx, tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, _, err := repository.AcquireAssessmentCycleIntegrityRun(ctx, ports.AssessmentCycleIntegrityAcquireRequest{Run: ports.AssessmentCycleIntegrityRun{
+		TenantID: tenantID, ID: "generation-run", BatchSize: 1, SnapshotAt: now, SourceGeneration: generation,
+		State: ports.AssessmentCycleIntegrityRunning, LeaseOwner: "worker", LeaseToken: "generation-token", LeaseExpiresAt: now.Add(time.Minute),
+		CreatedBy: "operator", CreatedAt: now, UpdatedAt: now,
+	}, LeaseDuration: time.Minute})
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := *assessment
+	changed.Name = "After"
+	changed.Audit.UpdatedAt = now.Add(time.Second)
+	if err := engagements.Update(ctx, &changed); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.FinishAssessmentCycleIntegrityRun(ctx, tenantID, run.ID, "worker", run.LeaseToken, ports.AssessmentCycleIntegrityCompleted, now.Add(2*time.Second)); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("completion over changed source=%v", err)
 	}
 }

--- a/internal/usecase/assessmentcycle/service.go
+++ b/internal/usecase/assessmentcycle/service.go
@@ -2,11 +2,14 @@ package assessmentcycle
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
@@ -70,6 +73,108 @@ type CreateInitialCycleInput struct {
 	ProjectID        shared.ID
 	RootAssessmentID shared.ID
 	Actor            string
+}
+
+type BackfillHistoricalSingletonInput struct {
+	TenantID      shared.ID
+	AssessmentID  shared.ID
+	SchemaVersion int
+	Actor         string
+	DryRun        bool
+}
+
+type BackfillHistoricalSingletonResult struct {
+	CycleID     shared.ID
+	Created     bool
+	WouldCreate bool
+	ReasonCode  string
+}
+
+// BackfillHistoricalSingleton creates one history-preserving singleton Cycle for an eligible legacy Assessment.
+func (s *Service) BackfillHistoricalSingleton(ctx context.Context, in BackfillHistoricalSingletonInput) (BackfillHistoricalSingletonResult, error) {
+	tenantID := shared.TenantOrDefault(in.TenantID)
+	if tenantID.IsZero() || in.AssessmentID.IsZero() || in.SchemaVersion <= 0 {
+		return BackfillHistoricalSingletonResult{}, fmt.Errorf("%w: tenant, assessment, and schema version are required", shared.ErrValidation)
+	}
+	var result BackfillHistoricalSingletonResult
+	err := s.tx.Run(ctx, tenantID, func(txCtx context.Context) error {
+		assessment, err := s.engagements.GetByID(txCtx, in.AssessmentID)
+		if err != nil {
+			return fmt.Errorf("%w: load historical assessment %q: %v", shared.ErrNotFound, in.AssessmentID, err)
+		}
+		if assessment.TenantID != tenantID {
+			return fmt.Errorf("%w: historical assessment %q does not belong to tenant %q", shared.ErrNotFound, in.AssessmentID, tenantID)
+		}
+		if !assessment.ProjectID.IsZero() {
+			return assessmentcycle.ErrHiddenProjectContext
+		}
+		if existing, err := s.cycles.GetCycleByAssessment(txCtx, tenantID, in.AssessmentID); err == nil {
+			result = BackfillHistoricalSingletonResult{CycleID: existing.ID, ReasonCode: "already_in_cycle"}
+			return nil
+		} else if !errors.Is(err, shared.ErrNotFound) {
+			return err
+		}
+		if in.DryRun {
+			result = BackfillHistoricalSingletonResult{WouldCreate: true, ReasonCode: "would_create"}
+			return nil
+		}
+
+		createdAt := assessment.Audit.CreatedAt.UTC()
+		if createdAt.IsZero() {
+			createdAt = s.clock.Now().UTC()
+		}
+		updatedAt := assessment.Audit.UpdatedAt.UTC()
+		if updatedAt.IsZero() || updatedAt.Before(createdAt) {
+			updatedAt = createdAt
+		}
+		createdBy := strings.TrimSpace(assessment.Audit.CreatedBy)
+		updatedBy := strings.TrimSpace(assessment.Audit.UpdatedBy)
+		if updatedBy == "" {
+			updatedBy = createdBy
+		}
+		boundary := assessmentcycle.BoundaryStandalone
+		if !assessment.BusinessAssetID.IsZero() {
+			boundary = assessmentcycle.BoundaryAsset
+		}
+		cycleID := historicalSingletonCycleID(tenantID, in.AssessmentID, in.SchemaVersion)
+		cycle, err := assessmentcycle.NewAssessmentCycle(cycleID, tenantID, assessment.Name, boundary, assessment.BusinessAssetID, "", assessment.ID, createdBy, createdAt)
+		if err != nil {
+			return err
+		}
+		switch assessment.Status {
+		case engdom.StatusCompleted:
+			cycle.Status = assessmentcycle.StatusCompleted
+		case engdom.StatusArchived:
+			cycle.Status = assessmentcycle.StatusArchived
+		}
+		cycle.UpdatedAt, cycle.UpdatedBy = updatedAt, updatedBy
+		root, err := assessmentcycle.NewInitialMember(tenantID, cycleID, assessment.ID, createdBy, createdAt)
+		if err != nil {
+			return err
+		}
+		if err := s.cycles.CreateCycle(txCtx, cycle); err != nil {
+			return err
+		}
+		if err := s.cycles.CreateMember(txCtx, root); err != nil {
+			if cleanup, ok := s.cycles.(ports.AssessmentCycleCompensationRepository); ok {
+				return errors.Join(err, cleanup.DeleteCycle(context.WithoutCancel(txCtx), tenantID, cycleID))
+			}
+			return err
+		}
+		if s.audit != nil {
+			_ = s.audit.Record(txCtx, ports.AuditEntry{Actor: strings.TrimSpace(in.Actor), Action: "assessment_cycle.backfill_created", Target: cycleID.String(), Metadata: map[string]string{
+				"tenant_id": tenantID.String(), "assessment_id": assessment.ID.String(), "schema_version": fmt.Sprintf("%d", in.SchemaVersion),
+			}, At: s.clock.Now().UTC()})
+		}
+		result = BackfillHistoricalSingletonResult{CycleID: cycleID, Created: true, ReasonCode: "created"}
+		return nil
+	})
+	return result, err
+}
+
+func historicalSingletonCycleID(tenantID, assessmentID shared.ID, schemaVersion int) shared.ID {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s\x00%s\x00%d", tenantID, assessmentID, schemaVersion)))
+	return shared.ID("acy-bf-" + hex.EncodeToString(sum[:16]))
 }
 
 // CreateInitialCycle atomically creates an AssessmentCycle and its root initial Member.
@@ -183,6 +288,9 @@ func (s *Service) CreateInitialCycle(ctx context.Context, in CreateInitialCycleI
 			return err
 		}
 		if err := s.cycles.CreateMember(txCtx, rootMember); err != nil {
+			if cleanup, ok := s.cycles.(ports.AssessmentCycleCompensationRepository); ok {
+				return errors.Join(err, cleanup.DeleteCycle(context.WithoutCancel(txCtx), tenantID, cycleID))
+			}
 			return err
 		}
 
@@ -221,8 +329,8 @@ type CreateRetestInput struct {
 // CreateRetest atomically adds a new re-test member to an open AssessmentCycle and updates the cycle sequence.
 func (s *Service) CreateRetest(ctx context.Context, in CreateRetestInput) (*assessmentcycle.Member, error) {
 	tenantID := shared.TenantOrDefault(in.TenantID)
-	if tenantID.IsZero() || in.CycleID.IsZero() || in.PredecessorAssessmentID.IsZero() || in.NewAssessmentID.IsZero() {
-		return nil, fmt.Errorf("%w: tenant, cycle, predecessor, and new assessment ids are required", shared.ErrValidation)
+	if tenantID.IsZero() || in.CycleID.IsZero() || in.NewAssessmentID.IsZero() {
+		return nil, fmt.Errorf("%w: tenant, cycle, and new assessment ids are required", shared.ErrValidation)
 	}
 
 	var createdMember *assessmentcycle.Member
@@ -234,16 +342,23 @@ func (s *Service) CreateRetest(ctx context.Context, in CreateRetestInput) (*asse
 			return err
 		}
 		if cycle.Status != assessmentcycle.StatusOpen {
-			return fmt.Errorf("%w: cannot add retest to non-open cycle (status: %s)", shared.ErrValidation, cycle.Status)
+			if cycle.Status == assessmentcycle.StatusCompleted {
+				return assessmentcycle.ErrCycleReopenRequired
+			}
+			return assessmentcycle.ErrCycleArchived
+		}
+		predecessorID := in.PredecessorAssessmentID
+		if predecessorID.IsZero() {
+			predecessorID = cycle.SelectedHeadAssessmentID
 		}
 
 		// 2. Validate predecessor member
-		predMember, err := s.cycles.GetMember(txCtx, tenantID, in.CycleID, in.PredecessorAssessmentID)
+		predMember, err := s.cycles.GetMember(txCtx, tenantID, in.CycleID, predecessorID)
 		if err != nil {
-			return fmt.Errorf("%w: predecessor %q not found in cycle: %v", shared.ErrNotFound, in.PredecessorAssessmentID, err)
+			return fmt.Errorf("%w: predecessor %q not found in cycle: %v", shared.ErrNotFound, predecessorID, err)
 		}
 		if predMember.IsArchived() {
-			return fmt.Errorf("%w: predecessor %q is archived", shared.ErrValidation, in.PredecessorAssessmentID)
+			return fmt.Errorf("%w: predecessor %q is archived", shared.ErrValidation, predecessorID)
 		}
 
 		// 3. Validate new assessment
@@ -288,14 +403,15 @@ func (s *Service) CreateRetest(ctx context.Context, in CreateRetestInput) (*asse
 			expectedVer = cycle.Version
 		}
 
-		retestNumber, err := cycle.AdvanceRetest(in.NewAssessmentID, in.PredecessorAssessmentID, expectedVer, in.Actor, now)
+		originalCycle := *cycle
+		retestNumber, err := cycle.AdvanceRetest(in.NewAssessmentID, predecessorID, expectedVer, in.Actor, now)
 		if err != nil {
 			return err
 		}
 
 		// 5. Build member
 		retestMember, err := assessmentcycle.NewRetestMember(
-			tenantID, in.CycleID, in.NewAssessmentID, in.PredecessorAssessmentID,
+			tenantID, in.CycleID, in.NewAssessmentID, predecessorID,
 			retestNumber, in.Actor, now,
 		)
 		if err != nil {
@@ -307,7 +423,7 @@ func (s *Service) CreateRetest(ctx context.Context, in CreateRetestInput) (*asse
 			return err
 		}
 		if err := s.cycles.CreateMember(txCtx, retestMember); err != nil {
-			return err
+			return errors.Join(err, s.cycles.UpdateCycleCAS(context.WithoutCancel(txCtx), &originalCycle, cycle.Version))
 		}
 
 		// 7. Audit event
@@ -319,7 +435,7 @@ func (s *Service) CreateRetest(ctx context.Context, in CreateRetestInput) (*asse
 				Metadata: map[string]string{
 					"tenant_id":        tenantID.String(),
 					"assessment_id":    in.NewAssessmentID.String(),
-					"predecessor_id":   in.PredecessorAssessmentID.String(),
+					"predecessor_id":   predecessorID.String(),
 					"retest_number":    fmt.Sprintf("%d", retestNumber),
 					"selected_head_id": cycle.SelectedHeadAssessmentID.String(),
 				},
@@ -692,6 +808,35 @@ func (s *Service) ArchiveCycle(ctx context.Context, in ArchiveCycleInput) error 
 
 		return nil
 	})
+}
+
+func (s *Service) compensateInitialCreate(ctx context.Context, tenantID, cycleID shared.ID) error {
+	cleanup, ok := s.cycles.(ports.AssessmentCycleCompensationRepository)
+	if !ok {
+		return fmt.Errorf("%w: assessment cycle compensation is unavailable", shared.ErrConflict)
+	}
+	return cleanup.DeleteCycle(ctx, shared.TenantOrDefault(tenantID), cycleID)
+}
+
+func (s *Service) compensateCycleMutation(ctx context.Context, original *assessmentcycle.AssessmentCycle, createdAssessmentID shared.ID) error {
+	if original == nil {
+		return fmt.Errorf("%w: original assessment cycle is required", shared.ErrValidation)
+	}
+	current, err := s.cycles.GetCycle(ctx, original.TenantID, original.ID)
+	if err != nil {
+		return err
+	}
+	if err := s.cycles.UpdateCycleCAS(ctx, original, current.Version); err != nil {
+		return err
+	}
+	if createdAssessmentID.IsZero() {
+		return nil
+	}
+	cleanup, ok := s.cycles.(ports.AssessmentCycleCompensationRepository)
+	if !ok {
+		return fmt.Errorf("%w: assessment cycle member compensation is unavailable", shared.ErrConflict)
+	}
+	return cleanup.DeleteMember(ctx, original.TenantID, original.ID, createdAssessmentID)
 }
 
 // GetCycle retrieves an AssessmentCycle by ID.

--- a/internal/usecase/assessmentcycle/service.go
+++ b/internal/usecase/assessmentcycle/service.go
@@ -162,9 +162,11 @@ func (s *Service) BackfillHistoricalSingleton(ctx context.Context, in BackfillHi
 			return err
 		}
 		if s.audit != nil {
-			_ = s.audit.Record(txCtx, ports.AuditEntry{Actor: strings.TrimSpace(in.Actor), Action: "assessment_cycle.backfill_created", Target: cycleID.String(), Metadata: map[string]string{
+			if err := s.audit.Record(txCtx, ports.AuditEntry{Actor: strings.TrimSpace(in.Actor), Action: "assessment_cycle.backfill_created", Target: cycleID.String(), Metadata: map[string]string{
 				"tenant_id": tenantID.String(), "assessment_id": assessment.ID.String(), "schema_version": fmt.Sprintf("%d", in.SchemaVersion),
-			}, At: s.clock.Now().UTC()})
+			}, At: s.clock.Now().UTC()}); err != nil {
+				return fmt.Errorf("audit assessment cycle backfill: %w", err)
+			}
 		}
 		result = BackfillHistoricalSingletonResult{CycleID: cycleID, Created: true, ReasonCode: "created"}
 		return nil
@@ -296,7 +298,7 @@ func (s *Service) CreateInitialCycle(ctx context.Context, in CreateInitialCycleI
 
 		// 8. Audit event
 		if s.audit != nil {
-			_ = s.audit.Record(txCtx, ports.AuditEntry{
+			if err := s.audit.Record(txCtx, ports.AuditEntry{
 				Actor:  in.Actor,
 				Action: "assessment_cycle.created",
 				Target: cycleID.String(),
@@ -306,7 +308,9 @@ func (s *Service) CreateInitialCycle(ctx context.Context, in CreateInitialCycleI
 					"root_assessment_id": in.RootAssessmentID.String(),
 				},
 				At: now,
-			})
+			}); err != nil {
+				return fmt.Errorf("audit assessment cycle creation: %w", err)
+			}
 		}
 
 		createdCycle = cycle
@@ -428,7 +432,7 @@ func (s *Service) CreateRetest(ctx context.Context, in CreateRetestInput) (*asse
 
 		// 7. Audit event
 		if s.audit != nil {
-			_ = s.audit.Record(txCtx, ports.AuditEntry{
+			if err := s.audit.Record(txCtx, ports.AuditEntry{
 				Actor:  in.Actor,
 				Action: "assessment_cycle.retest_created",
 				Target: in.CycleID.String(),
@@ -440,7 +444,9 @@ func (s *Service) CreateRetest(ctx context.Context, in CreateRetestInput) (*asse
 					"selected_head_id": cycle.SelectedHeadAssessmentID.String(),
 				},
 				At: now,
-			})
+			}); err != nil {
+				return fmt.Errorf("audit assessment cycle re-test creation: %w", err)
+			}
 		}
 
 		createdMember = retestMember
@@ -542,7 +548,7 @@ func (s *Service) ReparentWithinCycle(ctx context.Context, in ReparentInput) err
 
 		// 8. Audit event
 		if s.audit != nil {
-			_ = s.audit.Record(txCtx, ports.AuditEntry{
+			if err := s.audit.Record(txCtx, ports.AuditEntry{
 				Actor:  in.Actor,
 				Action: "assessment_cycle.reparented",
 				Target: in.CycleID.String(),
@@ -552,7 +558,9 @@ func (s *Service) ReparentWithinCycle(ctx context.Context, in ReparentInput) err
 					"new_predecessor_id": in.NewPredecessorAssessmentID.String(),
 				},
 				At: now,
-			})
+			}); err != nil {
+				return fmt.Errorf("audit assessment cycle reparent: %w", err)
+			}
 		}
 
 		return nil
@@ -615,7 +623,7 @@ func (s *Service) SelectHead(ctx context.Context, in SelectHeadInput) error {
 		}
 
 		if s.audit != nil {
-			_ = s.audit.Record(txCtx, ports.AuditEntry{
+			if err := s.audit.Record(txCtx, ports.AuditEntry{
 				Actor:  in.Actor,
 				Action: "assessment_cycle.head_selected",
 				Target: in.CycleID.String(),
@@ -624,7 +632,9 @@ func (s *Service) SelectHead(ctx context.Context, in SelectHeadInput) error {
 					"selected_head_id": in.TargetAssessmentID.String(),
 				},
 				At: now,
-			})
+			}); err != nil {
+				return fmt.Errorf("audit assessment cycle head selection: %w", err)
+			}
 		}
 
 		return nil
@@ -694,7 +704,7 @@ func (s *Service) ArchiveMember(ctx context.Context, in ArchiveMemberInput) erro
 		}
 
 		if s.audit != nil {
-			_ = s.audit.Record(txCtx, ports.AuditEntry{
+			if err := s.audit.Record(txCtx, ports.AuditEntry{
 				Actor:  in.Actor,
 				Action: "assessment_cycle.member_archived",
 				Target: in.CycleID.String(),
@@ -703,7 +713,9 @@ func (s *Service) ArchiveMember(ctx context.Context, in ArchiveMemberInput) erro
 					"assessment_id": in.AssessmentID.String(),
 				},
 				At: now,
-			})
+			}); err != nil {
+				return fmt.Errorf("audit assessment cycle member archive: %w", err)
+			}
 		}
 
 		return nil
@@ -715,13 +727,15 @@ type ReopenCycleInput struct {
 	CycleID              shared.ID
 	ExpectedCycleVersion int64
 	Actor                string
+	Reason               string
 }
 
 // ReopenCycle transitions a completed AssessmentCycle back to open.
 func (s *Service) ReopenCycle(ctx context.Context, in ReopenCycleInput) error {
 	tenantID := shared.TenantOrDefault(in.TenantID)
-	if tenantID.IsZero() || in.CycleID.IsZero() {
-		return fmt.Errorf("%w: tenant and cycle ids are required", shared.ErrValidation)
+	reason := strings.TrimSpace(in.Reason)
+	if tenantID.IsZero() || in.CycleID.IsZero() || reason == "" || len(reason) > 1024 {
+		return fmt.Errorf("%w: tenant, cycle, and a bounded reopen reason are required", shared.ErrValidation)
 	}
 
 	return s.tx.Run(ctx, tenantID, func(txCtx context.Context) error {
@@ -745,15 +759,18 @@ func (s *Service) ReopenCycle(ctx context.Context, in ReopenCycleInput) error {
 		}
 
 		if s.audit != nil {
-			_ = s.audit.Record(txCtx, ports.AuditEntry{
+			if err := s.audit.Record(txCtx, ports.AuditEntry{
 				Actor:  in.Actor,
 				Action: "assessment_cycle.reopened",
 				Target: in.CycleID.String(),
 				Metadata: map[string]string{
 					"tenant_id": tenantID.String(),
+					"reason":    reason,
 				},
 				At: now,
-			})
+			}); err != nil {
+				return fmt.Errorf("audit assessment cycle reopen: %w", err)
+			}
 		}
 
 		return nil
@@ -795,7 +812,7 @@ func (s *Service) ArchiveCycle(ctx context.Context, in ArchiveCycleInput) error 
 		}
 
 		if s.audit != nil {
-			_ = s.audit.Record(txCtx, ports.AuditEntry{
+			if err := s.audit.Record(txCtx, ports.AuditEntry{
 				Actor:  in.Actor,
 				Action: "assessment_cycle.archived",
 				Target: in.CycleID.String(),
@@ -803,7 +820,9 @@ func (s *Service) ArchiveCycle(ctx context.Context, in ArchiveCycleInput) error 
 					"tenant_id": tenantID.String(),
 				},
 				At: now,
-			})
+			}); err != nil {
+				return fmt.Errorf("audit assessment cycle archive: %w", err)
+			}
 		}
 
 		return nil

--- a/internal/usecase/assessmentcycle/service_test.go
+++ b/internal/usecase/assessmentcycle/service_test.go
@@ -374,7 +374,7 @@ func TestService_ArchiveMemberAndReopenCycle(t *testing.T) {
 		}
 
 		// Reopen from archived is rejected by state machine
-		err := svc.ReopenCycle(ctx, uc.ReopenCycleInput{TenantID: tenantID, CycleID: cycle.ID, Actor: "alice"})
+		err := svc.ReopenCycle(ctx, uc.ReopenCycleInput{TenantID: tenantID, CycleID: cycle.ID, Actor: "alice", Reason: "continue remediation verification"})
 		if !errors.Is(err, shared.ErrValidation) {
 			t.Fatalf("expected ErrValidation reopening archived cycle, got %v", err)
 		}

--- a/internal/usecase/assessmentsnapshot/backfill.go
+++ b/internal/usecase/assessmentsnapshot/backfill.go
@@ -1,0 +1,467 @@
+package assessmentsnapshot
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	AssessmentSnapshotBackfillSchemaVersion = 1
+	DefaultAssessmentSnapshotBackfillBatch  = 500
+	MaxAssessmentSnapshotBackfillBatch      = 2000
+	assessmentSnapshotBackfillRetries       = 3
+	defaultAssessmentSnapshotBackfillLease  = 10 * time.Minute
+)
+
+const (
+	SnapshotBackfillOutcomeCreated     = "created"
+	SnapshotBackfillOutcomeWouldCreate = "would_create"
+	SnapshotBackfillOutcomeSkipped     = "skipped"
+	SnapshotBackfillOutcomeFailed      = "failed"
+
+	SnapshotBackfillReasonCreated               = "created"
+	SnapshotBackfillReasonWouldCreate           = "would_create"
+	SnapshotBackfillReasonAlreadyProjected      = "already_projected"
+	SnapshotBackfillReasonCycleMissing          = "cycle_not_found"
+	SnapshotBackfillReasonScanRunMissing        = "scan_run_not_found"
+	SnapshotBackfillReasonVerifiedRunMissing    = "verified_run_unavailable"
+	SnapshotBackfillReasonInvalidSource         = "invalid_source"
+	SnapshotBackfillReasonSourceReadFailed      = "source_read_failed"
+	SnapshotBackfillReasonProjectionWriteFailed = "projection_write_failed"
+)
+
+type LegacyProjector struct {
+	snapshots ports.AssessmentSnapshotRepository
+	cycles    ports.AssessmentCycleRepository
+	tx        ports.TenantTransactionRunner
+	ids       ports.IDGenerator
+	clock     ports.Clock
+	audit     ports.AuditLogger
+}
+
+func NewLegacyProjector(snapshots ports.AssessmentSnapshotRepository, cycles ports.AssessmentCycleRepository, tx ports.TenantTransactionRunner, ids ports.IDGenerator, clock ports.Clock, audit ports.AuditLogger) (*LegacyProjector, error) {
+	if snapshots == nil || cycles == nil || tx == nil || ids == nil || clock == nil || audit == nil {
+		return nil, fmt.Errorf("%w: legacy assessment snapshot projector dependencies are required", shared.ErrValidation)
+	}
+	return &LegacyProjector{snapshots: snapshots, cycles: cycles, tx: tx, ids: ids, clock: clock, audit: audit}, nil
+}
+
+type LegacyProjectionInput struct {
+	TenantID     shared.ID
+	AssessmentID shared.ID
+	Actor        string
+	SourceHash   string
+	SelectedRun  domain.SelectedRun
+	DryRun       bool
+}
+
+type LegacyProjectionResult struct {
+	SnapshotID  shared.ID
+	Created     bool
+	WouldCreate bool
+	ReasonCode  string
+}
+
+func (projector *LegacyProjector) Project(ctx context.Context, input LegacyProjectionInput) (LegacyProjectionResult, error) {
+	tenantID, actor := shared.TenantOrDefault(input.TenantID), strings.TrimSpace(input.Actor)
+	if tenantID.IsZero() || input.AssessmentID.IsZero() || actor == "" || len(actor) > 256 || !validSnapshotBackfillHash(input.SourceHash) {
+		return LegacyProjectionResult{}, fmt.Errorf("%w: legacy assessment snapshot projection input is invalid", shared.ErrValidation)
+	}
+	requestKey := legacyProjectionRequestKey(input.SourceHash)
+	if existing, err := projector.snapshots.GetByRequestKey(ctx, tenantID, input.AssessmentID, requestKey); err == nil {
+		return LegacyProjectionResult{SnapshotID: existing.ID, ReasonCode: SnapshotBackfillReasonAlreadyProjected}, nil
+	} else if !errors.Is(err, shared.ErrNotFound) {
+		return LegacyProjectionResult{}, err
+	}
+	cycle, err := projector.cycles.GetCycleByAssessment(ctx, tenantID, input.AssessmentID)
+	if errors.Is(err, shared.ErrNotFound) {
+		return LegacyProjectionResult{ReasonCode: SnapshotBackfillReasonCycleMissing}, nil
+	}
+	if err != nil {
+		return LegacyProjectionResult{}, err
+	}
+	if _, err := projector.cycles.GetMember(ctx, tenantID, cycle.ID, input.AssessmentID); errors.Is(err, shared.ErrNotFound) {
+		return LegacyProjectionResult{ReasonCode: SnapshotBackfillReasonCycleMissing}, nil
+	} else if err != nil {
+		return LegacyProjectionResult{}, err
+	}
+	if input.DryRun {
+		return LegacyProjectionResult{WouldCreate: true, ReasonCode: SnapshotBackfillReasonWouldCreate}, nil
+	}
+
+	var result LegacyProjectionResult
+	err = projector.tx.Run(ctx, tenantID, func(txCtx context.Context) error {
+		locked, err := projector.cycles.LockCycleForUpdate(txCtx, tenantID, cycle.ID)
+		if err != nil {
+			return err
+		}
+		if _, err := projector.cycles.GetMember(txCtx, tenantID, locked.ID, input.AssessmentID); err != nil {
+			return err
+		}
+		now := projector.clock.Now().UTC()
+		candidate, err := domain.NewFinalized(tenantID, projector.ids.NewID(), locked.ID, input.AssessmentID, domain.Boundary{
+			Kind: locked.BoundaryKind, BusinessAssetID: locked.BusinessAssetID, ProjectID: locked.ProjectID,
+		}, requestKey, actor, now, []domain.SelectedRun{input.SelectedRun})
+		if err != nil {
+			return err
+		}
+		if candidate.Provenance != domain.ProvenanceLegacy {
+			return fmt.Errorf("%w: projected assessment snapshot must remain legacy", shared.ErrValidation)
+		}
+		candidate.RequestHash = legacyProjectionRequestHash(input.SourceHash, candidate.ContentHash)
+		stored, created, err := projector.snapshots.CreateLegacyProjection(txCtx, candidate)
+		if err != nil {
+			return err
+		}
+		result.SnapshotID = stored.ID
+		if !created {
+			result.ReasonCode = SnapshotBackfillReasonAlreadyProjected
+			return nil
+		}
+		result.Created, result.ReasonCode = true, SnapshotBackfillReasonCreated
+		if err := projector.audit.Record(txCtx, ports.AuditEntry{
+			Actor: actor, Action: "assessment_snapshot.legacy_projected", Target: stored.ID.String(), At: now,
+			Metadata: map[string]string{
+				"tenant_id": tenantID.String(), "cycle_id": locked.ID.String(), "assessment_id": input.AssessmentID.String(),
+				"source_hash": input.SourceHash, "content_hash": stored.ContentHash, "snapshot_number": strconv.Itoa(stored.SnapshotNumber),
+			},
+		}); err != nil {
+			return fmt.Errorf("audit legacy assessment snapshot projection: %w", err)
+		}
+		return nil
+	})
+	return result, err
+}
+
+type legacySnapshotProjector interface {
+	Project(context.Context, LegacyProjectionInput) (LegacyProjectionResult, error)
+}
+
+type AssessmentSnapshotBackfillObserver interface {
+	ObserveAssessmentSnapshotBackfillItem(outcome string)
+	ObserveAssessmentSnapshotBackfillRun(state string)
+}
+
+type BackfillRunner struct {
+	projector legacySnapshotProjector
+	source    ports.AssessmentSnapshotBackfillSource
+	store     ports.AssessmentSnapshotBackfillStore
+	runs      ports.AssessmentSnapshotRunReader
+	results   ports.ScanResultStore
+	ids       ports.IDGenerator
+	clock     ports.Clock
+	audit     ports.AuditLogger
+	observer  AssessmentSnapshotBackfillObserver
+}
+
+func NewBackfillRunner(projector legacySnapshotProjector, source ports.AssessmentSnapshotBackfillSource, store ports.AssessmentSnapshotBackfillStore, runs ports.AssessmentSnapshotRunReader, results ports.ScanResultStore, ids ports.IDGenerator, clock ports.Clock, audit ports.AuditLogger, observer AssessmentSnapshotBackfillObserver) (*BackfillRunner, error) {
+	if projector == nil || source == nil || store == nil || runs == nil || results == nil || ids == nil || clock == nil {
+		return nil, fmt.Errorf("%w: assessment snapshot backfill dependencies are required", shared.ErrValidation)
+	}
+	return &BackfillRunner{projector: projector, source: source, store: store, runs: runs, results: results, ids: ids, clock: clock, audit: audit, observer: observer}, nil
+}
+
+type BackfillRequest struct {
+	TenantID      shared.ID
+	Actor         string
+	LeaseOwner    string
+	DryRun        bool
+	BatchSize     int
+	ResumeAfter   shared.ID
+	LeaseDuration time.Duration
+}
+
+func (runner *BackfillRunner) Run(ctx context.Context, request BackfillRequest) (ports.AssessmentSnapshotBackfillRun, error) {
+	tenantID := shared.TenantOrDefault(request.TenantID)
+	actor, leaseOwner := strings.TrimSpace(request.Actor), strings.TrimSpace(request.LeaseOwner)
+	if tenantID.IsZero() || actor == "" || len(actor) > 256 || leaseOwner == "" || len(leaseOwner) > 256 {
+		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: tenant, actor, and lease owner are required", shared.ErrValidation)
+	}
+	batchSize := request.BatchSize
+	if batchSize == 0 {
+		batchSize = DefaultAssessmentSnapshotBackfillBatch
+	}
+	if batchSize < 1 || batchSize > MaxAssessmentSnapshotBackfillBatch {
+		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: batch size must be between 1 and %d", shared.ErrValidation, MaxAssessmentSnapshotBackfillBatch)
+	}
+	leaseDuration := request.LeaseDuration
+	if leaseDuration <= 0 {
+		leaseDuration = defaultAssessmentSnapshotBackfillLease
+	}
+	now := runner.clock.Now().UTC()
+	acquisitionID := runner.ids.NewID()
+	run, resumed, err := runner.store.AcquireAssessmentSnapshotBackfillRun(ctx, ports.AssessmentSnapshotBackfillAcquireRequest{
+		Run: ports.AssessmentSnapshotBackfillRun{
+			TenantID: tenantID, ID: acquisitionID, SchemaVersion: AssessmentSnapshotBackfillSchemaVersion,
+			DryRun: request.DryRun, BatchSize: batchSize, SnapshotAt: now, State: ports.AssessmentSnapshotBackfillRunning,
+			LeaseOwner: leaseOwner, LeaseToken: acquisitionID, LeaseExpiresAt: now.Add(leaseDuration), CreatedBy: actor, CreatedAt: now, UpdatedAt: now,
+		},
+		InitialCheckpoint: request.ResumeAfter,
+		LeaseDuration:     leaseDuration,
+	})
+	if err != nil {
+		return ports.AssessmentSnapshotBackfillRun{}, err
+	}
+	runner.record(ctx, actor, "assessment_snapshot.backfill_started", run.ID, map[string]string{
+		"tenant_id": tenantID.String(), "dry_run": strconv.FormatBool(run.DryRun), "resumed": strconv.FormatBool(resumed), "batch_size": strconv.Itoa(run.BatchSize),
+	})
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return runner.finish(ctx, run, leaseOwner, ports.AssessmentSnapshotBackfillCancelled, actor, err)
+		}
+		assessments, err := runner.source.ListAssessmentSnapshotBackfillEngagements(ctx, tenantID, run.CheckpointAssessment, run.SnapshotAt, run.BatchSize)
+		if err != nil {
+			return runner.finish(ctx, run, leaseOwner, snapshotBackfillTerminalState(err), actor, err)
+		}
+		if len(assessments) == 0 {
+			return runner.finish(ctx, run, leaseOwner, ports.AssessmentSnapshotBackfillCompleted, actor, nil)
+		}
+		if len(assessments) > run.BatchSize {
+			return runner.finish(ctx, run, leaseOwner, ports.AssessmentSnapshotBackfillFailed, actor, fmt.Errorf("backfill source returned %d rows for limit %d", len(assessments), run.BatchSize))
+		}
+		for _, assessment := range assessments {
+			if err := ctx.Err(); err != nil {
+				return runner.finish(ctx, run, leaseOwner, ports.AssessmentSnapshotBackfillCancelled, actor, err)
+			}
+			if _, err := runner.store.GetAssessmentSnapshotBackfillItem(ctx, tenantID, run.ID, assessment.ID); err == nil {
+				continue
+			} else if !errors.Is(err, shared.ErrNotFound) {
+				return runner.finish(ctx, run, leaseOwner, snapshotBackfillTerminalState(err), actor, err)
+			}
+			item, created, err := runner.store.CommitAssessmentSnapshotBackfillItem(ctx, tenantID, run.ID, run.LeaseToken, runner.clock.Now().UTC(), func(txCtx context.Context) (ports.AssessmentSnapshotBackfillItem, error) {
+				return runner.processItem(txCtx, run, assessment.ID, actor), nil
+			})
+			if err != nil {
+				return runner.finish(ctx, run, leaseOwner, snapshotBackfillTerminalState(err), actor, err)
+			}
+			if created && runner.observer != nil {
+				runner.observer.ObserveAssessmentSnapshotBackfillItem(item.Outcome)
+			}
+		}
+		checkpoint := assessments[len(assessments)-1].ID
+		run, err = runner.store.AdvanceAssessmentSnapshotBackfillRun(ctx, tenantID, run.ID, leaseOwner, run.LeaseToken, checkpoint, runner.clock.Now().UTC(), leaseDuration)
+		if err != nil {
+			return runner.finish(ctx, run, leaseOwner, snapshotBackfillTerminalState(err), actor, err)
+		}
+		runner.record(ctx, actor, "assessment_snapshot.backfill_batch_committed", run.ID, map[string]string{
+			"tenant_id": tenantID.String(), "checkpoint_assessment_id": checkpoint.String(), "processed_count": strconv.Itoa(run.ProcessedCount),
+		})
+	}
+}
+
+type projectionSource struct {
+	selected   domain.SelectedRun
+	sourceHash string
+	reasonCode string
+}
+
+func (runner *BackfillRunner) processItem(ctx context.Context, run ports.AssessmentSnapshotBackfillRun, assessmentID shared.ID, actor string) ports.AssessmentSnapshotBackfillItem {
+	source, sourceErr := runner.loadProjectionSource(ctx, run, assessmentID)
+	if source.sourceHash == "" {
+		source.sourceHash = fallbackProjectionSourceHash(assessmentID, run.SchemaVersion)
+	}
+	item := ports.AssessmentSnapshotBackfillItem{
+		TenantID: run.TenantID, RunID: run.ID, AssessmentID: assessmentID, SchemaVersion: run.SchemaVersion,
+		IdempotencyKey: snapshotBackfillIdempotencyKey(assessmentID, run.SchemaVersion, source.sourceHash), SourceHash: source.sourceHash,
+		ProcessedAt: runner.clock.Now().UTC(),
+	}
+	if sourceErr != nil {
+		item.Outcome, item.ReasonCode, item.Retryable, item.RepairGuidance = snapshotBackfillFailure(sourceErr, true)
+		return item
+	}
+	if source.reasonCode != "" {
+		item.Outcome, item.ReasonCode = SnapshotBackfillOutcomeSkipped, source.reasonCode
+		return item
+	}
+	var (
+		result LegacyProjectionResult
+		err    error
+	)
+	for attempt := 0; attempt < assessmentSnapshotBackfillRetries; attempt++ {
+		result, err = runner.projector.Project(ctx, LegacyProjectionInput{
+			TenantID: run.TenantID, AssessmentID: assessmentID, Actor: actor, SourceHash: source.sourceHash,
+			SelectedRun: source.selected, DryRun: run.DryRun,
+		})
+		if err == nil || !retryableAssessmentSnapshotBackfillError(err) {
+			break
+		}
+	}
+	if err != nil {
+		item.Outcome, item.ReasonCode, item.Retryable, item.RepairGuidance = snapshotBackfillFailure(err, false)
+		return item
+	}
+	item.SnapshotID = result.SnapshotID
+	switch {
+	case result.Created:
+		item.Outcome, item.ReasonCode = SnapshotBackfillOutcomeCreated, SnapshotBackfillReasonCreated
+	case result.WouldCreate:
+		item.Outcome, item.ReasonCode = SnapshotBackfillOutcomeWouldCreate, SnapshotBackfillReasonWouldCreate
+	default:
+		item.Outcome, item.ReasonCode = SnapshotBackfillOutcomeSkipped, result.ReasonCode
+	}
+	return item
+}
+
+func (runner *BackfillRunner) loadProjectionSource(ctx context.Context, run ports.AssessmentSnapshotBackfillRun, assessmentID shared.ID) (projectionSource, error) {
+	resultData, resultErr := runner.results.LatestResult(ctx, assessmentID)
+	if resultErr != nil && !errors.Is(resultErr, shared.ErrNotFound) {
+		return projectionSource{}, resultErr
+	}
+	resultHash := ""
+	if resultErr == nil {
+		// ponytail: scan_results is source evidence only, so raw stored bytes are sufficient here;
+		// switch to canonical JSON hashing if a second storage representation participates.
+		sum := sha256.Sum256(resultData)
+		resultHash = hex.EncodeToString(sum[:])
+	}
+	runs, err := runner.runs.ListScanRuns(ctx, run.TenantID, assessmentID)
+	if err != nil {
+		return projectionSource{}, err
+	}
+	eligible := make([]scanrun.ScanRun, 0, len(runs))
+	for _, candidate := range runs {
+		if !candidate.CreatedAt.After(run.SnapshotAt) {
+			eligible = append(eligible, candidate)
+		}
+	}
+	if len(eligible) == 0 {
+		return projectionSource{sourceHash: projectionSourceHash(assessmentID, run.SchemaVersion, "", "", resultHash), reasonCode: SnapshotBackfillReasonScanRunMissing}, nil
+	}
+	for _, candidate := range eligible {
+		if candidate.Provenance != scanrun.ProvenanceNative || validateTrustedScanRun(candidate) != nil {
+			continue
+		}
+		if err := validateProjectionRun(candidate, run.TenantID, assessmentID); err != nil {
+			return projectionSource{}, err
+		}
+		return projectionSource{
+			selected:   domain.SelectedRun{ID: candidate.ID, ManifestHash: candidate.ManifestHash, Provenance: scanrun.ProvenanceLegacy, TerminalStatus: candidate.TerminalStatus, Lanes: candidate.Lanes},
+			sourceHash: projectionSourceHash(assessmentID, run.SchemaVersion, candidate.ID, candidate.ManifestHash, resultHash),
+		}, nil
+	}
+	for _, candidate := range eligible {
+		if candidate.Provenance != scanrun.ProvenanceLegacy {
+			continue
+		}
+		if err := validateProjectionRun(candidate, run.TenantID, assessmentID); err != nil {
+			return projectionSource{}, err
+		}
+		hash := legacyRunHash(candidate)
+		return projectionSource{
+			selected:   domain.SelectedRun{ID: candidate.ID, ManifestHash: hash, Provenance: scanrun.ProvenanceLegacy, TerminalStatus: candidate.TerminalStatus, Lanes: candidate.Lanes},
+			sourceHash: projectionSourceHash(assessmentID, run.SchemaVersion, candidate.ID, hash, resultHash),
+		}, nil
+	}
+	return projectionSource{sourceHash: projectionSourceHash(assessmentID, run.SchemaVersion, "", "", resultHash), reasonCode: SnapshotBackfillReasonVerifiedRunMissing}, nil
+}
+
+func validateProjectionRun(run scanrun.ScanRun, tenantID, assessmentID shared.ID) error {
+	if strings.TrimSpace(run.ID) == "" || run.TenantID != tenantID || run.EngagementID != assessmentID || run.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: assessment snapshot projection run ownership is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (runner *BackfillRunner) finish(ctx context.Context, run ports.AssessmentSnapshotBackfillRun, leaseOwner string, state ports.AssessmentSnapshotBackfillState, actor string, cause error) (ports.AssessmentSnapshotBackfillRun, error) {
+	finishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	finished, err := runner.store.FinishAssessmentSnapshotBackfillRun(finishCtx, run.TenantID, run.ID, leaseOwner, run.LeaseToken, state, runner.clock.Now().UTC())
+	if err != nil {
+		if cause != nil {
+			return run, errors.Join(cause, err)
+		}
+		return run, err
+	}
+	if runner.observer != nil {
+		runner.observer.ObserveAssessmentSnapshotBackfillRun(string(state))
+	}
+	runner.record(finishCtx, actor, "assessment_snapshot.backfill_"+string(state), run.ID, map[string]string{
+		"tenant_id": run.TenantID.String(), "processed_count": strconv.Itoa(finished.ProcessedCount), "created_count": strconv.Itoa(finished.CreatedCount),
+		"would_create_count": strconv.Itoa(finished.WouldCreateCount), "skipped_count": strconv.Itoa(finished.SkippedCount), "failed_count": strconv.Itoa(finished.FailedCount),
+	})
+	if cause != nil {
+		return finished, cause
+	}
+	return finished, nil
+}
+
+func (runner *BackfillRunner) record(ctx context.Context, actor, action string, target shared.ID, metadata map[string]string) {
+	if runner.audit != nil {
+		_ = runner.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: action, Target: target.String(), Metadata: metadata, At: runner.clock.Now().UTC()})
+	}
+}
+
+func retryableAssessmentSnapshotBackfillError(err error) bool {
+	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, shared.ErrValidation) && !errors.Is(err, shared.ErrNotFound) && !errors.Is(err, shared.ErrConflict)
+}
+
+func snapshotBackfillTerminalState(err error) ports.AssessmentSnapshotBackfillState {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return ports.AssessmentSnapshotBackfillCancelled
+	}
+	return ports.AssessmentSnapshotBackfillFailed
+}
+
+func snapshotBackfillFailure(err error, sourceRead bool) (outcome, reason string, retryable bool, guidance string) {
+	switch {
+	case errors.Is(err, shared.ErrValidation):
+		return SnapshotBackfillOutcomeFailed, SnapshotBackfillReasonInvalidSource, false, "Correct the owned scan-run provenance before rerunning the projection."
+	case errors.Is(err, shared.ErrNotFound):
+		return SnapshotBackfillOutcomeSkipped, SnapshotBackfillReasonCycleMissing, false, "Run the singleton-Cycle backfill before rerunning the Snapshot projection."
+	case sourceRead:
+		return SnapshotBackfillOutcomeFailed, SnapshotBackfillReasonSourceReadFailed, true, "Retry after restoring source repository availability; source evidence is never copied into failure records."
+	default:
+		return SnapshotBackfillOutcomeFailed, SnapshotBackfillReasonProjectionWriteFailed, true, "Retry after restoring database availability; verify Snapshot integrity before cutover."
+	}
+}
+
+func legacyProjectionRequestKey(sourceHash string) string {
+	return "assessment-snapshot-backfill-v1-" + sourceHash
+}
+
+func legacyProjectionRequestHash(sourceHash, contentHash string) string {
+	sum := sha256.Sum256([]byte(sourceHash + "\x00" + contentHash))
+	return hex.EncodeToString(sum[:])
+}
+
+func projectionSourceHash(assessmentID shared.ID, schemaVersion int, runID, runHash, resultHash string) string {
+	payload, _ := json.Marshal(struct {
+		AssessmentID string `json:"assessment_id"`
+		ResultHash   string `json:"result_hash"`
+		RunHash      string `json:"run_hash"`
+		RunID        string `json:"run_id"`
+		Schema       int    `json:"schema_version"`
+	}{assessmentID.String(), resultHash, runHash, runID, schemaVersion})
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+func fallbackProjectionSourceHash(assessmentID shared.ID, schemaVersion int) string {
+	return projectionSourceHash(assessmentID, schemaVersion, "", "", "")
+}
+
+func snapshotBackfillIdempotencyKey(assessmentID shared.ID, schemaVersion int, sourceHash string) string {
+	sum := sha256.Sum256([]byte(assessmentID.String() + "\x00" + strconv.Itoa(schemaVersion) + "\x00" + sourceHash))
+	return "assessment-snapshot-backfill-v" + strconv.Itoa(schemaVersion) + "-" + hex.EncodeToString(sum[:])
+}
+
+func validSnapshotBackfillHash(value string) bool {
+	if len(value) != 64 || strings.ToLower(value) != value {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}

--- a/internal/usecase/assessmentsnapshot/backfill.go
+++ b/internal/usecase/assessmentsnapshot/backfill.go
@@ -214,9 +214,11 @@ func (runner *BackfillRunner) Run(ctx context.Context, request BackfillRequest) 
 	if err != nil {
 		return ports.AssessmentSnapshotBackfillRun{}, err
 	}
-	runner.record(ctx, actor, "assessment_snapshot.backfill_started", run.ID, map[string]string{
+	if err := runner.record(ctx, actor, "assessment_snapshot.backfill_started", run.ID, map[string]string{
 		"tenant_id": tenantID.String(), "dry_run": strconv.FormatBool(run.DryRun), "resumed": strconv.FormatBool(resumed), "batch_size": strconv.Itoa(run.BatchSize),
-	})
+	}); err != nil {
+		return runner.finish(ctx, run, leaseOwner, ports.AssessmentSnapshotBackfillFailed, actor, fmt.Errorf("audit assessment Snapshot backfill start: %w", err))
+	}
 
 	for {
 		if err := ctx.Err(); err != nil {
@@ -256,9 +258,11 @@ func (runner *BackfillRunner) Run(ctx context.Context, request BackfillRequest) 
 		if err != nil {
 			return runner.finish(ctx, run, leaseOwner, snapshotBackfillTerminalState(err), actor, err)
 		}
-		runner.record(ctx, actor, "assessment_snapshot.backfill_batch_committed", run.ID, map[string]string{
+		if err := runner.record(ctx, actor, "assessment_snapshot.backfill_batch_committed", run.ID, map[string]string{
 			"tenant_id": tenantID.String(), "checkpoint_assessment_id": checkpoint.String(), "processed_count": strconv.Itoa(run.ProcessedCount),
-		})
+		}); err != nil {
+			return runner.finish(ctx, run, leaseOwner, ports.AssessmentSnapshotBackfillFailed, actor, fmt.Errorf("audit assessment Snapshot backfill batch: %w", err))
+		}
 	}
 }
 
@@ -388,20 +392,27 @@ func (runner *BackfillRunner) finish(ctx context.Context, run ports.AssessmentSn
 	if runner.observer != nil {
 		runner.observer.ObserveAssessmentSnapshotBackfillRun(string(state))
 	}
-	runner.record(finishCtx, actor, "assessment_snapshot.backfill_"+string(state), run.ID, map[string]string{
+	auditErr := runner.record(finishCtx, actor, "assessment_snapshot.backfill_"+string(state), run.ID, map[string]string{
 		"tenant_id": run.TenantID.String(), "processed_count": strconv.Itoa(finished.ProcessedCount), "created_count": strconv.Itoa(finished.CreatedCount),
 		"would_create_count": strconv.Itoa(finished.WouldCreateCount), "skipped_count": strconv.Itoa(finished.SkippedCount), "failed_count": strconv.Itoa(finished.FailedCount),
 	})
 	if cause != nil {
+		if auditErr != nil {
+			return finished, errors.Join(cause, fmt.Errorf("audit assessment Snapshot backfill finish: %w", auditErr))
+		}
 		return finished, cause
+	}
+	if auditErr != nil {
+		return finished, fmt.Errorf("audit assessment Snapshot backfill finish: %w", auditErr)
 	}
 	return finished, nil
 }
 
-func (runner *BackfillRunner) record(ctx context.Context, actor, action string, target shared.ID, metadata map[string]string) {
+func (runner *BackfillRunner) record(ctx context.Context, actor, action string, target shared.ID, metadata map[string]string) error {
 	if runner.audit != nil {
-		_ = runner.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: action, Target: target.String(), Metadata: metadata, At: runner.clock.Now().UTC()})
+		return runner.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: action, Target: target.String(), Metadata: metadata, At: runner.clock.Now().UTC()})
 	}
+	return nil
 }
 
 func retryableAssessmentSnapshotBackfillError(err error) bool {

--- a/internal/usecase/assessmentsnapshot/backfill_test.go
+++ b/internal/usecase/assessmentsnapshot/backfill_test.go
@@ -1,0 +1,246 @@
+package assessmentsnapshot_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	uc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type snapshotBackfillClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (clock *snapshotBackfillClock) Now() time.Time {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	return clock.now
+}
+
+func (clock *snapshotBackfillClock) Advance(duration time.Duration) {
+	clock.mu.Lock()
+	clock.now = clock.now.Add(duration)
+	clock.mu.Unlock()
+}
+
+type staticBackfillRunStore struct{ runs []scanrun.ScanRun }
+
+func (store *staticBackfillRunStore) ListScanRuns(_ context.Context, tenantID, assessmentID shared.ID) ([]scanrun.ScanRun, error) {
+	var out []scanrun.ScanRun
+	for _, run := range store.runs {
+		if run.TenantID == tenantID && run.EngagementID == assessmentID {
+			out = append(out, run)
+		}
+	}
+	return out, nil
+}
+func (store *staticBackfillRunStore) GetScanRun(_ context.Context, tenantID shared.ID, runID string) (scanrun.ScanRun, error) {
+	for _, run := range store.runs {
+		if run.TenantID == tenantID && run.ID == runID {
+			return run, nil
+		}
+	}
+	return scanrun.ScanRun{}, shared.ErrNotFound
+}
+
+type retryingSnapshotProjector struct {
+	calls int
+	err   error
+}
+
+type cancellingSnapshotSource struct{ cancel context.CancelFunc }
+
+func (source cancellingSnapshotSource) ListAssessmentSnapshotBackfillEngagements(context.Context, shared.ID, shared.ID, time.Time, int) ([]*engagement.Engagement, error) {
+	source.cancel()
+	return nil, context.Canceled
+}
+
+func (projector *retryingSnapshotProjector) Project(context.Context, uc.LegacyProjectionInput) (uc.LegacyProjectionResult, error) {
+	projector.calls++
+	return uc.LegacyProjectionResult{}, projector.err
+}
+
+func TestSnapshotBackfillProjectsUnknownCoverageAndHashVersionedEvidence(t *testing.T) {
+	harness := newSnapshotBackfillHarness(t, nil)
+	run := nativeRun(t, "sealed-run", "assessment", "0123456789abcdef0123456789abcdef01234567")
+	harness.runs.runs = []scanrun.ScanRun{run}
+	if err := harness.results.SaveResult(context.Background(), "assessment", []byte(`{"findings":[{"id":"source-only"}]}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := harness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "process-1", BatchSize: 1})
+	if err != nil || first.CreatedCount != 1 || first.FailedCount != 0 {
+		t.Fatalf("first snapshot backfill=%+v err=%v", first, err)
+	}
+	snapshots, err := harness.snapshots.ListByAssessment(context.Background(), "tenant", "assessment")
+	if err != nil || len(snapshots) != 1 {
+		t.Fatalf("snapshots=%+v err=%v", snapshots, err)
+	}
+	if snapshots[0].Provenance != assessmentsnapshot.ProvenanceLegacy || len(snapshots[0].Dimensions) != 1 || snapshots[0].Dimensions[0].State != assessmentsnapshot.CoverageUnknown || snapshots[0].Dimensions[0].ReasonCode != assessmentsnapshot.ReasonLegacyProvenance {
+		t.Fatalf("legacy projection coverage=%+v", snapshots[0])
+	}
+	if _, _, err := harness.snapshots.GetDefault(context.Background(), "tenant", "assessment"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("legacy projection changed default pointer: %v", err)
+	}
+
+	second, err := harness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "process-2", BatchSize: 1})
+	if err != nil || second.SkippedCount != 1 || second.CreatedCount != 0 {
+		t.Fatalf("idempotent rerun=%+v err=%v", second, err)
+	}
+	if err := harness.results.SaveResult(context.Background(), "assessment", []byte(`{"findings":[{"id":"changed-source"}]}`)); err != nil {
+		t.Fatal(err)
+	}
+	third, err := harness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "process-3", BatchSize: 1})
+	if err != nil || third.CreatedCount != 1 {
+		t.Fatalf("hash-versioned rerun=%+v err=%v", third, err)
+	}
+	snapshots, err = harness.snapshots.ListByAssessment(context.Background(), "tenant", "assessment")
+	if err != nil || len(snapshots) != 2 || snapshots[0].ContentHash != snapshots[1].ContentHash || snapshots[0].RequestHash == snapshots[1].RequestHash {
+		t.Fatalf("hash-versioned snapshots=%+v err=%v", snapshots, err)
+	}
+}
+
+func TestSnapshotBackfillProjectsLegacyRunWithoutInventedDimensions(t *testing.T) {
+	legacy := scanrun.ScanRun{
+		TenantID: "tenant", ID: "legacy-run", EngagementID: "assessment",
+		CreatedAt: time.Date(2026, 8, 31, 9, 0, 0, 0, time.UTC), UpdatedAt: time.Date(2026, 8, 31, 9, 0, 0, 0, time.UTC),
+		Provenance: scanrun.ProvenanceLegacy, TerminalStatus: scanrun.StatusUnknown, ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion,
+		LegacyFindingKeys: []string{"legacy-finding"},
+	}
+	harness := newSnapshotBackfillHarness(t, []scanrun.ScanRun{legacy})
+	run, err := harness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "legacy", BatchSize: 1})
+	if err != nil || run.CreatedCount != 1 {
+		t.Fatalf("legacy no-lane backfill=%+v err=%v", run, err)
+	}
+	snapshots, err := harness.snapshots.ListByAssessment(context.Background(), "tenant", "assessment")
+	if err != nil || len(snapshots) != 1 || len(snapshots[0].RunReferences) != 1 || len(snapshots[0].Dimensions) != 0 {
+		t.Fatalf("legacy no-lane projection=%+v err=%v", snapshots, err)
+	}
+}
+
+func TestSnapshotBackfillLeaseResumeDryRunAndRedactedRetry(t *testing.T) {
+	harness := newSnapshotBackfillHarness(t, []scanrun.ScanRun{nativeRun(t, "sealed-run", "assessment", "0123456789abcdef0123456789abcdef01234567")})
+	dryRun, err := harness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "dry-run", DryRun: true, BatchSize: 1})
+	if err != nil || dryRun.WouldCreateCount != 1 {
+		t.Fatalf("dry run=%+v err=%v", dryRun, err)
+	}
+	if snapshots, _ := harness.snapshots.ListByAssessment(context.Background(), "tenant", "assessment"); len(snapshots) != 0 {
+		t.Fatalf("dry run created snapshots: %+v", snapshots)
+	}
+
+	lease := time.Minute
+	crashed, _, err := harness.store.AcquireAssessmentSnapshotBackfillRun(context.Background(), ports.AssessmentSnapshotBackfillAcquireRequest{Run: ports.AssessmentSnapshotBackfillRun{
+		TenantID: "tenant", ID: "crashed", SchemaVersion: uc.AssessmentSnapshotBackfillSchemaVersion, BatchSize: 1,
+		SnapshotAt: harness.clock.Now(), State: ports.AssessmentSnapshotBackfillRunning, LeaseOwner: "dead", LeaseToken: "dead-token", LeaseExpiresAt: harness.clock.Now().Add(lease),
+		CreatedBy: "operator", CreatedAt: harness.clock.Now(), UpdatedAt: harness.clock.Now(),
+	}, LeaseDuration: lease})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := harness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "live", BatchSize: 1, LeaseDuration: lease}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("concurrent lease=%v", err)
+	}
+	harness.clock.Advance(lease + time.Second)
+	resumed, err := harness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "live", BatchSize: 1, LeaseDuration: lease})
+	if err != nil || resumed.ID != crashed.ID || resumed.CreatedCount != 1 {
+		t.Fatalf("crash resume=%+v err=%v", resumed, err)
+	}
+
+	retryHarness := newSnapshotBackfillHarness(t, []scanrun.ScanRun{nativeRun(t, "retry-run", "assessment", "0123456789abcdef0123456789abcdef01234567")})
+	failing := &retryingSnapshotProjector{err: errors.New("database unavailable: secret-token")}
+	retryHarness.runner, err = uc.NewBackfillRunner(failing, retryHarness.engagements, retryHarness.store, retryHarness.runs, retryHarness.results, retryHarness.ids, retryHarness.clock, retryHarness.audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, err := retryHarness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "retry", BatchSize: 1})
+	if err != nil || failed.FailedCount != 1 || failing.calls != 3 {
+		t.Fatalf("bounded retry=%+v calls=%d err=%v", failed, failing.calls, err)
+	}
+	item, err := retryHarness.store.GetAssessmentSnapshotBackfillItem(context.Background(), "tenant", failed.ID, "assessment")
+	if err != nil || item.ReasonCode != uc.SnapshotBackfillReasonProjectionWriteFailed || !item.Retryable || strings.Contains(item.RepairGuidance, "secret-token") {
+		t.Fatalf("redacted failure=%+v err=%v", item, err)
+	}
+
+	cancelHarness := newSnapshotBackfillHarness(t, []scanrun.ScanRun{nativeRun(t, "cancel-run", "assessment", "0123456789abcdef0123456789abcdef01234567")})
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancelRunner, err := uc.NewBackfillRunner(cancelHarness.projector, cancellingSnapshotSource{cancel: cancel}, cancelHarness.store, cancelHarness.runs, cancelHarness.results, cancelHarness.ids, cancelHarness.clock, cancelHarness.audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancelled, err := cancelRunner.Run(cancelCtx, uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "cancel", BatchSize: 1})
+	if !errors.Is(err, context.Canceled) || cancelled.State != ports.AssessmentSnapshotBackfillCancelled {
+		t.Fatalf("cancelled run=%+v err=%v", cancelled, err)
+	}
+}
+
+type snapshotBackfillHarness struct {
+	runner      *uc.BackfillRunner
+	snapshots   *memory.AssessmentSnapshotRepository
+	engagements *memory.EngagementRepository
+	store       *memory.AssessmentSnapshotBackfillRepository
+	runs        *staticBackfillRunStore
+	results     *memory.ScanResultStore
+	ids         *sequenceIDs
+	clock       *snapshotBackfillClock
+	audit       *auditRecorder
+	projector   *uc.LegacyProjector
+}
+
+func newSnapshotBackfillHarness(t *testing.T, runs []scanrun.ScanRun) *snapshotBackfillHarness {
+	t.Helper()
+	ctx := context.Background()
+	clock := &snapshotBackfillClock{now: time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)}
+	engagements := memory.NewEngagementRepository()
+	assessment, err := engagement.New("assessment", "tenant", "Assessment", "", clock.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := assessment.Transition(engagement.StatusActive, clock.Now().Add(-23*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(ctx, assessment); err != nil {
+		t.Fatal(err)
+	}
+	cycles := memory.NewAssessmentCycleRepository()
+	cycle, err := assessmentcycle.NewAssessmentCycle("cycle", "tenant", "Cycle", assessmentcycle.BoundaryStandalone, "", "", "assessment", "operator", assessment.Audit.CreatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember("tenant", "cycle", "assessment", "operator", assessment.Audit.CreatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	store := memory.NewAssessmentSnapshotBackfillRepository()
+	runStore := &staticBackfillRunStore{runs: runs}
+	results := memory.NewScanResultStore()
+	ids := &sequenceIDs{}
+	audit := &auditRecorder{}
+	projector, err := uc.NewLegacyProjector(snapshots, cycles, memory.NewTenantTransactionRunner(), ids, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner, err := uc.NewBackfillRunner(projector, engagements, store, runStore, results, ids, clock, audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &snapshotBackfillHarness{runner: runner, snapshots: snapshots, engagements: engagements, store: store, runs: runStore, results: results, ids: ids, clock: clock, audit: audit, projector: projector}
+}

--- a/internal/usecase/assessmentsnapshot/backfill_test.go
+++ b/internal/usecase/assessmentsnapshot/backfill_test.go
@@ -130,6 +130,40 @@ func TestSnapshotBackfillProjectsLegacyRunWithoutInventedDimensions(t *testing.T
 	}
 }
 
+func TestLegacyProjectionRollsBackWhenAuditFails(t *testing.T) {
+	harness := newSnapshotBackfillHarness(t, nil)
+	auditErr := errors.New("audit unavailable")
+	projector, err := uc.NewLegacyProjector(
+		harness.snapshots,
+		harness.cycles,
+		memory.NewTenantTransactionRunner(),
+		harness.ids,
+		harness.clock,
+		failingAudit{err: auditErr},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = projector.Project(context.Background(), uc.LegacyProjectionInput{
+		TenantID:     "tenant",
+		AssessmentID: "assessment",
+		Actor:        "operator",
+		SourceHash:   strings.Repeat("a", 64),
+		SelectedRun: assessmentsnapshot.SelectedRun{
+			ID:             "legacy-run",
+			ManifestHash:   strings.Repeat("b", 64),
+			Provenance:     scanrun.ProvenanceLegacy,
+			TerminalStatus: scanrun.StatusUnknown,
+		},
+	})
+	if !errors.Is(err, auditErr) {
+		t.Fatalf("legacy projection audit failure=%v", err)
+	}
+	if snapshots, listErr := harness.snapshots.ListByAssessment(context.Background(), "tenant", "assessment"); listErr != nil || len(snapshots) != 0 {
+		t.Fatalf("legacy projection survived audit rollback: snapshots=%+v err=%v", snapshots, listErr)
+	}
+}
+
 func TestSnapshotBackfillLeaseResumeDryRunAndRedactedRetry(t *testing.T) {
 	harness := newSnapshotBackfillHarness(t, []scanrun.ScanRun{nativeRun(t, "sealed-run", "assessment", "0123456789abcdef0123456789abcdef01234567")})
 	dryRun, err := harness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "dry-run", DryRun: true, BatchSize: 1})
@@ -188,6 +222,7 @@ func TestSnapshotBackfillLeaseResumeDryRunAndRedactedRetry(t *testing.T) {
 type snapshotBackfillHarness struct {
 	runner      *uc.BackfillRunner
 	snapshots   *memory.AssessmentSnapshotRepository
+	cycles      *memory.AssessmentCycleRepository
 	engagements *memory.EngagementRepository
 	store       *memory.AssessmentSnapshotBackfillRepository
 	runs        *staticBackfillRunStore
@@ -242,5 +277,5 @@ func newSnapshotBackfillHarness(t *testing.T, runs []scanrun.ScanRun) *snapshotB
 	if err != nil {
 		t.Fatal(err)
 	}
-	return &snapshotBackfillHarness{runner: runner, snapshots: snapshots, engagements: engagements, store: store, runs: runStore, results: results, ids: ids, clock: clock, audit: audit, projector: projector}
+	return &snapshotBackfillHarness{runner: runner, snapshots: snapshots, cycles: cycles, engagements: engagements, store: store, runs: runStore, results: results, ids: ids, clock: clock, audit: audit, projector: projector}
 }

--- a/internal/usecase/assessmentsnapshot/service.go
+++ b/internal/usecase/assessmentsnapshot/service.go
@@ -1,0 +1,400 @@
+package assessmentsnapshot
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	maxSelectedRuns    = 100
+	maxSelectedLanes   = 100
+	maxSelectionIDSize = 256
+	maxRequestKeySize  = 128
+)
+
+var ErrIdempotencyBodyMismatch = errors.New("assessment snapshot idempotency body mismatch")
+
+type Service struct {
+	snapshots   ports.AssessmentSnapshotRepository
+	cycles      ports.AssessmentCycleRepository
+	engagements ports.EngagementRepository
+	runs        ports.AssessmentSnapshotRunReader
+	jobs        ports.ScanJobStore
+	tx          ports.TenantTransactionRunner
+	ids         ports.IDGenerator
+	clock       ports.Clock
+	audit       ports.AuditLogger
+}
+
+func NewService(snapshots ports.AssessmentSnapshotRepository, cycles ports.AssessmentCycleRepository, engagements ports.EngagementRepository, runs ports.AssessmentSnapshotRunReader, tx ports.TenantTransactionRunner, ids ports.IDGenerator, clock ports.Clock, audit ports.AuditLogger) (*Service, error) {
+	if snapshots == nil || cycles == nil || engagements == nil || runs == nil || tx == nil || ids == nil || clock == nil || audit == nil {
+		return nil, fmt.Errorf("%w: assessment snapshot dependencies are required", shared.ErrValidation)
+	}
+	return &Service{snapshots: snapshots, cycles: cycles, engagements: engagements, runs: runs, tx: tx, ids: ids, clock: clock, audit: audit}, nil
+}
+
+func (service *Service) SetScanJobStore(jobs ports.ScanJobStore) { service.jobs = jobs }
+
+type FinalizeInput struct {
+	TenantID               shared.ID
+	CycleID                shared.ID
+	AssessmentID           shared.ID
+	SelectedRunIDs         []string
+	SelectedRuns           []RunSelection
+	RequestKey             string
+	ExpectedDefaultVersion int64
+	Actor                  string
+}
+
+type RunSelection struct {
+	RunID    string
+	LaneKeys []string
+}
+
+func (service *Service) Finalize(ctx context.Context, input FinalizeInput) (*domain.Snapshot, bool, error) {
+	tenantID := shared.TenantOrDefault(input.TenantID)
+	requestKey := strings.TrimSpace(input.RequestKey)
+	actor := strings.TrimSpace(input.Actor)
+	selectedRuns, err := normalizedRunSelections(input.SelectedRunIDs, input.SelectedRuns)
+	if err != nil {
+		return nil, false, err
+	}
+	if tenantID.IsZero() || input.AssessmentID.IsZero() || requestKey == "" || actor == "" {
+		return nil, false, fmt.Errorf("%w: snapshot tenant, assessment, request key, and actor are required", shared.ErrValidation)
+	}
+	if len(requestKey) > maxRequestKeySize {
+		return nil, false, fmt.Errorf("%w: snapshot request key exceeds %d bytes", shared.ErrValidation, maxRequestKeySize)
+	}
+	if input.ExpectedDefaultVersion < 0 {
+		return nil, false, fmt.Errorf("%w: expected default version cannot be negative", shared.ErrValidation)
+	}
+	if input.CycleID.IsZero() {
+		cycle, err := service.cycles.GetCycleByAssessment(ctx, tenantID, input.AssessmentID)
+		if err != nil {
+			return nil, false, err
+		}
+		input.CycleID = cycle.ID
+	}
+	selectedRuns, err = service.expandRunSelections(ctx, tenantID, input.AssessmentID, selectedRuns)
+	if err != nil {
+		return nil, false, err
+	}
+	if replay, err := service.snapshots.GetByRequestKey(ctx, tenantID, input.AssessmentID, requestKey); err == nil {
+		if replay.CycleID != input.CycleID || !sameRunSelection(replay.RunReferences, selectedRuns) {
+			return nil, false, idempotencyBodyMismatch()
+		}
+		return replay, false, nil
+	} else if !errors.Is(err, shared.ErrNotFound) {
+		return nil, false, err
+	}
+
+	var finalized *domain.Snapshot
+	created := false
+	err = service.tx.Run(ctx, tenantID, func(txCtx context.Context) error {
+		cycle, err := service.cycles.LockCycleForUpdate(txCtx, tenantID, input.CycleID)
+		if err != nil {
+			return err
+		}
+		if cycle.Status != assessmentcycle.StatusOpen {
+			return fmt.Errorf("%w: snapshots require an open assessment cycle", shared.ErrValidation)
+		}
+		if _, err := service.cycles.GetMember(txCtx, tenantID, input.CycleID, input.AssessmentID); err != nil {
+			return err
+		}
+		assessment, err := service.engagements.GetByIDInTenant(txCtx, tenantID, input.AssessmentID)
+		if err != nil {
+			return err
+		}
+		if assessment.Status != engagement.StatusDraft && assessment.Status != engagement.StatusActive {
+			return fmt.Errorf("%w: snapshots require a draft or active assessment", shared.ErrValidation)
+		}
+
+		trustedRuns := make([]domain.SelectedRun, 0, len(selectedRuns))
+		for _, selection := range selectedRuns {
+			runID := selection.RunID
+			if service.jobs != nil {
+				job, jobErr := service.jobs.GetJob(txCtx, runID)
+				if jobErr == nil && job.Status == ports.ScanRunning {
+					return fmt.Errorf("%w: selected scan job %q is still running", shared.ErrConflict, runID)
+				}
+				if jobErr != nil && !errors.Is(jobErr, shared.ErrNotFound) {
+					return jobErr
+				}
+			}
+			run, err := service.runs.GetScanRun(txCtx, tenantID, runID)
+			if err != nil {
+				return err
+			}
+			if run.EngagementID != input.AssessmentID {
+				return fmt.Errorf("%w: selected scan run %q belongs to another assessment", shared.ErrValidation, runID)
+			}
+			selected, err := trustedSelectedRun(run, selection.LaneKeys)
+			if err != nil {
+				return err
+			}
+			trustedRuns = append(trustedRuns, selected)
+		}
+
+		now := service.clock.Now().UTC()
+		candidate, err := domain.NewFinalized(tenantID, service.ids.NewID(), input.CycleID, input.AssessmentID, domain.Boundary{
+			Kind: cycle.BoundaryKind, BusinessAssetID: cycle.BusinessAssetID, ProjectID: cycle.ProjectID,
+		}, requestKey, actor, now, trustedRuns)
+		if err != nil {
+			return err
+		}
+		finalized, created, err = service.snapshots.CreateFinalizedCAS(txCtx, candidate, input.ExpectedDefaultVersion)
+		if err != nil {
+			return classifySnapshotError(err)
+		}
+		if !created {
+			return nil
+		}
+		if err := service.audit.Record(txCtx, ports.AuditEntry{
+			Actor: actor, Action: "assessment_snapshot.finalized", Target: finalized.ID.String(), At: now,
+			Metadata: map[string]string{
+				"tenant_id": tenantID.String(), "cycle_id": input.CycleID.String(), "assessment_id": input.AssessmentID.String(),
+				"snapshot_number": fmt.Sprintf("%d", finalized.SnapshotNumber), "content_hash": finalized.ContentHash,
+			},
+		}); err != nil {
+			return fmt.Errorf("audit assessment snapshot finalization: %w", err)
+		}
+		return nil
+	})
+	return finalized, created, err
+}
+
+func (service *Service) Get(ctx context.Context, tenantID, snapshotID shared.ID) (*domain.Snapshot, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	if tenantID.IsZero() || snapshotID.IsZero() {
+		return nil, fmt.Errorf("%w: snapshot tenant and id are required", shared.ErrValidation)
+	}
+	return service.snapshots.Get(ctx, tenantID, snapshotID)
+}
+
+func (service *Service) ListByAssessment(ctx context.Context, tenantID, assessmentID shared.ID) ([]domain.Snapshot, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	if tenantID.IsZero() || assessmentID.IsZero() {
+		return nil, fmt.Errorf("%w: snapshot tenant and assessment are required", shared.ErrValidation)
+	}
+	return service.snapshots.ListByAssessment(ctx, tenantID, assessmentID)
+}
+
+func (service *Service) GetDefault(ctx context.Context, tenantID, assessmentID shared.ID) (*domain.Snapshot, ports.AssessmentSnapshotDefault, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	if tenantID.IsZero() || assessmentID.IsZero() {
+		return nil, ports.AssessmentSnapshotDefault{}, fmt.Errorf("%w: snapshot tenant and assessment are required", shared.ErrValidation)
+	}
+	return service.snapshots.GetDefault(ctx, tenantID, assessmentID)
+}
+
+func (service *Service) Compare(ctx context.Context, tenantID, baselineSnapshotID, currentSnapshotID shared.ID) ([]domain.DimensionComparison, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	baseline, err := service.snapshots.Get(ctx, tenantID, baselineSnapshotID)
+	if err != nil {
+		return nil, err
+	}
+	current, err := service.snapshots.Get(ctx, tenantID, currentSnapshotID)
+	if err != nil {
+		return nil, err
+	}
+	return domain.Compare(baseline, current)
+}
+
+func trustedSelectedRun(run scanrun.ScanRun, laneKeys []string) (domain.SelectedRun, error) {
+	selected := domain.SelectedRun{ID: run.ID, Provenance: run.Provenance, TerminalStatus: run.TerminalStatus, Lanes: run.Lanes}
+	switch run.Provenance {
+	case scanrun.ProvenanceNative:
+		if err := validateTrustedScanRun(run); err != nil {
+			return domain.SelectedRun{}, fmt.Errorf("selected scan run %q is not trusted: %w", run.ID, err)
+		}
+		selected.ManifestHash, selected.Trusted = run.ManifestHash, true
+	case scanrun.ProvenanceLegacy:
+		selected.ManifestHash = legacyRunHash(run)
+	default:
+		return domain.SelectedRun{}, fmt.Errorf("%w: selected scan run provenance is invalid", shared.ErrValidation)
+	}
+	lanes, err := selectRunLanes(run.Lanes, laneKeys)
+	if err != nil {
+		return domain.SelectedRun{}, fmt.Errorf("selected scan run %q: %w", run.ID, err)
+	}
+	selected.Lanes = lanes
+	return selected, nil
+}
+
+func validateTrustedScanRun(run scanrun.ScanRun) error {
+	if err := run.Validate(); err != nil {
+		return err
+	}
+	if run.Provenance != scanrun.ProvenanceNative || !run.TerminalStatus.IsTerminal() || !run.IsSealed() || len(run.Lanes) == 0 {
+		return fmt.Errorf("%w: native run must have terminal, sealed provenance", shared.ErrValidation)
+	}
+	want, err := scanrun.ComputeRunManifestHash(run.Lanes)
+	if err != nil {
+		return err
+	}
+	if want == "" || want != run.ManifestHash {
+		return fmt.Errorf("%w: run manifest hash mismatch", shared.ErrValidation)
+	}
+	return nil
+}
+
+func legacyRunHash(run scanrun.ScanRun) string {
+	findingKeys := append([]string(nil), run.LegacyFindingKeys...)
+	sort.Strings(findingKeys)
+	payload, _ := json.Marshal(struct {
+		CreatedAt    string          `json:"created_at"`
+		EngagementID string          `json:"engagement_id"`
+		FindingKeys  []string        `json:"finding_keys"`
+		ID           string          `json:"id"`
+		Manifest     json.RawMessage `json:"manifest"`
+	}{run.CreatedAt.UTC().Format("2006-01-02T15:04:05.999999999Z07:00"), run.EngagementID.String(), findingKeys, run.ID, run.LegacyManifest})
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+func normalizedRunSelections(runIDs []string, selections []RunSelection) ([]RunSelection, error) {
+	if len(runIDs) > 0 && len(selections) > 0 {
+		return nil, fmt.Errorf("%w: use either selected run ids or selected runs", shared.ErrValidation)
+	}
+	if len(selections) == 0 {
+		selections = make([]RunSelection, len(runIDs))
+		for index, runID := range runIDs {
+			selections[index].RunID = runID
+		}
+	}
+	if len(selections) == 0 {
+		return nil, fmt.Errorf("%w: at least one selected scan run is required", shared.ErrValidation)
+	}
+	if len(selections) > maxSelectedRuns {
+		return nil, fmt.Errorf("%w: at most %d scan runs may be selected", shared.ErrValidation, maxSelectedRuns)
+	}
+	seen := map[string]struct{}{}
+	out := make([]RunSelection, 0, len(selections))
+	for _, selection := range selections {
+		selection.RunID = strings.TrimSpace(selection.RunID)
+		if selection.RunID == "" || len(selection.RunID) > maxSelectionIDSize {
+			return nil, fmt.Errorf("%w: selected scan run id is required", shared.ErrValidation)
+		}
+		if _, exists := seen[selection.RunID]; exists {
+			return nil, fmt.Errorf("%w: selected scan run %q is duplicated", shared.ErrValidation, selection.RunID)
+		}
+		seen[selection.RunID] = struct{}{}
+		if len(selection.LaneKeys) > maxSelectedLanes {
+			return nil, fmt.Errorf("%w: at most %d lanes may be selected per run", shared.ErrValidation, maxSelectedLanes)
+		}
+		laneSeen := map[string]struct{}{}
+		lanes := make([]string, 0, len(selection.LaneKeys))
+		for _, laneKey := range selection.LaneKeys {
+			laneKey = strings.TrimSpace(laneKey)
+			if laneKey == "" || len(laneKey) > maxSelectionIDSize {
+				return nil, fmt.Errorf("%w: selected lane key is invalid", shared.ErrValidation)
+			}
+			if _, exists := laneSeen[laneKey]; exists {
+				return nil, fmt.Errorf("%w: selected lane %q is duplicated", shared.ErrValidation, laneKey)
+			}
+			laneSeen[laneKey] = struct{}{}
+			lanes = append(lanes, laneKey)
+		}
+		sort.Strings(lanes)
+		selection.LaneKeys = lanes
+		out = append(out, selection)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].RunID < out[j].RunID })
+	return out, nil
+}
+
+func sameRunSelection(references []domain.RunReference, selected []RunSelection) bool {
+	if len(references) != len(selected) {
+		return false
+	}
+	byRun := make(map[string]domain.RunReference, len(references))
+	for _, reference := range references {
+		byRun[reference.RunID] = reference
+	}
+	for _, selection := range selected {
+		reference, ok := byRun[selection.RunID]
+		if !ok {
+			return false
+		}
+		if len(reference.LaneReferences) != len(selection.LaneKeys) {
+			return false
+		}
+		for index, lane := range reference.LaneReferences {
+			if lane.LaneKey != selection.LaneKeys[index] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (service *Service) expandRunSelections(ctx context.Context, tenantID, assessmentID shared.ID, selections []RunSelection) ([]RunSelection, error) {
+	for index := range selections {
+		if len(selections[index].LaneKeys) > 0 {
+			continue
+		}
+		run, err := service.runs.GetScanRun(ctx, tenantID, selections[index].RunID)
+		if err != nil {
+			return nil, err
+		}
+		if run.EngagementID != assessmentID {
+			return nil, fmt.Errorf("%w: selected scan run %q belongs to another assessment", shared.ErrValidation, run.ID)
+		}
+		if len(run.Lanes) == 0 {
+			return nil, fmt.Errorf("%w: selected scan run %q has no provenance lanes", shared.ErrValidation, run.ID)
+		}
+		laneKeys := make([]string, len(run.Lanes))
+		for laneIndex, lane := range run.Lanes {
+			laneKeys[laneIndex] = lane.LaneKey
+		}
+		sort.Strings(laneKeys)
+		selections[index].LaneKeys = laneKeys
+	}
+	return selections, nil
+}
+
+func selectRunLanes(lanes []scanrun.Lane, selectedKeys []string) ([]scanrun.Lane, error) {
+	if len(lanes) == 0 {
+		return nil, fmt.Errorf("%w: selected run has no provenance lanes", shared.ErrValidation)
+	}
+	if len(selectedKeys) == 0 {
+		return append([]scanrun.Lane(nil), lanes...), nil
+	}
+	byKey := make(map[string]scanrun.Lane, len(lanes))
+	for _, lane := range lanes {
+		byKey[lane.LaneKey] = lane
+	}
+	selected := make([]scanrun.Lane, 0, len(selectedKeys))
+	for _, key := range selectedKeys {
+		lane, ok := byKey[key]
+		if !ok {
+			return nil, fmt.Errorf("%w: lane %q does not belong to the run", shared.ErrValidation, key)
+		}
+		selected = append(selected, lane)
+	}
+	return selected, nil
+}
+
+func idempotencyBodyMismatch() error {
+	return fmt.Errorf("%w: %w", shared.ErrConflict, ErrIdempotencyBodyMismatch)
+}
+
+func classifySnapshotError(err error) error {
+	if errors.Is(err, shared.ErrConflict) && strings.Contains(err.Error(), "request key was reused with different content") {
+		return idempotencyBodyMismatch()
+	}
+	return err
+}

--- a/internal/usecase/assessmentsnapshot/service.go
+++ b/internal/usecase/assessmentsnapshot/service.go
@@ -3,11 +3,13 @@ package assessmentsnapshot
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
@@ -19,10 +21,12 @@ import (
 )
 
 const (
-	maxSelectedRuns    = 100
-	maxSelectedLanes   = 100
-	maxSelectionIDSize = 256
-	maxRequestKeySize  = 128
+	maxSelectedRuns         = 100
+	maxSelectedLanes        = 100
+	maxSelectionIDSize      = 256
+	maxRequestKeySize       = 128
+	defaultSnapshotPageSize = 50
+	maxSnapshotPageSize     = 100
 )
 
 var ErrIdempotencyBodyMismatch = errors.New("assessment snapshot idempotency body mismatch")
@@ -96,6 +100,18 @@ func (service *Service) Finalize(ctx context.Context, input FinalizeInput) (*dom
 		if replay.CycleID != input.CycleID || !sameRunSelection(replay.RunReferences, selectedRuns) {
 			return nil, false, idempotencyBodyMismatch()
 		}
+		// The retained request was admitted against the pointer version immediately
+		// preceding this Snapshot. Keep the original precondition part of the
+		// idempotency identity so a caller cannot reuse a key with an arbitrary
+		// If-Match value while still returning the current pointer version below.
+		if input.ExpectedDefaultVersion != replay.DefaultVersion-1 {
+			return nil, false, fmt.Errorf("%w: assessment snapshot replay precondition mismatch", shared.ErrConflict)
+		}
+		_, pointer, err := service.snapshots.GetDefault(ctx, tenantID, input.AssessmentID)
+		if err != nil {
+			return nil, false, fmt.Errorf("load current assessment snapshot default: %w", err)
+		}
+		replay.DefaultVersion = pointer.Version
 		return replay, false, nil
 	} else if !errors.Is(err, shared.ErrNotFound) {
 		return nil, false, err
@@ -141,6 +157,9 @@ func (service *Service) Finalize(ctx context.Context, input FinalizeInput) (*dom
 			if run.EngagementID != input.AssessmentID {
 				return fmt.Errorf("%w: selected scan run %q belongs to another assessment", shared.ErrValidation, runID)
 			}
+			if run.Provenance != scanrun.ProvenanceNative {
+				return fmt.Errorf("%w: interactive snapshot finalization requires native scan run provenance", shared.ErrValidation)
+			}
 			selected, err := trustedSelectedRun(run, selection.LaneKeys)
 			if err != nil {
 				return err
@@ -184,12 +203,56 @@ func (service *Service) Get(ctx context.Context, tenantID, snapshotID shared.ID)
 	return service.snapshots.Get(ctx, tenantID, snapshotID)
 }
 
-func (service *Service) ListByAssessment(ctx context.Context, tenantID, assessmentID shared.ID) ([]domain.Snapshot, error) {
+type SnapshotPage struct {
+	Items      []domain.Snapshot
+	NextCursor string
+}
+
+func (service *Service) ListByAssessment(ctx context.Context, tenantID, assessmentID shared.ID, cursor string, limit int) (SnapshotPage, error) {
 	tenantID = shared.TenantOrDefault(tenantID)
 	if tenantID.IsZero() || assessmentID.IsZero() {
-		return nil, fmt.Errorf("%w: snapshot tenant and assessment are required", shared.ErrValidation)
+		return SnapshotPage{}, fmt.Errorf("%w: snapshot tenant and assessment are required", shared.ErrValidation)
 	}
-	return service.snapshots.ListByAssessment(ctx, tenantID, assessmentID)
+	if limit == 0 {
+		limit = defaultSnapshotPageSize
+	}
+	if limit < 1 || limit > maxSnapshotPageSize {
+		return SnapshotPage{}, fmt.Errorf("%w: snapshot page size must be between 1 and %d", shared.ErrValidation, maxSnapshotPageSize)
+	}
+	after, err := decodeSnapshotCursor(cursor)
+	if err != nil {
+		return SnapshotPage{}, err
+	}
+	page, err := service.snapshots.ListAssessmentSnapshots(ctx, ports.AssessmentSnapshotListQuery{
+		TenantID: tenantID, AssessmentID: assessmentID, AfterSnapshotNumber: after, Limit: limit,
+	})
+	if err != nil {
+		return SnapshotPage{}, err
+	}
+	result := SnapshotPage{Items: page.Items}
+	if page.HasMore && len(page.Items) > 0 {
+		result.NextCursor = base64.RawURLEncoding.EncodeToString([]byte(strconv.Itoa(page.Items[len(page.Items)-1].SnapshotNumber)))
+	}
+	return result, nil
+}
+
+func decodeSnapshotCursor(cursor string) (int, error) {
+	cursor = strings.TrimSpace(cursor)
+	if cursor == "" {
+		return 0, nil
+	}
+	if len(cursor) > 128 {
+		return 0, fmt.Errorf("%w: snapshot cursor is invalid", shared.ErrValidation)
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return 0, fmt.Errorf("%w: snapshot cursor is invalid", shared.ErrValidation)
+	}
+	value, err := strconv.Atoi(string(decoded))
+	if err != nil || value < 1 {
+		return 0, fmt.Errorf("%w: snapshot cursor is invalid", shared.ErrValidation)
+	}
+	return value, nil
 }
 
 func (service *Service) GetDefault(ctx context.Context, tenantID, assessmentID shared.ID) (*domain.Snapshot, ports.AssessmentSnapshotDefault, error) {

--- a/internal/usecase/assessmentsnapshot/service_test.go
+++ b/internal/usecase/assessmentsnapshot/service_test.go
@@ -1,0 +1,228 @@
+package assessmentsnapshot_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	uc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fixedClock struct{ now time.Time }
+
+func (clock fixedClock) Now() time.Time { return clock.now }
+
+type sequenceIDs struct{ next int }
+
+func (ids *sequenceIDs) NewID() shared.ID {
+	ids.next++
+	return shared.ID(fmt.Sprintf("snapshot-%d", ids.next))
+}
+
+type auditRecorder struct{ entries []ports.AuditEntry }
+
+func (audit *auditRecorder) Record(_ context.Context, entry ports.AuditEntry) error {
+	audit.entries = append(audit.entries, entry)
+	return nil
+}
+
+func TestFinalizeReplayReplacementAndCAS(t *testing.T) {
+	harness := newHarness(t)
+	first, created, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"run-1"},
+		RequestKey: "request-1", ExpectedDefaultVersion: 0, Actor: "operator",
+	})
+	if err != nil || !created || first.SnapshotNumber != 1 || first.Lifecycle != assessmentsnapshot.LifecycleFinalized {
+		t.Fatalf("first finalize=%+v created=%v err=%v", first, created, err)
+	}
+	replay, created, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"run-1"},
+		RequestKey: "request-1", ExpectedDefaultVersion: 0, Actor: "operator",
+	})
+	if err != nil || created || replay.ID != first.ID {
+		t.Fatalf("replay=%+v created=%v err=%v", replay, created, err)
+	}
+
+	harness.saveRun(t, nativeRun(t, "run-2", "assessment", "0123456789abcdef0123456789abcdef01234568"))
+	second, created, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"run-2"},
+		RequestKey: "request-2", ExpectedDefaultVersion: 1, Actor: "operator",
+	})
+	if err != nil || !created || second.SnapshotNumber != 2 {
+		t.Fatalf("second finalize=%+v created=%v err=%v", second, created, err)
+	}
+	old, err := harness.snapshots.Get(context.Background(), "tenant", first.ID)
+	if err != nil || old.Lifecycle != assessmentsnapshot.LifecycleSuperseded {
+		t.Fatalf("old snapshot=%+v err=%v", old, err)
+	}
+	if _, _, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"run-1"},
+		RequestKey: "request-stale", ExpectedDefaultVersion: 1, Actor: "operator",
+	}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale CAS error=%v", err)
+	}
+	if len(harness.audit.entries) != 2 {
+		t.Fatalf("audit entries=%d, want 2", len(harness.audit.entries))
+	}
+	for _, entry := range harness.audit.entries {
+		for key, value := range entry.Metadata {
+			joined := key + "=" + value
+			if strings.Contains(joined, "request-") || strings.Contains(joined, "result:") || strings.Contains(joined, "evidence:") {
+				t.Fatalf("snapshot audit leaked request/evidence material: %s", joined)
+			}
+		}
+	}
+}
+
+func TestFinalizeRejectsTerminalAssessmentAndBuildingRun(t *testing.T) {
+	harness := newHarness(t)
+	assessment, err := harness.engagements.GetByIDInTenant(context.Background(), "tenant", "assessment")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := assessment.Transition(engagement.StatusCompleted, harness.clock.now); err != nil {
+		t.Fatal(err)
+	}
+	if err := harness.engagements.Update(context.Background(), assessment); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"run-1"},
+		RequestKey: "completed", Actor: "operator",
+	}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("completed assessment error=%v", err)
+	}
+
+	other := newHarness(t)
+	building := scanrun.ScanRun{TenantID: "tenant", ID: "building", EngagementID: "assessment", CreatedAt: other.clock.now, UpdatedAt: other.clock.now, Provenance: scanrun.ProvenanceNative, TerminalStatus: scanrun.StatusBuilding, ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion}
+	if err := other.runs.SaveScanRun(context.Background(), building); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := other.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"building"},
+		RequestKey: "building", Actor: "operator",
+	}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("building run error=%v", err)
+	}
+}
+
+func TestFinalizeDerivesCycleAndScopesIdempotencyToSelectedLanes(t *testing.T) {
+	harness := newHarness(t)
+	finalized, created, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", AssessmentID: "assessment",
+		SelectedRuns: []uc.RunSelection{{RunID: "run-1", LaneKeys: []string{"sca"}}},
+		RequestKey:   "derived-cycle", ExpectedDefaultVersion: 0, Actor: "operator",
+	})
+	if err != nil || !created || finalized.CycleID != "cycle" || len(finalized.RunReferences) != 1 || len(finalized.RunReferences[0].LaneReferences) != 1 {
+		t.Fatalf("derived cycle finalize=%+v created=%v err=%v", finalized, created, err)
+	}
+	if _, _, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", AssessmentID: "assessment",
+		SelectedRuns: []uc.RunSelection{{RunID: "run-1", LaneKeys: []string{"other"}}},
+		RequestKey:   "derived-cycle", ExpectedDefaultVersion: 0, Actor: "operator",
+	}); !errors.Is(err, uc.ErrIdempotencyBodyMismatch) || !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("selected-lane idempotency mismatch=%v", err)
+	}
+}
+
+type harness struct {
+	service     *uc.Service
+	snapshots   *memory.AssessmentSnapshotRepository
+	engagements *memory.EngagementRepository
+	runs        *memory.ScanRunStore
+	audit       *auditRecorder
+	clock       fixedClock
+}
+
+func newHarness(t *testing.T) *harness {
+	t.Helper()
+	clock := fixedClock{now: time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)}
+	engagements := memory.NewEngagementRepository()
+	assessment, err := engagement.New("assessment", "tenant", "Assessment", "", clock.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := assessment.Transition(engagement.StatusActive, clock.now); err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(context.Background(), assessment); err != nil {
+		t.Fatal(err)
+	}
+	cycles := memory.NewAssessmentCycleRepository()
+	cycle, err := assessmentcycle.NewAssessmentCycle("cycle", "tenant", "Cycle", assessmentcycle.BoundaryStandalone, "", "", "assessment", "operator", clock.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember("tenant", "cycle", "assessment", "operator", clock.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateCycle(context.Background(), cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(context.Background(), member); err != nil {
+		t.Fatal(err)
+	}
+	runs := memory.NewScanRunStore()
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	audit := &auditRecorder{}
+	service, err := uc.NewService(snapshots, cycles, engagements, runs, memory.NewTenantTransactionRunner(), &sequenceIDs{}, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	h := &harness{service: service, snapshots: snapshots, engagements: engagements, runs: runs, audit: audit, clock: clock}
+	h.saveRun(t, nativeRun(t, "run-1", "assessment", "0123456789abcdef0123456789abcdef01234567"))
+	return h
+}
+
+func (h *harness) saveRun(t *testing.T, run scanrun.ScanRun) {
+	t.Helper()
+	if err := h.runs.SaveScanRun(context.Background(), run); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func nativeRun(t *testing.T, id, assessmentID, revision string) scanrun.ScanRun {
+	t.Helper()
+	started := time.Date(2026, 8, 31, 11, 0, 0, 0, time.UTC)
+	finished := started.Add(time.Minute)
+	target, err := scanrun.CanonicalizeRepositoryTarget("https://example.com/repo.git", revision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := scanrun.ScanRun{
+		TenantID: "tenant", ID: id, EngagementID: shared.ID(assessmentID), CreatedAt: started, UpdatedAt: started,
+		Provenance: scanrun.ProvenanceNative, TerminalStatus: scanrun.StatusBuilding,
+		ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion,
+		Lanes: []scanrun.Lane{{
+			TenantID: "tenant", EngagementID: shared.ID(assessmentID), ScanRunID: id,
+			LaneKey: "sca", Producer: "sca", TerminalStatus: scanrun.StatusSucceeded, Target: target,
+			AuthoritativeFindingKinds: []string{"vulnerability"}, IncludedScope: []string{"src/**"}, ExcludedScope: []string{"vendor/**"},
+			StartedAt: started, FinishedAt: &finished, ResultRef: "result:" + id, EvidenceRef: "evidence:" + id,
+			ResultSHA256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ManifestSchemaVersion: 1,
+			Versions: []scanrun.LaneVersion{{VersionKind: scanrun.VersionScanner, Name: "sca", Version: "1"}, {VersionKind: scanrun.VersionRulePack, Name: "rules", Version: "1"}},
+			Stages:   []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSucceeded, StartedAt: started, FinishedAt: &finished}},
+		}},
+	}
+	run.Lanes[0].SealedAt = &finished
+	run.Lanes[0].ManifestHash, err = scanrun.ComputeManifestHash(run.Lanes[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.ManifestHash, err = scanrun.ComputeRunManifestHash(run.Lanes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.TerminalStatus, run.SealedAt, run.UpdatedAt = scanrun.StatusSucceeded, &finished, finished
+	return run
+}

--- a/internal/usecase/assessmentsnapshot/service_test.go
+++ b/internal/usecase/assessmentsnapshot/service_test.go
@@ -36,6 +36,10 @@ func (audit *auditRecorder) Record(_ context.Context, entry ports.AuditEntry) er
 	return nil
 }
 
+type failingAudit struct{ err error }
+
+func (audit failingAudit) Record(context.Context, ports.AuditEntry) error { return audit.err }
+
 func TestFinalizeReplayReplacementAndCAS(t *testing.T) {
 	harness := newHarness(t)
 	first, created, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
@@ -61,6 +65,19 @@ func TestFinalizeReplayReplacementAndCAS(t *testing.T) {
 	if err != nil || !created || second.SnapshotNumber != 2 {
 		t.Fatalf("second finalize=%+v created=%v err=%v", second, created, err)
 	}
+	replayedOld, created, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"run-1"},
+		RequestKey: "request-1", ExpectedDefaultVersion: 0, Actor: "operator",
+	})
+	if err != nil || created || replayedOld.DefaultVersion != 2 {
+		t.Fatalf("old replay must return current default version: replay=%+v created=%v err=%v", replayedOld, created, err)
+	}
+	if _, _, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"run-1"},
+		RequestKey: "request-1", ExpectedDefaultVersion: 77, Actor: "operator",
+	}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("replay with mismatched precondition error=%v", err)
+	}
 	old, err := harness.snapshots.Get(context.Background(), "tenant", first.ID)
 	if err != nil || old.Lifecycle != assessmentsnapshot.LifecycleSuperseded {
 		t.Fatalf("old snapshot=%+v err=%v", old, err)
@@ -81,6 +98,58 @@ func TestFinalizeReplayReplacementAndCAS(t *testing.T) {
 				t.Fatalf("snapshot audit leaked request/evidence material: %s", joined)
 			}
 		}
+	}
+}
+
+func TestFinalizeRejectsLegacyRunAndRollsBackOnAuditFailure(t *testing.T) {
+	harness := newHarness(t)
+	legacy := scanrun.ScanRun{
+		TenantID: "tenant", ID: "legacy-run", EngagementID: "assessment", CreatedAt: harness.clock.now, UpdatedAt: harness.clock.now,
+		Provenance: scanrun.ProvenanceLegacy, TerminalStatus: scanrun.StatusUnknown, ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion,
+		LegacyFindingKeys: []string{"legacy-finding"},
+	}
+	harness.saveRun(t, legacy)
+	if _, _, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"legacy-run"},
+		RequestKey: "legacy-interactive", Actor: "operator",
+	}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("interactive legacy finalization error=%v", err)
+	}
+
+	auditErr := errors.New("audit unavailable")
+	failing := newHarnessWithAudit(t, failingAudit{err: auditErr})
+	if _, _, err := failing.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"run-1"},
+		RequestKey: "audit-failure", Actor: "operator",
+	}); !errors.Is(err, auditErr) {
+		t.Fatalf("audit failure=%v", err)
+	}
+	if _, err := failing.snapshots.GetByRequestKey(context.Background(), "tenant", "assessment", "audit-failure"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("snapshot survived failed audit: %v", err)
+	}
+}
+
+func TestSnapshotHistoryUsesBoundedCursorPages(t *testing.T) {
+	harness := newHarness(t)
+	for index, runID := range []string{"run-2", "run-3", "run-4"} {
+		harness.saveRun(t, nativeRun(t, runID, "assessment", fmt.Sprintf("%040d", index+1)))
+		if _, created, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+			TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{runID},
+			RequestKey: "page-" + runID, ExpectedDefaultVersion: int64(index), Actor: "operator",
+		}); err != nil || !created {
+			t.Fatalf("finalize %s created=%v err=%v", runID, created, err)
+		}
+	}
+	first, err := harness.service.ListByAssessment(context.Background(), "tenant", "assessment", "", 1)
+	if err != nil || len(first.Items) != 1 || first.NextCursor == "" || first.Items[0].SnapshotNumber != 1 {
+		t.Fatalf("first page=%+v err=%v", first, err)
+	}
+	second, err := harness.service.ListByAssessment(context.Background(), "tenant", "assessment", first.NextCursor, 1)
+	if err != nil || len(second.Items) != 1 || second.NextCursor == "" || second.Items[0].SnapshotNumber != 2 {
+		t.Fatalf("second page=%+v err=%v", second, err)
+	}
+	if _, err := harness.service.ListByAssessment(context.Background(), "tenant", "assessment", "not-base64!", 1); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("invalid cursor=%v", err)
 	}
 }
 
@@ -145,6 +214,11 @@ type harness struct {
 }
 
 func newHarness(t *testing.T) *harness {
+	audit := &auditRecorder{}
+	return newHarnessWithAudit(t, audit)
+}
+
+func newHarnessWithAudit(t *testing.T, audit ports.AuditLogger) *harness {
 	t.Helper()
 	clock := fixedClock{now: time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)}
 	engagements := memory.NewEngagementRepository()
@@ -175,12 +249,12 @@ func newHarness(t *testing.T) *harness {
 	}
 	runs := memory.NewScanRunStore()
 	snapshots := memory.NewAssessmentSnapshotRepository()
-	audit := &auditRecorder{}
 	service, err := uc.NewService(snapshots, cycles, engagements, runs, memory.NewTenantTransactionRunner(), &sequenceIDs{}, clock, audit)
 	if err != nil {
 		t.Fatal(err)
 	}
-	h := &harness{service: service, snapshots: snapshots, engagements: engagements, runs: runs, audit: audit, clock: clock}
+	recorder, _ := audit.(*auditRecorder)
+	h := &harness{service: service, snapshots: snapshots, engagements: engagements, runs: runs, audit: recorder, clock: clock}
 	h.saveRun(t, nativeRun(t, "run-1", "assessment", "0123456789abcdef0123456789abcdef01234567"))
 	return h
 }

--- a/internal/usecase/businessassetuc/service.go
+++ b/internal/usecase/businessassetuc/service.go
@@ -27,6 +27,11 @@ type Service struct {
 	audit     ports.AuditLogger
 	clock     ports.Clock
 	ids       ports.IDGenerator
+	cycles    ports.AssessmentCycleRepository
+}
+
+func (s *Service) SetAssessmentCycleReader(cycles ports.AssessmentCycleRepository) {
+	s.cycles = cycles
 }
 
 func NewService(repo ports.BusinessAssetRepository, findings ports.FindingRepository, imported ports.ImportedFindingStore, judgments ports.JudgmentStore, retests ports.RetestRepository, audit ports.AuditLogger, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
@@ -198,6 +203,13 @@ func (s *Service) TechnicalAssets(ctx context.Context, tenantID, id shared.ID) (
 
 func (s *Service) AssignEngagement(ctx context.Context, tenantID, engagementID, assetID shared.ID, actor string) error {
 	tenantID = shared.TenantOrDefault(tenantID)
+	if s.cycles != nil {
+		if _, err := s.cycles.GetCycleByAssessment(ctx, tenantID, engagementID); err == nil {
+			return fmt.Errorf("%w: an Assessment Cycle freezes its Business Asset boundary", shared.ErrConflict)
+		} else if !errors.Is(err, shared.ErrNotFound) {
+			return err
+		}
+	}
 	if !assetID.IsZero() {
 		a, err := s.resolveAsset(ctx, tenantID, assetID)
 		if err != nil {

--- a/internal/usecase/businessassetuc/service_test.go
+++ b/internal/usecase/businessassetuc/service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
@@ -108,6 +109,50 @@ func TestCoverageAndRetiredAssignment(t *testing.T) {
 	}
 	if err := service.AssignEngagement(ctx, "t1", e.ID, updated.ID, "alice"); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("retired assignment error=%v", err)
+	}
+}
+
+func TestAssignEngagementRejectsFrozenAssessmentCycleBoundary(t *testing.T) {
+	service, _, engagements, _, _, _, clock := newBusinessAssetService(t)
+	ctx := context.Background()
+	first, err := service.Create(ctx, CreateInput{TenantID: "t1", Key: "first", Name: "First", Type: asset.BusinessAssetApplication, Criticality: asset.CriticalityHigh, Owner: "team", Actor: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := service.Create(ctx, CreateInput{TenantID: "t1", Key: "second", Name: "Second", Type: asset.BusinessAssetApplication, Criticality: asset.CriticalityHigh, Owner: "team", Actor: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assessment, err := engagement.New("assessment-frozen", "t1", "Frozen", "", clock.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assessment.BusinessAssetID = first.ID
+	if err := engagements.Create(ctx, assessment); err != nil {
+		t.Fatal(err)
+	}
+	cycles := memory.NewAssessmentCycleRepository()
+	cycle, err := assessmentcycle.NewAssessmentCycle("cycle-frozen", "t1", "Frozen", assessmentcycle.BoundaryAsset, first.ID, "", assessment.ID, "alice", clock.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember("t1", cycle.ID, assessment.ID, "alice", clock.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+	service.SetAssessmentCycleReader(cycles)
+	if err := service.AssignEngagement(ctx, "t1", assessment.ID, second.ID, "alice"); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("frozen boundary reassignment=%v", err)
+	}
+	stored, err := engagements.GetByIDInTenant(ctx, "t1", assessment.ID)
+	if err != nil || stored.BusinessAssetID != first.ID {
+		t.Fatalf("frozen boundary changed: assessment=%+v err=%v", stored, err)
 	}
 }
 

--- a/internal/usecase/engagement/service.go
+++ b/internal/usecase/engagement/service.go
@@ -3,12 +3,14 @@ package engagement
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
 	domain "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
@@ -17,11 +19,12 @@ import (
 
 // Service implements engagement use cases.
 type Service struct {
-	repo    ports.EngagementRepository
-	clock   ports.Clock
-	ids     ports.IDGenerator
-	audit   ports.AuditLogger
-	sources ports.EngagementSourceStore
+	repo      ports.EngagementRepository
+	clock     ports.Clock
+	ids       ports.IDGenerator
+	audit     ports.AuditLogger
+	sources   ports.EngagementSourceStore
+	snapshots ports.AssessmentSnapshotDefaultReader
 }
 
 // NewService wires the engagement use case with its driven ports.
@@ -31,18 +34,24 @@ func NewService(repo ports.EngagementRepository, clock ports.Clock, ids ports.ID
 
 func (s *Service) SetSourceStore(store ports.EngagementSourceStore) { s.sources = store }
 
+func (s *Service) SetCompletionSnapshotReader(reader ports.AssessmentSnapshotDefaultReader) {
+	s.snapshots = reader
+}
+
 // CreateInput is the input for creating an engagement.
 type CreateInput struct {
-	TenantID        shared.ID
-	BusinessAssetID shared.ID
-	CreatedBy       string // the authenticated actor that owns the engagement (ownership)
-	Name            string
-	Client          string
-	InScope         []domain.Target
-	OutOfScope      []domain.Target
-	AuthorizedFrom  *time.Time
-	AuthorizedTo    *time.Time
-	Timezone        string
+	TenantID                               shared.ID
+	BusinessAssetID                        shared.ID
+	CreatedBy                              string // the authenticated actor that owns the engagement (ownership)
+	Name                                   string
+	Client                                 string
+	InScope                                []domain.Target
+	OutOfScope                             []domain.Target
+	AuthorizedFrom                         *time.Time
+	AuthorizedTo                           *time.Time
+	Timezone                               string
+	RoE                                    *domain.RoE
+	RequiresExplicitExecutionAuthorization bool
 }
 
 // Create validates and persists a new engagement with its scope.
@@ -78,6 +87,15 @@ func (s *Service) CreateFromSourcePackage(ctx context.Context, in CreateInput, f
 	return engagement, item, nil
 }
 
+func (s *Service) CompensateCreate(ctx context.Context, tenantID, engagementID shared.ID) error {
+	var cleanupErr error
+	if s.sources != nil {
+		cleanupErr = s.sources.Delete(context.WithoutCancel(ctx), shared.TenantOrDefault(tenantID), engagementID)
+	}
+	deleteErr := s.repo.Delete(ctx, engagementID)
+	return errors.Join(cleanupErr, deleteErr)
+}
+
 func (s *Service) create(ctx context.Context, in CreateInput, id shared.ID) (*domain.Engagement, error) {
 	now := s.clock.Now()
 	e, err := domain.New(id, in.TenantID, in.Name, in.Client, now)
@@ -85,11 +103,17 @@ func (s *Service) create(ctx context.Context, in CreateInput, id shared.ID) (*do
 		return nil, err
 	}
 	e.BusinessAssetID = in.BusinessAssetID
+	e.RequiresExplicitExecutionAuthorization = in.RequiresExplicitExecutionAuthorization
 	if err := e.SetScope(in.InScope, in.OutOfScope, now); err != nil {
 		return nil, err
 	}
 	if err := e.SetAuthorizationWindow(in.AuthorizedFrom, in.AuthorizedTo, in.Timezone, now); err != nil {
 		return nil, err
+	}
+	if in.RoE != nil {
+		if err := e.SetRoE(*in.RoE, now); err != nil {
+			return nil, err
+		}
 	}
 	// Ownership: the creating actor owns the engagement; updated_by starts equal.
 	e.Audit.CreatedBy = in.CreatedBy
@@ -176,6 +200,21 @@ func (s *Service) Transition(ctx context.Context, actor string, tenantID, id sha
 	e, err := s.repo.GetByIDInTenant(ctx, tenantID, id)
 	if err != nil {
 		return nil, err
+	}
+	if to == domain.StatusCompleted && e.Status != domain.StatusCompleted {
+		if s.snapshots == nil {
+			return nil, fmt.Errorf("%w: assessment snapshot completion guard is not configured", shared.ErrValidation)
+		}
+		snapshot, _, err := s.snapshots.GetDefault(ctx, shared.TenantOrDefault(tenantID), id)
+		if err != nil {
+			if errors.Is(err, shared.ErrNotFound) {
+				return nil, fmt.Errorf("%w: engagement requires a default finalized assessment snapshot before completion", shared.ErrValidation)
+			}
+			return nil, fmt.Errorf("load default assessment snapshot: %w", err)
+		}
+		if snapshot.Lifecycle != assessmentsnapshot.LifecycleFinalized {
+			return nil, fmt.Errorf("%w: engagement default assessment snapshot is not finalized", shared.ErrValidation)
+		}
 	}
 	now := s.clock.Now()
 	cp := *e

--- a/internal/usecase/engagement/service.go
+++ b/internal/usecase/engagement/service.go
@@ -19,12 +19,13 @@ import (
 
 // Service implements engagement use cases.
 type Service struct {
-	repo      ports.EngagementRepository
-	clock     ports.Clock
-	ids       ports.IDGenerator
-	audit     ports.AuditLogger
-	sources   ports.EngagementSourceStore
-	snapshots ports.AssessmentSnapshotDefaultReader
+	repo                      ports.EngagementRepository
+	clock                     ports.Clock
+	ids                       ports.IDGenerator
+	audit                     ports.AuditLogger
+	sources                   ports.EngagementSourceStore
+	snapshots                 ports.AssessmentSnapshotDefaultReader
+	requireCompletionSnapshot func(string) bool
 }
 
 // NewService wires the engagement use case with its driven ports.
@@ -36,6 +37,15 @@ func (s *Service) SetSourceStore(store ports.EngagementSourceStore) { s.sources 
 
 func (s *Service) SetCompletionSnapshotReader(reader ports.AssessmentSnapshotDefaultReader) {
 	s.snapshots = reader
+	s.requireCompletionSnapshot = func(string) bool { return true }
+}
+
+// SetCompletionSnapshotPolicy enables the finalized-Snapshot completion guard
+// only for tenants that have passed the lifecycle rollout. A disabled policy
+// preserves legacy completion behavior.
+func (s *Service) SetCompletionSnapshotPolicy(reader ports.AssessmentSnapshotDefaultReader, required func(string) bool) {
+	s.snapshots = reader
+	s.requireCompletionSnapshot = required
 }
 
 // CreateInput is the input for creating an engagement.
@@ -202,20 +212,24 @@ func (s *Service) Transition(ctx context.Context, actor string, tenantID, id sha
 		return nil, err
 	}
 	if to == domain.StatusCompleted && e.Status != domain.StatusCompleted {
-		if s.snapshots == nil {
-			return nil, fmt.Errorf("%w: assessment snapshot completion guard is not configured", shared.ErrValidation)
-		}
-		snapshot, _, err := s.snapshots.GetDefault(ctx, shared.TenantOrDefault(tenantID), id)
-		if err != nil {
-			if errors.Is(err, shared.ErrNotFound) {
-				return nil, fmt.Errorf("%w: engagement requires a default finalized assessment snapshot before completion", shared.ErrValidation)
+		required := s.requireCompletionSnapshot != nil && s.requireCompletionSnapshot(shared.TenantOrDefault(tenantID).String())
+		if required {
+			if s.snapshots == nil {
+				return nil, fmt.Errorf("%w: assessment snapshot completion guard is not configured", shared.ErrValidation)
 			}
-			return nil, fmt.Errorf("load default assessment snapshot: %w", err)
-		}
-		if snapshot.Lifecycle != assessmentsnapshot.LifecycleFinalized {
-			return nil, fmt.Errorf("%w: engagement default assessment snapshot is not finalized", shared.ErrValidation)
+			snapshot, _, err := s.snapshots.GetDefault(ctx, shared.TenantOrDefault(tenantID), id)
+			if err != nil {
+				if errors.Is(err, shared.ErrNotFound) {
+					return nil, fmt.Errorf("%w: engagement requires a default finalized assessment snapshot before completion", shared.ErrValidation)
+				}
+				return nil, fmt.Errorf("load default assessment snapshot: %w", err)
+			}
+			if snapshot.Lifecycle != assessmentsnapshot.LifecycleFinalized {
+				return nil, fmt.Errorf("%w: engagement default assessment snapshot is not finalized", shared.ErrValidation)
+			}
 		}
 	}
+
 	now := s.clock.Now()
 	cp := *e
 	if err := cp.Transition(to, now); err != nil {

--- a/internal/usecase/engagement/service_test.go
+++ b/internal/usecase/engagement/service_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
 	domain "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
@@ -78,6 +79,12 @@ func (c fixedClock) Now() time.Time { return c.t }
 type fixedIDs struct{}
 
 func (fixedIDs) NewID() shared.ID { return shared.ID("eng-1") }
+
+type finalizedSnapshotReader struct{}
+
+func (finalizedSnapshotReader) GetDefault(context.Context, shared.ID, shared.ID) (*assessmentsnapshot.Snapshot, ports.AssessmentSnapshotDefault, error) {
+	return &assessmentsnapshot.Snapshot{Lifecycle: assessmentsnapshot.LifecycleFinalized}, ports.AssessmentSnapshotDefault{}, nil
+}
 
 type capAudit struct{ entries []ports.AuditEntry }
 
@@ -261,6 +268,7 @@ func TestEngagementMutationsAndGatePickup(t *testing.T) {
 	}
 
 	// Lifecycle: draft -> active -> completed; completed blocks execution.
+	svc.SetCompletionSnapshotReader(finalizedSnapshotReader{})
 	if _, err := svc.Transition(ctx, "operator", "", id, domain.StatusActive); err != nil {
 		t.Fatalf("activate: %v", err)
 	}
@@ -280,6 +288,21 @@ func TestEngagementMutationsAndGatePickup(t *testing.T) {
 	}
 	if _, err := svc.UpdateScope(ctx, "  ", "", id, nil, nil); !errors.Is(err, shared.ErrValidation) {
 		t.Errorf("empty actor should be ErrValidation, got %v", err)
+	}
+}
+
+func TestCompletionRequiresDefaultFinalizedSnapshot(t *testing.T) {
+	repo := newMemRepo()
+	svc := NewService(repo, fixedClock{time.Now().UTC()}, fixedIDs{}, &capAudit{})
+	item, err := svc.Create(context.Background(), CreateInput{Name: "Assessment", CreatedBy: "operator"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Transition(context.Background(), "operator", "", item.ID, domain.StatusActive); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Transition(context.Background(), "operator", "", item.ID, domain.StatusCompleted); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("completion without default snapshot=%v", err)
 	}
 }
 

--- a/internal/usecase/engagement/service_test.go
+++ b/internal/usecase/engagement/service_test.go
@@ -301,8 +301,24 @@ func TestCompletionRequiresDefaultFinalizedSnapshot(t *testing.T) {
 	if _, err := svc.Transition(context.Background(), "operator", "", item.ID, domain.StatusActive); err != nil {
 		t.Fatal(err)
 	}
+	svc.SetCompletionSnapshotPolicy(nil, func(string) bool { return true })
 	if _, err := svc.Transition(context.Background(), "operator", "", item.ID, domain.StatusCompleted); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("completion without default snapshot=%v", err)
+	}
+}
+
+func TestCompletionSnapshotPolicyDefaultsToLegacyCompatible(t *testing.T) {
+	repo := newMemRepo()
+	svc := NewService(repo, fixedClock{time.Now().UTC()}, fixedIDs{}, &capAudit{})
+	item, err := svc.Create(context.Background(), CreateInput{Name: "Legacy Assessment", CreatedBy: "operator"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Transition(context.Background(), "operator", "", item.ID, domain.StatusActive); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Transition(context.Background(), "operator", "", item.ID, domain.StatusCompleted); err != nil {
+		t.Fatalf("default-off completion must preserve legacy behavior: %v", err)
 	}
 }
 

--- a/internal/usecase/execution/guard.go
+++ b/internal/usecase/execution/guard.go
@@ -50,7 +50,11 @@ func (g *Guard) Authorize(ctx context.Context, req Request) (time.Time, error) {
 	}
 	now := g.clock.Now()
 	if !eng.AllowsExecution() {
-		g.auditDenied(ctx, req, now, "engagement_inactive")
+		reason := "engagement_inactive"
+		if eng.RequiresExplicitExecutionAuthorization && eng.Status != engagement.StatusCompleted && eng.Status != engagement.StatusArchived {
+			reason = "explicit_authorization_required"
+		}
+		g.auditDenied(ctx, req, now, reason)
 		return time.Time{}, fmt.Errorf("%w: engagement %s is not in an executable state", shared.ErrForbidden, req.EngagementID)
 	}
 	if !eng.IsAuthorizedAt(now) {
@@ -90,7 +94,11 @@ func (g *Guard) AuthorizeEngagementArtifact(ctx context.Context, req Request) (t
 	}
 	now := g.clock.Now()
 	if !eng.AllowsExecution() {
-		g.auditDenied(ctx, req, now, "engagement_inactive")
+		reason := "engagement_inactive"
+		if eng.RequiresExplicitExecutionAuthorization && eng.Status != engagement.StatusCompleted && eng.Status != engagement.StatusArchived {
+			reason = "explicit_authorization_required"
+		}
+		g.auditDenied(ctx, req, now, reason)
 		return time.Time{}, fmt.Errorf("%w: engagement %s is not in an executable state", shared.ErrForbidden, req.EngagementID)
 	}
 	if !eng.IsAuthorizedAt(now) {

--- a/internal/usecase/execution/guard_test.go
+++ b/internal/usecase/execution/guard_test.go
@@ -169,6 +169,22 @@ func TestAuthorizeDeniesTerminalEngagement(t *testing.T) {
 	}
 }
 
+func TestAuthorizeDeniesRetestWithoutExplicitAuthorization(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	audit := &fakeAudit{}
+	eng := engAt(now, false)
+	eng.RequiresExplicitExecutionAuthorization = true
+	eng.RoE = engagement.RoE{}
+	guard, _ := NewGuard(&fakeEngRepo{eng: eng}, fakeClock{now}, audit)
+
+	if _, err := guard.Authorize(context.Background(), newReq("app.acme.io")); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("Re-test without explicit RoE must be forbidden, got %v", err)
+	}
+	if got := audit.entries[len(audit.entries)-1].Metadata["reason"]; got != "explicit_authorization_required" {
+		t.Fatalf("deny reason = %q, want explicit_authorization_required", got)
+	}
+}
+
 func TestAuthorizeRoEDenies(t *testing.T) {
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 	// In-window, in-scope, active – but RoE blocks the recon tool class.

--- a/internal/usecase/ports/assessment_cycle.go
+++ b/internal/usecase/ports/assessment_cycle.go
@@ -2,10 +2,83 @@ package ports
 
 import (
 	"context"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
+
+type AssessmentCycleListQuery struct {
+	TenantID         shared.ID
+	Status           assessmentcycle.Status
+	BoundaryKind     assessmentcycle.BoundaryKind
+	AssessmentStatus engagement.Status
+	SelectedHeadID   shared.ID
+	AssessmentType   assessmentcycle.AssessmentType
+	ScanStaleness    string
+	ScanStaleBefore  time.Time
+	Search           string
+	AfterUpdatedAt   time.Time
+	AfterCycleID     shared.ID
+	Limit            int
+	MemberLimit      int
+}
+
+type AssessmentCycleListRecord struct {
+	Cycle              assessmentcycle.AssessmentCycle
+	MemberCount        int
+	ActiveBranchCount  int
+	LatestAssessmentID shared.ID
+	LatestRetestNumber int
+	Members            []assessmentcycle.Member
+	MembersHaveMore    bool
+	RootSnapshotID     shared.ID
+	CurrentSnapshotID  shared.ID
+	SelectedHeadScanAt *time.Time
+	ScanStaleness      string
+}
+
+type AssessmentCycleListRepository interface {
+	ListCycles(ctx context.Context, query AssessmentCycleListQuery) ([]AssessmentCycleListRecord, error)
+	ListMigrationPendingAssessments(ctx context.Context, query AssessmentCycleListQuery) ([]AssessmentCycleMigrationPendingRecord, int, error)
+}
+
+type AssessmentCycleMigrationPendingRecord struct {
+	AssessmentID    shared.ID
+	Name            string
+	Status          string
+	BoundaryKind    assessmentcycle.BoundaryKind
+	BusinessAssetID shared.ID
+	UpdatedAt       time.Time
+}
+
+type AssessmentCycleCompensationRepository interface {
+	DeleteCycle(ctx context.Context, tenantID, cycleID shared.ID) error
+	DeleteMember(ctx context.Context, tenantID, cycleID, assessmentID shared.ID) error
+}
+
+type AssessmentCycleRequestScope struct {
+	TenantID       shared.ID
+	Actor          string
+	Route          string
+	IdempotencyKey string
+}
+
+type AssessmentCycleRequest struct {
+	Scope        AssessmentCycleRequestScope
+	RequestHash  string
+	StatusCode   int
+	ResponseBody []byte
+	CreatedAt    time.Time
+	CompletedAt  *time.Time
+}
+
+type AssessmentCycleRequestStore interface {
+	BeginAssessmentCycleRequest(ctx context.Context, request AssessmentCycleRequest) (stored AssessmentCycleRequest, created bool, err error)
+	CompleteAssessmentCycleRequest(ctx context.Context, scope AssessmentCycleRequestScope, requestHash string, statusCode int, responseBody []byte, completedAt time.Time) error
+	AbortAssessmentCycleRequest(ctx context.Context, scope AssessmentCycleRequestScope, requestHash string) error
+}
 
 // AssessmentCycleRepository persists tenant-scoped AssessmentCycle aggregates and their members.
 type AssessmentCycleRepository interface {

--- a/internal/usecase/ports/assessment_cycle.go
+++ b/internal/usecase/ports/assessment_cycle.go
@@ -71,6 +71,7 @@ type AssessmentCycleRequest struct {
 	StatusCode   int
 	ResponseBody []byte
 	CreatedAt    time.Time
+	ExpiresAt    time.Time
 	CompletedAt  *time.Time
 }
 

--- a/internal/usecase/ports/assessment_cycle_backfill.go
+++ b/internal/usecase/ports/assessment_cycle_backfill.go
@@ -1,0 +1,74 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type AssessmentCycleBackfillState string
+
+const (
+	AssessmentCycleBackfillRunning   AssessmentCycleBackfillState = "running"
+	AssessmentCycleBackfillCompleted AssessmentCycleBackfillState = "completed"
+	AssessmentCycleBackfillCancelled AssessmentCycleBackfillState = "cancelled"
+	AssessmentCycleBackfillFailed    AssessmentCycleBackfillState = "failed"
+)
+
+type AssessmentCycleBackfillRun struct {
+	TenantID             shared.ID
+	ID                   shared.ID
+	SchemaVersion        int
+	DryRun               bool
+	BatchSize            int
+	SnapshotAt           time.Time
+	CheckpointAssessment shared.ID
+	State                AssessmentCycleBackfillState
+	LeaseOwner           string
+	LeaseToken           shared.ID
+	LeaseExpiresAt       time.Time
+	ProcessedCount       int
+	CreatedCount         int
+	WouldCreateCount     int
+	SkippedCount         int
+	FailedCount          int
+	CreatedBy            string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	CompletedAt          *time.Time
+}
+
+type AssessmentCycleBackfillAcquireRequest struct {
+	Run               AssessmentCycleBackfillRun
+	InitialCheckpoint shared.ID
+	LeaseDuration     time.Duration
+}
+
+type AssessmentCycleBackfillItem struct {
+	TenantID       shared.ID
+	RunID          shared.ID
+	AssessmentID   shared.ID
+	SchemaVersion  int
+	IdempotencyKey string
+	CycleID        shared.ID
+	Outcome        string
+	ReasonCode     string
+	Retryable      bool
+	RepairGuidance string
+	ProcessedAt    time.Time
+}
+
+type AssessmentCycleBackfillSource interface {
+	ListAssessmentCycleBackfillEngagements(ctx context.Context, tenantID, after shared.ID, snapshotAt time.Time, limit int) ([]*engdom.Engagement, error)
+}
+
+type AssessmentCycleBackfillStore interface {
+	AcquireAssessmentCycleBackfillRun(ctx context.Context, request AssessmentCycleBackfillAcquireRequest) (run AssessmentCycleBackfillRun, resumed bool, err error)
+	GetAssessmentCycleBackfillRun(ctx context.Context, tenantID, runID shared.ID) (AssessmentCycleBackfillRun, error)
+	GetAssessmentCycleBackfillItem(ctx context.Context, tenantID, runID, assessmentID shared.ID) (AssessmentCycleBackfillItem, error)
+	CommitAssessmentCycleBackfillItem(ctx context.Context, tenantID, runID, leaseToken shared.ID, now time.Time, build func(context.Context) (AssessmentCycleBackfillItem, error)) (item AssessmentCycleBackfillItem, created bool, err error)
+	AdvanceAssessmentCycleBackfillRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken, checkpoint shared.ID, now time.Time, leaseDuration time.Duration) (AssessmentCycleBackfillRun, error)
+	FinishAssessmentCycleBackfillRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken shared.ID, state AssessmentCycleBackfillState, now time.Time) (AssessmentCycleBackfillRun, error)
+}

--- a/internal/usecase/ports/assessment_cycle_integrity.go
+++ b/internal/usecase/ports/assessment_cycle_integrity.go
@@ -1,0 +1,101 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type AssessmentCycleIntegrityState string
+
+const (
+	AssessmentCycleIntegrityRunning   AssessmentCycleIntegrityState = "running"
+	AssessmentCycleIntegrityCompleted AssessmentCycleIntegrityState = "completed"
+	AssessmentCycleIntegrityCancelled AssessmentCycleIntegrityState = "cancelled"
+	AssessmentCycleIntegrityFailed    AssessmentCycleIntegrityState = "failed"
+)
+
+type AssessmentCycleIntegrityRun struct {
+	TenantID             shared.ID
+	ID                   shared.ID
+	BatchSize            int
+	SnapshotAt           time.Time
+	CheckpointAssessment shared.ID
+	State                AssessmentCycleIntegrityState
+	LeaseOwner           string
+	LeaseToken           shared.ID
+	LeaseExpiresAt       time.Time
+	ScannedCount         int
+	CleanCount           int
+	FindingCount         int
+	CreatedBy            string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	CompletedAt          *time.Time
+}
+
+type AssessmentCycleIntegrityAcquireRequest struct {
+	Run           AssessmentCycleIntegrityRun
+	LeaseDuration time.Duration
+}
+
+type AssessmentCycleIntegrityMember struct {
+	Member           cycledom.Member
+	AssessmentExists bool
+	AssessmentStatus engdom.Status
+	BusinessAssetID  shared.ID
+	ProjectID        shared.ID
+}
+
+type AssessmentCycleIntegrityCycle struct {
+	Cycle                  cycledom.AssessmentCycle
+	CycleExists            bool
+	SubjectMembershipCount int
+	Members                []AssessmentCycleIntegrityMember
+}
+
+type AssessmentCycleIntegritySubject struct {
+	TenantID     shared.ID
+	AssessmentID shared.ID
+	Cycles       []AssessmentCycleIntegrityCycle
+}
+
+type AssessmentCycleIntegritySubjectResult struct {
+	TenantID     shared.ID
+	RunID        shared.ID
+	AssessmentID shared.ID
+	Clean        bool
+	FindingCount int
+	ProcessedAt  time.Time
+}
+
+type AssessmentCycleIntegrityFinding struct {
+	TenantID     shared.ID
+	RunID        shared.ID
+	OccurrenceID string
+	AssessmentID shared.ID
+	CycleID      shared.ID
+	MemberID     shared.ID
+	ReasonCode   string
+	Severity     string
+	RepairPlan   []byte
+	DetectedAt   time.Time
+}
+
+type AssessmentCycleIntegritySource interface {
+	ListAssessmentCycleIntegritySubjects(ctx context.Context, tenantID, after shared.ID, snapshotAt time.Time, limit int) ([]AssessmentCycleIntegritySubject, error)
+	CountAssessmentCycleIntegritySubjects(ctx context.Context, tenantID shared.ID, snapshotAt time.Time) (eligible int, memberships int, err error)
+}
+
+type AssessmentCycleIntegrityStore interface {
+	AcquireAssessmentCycleIntegrityRun(ctx context.Context, request AssessmentCycleIntegrityAcquireRequest) (run AssessmentCycleIntegrityRun, resumed bool, err error)
+	GetAssessmentCycleIntegrityRun(ctx context.Context, tenantID, runID shared.ID) (AssessmentCycleIntegrityRun, error)
+	GetAssessmentCycleIntegritySubject(ctx context.Context, tenantID, runID, assessmentID shared.ID) (AssessmentCycleIntegritySubjectResult, error)
+	ListAssessmentCycleIntegrityFindings(ctx context.Context, tenantID, runID shared.ID) ([]AssessmentCycleIntegrityFinding, error)
+	SaveAssessmentCycleIntegritySubject(ctx context.Context, leaseToken shared.ID, now time.Time, result AssessmentCycleIntegritySubjectResult, findings []AssessmentCycleIntegrityFinding) (created bool, err error)
+	AdvanceAssessmentCycleIntegrityRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken, checkpoint shared.ID, now time.Time, leaseDuration time.Duration) (AssessmentCycleIntegrityRun, error)
+	FinishAssessmentCycleIntegrityRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken shared.ID, state AssessmentCycleIntegrityState, now time.Time) (AssessmentCycleIntegrityRun, error)
+}

--- a/internal/usecase/ports/assessment_cycle_integrity.go
+++ b/internal/usecase/ports/assessment_cycle_integrity.go
@@ -23,6 +23,7 @@ type AssessmentCycleIntegrityRun struct {
 	ID                   shared.ID
 	BatchSize            int
 	SnapshotAt           time.Time
+	SourceGeneration     int64
 	CheckpointAssessment shared.ID
 	State                AssessmentCycleIntegrityState
 	LeaseOwner           string
@@ -86,6 +87,7 @@ type AssessmentCycleIntegrityFinding struct {
 }
 
 type AssessmentCycleIntegritySource interface {
+	AssessmentCycleIntegrityGeneration(ctx context.Context, tenantID shared.ID) (int64, error)
 	ListAssessmentCycleIntegritySubjects(ctx context.Context, tenantID, after shared.ID, snapshotAt time.Time, limit int) ([]AssessmentCycleIntegritySubject, error)
 	CountAssessmentCycleIntegritySubjects(ctx context.Context, tenantID shared.ID, snapshotAt time.Time) (eligible int, memberships int, err error)
 }

--- a/internal/usecase/ports/assessment_snapshot.go
+++ b/internal/usecase/ports/assessment_snapshot.go
@@ -1,0 +1,106 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type AssessmentSnapshotDefault struct {
+	TenantID     shared.ID
+	AssessmentID shared.ID
+	SnapshotID   shared.ID
+	Version      int64
+	UpdatedAt    time.Time
+	UpdatedBy    string
+}
+
+type AssessmentSnapshotRepository interface {
+	CreateFinalizedCAS(ctx context.Context, snapshot *assessmentsnapshot.Snapshot, expectedDefaultVersion int64) (*assessmentsnapshot.Snapshot, bool, error)
+	CreateLegacyProjection(ctx context.Context, snapshot *assessmentsnapshot.Snapshot) (*assessmentsnapshot.Snapshot, bool, error)
+	Get(ctx context.Context, tenantID, snapshotID shared.ID) (*assessmentsnapshot.Snapshot, error)
+	GetByRequestKey(ctx context.Context, tenantID, assessmentID shared.ID, requestKey string) (*assessmentsnapshot.Snapshot, error)
+	GetDefault(ctx context.Context, tenantID, assessmentID shared.ID) (*assessmentsnapshot.Snapshot, AssessmentSnapshotDefault, error)
+	ListByAssessment(ctx context.Context, tenantID, assessmentID shared.ID) ([]assessmentsnapshot.Snapshot, error)
+}
+
+type AssessmentSnapshotDefaultReader interface {
+	GetDefault(ctx context.Context, tenantID, assessmentID shared.ID) (*assessmentsnapshot.Snapshot, AssessmentSnapshotDefault, error)
+}
+
+// AssessmentSnapshotRunReader exposes the tenant-scoped provenance reads used by
+// snapshot finalization and backfill without coupling them to legacy scan-run writes.
+type AssessmentSnapshotRunReader interface {
+	GetScanRun(ctx context.Context, tenantID shared.ID, runID string) (scanrun.ScanRun, error)
+	ListScanRuns(ctx context.Context, tenantID, engagementID shared.ID) ([]scanrun.ScanRun, error)
+}
+
+type AssessmentSnapshotBackfillState string
+
+const (
+	AssessmentSnapshotBackfillRunning   AssessmentSnapshotBackfillState = "running"
+	AssessmentSnapshotBackfillCompleted AssessmentSnapshotBackfillState = "completed"
+	AssessmentSnapshotBackfillCancelled AssessmentSnapshotBackfillState = "cancelled"
+	AssessmentSnapshotBackfillFailed    AssessmentSnapshotBackfillState = "failed"
+)
+
+type AssessmentSnapshotBackfillRun struct {
+	TenantID             shared.ID
+	ID                   shared.ID
+	SchemaVersion        int
+	DryRun               bool
+	BatchSize            int
+	SnapshotAt           time.Time
+	CheckpointAssessment shared.ID
+	State                AssessmentSnapshotBackfillState
+	LeaseOwner           string
+	LeaseToken           shared.ID
+	LeaseExpiresAt       time.Time
+	ProcessedCount       int
+	CreatedCount         int
+	WouldCreateCount     int
+	SkippedCount         int
+	FailedCount          int
+	CreatedBy            string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	CompletedAt          *time.Time
+}
+
+type AssessmentSnapshotBackfillAcquireRequest struct {
+	Run               AssessmentSnapshotBackfillRun
+	InitialCheckpoint shared.ID
+	LeaseDuration     time.Duration
+}
+
+type AssessmentSnapshotBackfillItem struct {
+	TenantID       shared.ID
+	RunID          shared.ID
+	AssessmentID   shared.ID
+	SchemaVersion  int
+	IdempotencyKey string
+	SourceHash     string
+	SnapshotID     shared.ID
+	Outcome        string
+	ReasonCode     string
+	Retryable      bool
+	RepairGuidance string
+	ProcessedAt    time.Time
+}
+
+type AssessmentSnapshotBackfillSource interface {
+	ListAssessmentSnapshotBackfillEngagements(ctx context.Context, tenantID, after shared.ID, snapshotAt time.Time, limit int) ([]*engdom.Engagement, error)
+}
+
+type AssessmentSnapshotBackfillStore interface {
+	AcquireAssessmentSnapshotBackfillRun(ctx context.Context, request AssessmentSnapshotBackfillAcquireRequest) (run AssessmentSnapshotBackfillRun, resumed bool, err error)
+	GetAssessmentSnapshotBackfillRun(ctx context.Context, tenantID, runID shared.ID) (AssessmentSnapshotBackfillRun, error)
+	GetAssessmentSnapshotBackfillItem(ctx context.Context, tenantID, runID, assessmentID shared.ID) (AssessmentSnapshotBackfillItem, error)
+	CommitAssessmentSnapshotBackfillItem(ctx context.Context, tenantID, runID, leaseToken shared.ID, now time.Time, build func(context.Context) (AssessmentSnapshotBackfillItem, error)) (item AssessmentSnapshotBackfillItem, created bool, err error)
+	AdvanceAssessmentSnapshotBackfillRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken, checkpoint shared.ID, now time.Time, leaseDuration time.Duration) (AssessmentSnapshotBackfillRun, error)
+	FinishAssessmentSnapshotBackfillRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken shared.ID, state AssessmentSnapshotBackfillState, now time.Time) (AssessmentSnapshotBackfillRun, error)
+}

--- a/internal/usecase/ports/assessment_snapshot.go
+++ b/internal/usecase/ports/assessment_snapshot.go
@@ -19,13 +19,25 @@ type AssessmentSnapshotDefault struct {
 	UpdatedBy    string
 }
 
+type AssessmentSnapshotListQuery struct {
+	TenantID            shared.ID
+	AssessmentID        shared.ID
+	AfterSnapshotNumber int
+	Limit               int
+}
+
+type AssessmentSnapshotPage struct {
+	Items   []assessmentsnapshot.Snapshot
+	HasMore bool
+}
+
 type AssessmentSnapshotRepository interface {
 	CreateFinalizedCAS(ctx context.Context, snapshot *assessmentsnapshot.Snapshot, expectedDefaultVersion int64) (*assessmentsnapshot.Snapshot, bool, error)
 	CreateLegacyProjection(ctx context.Context, snapshot *assessmentsnapshot.Snapshot) (*assessmentsnapshot.Snapshot, bool, error)
 	Get(ctx context.Context, tenantID, snapshotID shared.ID) (*assessmentsnapshot.Snapshot, error)
 	GetByRequestKey(ctx context.Context, tenantID, assessmentID shared.ID, requestKey string) (*assessmentsnapshot.Snapshot, error)
 	GetDefault(ctx context.Context, tenantID, assessmentID shared.ID) (*assessmentsnapshot.Snapshot, AssessmentSnapshotDefault, error)
-	ListByAssessment(ctx context.Context, tenantID, assessmentID shared.ID) ([]assessmentsnapshot.Snapshot, error)
+	ListAssessmentSnapshots(ctx context.Context, query AssessmentSnapshotListQuery) (AssessmentSnapshotPage, error)
 }
 
 type AssessmentSnapshotDefaultReader interface {

--- a/migrations/0131_assessment_snapshots.sql
+++ b/migrations/0131_assessment_snapshots.sql
@@ -1,0 +1,220 @@
+-- +goose Up
+-- Assessment Snapshot schema follows the scan-run provenance foundation (0129).
+-- A2 (#696): immutable Assessment Snapshots and deterministic coverage comparability.
+
+CREATE TABLE assessment_snapshots (
+    tenant_id        TEXT NOT NULL,
+    id               TEXT NOT NULL,
+    cycle_id         TEXT NOT NULL,
+    assessment_id    TEXT NOT NULL,
+    snapshot_number  INTEGER NOT NULL CHECK (snapshot_number > 0),
+    default_version BIGINT NOT NULL DEFAULT 0 CHECK (default_version >= 0),
+    lifecycle        TEXT NOT NULL CHECK (lifecycle IN ('building','finalized','superseded')),
+    provenance       TEXT NOT NULL CHECK (provenance IN ('native','legacy')),
+    boundary_kind    TEXT NOT NULL CHECK (boundary_kind IN ('standalone','asset','project','asset_project')),
+    business_asset_id TEXT,
+    project_id       TEXT,
+    schema_version   INTEGER NOT NULL CHECK (schema_version = 1),
+    content_hash     TEXT NOT NULL CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+    request_key      TEXT NOT NULL CHECK (btrim(request_key) <> ''),
+    request_hash     TEXT NOT NULL CHECK (request_hash ~ '^[0-9a-f]{64}$'),
+    created_at       TIMESTAMPTZ NOT NULL,
+    created_by       TEXT NOT NULL,
+    finalized_at     TIMESTAMPTZ,
+    finalized_by     TEXT NOT NULL DEFAULT '',
+    superseded_at    TIMESTAMPTZ,
+    superseded_by    TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (tenant_id, id),
+    UNIQUE (tenant_id, assessment_id, snapshot_number),
+    UNIQUE (tenant_id, assessment_id, request_key),
+    FOREIGN KEY (tenant_id, cycle_id, assessment_id)
+        REFERENCES assessment_cycle_members(tenant_id, cycle_id, assessment_id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, assessment_id)
+        REFERENCES engagements(tenant_id, id) ON DELETE RESTRICT,
+    CONSTRAINT assessment_snapshots_boundary_check CHECK (
+        (boundary_kind = 'standalone' AND business_asset_id IS NULL AND project_id IS NULL) OR
+        (boundary_kind = 'asset' AND business_asset_id IS NOT NULL AND project_id IS NULL) OR
+        (boundary_kind = 'project' AND business_asset_id IS NULL AND project_id IS NOT NULL) OR
+        (boundary_kind = 'asset_project' AND business_asset_id IS NOT NULL AND project_id IS NOT NULL)
+    ),
+    CONSTRAINT assessment_snapshots_lifecycle_metadata_check CHECK (
+        (lifecycle = 'building' AND finalized_at IS NULL AND finalized_by = '' AND superseded_at IS NULL AND superseded_by = '') OR
+        (lifecycle = 'finalized' AND finalized_at IS NOT NULL AND finalized_by <> '' AND superseded_at IS NULL AND superseded_by = '') OR
+        (lifecycle = 'superseded' AND finalized_at IS NOT NULL AND finalized_by <> '' AND superseded_at IS NOT NULL AND superseded_by <> '')
+    )
+);
+
+CREATE TABLE assessment_snapshot_run_refs (
+    tenant_id       TEXT NOT NULL,
+    snapshot_id     TEXT NOT NULL,
+    position        INTEGER NOT NULL CHECK (position >= 0),
+    scan_run_id     TEXT NOT NULL,
+    manifest_hash   TEXT NOT NULL CHECK (manifest_hash ~ '^[0-9a-f]{64}$'),
+    PRIMARY KEY (tenant_id, snapshot_id, position),
+    UNIQUE (tenant_id, snapshot_id, scan_run_id),
+    UNIQUE (tenant_id, snapshot_id, position, scan_run_id),
+    FOREIGN KEY (tenant_id, snapshot_id) REFERENCES assessment_snapshots(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, scan_run_id) REFERENCES scan_runs(tenant_id, id) ON DELETE RESTRICT
+);
+
+CREATE TABLE assessment_snapshot_lane_refs (
+    tenant_id       TEXT NOT NULL,
+    snapshot_id     TEXT NOT NULL,
+    run_position    INTEGER NOT NULL,
+    scan_run_id     TEXT NOT NULL,
+    lane_key        TEXT NOT NULL,
+    manifest_hash   TEXT NOT NULL CHECK (manifest_hash ~ '^[0-9a-f]{64}$'),
+    PRIMARY KEY (tenant_id, snapshot_id, run_position, lane_key),
+    FOREIGN KEY (tenant_id, snapshot_id, run_position, scan_run_id)
+        REFERENCES assessment_snapshot_run_refs(tenant_id, snapshot_id, position, scan_run_id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, scan_run_id, lane_key)
+        REFERENCES scan_run_lanes(tenant_id, scan_run_id, lane_key) ON DELETE RESTRICT
+);
+
+CREATE TABLE assessment_snapshot_dimensions (
+    tenant_id          TEXT NOT NULL,
+    snapshot_id        TEXT NOT NULL,
+    position           INTEGER NOT NULL CHECK (position >= 0),
+    run_id             TEXT NOT NULL,
+    lane_key           TEXT NOT NULL,
+    lane_manifest_hash TEXT NOT NULL CHECK (lane_manifest_hash ~ '^[0-9a-f]{64}$'),
+    producer           TEXT NOT NULL CHECK (btrim(producer) <> ''),
+    finding_kind       TEXT NOT NULL CHECK (btrim(finding_kind) <> ''),
+    target_kind        TEXT NOT NULL,
+    target_schema_version INTEGER NOT NULL CHECK (target_schema_version > 0),
+    target_canonical   TEXT NOT NULL CHECK (btrim(target_canonical) <> ''),
+    evaluated_revision TEXT NOT NULL DEFAULT '',
+    coverage_state     TEXT NOT NULL CHECK (coverage_state IN ('complete','partial','unknown')),
+    reason_code        TEXT NOT NULL CHECK (btrim(reason_code) <> ''),
+    included_scope     JSONB NOT NULL CHECK (jsonb_typeof(included_scope) = 'array'),
+    excluded_scope     JSONB NOT NULL CHECK (jsonb_typeof(excluded_scope) = 'array'),
+    versions           JSONB NOT NULL CHECK (jsonb_typeof(versions) = 'array'),
+    PRIMARY KEY (tenant_id, snapshot_id, position),
+    UNIQUE (tenant_id, snapshot_id, target_kind, target_schema_version, target_canonical, producer, finding_kind),
+    FOREIGN KEY (tenant_id, snapshot_id) REFERENCES assessment_snapshots(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, snapshot_id, run_id) REFERENCES assessment_snapshot_run_refs(tenant_id, snapshot_id, scan_run_id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, run_id, lane_key) REFERENCES scan_run_lanes(tenant_id, scan_run_id, lane_key) ON DELETE RESTRICT
+);
+
+CREATE TABLE assessment_snapshot_counters (
+    tenant_id            TEXT NOT NULL,
+    assessment_id        TEXT NOT NULL,
+    next_snapshot_number INTEGER NOT NULL CHECK (next_snapshot_number >= 1),
+    PRIMARY KEY (tenant_id, assessment_id),
+    FOREIGN KEY (tenant_id, assessment_id) REFERENCES engagements(tenant_id, id) ON DELETE RESTRICT
+);
+
+CREATE TABLE assessment_snapshot_defaults (
+    tenant_id      TEXT NOT NULL,
+    assessment_id  TEXT NOT NULL,
+    snapshot_id    TEXT NOT NULL,
+    version        BIGINT NOT NULL CHECK (version >= 1),
+    updated_at     TIMESTAMPTZ NOT NULL,
+    updated_by     TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, assessment_id),
+    FOREIGN KEY (tenant_id, assessment_id) REFERENCES engagements(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, snapshot_id) REFERENCES assessment_snapshots(tenant_id, id) ON DELETE RESTRICT
+);
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION synapse_assessment_snapshot_guard() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE engagement_status TEXT;
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        SELECT status INTO engagement_status FROM engagements WHERE tenant_id = NEW.tenant_id AND id = NEW.assessment_id;
+        IF engagement_status NOT IN ('draft','active') THEN
+            RAISE EXCEPTION 'assessment snapshot requires draft/active engagement';
+        END IF;
+        RETURN NEW;
+    END IF;
+    IF OLD.lifecycle = 'building' AND NEW.lifecycle = 'finalized' AND
+	   (NEW.tenant_id,NEW.id,NEW.cycle_id,NEW.assessment_id,NEW.snapshot_number,NEW.default_version,NEW.provenance,NEW.boundary_kind,
+        NEW.business_asset_id,NEW.project_id,NEW.schema_version,NEW.content_hash,NEW.request_key,NEW.request_hash,
+        NEW.created_at,NEW.created_by,NEW.superseded_at,NEW.superseded_by)
+       IS NOT DISTINCT FROM
+	   (OLD.tenant_id,OLD.id,OLD.cycle_id,OLD.assessment_id,OLD.snapshot_number,OLD.default_version,OLD.provenance,OLD.boundary_kind,
+        OLD.business_asset_id,OLD.project_id,OLD.schema_version,OLD.content_hash,OLD.request_key,OLD.request_hash,
+        OLD.created_at,OLD.created_by,OLD.superseded_at,OLD.superseded_by) THEN
+        RETURN NEW;
+    END IF;
+    IF OLD.lifecycle = 'finalized' AND NEW.lifecycle = 'superseded' AND
+	   (NEW.tenant_id,NEW.id,NEW.cycle_id,NEW.assessment_id,NEW.snapshot_number,NEW.default_version,NEW.provenance,NEW.boundary_kind,
+        NEW.business_asset_id,NEW.project_id,NEW.schema_version,NEW.content_hash,NEW.request_key,NEW.request_hash,
+        NEW.created_at,NEW.created_by,NEW.finalized_at,NEW.finalized_by)
+       IS NOT DISTINCT FROM
+	   (OLD.tenant_id,OLD.id,OLD.cycle_id,OLD.assessment_id,OLD.snapshot_number,OLD.default_version,OLD.provenance,OLD.boundary_kind,
+        OLD.business_asset_id,OLD.project_id,OLD.schema_version,OLD.content_hash,OLD.request_key,OLD.request_hash,
+        OLD.created_at,OLD.created_by,OLD.finalized_at,OLD.finalized_by) THEN
+        RETURN NEW;
+    END IF;
+    RAISE EXCEPTION 'assessment snapshot is immutable';
+END $$;
+-- +goose StatementEnd
+
+CREATE TRIGGER assessment_snapshots_guard
+BEFORE INSERT OR UPDATE OR DELETE ON assessment_snapshots
+FOR EACH ROW EXECUTE FUNCTION synapse_assessment_snapshot_guard();
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION synapse_assessment_snapshot_child_guard() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE state TEXT;
+DECLARE sid TEXT;
+DECLARE tenant TEXT;
+BEGIN
+    sid := CASE WHEN TG_OP = 'DELETE' THEN OLD.snapshot_id ELSE NEW.snapshot_id END;
+    tenant := CASE WHEN TG_OP = 'DELETE' THEN OLD.tenant_id ELSE NEW.tenant_id END;
+    SELECT lifecycle INTO state FROM assessment_snapshots WHERE tenant_id = tenant AND id = sid;
+    IF state <> 'building' THEN
+        RAISE EXCEPTION 'finalized assessment snapshot child is immutable';
+    END IF;
+    RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END $$;
+-- +goose StatementEnd
+
+CREATE TRIGGER assessment_snapshot_run_refs_guard BEFORE INSERT OR UPDATE OR DELETE ON assessment_snapshot_run_refs FOR EACH ROW EXECUTE FUNCTION synapse_assessment_snapshot_child_guard();
+CREATE TRIGGER assessment_snapshot_lane_refs_guard BEFORE INSERT OR UPDATE OR DELETE ON assessment_snapshot_lane_refs FOR EACH ROW EXECUTE FUNCTION synapse_assessment_snapshot_child_guard();
+CREATE TRIGGER assessment_snapshot_dimensions_guard BEFORE INSERT OR UPDATE OR DELETE ON assessment_snapshot_dimensions FOR EACH ROW EXECUTE FUNCTION synapse_assessment_snapshot_child_guard();
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION synapse_assessment_snapshot_default_guard() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE engagement_status TEXT;
+DECLARE snapshot_state TEXT;
+BEGIN
+    SELECT status INTO engagement_status FROM engagements WHERE tenant_id = NEW.tenant_id AND id = NEW.assessment_id;
+    IF engagement_status NOT IN ('draft','active') THEN
+        RAISE EXCEPTION 'default assessment snapshot cannot change after engagement completion';
+    END IF;
+    SELECT lifecycle INTO snapshot_state FROM assessment_snapshots WHERE tenant_id = NEW.tenant_id AND id = NEW.snapshot_id;
+    IF snapshot_state <> 'finalized' THEN
+        RAISE EXCEPTION 'default assessment snapshot must be finalized';
+    END IF;
+    RETURN NEW;
+END $$;
+-- +goose StatementEnd
+
+CREATE TRIGGER assessment_snapshot_defaults_guard BEFORE INSERT OR UPDATE ON assessment_snapshot_defaults FOR EACH ROW EXECUTE FUNCTION synapse_assessment_snapshot_default_guard();
+
+CALL synapse_enable_tenant_rls('assessment_snapshots');
+CALL synapse_enable_tenant_rls('assessment_snapshot_run_refs');
+CALL synapse_enable_tenant_rls('assessment_snapshot_lane_refs');
+CALL synapse_enable_tenant_rls('assessment_snapshot_dimensions');
+CALL synapse_enable_tenant_rls('assessment_snapshot_counters');
+CALL synapse_enable_tenant_rls('assessment_snapshot_defaults');
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM assessment_snapshots LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back assessment snapshots while snapshot rows exist';
+    END IF;
+END $$;
+-- +goose StatementEnd
+DROP TABLE IF EXISTS assessment_snapshot_defaults;
+DROP TABLE IF EXISTS assessment_snapshot_counters;
+DROP TABLE IF EXISTS assessment_snapshot_dimensions;
+DROP TABLE IF EXISTS assessment_snapshot_lane_refs;
+DROP TABLE IF EXISTS assessment_snapshot_run_refs;
+DROP TABLE IF EXISTS assessment_snapshots;
+DROP FUNCTION IF EXISTS synapse_assessment_snapshot_default_guard();
+DROP FUNCTION IF EXISTS synapse_assessment_snapshot_child_guard();
+DROP FUNCTION IF EXISTS synapse_assessment_snapshot_guard();

--- a/migrations/0131_assessment_snapshots.sql
+++ b/migrations/0131_assessment_snapshots.sql
@@ -25,6 +25,7 @@ CREATE TABLE assessment_snapshots (
     superseded_at    TIMESTAMPTZ,
     superseded_by    TEXT NOT NULL DEFAULT '',
     PRIMARY KEY (tenant_id, id),
+	UNIQUE (tenant_id, assessment_id, id),
     UNIQUE (tenant_id, assessment_id, snapshot_number),
     UNIQUE (tenant_id, assessment_id, request_key),
     FOREIGN KEY (tenant_id, cycle_id, assessment_id)
@@ -113,7 +114,7 @@ CREATE TABLE assessment_snapshot_defaults (
     updated_by     TEXT NOT NULL,
     PRIMARY KEY (tenant_id, assessment_id),
     FOREIGN KEY (tenant_id, assessment_id) REFERENCES engagements(tenant_id, id) ON DELETE RESTRICT,
-    FOREIGN KEY (tenant_id, snapshot_id) REFERENCES assessment_snapshots(tenant_id, id) ON DELETE RESTRICT
+	FOREIGN KEY (tenant_id, assessment_id, snapshot_id) REFERENCES assessment_snapshots(tenant_id, assessment_id, id) ON DELETE RESTRICT
 );
 
 -- +goose StatementBegin
@@ -122,7 +123,7 @@ DECLARE engagement_status TEXT;
 BEGIN
     IF TG_OP = 'INSERT' THEN
         SELECT status INTO engagement_status FROM engagements WHERE tenant_id = NEW.tenant_id AND id = NEW.assessment_id;
-        IF engagement_status NOT IN ('draft','active') THEN
+		IF NEW.provenance = 'native' AND engagement_status NOT IN ('draft','active') THEN
             RAISE EXCEPTION 'assessment snapshot requires draft/active engagement';
         END IF;
         RETURN NEW;
@@ -194,6 +195,38 @@ END $$;
 
 CREATE TRIGGER assessment_snapshot_defaults_guard BEFORE INSERT OR UPDATE ON assessment_snapshot_defaults FOR EACH ROW EXECUTE FUNCTION synapse_assessment_snapshot_default_guard();
 
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION synapse_assessment_snapshot_pointer_delete_guard() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+	RAISE EXCEPTION 'assessment snapshot pointer and counter rows cannot be deleted';
+END $$;
+-- +goose StatementEnd
+
+CREATE TRIGGER assessment_snapshot_defaults_delete_guard BEFORE DELETE ON assessment_snapshot_defaults FOR EACH ROW EXECUTE FUNCTION synapse_assessment_snapshot_pointer_delete_guard();
+CREATE TRIGGER assessment_snapshot_counters_delete_guard BEFORE DELETE ON assessment_snapshot_counters FOR EACH ROW EXECUTE FUNCTION synapse_assessment_snapshot_pointer_delete_guard();
+
+-- Once an Assessment joins a Cycle its governed Business Asset boundary is
+-- immutable. This invariant lives in the first migration introduced by this
+-- slice so upgrades from an already-applied 0126 install it as well.
+-- +goose StatementBegin
+CREATE FUNCTION synapse_reject_assessment_cycle_boundary_change() RETURNS trigger AS $$
+BEGIN
+    IF NEW.business_asset_id IS DISTINCT FROM OLD.business_asset_id AND EXISTS (
+        SELECT 1 FROM assessment_cycle_members
+        WHERE tenant_id = OLD.tenant_id AND assessment_id = OLD.id
+    ) THEN
+        RAISE EXCEPTION 'Assessment Cycle membership freezes the Business Asset boundary'
+            USING ERRCODE = '23514', CONSTRAINT = 'assessment_cycle_frozen_business_asset';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER trg_assessment_cycle_frozen_business_asset
+    BEFORE UPDATE OF business_asset_id ON engagements
+    FOR EACH ROW EXECUTE FUNCTION synapse_reject_assessment_cycle_boundary_change();
+
 CALL synapse_enable_tenant_rls('assessment_snapshots');
 CALL synapse_enable_tenant_rls('assessment_snapshot_run_refs');
 CALL synapse_enable_tenant_rls('assessment_snapshot_lane_refs');
@@ -209,6 +242,8 @@ DO $$ BEGIN
     END IF;
 END $$;
 -- +goose StatementEnd
+DROP TRIGGER IF EXISTS trg_assessment_cycle_frozen_business_asset ON engagements;
+DROP FUNCTION IF EXISTS synapse_reject_assessment_cycle_boundary_change();
 DROP TABLE IF EXISTS assessment_snapshot_defaults;
 DROP TABLE IF EXISTS assessment_snapshot_counters;
 DROP TABLE IF EXISTS assessment_snapshot_dimensions;
@@ -218,3 +253,4 @@ DROP TABLE IF EXISTS assessment_snapshots;
 DROP FUNCTION IF EXISTS synapse_assessment_snapshot_default_guard();
 DROP FUNCTION IF EXISTS synapse_assessment_snapshot_child_guard();
 DROP FUNCTION IF EXISTS synapse_assessment_snapshot_guard();
+DROP FUNCTION IF EXISTS synapse_assessment_snapshot_pointer_delete_guard();

--- a/migrations/0132_assessment_cycle_api.sql
+++ b/migrations/0132_assessment_cycle_api.sql
@@ -1,0 +1,78 @@
+-- +goose Up
+-- Assessment Cycle HTTP/idempotency schema.
+-- A5 (#699): tenant-scoped retained responses for Cycle/Re-test API idempotency.
+
+ALTER TABLE engagements
+    ADD COLUMN requires_explicit_execution_authorization BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE TABLE assessment_cycle_api_requests (
+    tenant_id       TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+    actor           TEXT NOT NULL,
+    route           TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    request_hash    TEXT NOT NULL,
+    status_code     INTEGER NULL,
+    response_body   BYTEA NULL,
+    created_at      TIMESTAMPTZ NOT NULL,
+    completed_at    TIMESTAMPTZ NULL,
+    PRIMARY KEY (tenant_id, actor, route, idempotency_key),
+    CONSTRAINT assessment_cycle_api_requests_actor_check CHECK (actor = btrim(actor) AND length(actor) BETWEEN 1 AND 256),
+    CONSTRAINT assessment_cycle_api_requests_route_check CHECK (route = btrim(route) AND length(route) BETWEEN 1 AND 256),
+    CONSTRAINT assessment_cycle_api_requests_key_check CHECK (idempotency_key = btrim(idempotency_key) AND length(idempotency_key) BETWEEN 1 AND 128),
+    CONSTRAINT assessment_cycle_api_requests_hash_check CHECK (request_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT assessment_cycle_api_requests_response_check CHECK (
+        (status_code IS NULL AND response_body IS NULL AND completed_at IS NULL) OR
+        (status_code BETWEEN 200 AND 599 AND response_body IS NOT NULL AND completed_at IS NOT NULL AND octet_length(response_body) <= 2097152)
+    )
+);
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION synapse_guard_assessment_cycle_api_request()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.tenant_id <> NEW.tenant_id OR OLD.actor <> NEW.actor OR OLD.route <> NEW.route OR
+       OLD.idempotency_key <> NEW.idempotency_key OR OLD.request_hash <> NEW.request_hash OR
+       OLD.created_at <> NEW.created_at THEN
+        RAISE EXCEPTION 'assessment cycle idempotency identity is immutable';
+    END IF;
+    IF OLD.completed_at IS NOT NULL THEN
+        RAISE EXCEPTION 'completed assessment cycle idempotency response is immutable';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE TRIGGER assessment_cycle_api_requests_guard
+BEFORE UPDATE ON assessment_cycle_api_requests
+FOR EACH ROW EXECUTE FUNCTION synapse_guard_assessment_cycle_api_request();
+
+CALL synapse_enable_tenant_rls('assessment_cycle_api_requests');
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM assessment_cycle_api_requests LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back assessment cycle API idempotency while retained responses exist';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+DROP TABLE IF EXISTS assessment_cycle_api_requests;
+DROP FUNCTION IF EXISTS synapse_guard_assessment_cycle_api_request();
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM engagements WHERE requires_explicit_execution_authorization LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back explicit Re-test execution authorization while guarded engagements exist';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+ALTER TABLE engagements DROP COLUMN requires_explicit_execution_authorization;

--- a/migrations/0132_assessment_cycle_api.sql
+++ b/migrations/0132_assessment_cycle_api.sql
@@ -14,12 +14,14 @@ CREATE TABLE assessment_cycle_api_requests (
     status_code     INTEGER NULL,
     response_body   BYTEA NULL,
     created_at      TIMESTAMPTZ NOT NULL,
+	expires_at      TIMESTAMPTZ NOT NULL,
     completed_at    TIMESTAMPTZ NULL,
     PRIMARY KEY (tenant_id, actor, route, idempotency_key),
     CONSTRAINT assessment_cycle_api_requests_actor_check CHECK (actor = btrim(actor) AND length(actor) BETWEEN 1 AND 256),
     CONSTRAINT assessment_cycle_api_requests_route_check CHECK (route = btrim(route) AND length(route) BETWEEN 1 AND 256),
     CONSTRAINT assessment_cycle_api_requests_key_check CHECK (idempotency_key = btrim(idempotency_key) AND length(idempotency_key) BETWEEN 1 AND 128),
     CONSTRAINT assessment_cycle_api_requests_hash_check CHECK (request_hash ~ '^[0-9a-f]{64}$'),
+	CONSTRAINT assessment_cycle_api_requests_expiry_check CHECK (expires_at > created_at),
     CONSTRAINT assessment_cycle_api_requests_response_check CHECK (
         (status_code IS NULL AND response_body IS NULL AND completed_at IS NULL) OR
         (status_code BETWEEN 200 AND 599 AND response_body IS NOT NULL AND completed_at IS NOT NULL AND octet_length(response_body) <= 2097152)
@@ -34,7 +36,7 @@ AS $$
 BEGIN
     IF OLD.tenant_id <> NEW.tenant_id OR OLD.actor <> NEW.actor OR OLD.route <> NEW.route OR
        OLD.idempotency_key <> NEW.idempotency_key OR OLD.request_hash <> NEW.request_hash OR
-       OLD.created_at <> NEW.created_at THEN
+	   OLD.created_at <> NEW.created_at OR OLD.expires_at <> NEW.expires_at THEN
         RAISE EXCEPTION 'assessment cycle idempotency identity is immutable';
     END IF;
     IF OLD.completed_at IS NOT NULL THEN
@@ -48,6 +50,9 @@ $$;
 CREATE TRIGGER assessment_cycle_api_requests_guard
 BEFORE UPDATE ON assessment_cycle_api_requests
 FOR EACH ROW EXECUTE FUNCTION synapse_guard_assessment_cycle_api_request();
+
+CREATE INDEX idx_assessment_cycle_api_requests_expiry
+    ON assessment_cycle_api_requests (tenant_id, expires_at);
 
 CALL synapse_enable_tenant_rls('assessment_cycle_api_requests');
 

--- a/migrations/0133_assessment_cycle_backfill.sql
+++ b/migrations/0133_assessment_cycle_backfill.sql
@@ -1,0 +1,97 @@
+-- +goose Up
+-- Assessment Cycle historical backfill schema.
+-- A9b.1 (#717): resumable singleton-Cycle historical backfill runs and stable item outcomes.
+
+CREATE TABLE assessment_cycle_backfill_runs (
+    tenant_id                TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+    id                       TEXT NOT NULL,
+    schema_version           INTEGER NOT NULL,
+    dry_run                  BOOLEAN NOT NULL,
+    batch_size               INTEGER NOT NULL,
+    snapshot_at              TIMESTAMPTZ NOT NULL,
+    checkpoint_assessment_id TEXT NOT NULL DEFAULT '',
+    state                    TEXT NOT NULL,
+    lease_owner              TEXT NOT NULL DEFAULT '',
+    lease_token              TEXT NOT NULL DEFAULT '',
+    lease_expires_at         TIMESTAMPTZ NULL,
+    processed_count          INTEGER NOT NULL DEFAULT 0,
+    created_count            INTEGER NOT NULL DEFAULT 0,
+    would_create_count       INTEGER NOT NULL DEFAULT 0,
+    skipped_count            INTEGER NOT NULL DEFAULT 0,
+    failed_count             INTEGER NOT NULL DEFAULT 0,
+    created_by               TEXT NOT NULL,
+    created_at               TIMESTAMPTZ NOT NULL,
+    updated_at               TIMESTAMPTZ NOT NULL,
+    completed_at             TIMESTAMPTZ NULL,
+    PRIMARY KEY (tenant_id, id),
+    CONSTRAINT assessment_cycle_backfill_runs_schema_check CHECK (schema_version > 0),
+    CONSTRAINT assessment_cycle_backfill_runs_batch_check CHECK (batch_size BETWEEN 1 AND 2000),
+    CONSTRAINT assessment_cycle_backfill_runs_checkpoint_check CHECK (octet_length(checkpoint_assessment_id) <= 512),
+    CONSTRAINT assessment_cycle_backfill_runs_state_check CHECK (state IN ('running', 'completed', 'cancelled', 'failed')),
+    CONSTRAINT assessment_cycle_backfill_runs_lease_check CHECK (
+        (state = 'running' AND lease_owner = btrim(lease_owner) AND length(lease_owner) BETWEEN 1 AND 256 AND length(lease_token) BETWEEN 1 AND 512 AND lease_expires_at IS NOT NULL AND completed_at IS NULL) OR
+        (state <> 'running' AND lease_owner = '' AND lease_token = '' AND lease_expires_at IS NULL AND completed_at IS NOT NULL)
+    ),
+    CONSTRAINT assessment_cycle_backfill_runs_counts_check CHECK (
+        processed_count >= 0 AND created_count >= 0 AND would_create_count >= 0 AND skipped_count >= 0 AND failed_count >= 0 AND
+        processed_count = created_count + would_create_count + skipped_count + failed_count
+    ),
+    CONSTRAINT assessment_cycle_backfill_runs_actor_check CHECK (created_by = btrim(created_by) AND length(created_by) BETWEEN 1 AND 256),
+    CONSTRAINT assessment_cycle_backfill_runs_time_check CHECK (updated_at >= created_at AND snapshot_at <= created_at AND (completed_at IS NULL OR completed_at >= created_at))
+);
+
+CREATE UNIQUE INDEX uq_assessment_cycle_backfill_runs_active
+    ON assessment_cycle_backfill_runs (tenant_id)
+    WHERE state = 'running';
+CREATE INDEX idx_assessment_cycle_backfill_runs_history
+    ON assessment_cycle_backfill_runs (tenant_id, created_at DESC, id DESC);
+
+CREATE TABLE assessment_cycle_backfill_items (
+    tenant_id       TEXT NOT NULL,
+    run_id          TEXT NOT NULL,
+    assessment_id   TEXT NOT NULL,
+    schema_version  INTEGER NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    cycle_id        TEXT NULL,
+    outcome         TEXT NOT NULL,
+    reason_code     TEXT NOT NULL,
+    retryable       BOOLEAN NOT NULL DEFAULT FALSE,
+    repair_guidance TEXT NOT NULL DEFAULT '',
+    processed_at    TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, assessment_id),
+    FOREIGN KEY (tenant_id, run_id) REFERENCES assessment_cycle_backfill_runs(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, assessment_id) REFERENCES engagements(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id) REFERENCES assessment_cycles(tenant_id, id) ON DELETE RESTRICT,
+    UNIQUE (tenant_id, run_id, idempotency_key),
+    CONSTRAINT assessment_cycle_backfill_items_schema_check CHECK (schema_version > 0),
+    CONSTRAINT assessment_cycle_backfill_items_key_check CHECK (idempotency_key = btrim(idempotency_key) AND length(idempotency_key) BETWEEN 1 AND 128),
+    CONSTRAINT assessment_cycle_backfill_items_outcome_check CHECK (outcome IN ('created', 'would_create', 'skipped', 'failed')),
+    CONSTRAINT assessment_cycle_backfill_items_reason_check CHECK (reason_code ~ '^[a-z0-9_]{1,64}$'),
+    CONSTRAINT assessment_cycle_backfill_items_guidance_check CHECK (octet_length(repair_guidance) <= 1024),
+    CONSTRAINT assessment_cycle_backfill_items_cycle_check CHECK (
+        (outcome = 'created' AND cycle_id IS NOT NULL) OR
+        (outcome IN ('would_create', 'failed') AND cycle_id IS NULL) OR
+        outcome = 'skipped'
+    )
+);
+
+CREATE INDEX idx_assessment_cycle_backfill_items_outcome
+    ON assessment_cycle_backfill_items (tenant_id, run_id, outcome, assessment_id);
+
+CALL synapse_enable_tenant_rls('assessment_cycle_backfill_runs');
+CALL synapse_enable_tenant_rls('assessment_cycle_backfill_items');
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM assessment_cycle_backfill_items LIMIT 1) OR
+       EXISTS (SELECT 1 FROM assessment_cycle_backfill_runs LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back assessment cycle backfill state while run history exists';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+DROP TABLE IF EXISTS assessment_cycle_backfill_items;
+DROP TABLE IF EXISTS assessment_cycle_backfill_runs;

--- a/migrations/0134_assessment_cycle_integrity.sql
+++ b/migrations/0134_assessment_cycle_integrity.sql
@@ -1,0 +1,99 @@
+-- +goose Up
+-- Assessment Cycle integrity verification schema.
+-- A9b.2 (#731): resumable, read-only Assessment Cycle integrity verification and repair plans.
+
+CREATE TABLE assessment_cycle_integrity_runs (
+    tenant_id                TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+    id                       TEXT NOT NULL,
+    batch_size               INTEGER NOT NULL,
+    snapshot_at              TIMESTAMPTZ NOT NULL,
+    checkpoint_assessment_id TEXT NOT NULL DEFAULT '',
+    state                    TEXT NOT NULL,
+    lease_owner              TEXT NOT NULL DEFAULT '',
+    lease_token              TEXT NOT NULL DEFAULT '',
+    lease_expires_at         TIMESTAMPTZ NULL,
+    scanned_count            INTEGER NOT NULL DEFAULT 0,
+    clean_count              INTEGER NOT NULL DEFAULT 0,
+    finding_count            INTEGER NOT NULL DEFAULT 0,
+    created_by               TEXT NOT NULL,
+    created_at               TIMESTAMPTZ NOT NULL,
+    updated_at               TIMESTAMPTZ NOT NULL,
+    completed_at             TIMESTAMPTZ NULL,
+    PRIMARY KEY (tenant_id, id),
+    CONSTRAINT assessment_cycle_integrity_runs_batch_check CHECK (batch_size BETWEEN 1 AND 2000),
+    CONSTRAINT assessment_cycle_integrity_runs_checkpoint_check CHECK (octet_length(checkpoint_assessment_id) <= 512),
+    CONSTRAINT assessment_cycle_integrity_runs_state_check CHECK (state IN ('running', 'completed', 'cancelled', 'failed')),
+    CONSTRAINT assessment_cycle_integrity_runs_lease_check CHECK (
+        (state = 'running' AND lease_owner = btrim(lease_owner) AND length(lease_owner) BETWEEN 1 AND 256 AND length(lease_token) BETWEEN 1 AND 512 AND lease_expires_at IS NOT NULL AND completed_at IS NULL) OR
+        (state <> 'running' AND lease_owner = '' AND lease_token = '' AND lease_expires_at IS NULL AND completed_at IS NOT NULL)
+    ),
+    CONSTRAINT assessment_cycle_integrity_runs_counts_check CHECK (
+        scanned_count >= 0 AND clean_count >= 0 AND finding_count >= 0 AND clean_count <= scanned_count AND
+        (finding_count > 0 OR clean_count = scanned_count)
+    ),
+    CONSTRAINT assessment_cycle_integrity_runs_actor_check CHECK (created_by = btrim(created_by) AND length(created_by) BETWEEN 1 AND 256),
+    CONSTRAINT assessment_cycle_integrity_runs_time_check CHECK (updated_at >= created_at AND snapshot_at <= created_at AND (completed_at IS NULL OR completed_at >= created_at))
+);
+
+CREATE UNIQUE INDEX uq_assessment_cycle_integrity_runs_active
+    ON assessment_cycle_integrity_runs (tenant_id)
+    WHERE state = 'running';
+CREATE INDEX idx_assessment_cycle_integrity_runs_history
+    ON assessment_cycle_integrity_runs (tenant_id, created_at DESC, id DESC);
+
+CREATE TABLE assessment_cycle_integrity_subjects (
+    tenant_id      TEXT NOT NULL,
+    run_id         TEXT NOT NULL,
+    assessment_id  TEXT NOT NULL,
+    clean           BOOLEAN NOT NULL,
+    finding_count   INTEGER NOT NULL,
+    processed_at    TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, assessment_id),
+    FOREIGN KEY (tenant_id, run_id) REFERENCES assessment_cycle_integrity_runs(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, assessment_id) REFERENCES engagements(tenant_id, id) ON DELETE RESTRICT,
+    CONSTRAINT assessment_cycle_integrity_subjects_counts_check CHECK (finding_count >= 0 AND clean = (finding_count = 0))
+);
+
+CREATE TABLE assessment_cycle_integrity_findings (
+    tenant_id       TEXT NOT NULL,
+    run_id          TEXT NOT NULL,
+    occurrence_id   TEXT NOT NULL,
+    assessment_id   TEXT NOT NULL,
+    cycle_id        TEXT NULL,
+    member_id       TEXT NULL,
+    reason_code     TEXT NOT NULL,
+    severity        TEXT NOT NULL,
+    repair_plan     JSONB NOT NULL,
+    detected_at     TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, occurrence_id),
+    FOREIGN KEY (tenant_id, run_id, assessment_id) REFERENCES assessment_cycle_integrity_subjects(tenant_id, run_id, assessment_id) ON DELETE RESTRICT,
+    CONSTRAINT assessment_cycle_integrity_findings_occurrence_check CHECK (occurrence_id ~ '^[0-9a-f]{32}$'),
+    CONSTRAINT assessment_cycle_integrity_findings_member_check CHECK ((cycle_id IS NULL AND member_id IS NULL) OR cycle_id IS NOT NULL),
+    CONSTRAINT assessment_cycle_integrity_findings_reason_check CHECK (reason_code ~ '^[a-z0-9_]{1,64}$'),
+    CONSTRAINT assessment_cycle_integrity_findings_severity_check CHECK (severity IN ('medium', 'high', 'critical')),
+    CONSTRAINT assessment_cycle_integrity_findings_repair_check CHECK (jsonb_typeof(repair_plan) = 'object' AND octet_length(repair_plan::text) <= 8192)
+);
+
+CREATE INDEX idx_assessment_cycle_integrity_findings_reason
+    ON assessment_cycle_integrity_findings (tenant_id, run_id, severity, reason_code, occurrence_id);
+
+CALL synapse_enable_tenant_rls('assessment_cycle_integrity_runs');
+CALL synapse_enable_tenant_rls('assessment_cycle_integrity_subjects');
+CALL synapse_enable_tenant_rls('assessment_cycle_integrity_findings');
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM assessment_cycle_integrity_findings LIMIT 1) OR
+       EXISTS (SELECT 1 FROM assessment_cycle_integrity_subjects LIMIT 1) OR
+       EXISTS (SELECT 1 FROM assessment_cycle_integrity_runs LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back assessment cycle integrity state while verification history exists';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+DROP TABLE IF EXISTS assessment_cycle_integrity_findings;
+DROP TABLE IF EXISTS assessment_cycle_integrity_subjects;
+DROP TABLE IF EXISTS assessment_cycle_integrity_runs;

--- a/migrations/0134_assessment_cycle_integrity.sql
+++ b/migrations/0134_assessment_cycle_integrity.sql
@@ -2,11 +2,17 @@
 -- Assessment Cycle integrity verification schema.
 -- A9b.2 (#731): resumable, read-only Assessment Cycle integrity verification and repair plans.
 
+CREATE TABLE assessment_cycle_integrity_generations (
+    tenant_id  TEXT PRIMARY KEY REFERENCES tenants(id) ON DELETE RESTRICT,
+    generation BIGINT NOT NULL DEFAULT 0 CHECK (generation >= 0)
+);
+
 CREATE TABLE assessment_cycle_integrity_runs (
     tenant_id                TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
     id                       TEXT NOT NULL,
     batch_size               INTEGER NOT NULL,
     snapshot_at              TIMESTAMPTZ NOT NULL,
+    source_generation        BIGINT NOT NULL,
     checkpoint_assessment_id TEXT NOT NULL DEFAULT '',
     state                    TEXT NOT NULL,
     lease_owner              TEXT NOT NULL DEFAULT '',
@@ -21,6 +27,7 @@ CREATE TABLE assessment_cycle_integrity_runs (
     completed_at             TIMESTAMPTZ NULL,
     PRIMARY KEY (tenant_id, id),
     CONSTRAINT assessment_cycle_integrity_runs_batch_check CHECK (batch_size BETWEEN 1 AND 2000),
+    CONSTRAINT assessment_cycle_integrity_runs_generation_check CHECK (source_generation >= 0),
     CONSTRAINT assessment_cycle_integrity_runs_checkpoint_check CHECK (octet_length(checkpoint_assessment_id) <= 512),
     CONSTRAINT assessment_cycle_integrity_runs_state_check CHECK (state IN ('running', 'completed', 'cancelled', 'failed')),
     CONSTRAINT assessment_cycle_integrity_runs_lease_check CHECK (
@@ -80,6 +87,37 @@ CREATE INDEX idx_assessment_cycle_integrity_findings_reason
 CALL synapse_enable_tenant_rls('assessment_cycle_integrity_runs');
 CALL synapse_enable_tenant_rls('assessment_cycle_integrity_subjects');
 CALL synapse_enable_tenant_rls('assessment_cycle_integrity_findings');
+CALL synapse_enable_tenant_rls('assessment_cycle_integrity_generations');
+
+-- Serialize lifecycle source mutations with verifier completion and advance a
+-- tenant-local generation for every integrity-relevant change.
+-- +goose StatementBegin
+CREATE FUNCTION synapse_bump_assessment_cycle_integrity_generation() RETURNS trigger AS $$
+DECLARE
+    affected_tenant TEXT;
+BEGIN
+    affected_tenant := CASE WHEN TG_OP = 'DELETE' THEN OLD.tenant_id ELSE NEW.tenant_id END;
+    PERFORM pg_advisory_xact_lock(hashtextextended('assessment-cycle-integrity:' || affected_tenant, 0));
+    INSERT INTO assessment_cycle_integrity_generations(tenant_id,generation)
+    VALUES(affected_tenant,1)
+    ON CONFLICT (tenant_id) DO UPDATE SET generation=assessment_cycle_integrity_generations.generation+1;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER trg_engagement_integrity_generation
+    AFTER INSERT OR UPDATE OR DELETE ON engagements
+    FOR EACH ROW EXECUTE FUNCTION synapse_bump_assessment_cycle_integrity_generation();
+CREATE TRIGGER trg_assessment_cycle_integrity_generation
+    AFTER INSERT OR UPDATE OR DELETE ON assessment_cycles
+    FOR EACH ROW EXECUTE FUNCTION synapse_bump_assessment_cycle_integrity_generation();
+CREATE TRIGGER trg_assessment_cycle_member_integrity_generation
+    AFTER INSERT OR UPDATE OR DELETE ON assessment_cycle_members
+    FOR EACH ROW EXECUTE FUNCTION synapse_bump_assessment_cycle_integrity_generation();
 
 -- +goose Down
 -- +goose StatementBegin
@@ -94,6 +132,12 @@ END;
 $$;
 -- +goose StatementEnd
 
+DROP TRIGGER IF EXISTS trg_assessment_cycle_member_integrity_generation ON assessment_cycle_members;
+DROP TRIGGER IF EXISTS trg_assessment_cycle_integrity_generation ON assessment_cycles;
+DROP TRIGGER IF EXISTS trg_engagement_integrity_generation ON engagements;
+DROP FUNCTION IF EXISTS synapse_bump_assessment_cycle_integrity_generation();
+
 DROP TABLE IF EXISTS assessment_cycle_integrity_findings;
 DROP TABLE IF EXISTS assessment_cycle_integrity_subjects;
 DROP TABLE IF EXISTS assessment_cycle_integrity_runs;
+DROP TABLE IF EXISTS assessment_cycle_integrity_generations;

--- a/migrations/0135_assessment_snapshot_backfill.sql
+++ b/migrations/0135_assessment_snapshot_backfill.sql
@@ -1,0 +1,104 @@
+-- +goose Up
+-- Assessment Snapshot legacy projection backfill schema.
+-- A9c (#718): resumable, append-only legacy Assessment Snapshot projection state.
+
+ALTER TABLE assessment_snapshots
+    ADD CONSTRAINT assessment_snapshots_tenant_assessment_id_unique UNIQUE (tenant_id, assessment_id, id);
+
+CREATE TABLE assessment_snapshot_backfill_runs (
+    tenant_id               TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+    id                      TEXT NOT NULL,
+    schema_version          INTEGER NOT NULL,
+    dry_run                 BOOLEAN NOT NULL,
+    batch_size              INTEGER NOT NULL,
+    snapshot_at             TIMESTAMPTZ NOT NULL,
+    checkpoint_assessment_id TEXT NOT NULL DEFAULT '',
+    state                   TEXT NOT NULL,
+    lease_owner             TEXT NOT NULL DEFAULT '',
+    lease_token             TEXT NOT NULL DEFAULT '',
+    lease_expires_at        TIMESTAMPTZ NULL,
+    processed_count         INTEGER NOT NULL DEFAULT 0,
+    created_count           INTEGER NOT NULL DEFAULT 0,
+    would_create_count      INTEGER NOT NULL DEFAULT 0,
+    skipped_count           INTEGER NOT NULL DEFAULT 0,
+    failed_count            INTEGER NOT NULL DEFAULT 0,
+    created_by              TEXT NOT NULL,
+    created_at              TIMESTAMPTZ NOT NULL,
+    updated_at              TIMESTAMPTZ NOT NULL,
+    completed_at            TIMESTAMPTZ NULL,
+    PRIMARY KEY (tenant_id, id),
+    CONSTRAINT assessment_snapshot_backfill_runs_schema_check CHECK (schema_version > 0),
+    CONSTRAINT assessment_snapshot_backfill_runs_batch_check CHECK (batch_size BETWEEN 1 AND 2000),
+    CONSTRAINT assessment_snapshot_backfill_runs_checkpoint_check CHECK (octet_length(checkpoint_assessment_id) <= 512),
+    CONSTRAINT assessment_snapshot_backfill_runs_state_check CHECK (state IN ('running', 'completed', 'cancelled', 'failed')),
+    CONSTRAINT assessment_snapshot_backfill_runs_lease_check CHECK (
+        (state = 'running' AND lease_owner = btrim(lease_owner) AND length(lease_owner) BETWEEN 1 AND 256 AND length(lease_token) BETWEEN 1 AND 512 AND lease_expires_at IS NOT NULL AND completed_at IS NULL) OR
+        (state <> 'running' AND lease_owner = '' AND lease_token = '' AND lease_expires_at IS NULL AND completed_at IS NOT NULL)
+    ),
+    CONSTRAINT assessment_snapshot_backfill_runs_counts_check CHECK (
+        processed_count >= 0 AND created_count >= 0 AND would_create_count >= 0 AND skipped_count >= 0 AND failed_count >= 0 AND
+        processed_count = created_count + would_create_count + skipped_count + failed_count
+    ),
+    CONSTRAINT assessment_snapshot_backfill_runs_actor_check CHECK (created_by = btrim(created_by) AND length(created_by) BETWEEN 1 AND 256),
+    CONSTRAINT assessment_snapshot_backfill_runs_time_check CHECK (updated_at >= created_at AND snapshot_at <= created_at AND (completed_at IS NULL OR completed_at >= created_at))
+);
+
+CREATE UNIQUE INDEX uq_assessment_snapshot_backfill_runs_active
+    ON assessment_snapshot_backfill_runs (tenant_id)
+    WHERE state = 'running';
+CREATE INDEX idx_assessment_snapshot_backfill_runs_history
+    ON assessment_snapshot_backfill_runs (tenant_id, created_at DESC, id DESC);
+
+CREATE TABLE assessment_snapshot_backfill_items (
+    tenant_id       TEXT NOT NULL,
+    run_id          TEXT NOT NULL,
+    assessment_id   TEXT NOT NULL,
+    schema_version  INTEGER NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    source_hash     TEXT NOT NULL,
+    snapshot_id     TEXT NULL,
+    outcome         TEXT NOT NULL,
+    reason_code     TEXT NOT NULL,
+    retryable       BOOLEAN NOT NULL DEFAULT FALSE,
+    repair_guidance TEXT NOT NULL DEFAULT '',
+    processed_at    TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, assessment_id),
+    FOREIGN KEY (tenant_id, run_id) REFERENCES assessment_snapshot_backfill_runs(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, assessment_id) REFERENCES engagements(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, assessment_id, snapshot_id)
+        REFERENCES assessment_snapshots(tenant_id, assessment_id, id) ON DELETE RESTRICT,
+    UNIQUE (tenant_id, run_id, idempotency_key),
+    CONSTRAINT assessment_snapshot_backfill_items_schema_check CHECK (schema_version > 0),
+    CONSTRAINT assessment_snapshot_backfill_items_key_check CHECK (idempotency_key = btrim(idempotency_key) AND length(idempotency_key) BETWEEN 1 AND 128),
+    CONSTRAINT assessment_snapshot_backfill_items_source_hash_check CHECK (source_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT assessment_snapshot_backfill_items_outcome_check CHECK (outcome IN ('created', 'would_create', 'skipped', 'failed')),
+    CONSTRAINT assessment_snapshot_backfill_items_reason_check CHECK (reason_code ~ '^[a-z0-9_]{1,64}$'),
+    CONSTRAINT assessment_snapshot_backfill_items_guidance_check CHECK (octet_length(repair_guidance) <= 1024),
+    CONSTRAINT assessment_snapshot_backfill_items_snapshot_check CHECK (
+        (outcome = 'created' AND snapshot_id IS NOT NULL) OR
+        (outcome IN ('would_create', 'failed') AND snapshot_id IS NULL) OR
+        outcome = 'skipped'
+    )
+);
+
+CREATE INDEX idx_assessment_snapshot_backfill_items_outcome
+    ON assessment_snapshot_backfill_items (tenant_id, run_id, outcome, assessment_id);
+
+CALL synapse_enable_tenant_rls('assessment_snapshot_backfill_runs');
+CALL synapse_enable_tenant_rls('assessment_snapshot_backfill_items');
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM assessment_snapshot_backfill_items LIMIT 1) OR
+       EXISTS (SELECT 1 FROM assessment_snapshot_backfill_runs LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back assessment snapshot backfill state while run history exists';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+DROP TABLE IF EXISTS assessment_snapshot_backfill_items;
+DROP TABLE IF EXISTS assessment_snapshot_backfill_runs;
+ALTER TABLE assessment_snapshots DROP CONSTRAINT IF EXISTS assessment_snapshots_tenant_assessment_id_unique;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
   - Assessment workflows:
       - Project code quality: project-code-quality.md
       - Governed assessments: governed-assessment-workflows.md
+      - Assessment lifecycle operations: assessment-lifecycle-operations.md
       - Vulnerability intelligence: vulnerability-intelligence.md
       - Cloud posture (CSPM): cloud-posture.md
       - Fleet and runtime defense: fleet-blue-team.md

--- a/web/src/App.rules.test.tsx
+++ b/web/src/App.rules.test.tsx
@@ -80,7 +80,7 @@ describe('App Routing - Rules', () => {
       </MemoryRouter>
     )
 
-    expect(await screen.findByRole('heading', { name: 'Security Operations' }, { timeout: 8000 })).toBeInTheDocument()
+    expect(await screen.findByRole('heading', { name: 'Security Operations' }, { timeout: 15000 })).toBeInTheDocument()
   })
 
   it('renders RuleDetail page on /rules/:key route and decodes colon exactly once', async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,15 +1,18 @@
 import { Menu01 } from '@untitledui/icons'
-import { lazy, Suspense, useState } from 'react'
+import { lazy, Suspense, useState, type ReactNode } from 'react'
 import { Navigate, Outlet, Route, Routes, useLocation } from 'react-router-dom'
 import { AuthProvider, useAuth } from './auth/AuthContext'
 import { ErrorBoundary } from './components/layout/ErrorBoundary'
 import { LoadingFallback } from './components/layout/LoadingFallback'
 import { MobileSidebar, Sidebar } from './components/layout/Sidebar'
+import { useFetch } from './hooks'
+import { api } from './lib/api'
 import { Connect } from './pages/Connect'
 
 // --- Lazy-loaded page components ---
 const Dashboard = lazy(() => import('./pages/Dashboard/DashboardPage').then(m => ({ default: m.DashboardPage })))
 const Engagements = lazy(() => import('./pages/Engagements/EngagementsPage').then(m => ({ default: m.EngagementsPage })))
+const AssessmentCycles = lazy(() => import('./pages/AssessmentCycles/AssessmentCyclesPage').then(m => ({ default: m.AssessmentCyclesPage })))
 const NewEngagement = lazy(() => import('./pages/Engagements/NewEngagementPage').then(m => ({ default: m.NewEngagementPage })))
 const EngagementDetail = lazy(() => import('./pages/EngagementDetail').then(m => ({ default: m.EngagementDetail })))
 const Assets = lazy(() => import('./pages/Assets/Assets').then(m => ({ default: m.Assets })))
@@ -62,6 +65,7 @@ function Gate() {
         <Route index element={<Navigate to="/dashboard" replace />} />
         <Route path="dashboard" element={<Dashboard />} />
         <Route path="engagements" element={<Engagements />} />
+        <Route path="assessment-cycles" element={<AssessmentLifecycleRoute><AssessmentCycles /></AssessmentLifecycleRoute>} />
         <Route path="engagements/new" element={<NewEngagement />} />
         <Route path="engagements/:id" element={<EngagementDetail />} />
         <Route path="engagements/:id/:tabSlug" element={<EngagementDetail />} />
@@ -107,6 +111,13 @@ function Gate() {
       </Route>
     </Routes>
   )
+}
+
+function AssessmentLifecycleRoute({ children }: { children: ReactNode }) {
+  const meFetch = useFetch(() => api.me().catch(() => null), { deps: [] })
+  if (meFetch.loading) return <LoadingFallback />
+  if (meFetch.data?.features?.assessmentLifecycleUIDefault !== true) return <Navigate to="/engagements" replace />
+  return children
 }
 
 function Shell() {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,8 +5,6 @@ import { AuthProvider, useAuth } from './auth/AuthContext'
 import { ErrorBoundary } from './components/layout/ErrorBoundary'
 import { LoadingFallback } from './components/layout/LoadingFallback'
 import { MobileSidebar, Sidebar } from './components/layout/Sidebar'
-import { useFetch } from './hooks'
-import { api } from './lib/api'
 import { Connect } from './pages/Connect'
 
 // --- Lazy-loaded page components ---
@@ -114,9 +112,8 @@ function Gate() {
 }
 
 function AssessmentLifecycleRoute({ children }: { children: ReactNode }) {
-  const meFetch = useFetch(() => api.me().catch(() => null), { deps: [] })
-  if (meFetch.loading) return <LoadingFallback />
-  if (meFetch.data?.features?.assessmentLifecycleUIDefault !== true) return <Navigate to="/engagements" replace />
+  const { currentUser } = useAuth()
+  if (currentUser?.features?.assessmentLifecycleUIDefault !== true) return <Navigate to="/engagements" replace />
   return children
 }
 

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
 } from 'react'
 import { api, ApiError, discoverSession, logoutSession, setCSRFToken, setToken as setApiToken, setUnauthorizedHandler } from '../lib/api'
-import type { AupStatus } from '../lib/types'
+import type { AupStatus, CurrentUser } from '../lib/types'
 
 // The development/automation bearer token is kept in sessionStorage so it dies with the
 // browser tab instead of persisting across restarts for later XSS to read.
@@ -18,6 +18,7 @@ type Phase = 'connecting' | 'unauthenticated' | 'need-aup' | 'ready'
 interface AuthState {
   phase: Phase
   aup: AupStatus | null
+  currentUser: CurrentUser | null
   error: string | null
   connecting: boolean
   oidcAvailable: boolean
@@ -43,6 +44,7 @@ export function useOptionalAuth(): AuthState | null {
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [phase, setPhase] = useState<Phase>('connecting')
   const [aup, setAup] = useState<AupStatus | null>(null)
+  const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [connecting, setConnecting] = useState(false)
   const [oidcAvailable, setOidcAvailable] = useState(true)
@@ -54,11 +56,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setCSRFToken('')
     setAuthMethod(null)
     setAup(null)
+    setCurrentUser(null)
   }, [])
 
   const refreshAup = useCallback(async () => {
     const status = await api.aup()
     setAup(status)
+    const me = status.accepted && typeof api.me === 'function' ? await api.me().catch(() => null) : null
+    setCurrentUser(me)
     setPhase(status.accepted ? 'ready' : 'need-aup')
   }, [])
 
@@ -198,8 +203,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [clearAuthentication, refreshAup])
 
   const value = useMemo(
-    () => ({ phase, aup, error, connecting, oidcAvailable, connect, acceptAup, logout }),
-    [phase, aup, error, connecting, oidcAvailable, connect, acceptAup, logout],
+    () => ({ phase, aup, currentUser, error, connecting, oidcAvailable, connect, acceptAup, logout }),
+    [phase, aup, currentUser, error, connecting, oidcAvailable, connect, acceptAup, logout],
   )
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -8,6 +8,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Cube01,
+  GitBranch01,
   LogOut01,
   Plus,
   Server01,
@@ -21,6 +22,8 @@ import { useEffect, useRef, useState, type ComponentType } from 'react'
 import { Link, NavLink, useLocation } from 'react-router-dom'
 import logo from '../../assets/logo.png'
 import { useOptionalAuth } from '../../auth/AuthContext'
+import { useFetch } from '../../hooks'
+import { api } from '../../lib/api'
 import { cn } from '../ui'
 
 type IconComponent = ComponentType<{ className?: string; 'aria-hidden'?: boolean | 'true' | 'false' }>
@@ -44,6 +47,7 @@ const NAV_GROUPS: Array<{
       label: 'Security operations',
       items: [
         { icon: Target04, label: 'Engagements', to: '/engagements' },
+        { icon: GitBranch01, label: 'Assessment Cycles', to: '/assessment-cycles' },
         { icon: ShieldTick, label: 'Review Queue', to: '/ai-triage/reviews' },
       ],
     },
@@ -95,6 +99,8 @@ function storageSet(key: string, value: string) {
 
 function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; onNavigate?: () => void }) {
   const auth = useOptionalAuth()
+  const meFetch = useFetch(fetchCurrentUser, { deps: [] })
+  const lifecycleUIEnabled = meFetch.data?.features?.assessmentLifecycleUIDefault === true
   const [signingOut, setSigningOut] = useState(false)
   async function onSignOut() {
     if (!auth) return
@@ -119,7 +125,7 @@ function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; on
   }
 
   function renderItems(items: NavItem[]) {
-    return items.map(({ icon: Icon, label, to, end, children }) => {
+    return items.filter((item) => item.to !== '/assessment-cycles' || lifecycleUIEnabled).map(({ icon: Icon, label, to, end, children }) => {
       const hasChildren = Boolean(children && children.length > 0)
       const isExpanded = Boolean(expandedItems[to])
       const isSubRouteActive = Boolean(
@@ -298,6 +304,11 @@ function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; on
       </div>
     </>
   )
+}
+
+function fetchCurrentUser() {
+  const fetcher = api.me
+  return typeof fetcher === 'function' ? fetcher().catch(() => null) : Promise.resolve(null)
 }
 
 export function Sidebar() {

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -22,8 +22,6 @@ import { useEffect, useRef, useState, type ComponentType } from 'react'
 import { Link, NavLink, useLocation } from 'react-router-dom'
 import logo from '../../assets/logo.png'
 import { useOptionalAuth } from '../../auth/AuthContext'
-import { useFetch } from '../../hooks'
-import { api } from '../../lib/api'
 import { cn } from '../ui'
 
 type IconComponent = ComponentType<{ className?: string; 'aria-hidden'?: boolean | 'true' | 'false' }>
@@ -99,8 +97,7 @@ function storageSet(key: string, value: string) {
 
 function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; onNavigate?: () => void }) {
   const auth = useOptionalAuth()
-  const meFetch = useFetch(fetchCurrentUser, { deps: [] })
-  const lifecycleUIEnabled = meFetch.data?.features?.assessmentLifecycleUIDefault === true
+  const lifecycleUIEnabled = auth?.currentUser?.features?.assessmentLifecycleUIDefault === true
   const [signingOut, setSigningOut] = useState(false)
   async function onSignOut() {
     if (!auth) return
@@ -304,11 +301,6 @@ function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; on
       </div>
     </>
   )
-}
-
-function fetchCurrentUser() {
-  const fetcher = api.me
-  return typeof fetcher === 'function' ? fetcher().catch(() => null) : Promise.resolve(null)
 }
 
 export function Sidebar() {

--- a/web/src/lib/api.engagements.test.ts
+++ b/web/src/lib/api.engagements.test.ts
@@ -25,12 +25,13 @@ describe('Engagements API', () => {
       inScope: [],
       outOfScope: [],
       timezone: 'Asia/Ho_Chi_Minh',
-    }, source)
+    }, source, 'stable-upload-request')
 
     const init = fetchSpy.mock.calls[0][1] as RequestInit
     expect(fetchSpy.mock.calls[0][0]).toBe('/api/v1/engagements')
     expect(init.body).toBeInstanceOf(FormData)
     expect(init.headers).not.toHaveProperty('content-type')
+		expect(init.headers).toHaveProperty('Idempotency-Key', 'stable-upload-request')
     const form = init.body as FormData
     expect(form.get('source')).toBe(source)
     expect(JSON.parse(String(form.get('metadata')))).toMatchObject({

--- a/web/src/lib/api/assessment-cycles.test.ts
+++ b/web/src/lib/api/assessment-cycles.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest'
+import { assessmentCyclesApi } from './assessment-cycles'
+
+describe('assessmentCyclesApi', () => {
+  it('sends a retained re-test request and maps the lifecycle response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      engagement: { ID: 'assessment-2', Scope: {}, RoE: {} },
+      cycle: { id: 'cycle-1', name: 'Payments', boundary_kind: 'asset', version: 2 },
+      member: { assessment_id: 'assessment-2', assessment_type: 'retest', retest_number: 1 },
+      inheritance_diff: { scope: 'copy', authorization: 'explicit_only', roe: 'explicit_only', scanner_profile: 'none' },
+      warnings: ['authorization_not_inherited'],
+    }), { status: 201, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await assessmentCyclesApi.createRetest('assessment/1', {
+      name: 'Payments Re-test', predecessorAssessmentId: 'assessment-1', idempotencyKey: 'request-1',
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/engagements/assessment%2F1/retests', expect.objectContaining({
+      method: 'POST', headers: expect.objectContaining({ 'Idempotency-Key': 'request-1' }),
+    }))
+    expect(result.cycle.id).toBe('cycle-1')
+    expect(result.member.assessmentType).toBe('retest')
+  })
+
+  it('uses only Cycle and Snapshot filters in list queries', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ items: [], migration_pending: [] }), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await assessmentCyclesApi.listAssessmentCycles({
+      status: 'open', assessmentStatus: 'completed', assessmentType: 'retest', scanStaleness: 'stale', search: 'payments', limit: 25,
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/v1/assessment-cycles?status=open&assessment_status=completed&assessment_type=retest&scan_staleness=stale&q=payments&limit=25',
+      expect.any(Object),
+    )
+  })
+})

--- a/web/src/lib/api/assessment-cycles.ts
+++ b/web/src/lib/api/assessment-cycles.ts
@@ -1,0 +1,149 @@
+import type {
+  AssessmentCycle,
+  AssessmentCycleDetail,
+  AssessmentCycleListFilters,
+  AssessmentCycleMember,
+  AssessmentCycleMemberPage,
+  AssessmentCyclePage,
+  AssessmentLifecycle,
+  CreateAssessmentRetestInput,
+  CreateAssessmentRetestResponse,
+} from '../types'
+import { newIdempotencyKey, req } from './client'
+import { mapEngagement } from './engagements'
+
+const id = encodeURIComponent
+
+function mapMember(value: any): AssessmentCycleMember {
+  return {
+    assessmentId: value.assessment_id ?? '',
+    assessmentType: value.assessment_type ?? 'initial',
+    predecessorAssessmentId: value.predecessor_assessment_id ?? '',
+    retestNumber: Number(value.retest_number ?? 0),
+    relationshipVersion: Number(value.relationship_version ?? 0),
+    createdAt: value.created_at ?? '',
+    createdBy: value.created_by ?? '',
+    archivedAt: value.archived_at ?? null,
+  }
+}
+
+function mapCycle(value: any): AssessmentCycle {
+  return {
+    id: value.id ?? '',
+    name: value.name ?? '',
+    boundaryKind: value.boundary_kind ?? 'standalone',
+    businessAssetId: value.business_asset_id ?? '',
+    projectId: value.project_id ?? '',
+    status: value.status ?? 'open',
+    rootAssessmentId: value.root_assessment_id ?? '',
+    selectedHeadAssessmentId: value.selected_head_assessment_id ?? '',
+    nextRetestNumber: Number(value.next_retest_number ?? 1),
+    version: Number(value.version ?? 0),
+    createdAt: value.created_at ?? '',
+    updatedAt: value.updated_at ?? '',
+    createdBy: value.created_by ?? '',
+    updatedBy: value.updated_by ?? '',
+  }
+}
+
+function mapDetail(value: any): AssessmentCycleDetail {
+  return {
+    cycle: mapCycle(value.cycle ?? {}),
+    members: (value.members ?? []).map(mapMember),
+    branchHeads: (value.branch_heads ?? []).map(mapMember),
+  }
+}
+
+export const assessmentCyclesApi = {
+  createRetest: async (assessmentId: string, input: CreateAssessmentRetestInput = {}): Promise<CreateAssessmentRetestResponse> => {
+    const value = await req(`/engagements/${id(assessmentId)}/retests`, {
+      method: 'POST',
+      headers: { 'Idempotency-Key': input.idempotencyKey ?? newIdempotencyKey() },
+      body: JSON.stringify({
+        name: input.name ?? '',
+        predecessor_assessment_id: input.predecessorAssessmentId ?? '',
+        scope_strategy: input.scopeStrategy ?? 'copy',
+        profile_strategy: input.profileStrategy ?? 'none',
+        authorized_from: input.authorizedFrom ?? '',
+        authorized_to: input.authorizedTo ?? '',
+        timezone: input.timezone ?? '',
+        roe: input.roe
+          ? { allowed_tool_classes: input.roe.allowedToolClasses, blackouts: input.roe.blackouts }
+          : undefined,
+      }),
+    })
+    return {
+      engagement: mapEngagement(value.engagement ?? {}),
+      cycle: mapCycle(value.cycle ?? {}),
+      member: mapMember(value.member ?? {}),
+      inheritanceDiff: {
+        scope: value.inheritance_diff?.scope ?? 'copy',
+        authorization: value.inheritance_diff?.authorization ?? 'explicit_only',
+        roe: value.inheritance_diff?.roe ?? 'explicit_only',
+        scannerProfile: value.inheritance_diff?.scanner_profile ?? 'none',
+      },
+      warnings: value.warnings ?? [],
+    }
+  },
+
+  assessmentLifecycle: async (assessmentId: string): Promise<AssessmentLifecycle> => {
+    const value = await req(`/engagements/${id(assessmentId)}/lifecycle`)
+    return { assessmentId: value.assessment_id ?? '', ...mapDetail(value) }
+  },
+
+  assessmentCycle: async (cycleId: string): Promise<AssessmentCycleDetail> =>
+    mapDetail(await req(`/assessment-cycles/${id(cycleId)}`)),
+
+  listAssessmentCycles: async (input: AssessmentCycleListFilters = {}): Promise<AssessmentCyclePage> => {
+    const query = new URLSearchParams()
+    if (input.status) query.set('status', input.status)
+    if (input.boundaryKind) query.set('boundary_kind', input.boundaryKind)
+    if (input.assessmentStatus) query.set('assessment_status', input.assessmentStatus)
+    if (input.selectedHeadAssessmentId) query.set('selected_head_assessment_id', input.selectedHeadAssessmentId)
+    if (input.assessmentType) query.set('assessment_type', input.assessmentType)
+    if (input.scanStaleness) query.set('scan_staleness', input.scanStaleness)
+    if (input.search) query.set('q', input.search)
+    if (input.cursor) query.set('cursor', input.cursor)
+    if (input.limit) query.set('limit', String(input.limit))
+    const value = await req(`/assessment-cycles${query.size ? `?${query}` : ''}`)
+    return {
+      items: (value.items ?? []).map((item: any) => ({
+        ...mapCycle(item),
+        memberCount: Number(item.member_count ?? 0),
+        activeBranchCount: Number(item.active_branch_count ?? 0),
+        latestAssessmentId: item.latest_assessment_id ?? '',
+        latestRetestNumber: Number(item.latest_retest_number ?? 0),
+        members: (item.members ?? []).map(mapMember),
+        membersNextCursor: item.members_next_cursor ?? '',
+        rootSnapshotId: item.root_snapshot_id ?? '',
+        currentSnapshotId: item.current_snapshot_id ?? '',
+        selectedHeadLastScanAt: item.selected_head_last_scan_at ?? null,
+        scanStaleness: item.scan_staleness ?? 'missing',
+      })),
+      nextCursor: value.next_cursor ?? '',
+      migrationPending: (value.migration_pending ?? []).map((item: any) => ({
+        assessmentId: item.assessment_id ?? '',
+        name: item.name ?? '',
+        status: item.status ?? '',
+        boundaryKind: item.boundary_kind ?? 'standalone',
+        businessAssetId: item.business_asset_id ?? '',
+        updatedAt: item.updated_at ?? '',
+      })),
+      migrationPendingTotal: Number(value.migration_pending_total ?? 0),
+    }
+  },
+
+  listAssessmentCycleMembers: async (cycleId: string, cursor = '', limit = 25): Promise<AssessmentCycleMemberPage> => {
+    const query = new URLSearchParams({ limit: String(limit) })
+    if (cursor) query.set('cursor', cursor)
+    const value = await req(`/assessment-cycles/${id(cycleId)}/members?${query}`)
+    return { items: (value.items ?? []).map(mapMember), nextCursor: value.next_cursor ?? '' }
+  },
+
+  archiveAssessmentCycle: async (cycleId: string, version: number): Promise<AssessmentCycleDetail> =>
+    mapDetail(await req(`/assessment-cycles/${id(cycleId)}/archive`, {
+      method: 'POST',
+      headers: { 'Idempotency-Key': newIdempotencyKey(), 'If-Match': String(version) },
+      body: '{}',
+    })),
+}

--- a/web/src/lib/api/assessment-cycles.ts
+++ b/web/src/lib/api/assessment-cycles.ts
@@ -146,4 +146,11 @@ export const assessmentCyclesApi = {
       headers: { 'Idempotency-Key': newIdempotencyKey(), 'If-Match': String(version) },
       body: '{}',
     })),
+
+  reopenAssessmentCycle: async (cycleId: string, version: number, reason: string, idempotencyKey = newIdempotencyKey()): Promise<AssessmentCycleDetail> =>
+    mapDetail(await req(`/assessment-cycles/${id(cycleId)}/reopen`, {
+      method: 'POST',
+      headers: { 'Idempotency-Key': idempotencyKey, 'If-Match': String(version) },
+      body: JSON.stringify({ reason }),
+    })),
 }

--- a/web/src/lib/api/assessment-snapshots.test.ts
+++ b/web/src/lib/api/assessment-snapshots.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import { assessmentSnapshotsApi } from './assessment-snapshots'
+
+describe('assessmentSnapshotsApi', () => {
+  it('sends concurrency headers and maps immutable snapshot fields', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      snapshot: {
+        id: 'snapshot-1', cycle_id: 'cycle-1', assessment_id: 'assessment-1', snapshot_number: 1,
+        lifecycle: 'finalized', provenance: 'native', boundary: { boundary_kind: 'standalone' },
+        run_references: [{ run_id: 'run-1', manifest_hash: 'a'.repeat(64), lane_refs: [{ lane_key: 'sca', manifest_hash: 'b'.repeat(64) }] }],
+        dimensions: [{
+          run_id: 'run-1', lane_key: 'sca', lane_manifest_hash: 'b'.repeat(64), producer: 'sca', finding_kind: 'vulnerability',
+          target: { kind: 'repository', schema_version: 1, canonical: 'https://example.com/repo', evaluated_revision: 'abc' },
+          state: 'complete', reason_code: 'trusted_terminal_lane', included_scope: ['src/**'], excluded_scope: [],
+          versions: [{ kind: 'scanner', name: 'sca', version: '1' }],
+        }],
+        schema_version: 1, content_hash: 'c'.repeat(64), created_at: '2026-09-01T07:00:00Z', created_by: 'operator',
+        finalized_at: '2026-09-01T07:00:00Z', finalized_by: 'operator',
+      },
+      default_version: 1,
+    }), { status: 201, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await assessmentSnapshotsApi.finalizeAssessmentSnapshot('assessment/1', {
+      selectedRuns: [{ runId: 'run-1', laneKeys: ['sca'] }], expectedDefaultVersion: 0, idempotencyKey: 'snapshot-request-1',
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/engagements/assessment%2F1/snapshots/finalize', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ 'Idempotency-Key': 'snapshot-request-1', 'If-Match': '0' }),
+      body: JSON.stringify({ selected_runs: [{ run_id: 'run-1', lane_keys: ['sca'] }] }),
+    }))
+    expect(result.defaultVersion).toBe(1)
+    expect(result.snapshot.runReferences[0].laneReferences[0].laneKey).toBe('sca')
+    expect(result.snapshot.dimensions[0].target.schemaVersion).toBe(1)
+    expect(result.snapshot.supersededAt).toBeNull()
+  })
+})

--- a/web/src/lib/api/assessment-snapshots.ts
+++ b/web/src/lib/api/assessment-snapshots.ts
@@ -1,0 +1,101 @@
+import type {
+  AssessmentSnapshot,
+  AssessmentSnapshotDimension,
+  AssessmentSnapshotListResponse,
+  AssessmentSnapshotRunReference,
+  AssessmentSnapshotVersion,
+  FinalizeAssessmentSnapshotInput,
+  FinalizeAssessmentSnapshotResponse,
+} from '../types'
+import { newIdempotencyKey, req } from './client'
+
+const id = encodeURIComponent
+
+function mapVersion(value: any): AssessmentSnapshotVersion {
+  return { kind: value.kind ?? 'tool', name: value.name ?? '', version: value.version ?? '', digest: value.digest ?? '' }
+}
+
+function mapRunReference(value: any): AssessmentSnapshotRunReference {
+  return {
+    runId: value.run_id ?? '',
+    manifestHash: value.manifest_hash ?? '',
+    laneReferences: (value.lane_refs ?? []).map((lane: any) => ({
+      laneKey: lane.lane_key ?? '', manifestHash: lane.manifest_hash ?? '',
+    })),
+  }
+}
+
+function mapDimension(value: any): AssessmentSnapshotDimension {
+  return {
+    runId: value.run_id ?? '',
+    laneKey: value.lane_key ?? '',
+    laneManifestHash: value.lane_manifest_hash ?? '',
+    producer: value.producer ?? '',
+    findingKind: value.finding_kind ?? '',
+    target: {
+      kind: value.target?.kind ?? 'repository',
+      schemaVersion: Number(value.target?.schema_version ?? 0),
+      canonical: value.target?.canonical ?? '',
+      evaluatedRevision: value.target?.evaluated_revision ?? '',
+    },
+    state: value.state ?? 'unknown',
+    reasonCode: value.reason_code ?? '',
+    includedScope: value.included_scope ?? [],
+    excludedScope: value.excluded_scope ?? [],
+    versions: (value.versions ?? []).map(mapVersion),
+  }
+}
+
+export function mapAssessmentSnapshot(value: any): AssessmentSnapshot {
+  return {
+    id: value.id ?? '',
+    cycleId: value.cycle_id ?? '',
+    assessmentId: value.assessment_id ?? '',
+    snapshotNumber: Number(value.snapshot_number ?? 0),
+    lifecycle: value.lifecycle ?? 'finalized',
+    provenance: value.provenance ?? 'native',
+    boundary: {
+      boundaryKind: value.boundary?.boundary_kind ?? 'standalone',
+      businessAssetId: value.boundary?.business_asset_id ?? '',
+      projectId: value.boundary?.project_id ?? '',
+    },
+    runReferences: (value.run_references ?? []).map(mapRunReference),
+    dimensions: (value.dimensions ?? []).map(mapDimension),
+    schemaVersion: Number(value.schema_version ?? 0),
+    contentHash: value.content_hash ?? '',
+    createdAt: value.created_at ?? '',
+    createdBy: value.created_by ?? '',
+    finalizedAt: value.finalized_at ?? '',
+    finalizedBy: value.finalized_by ?? '',
+    supersededAt: value.superseded_at ?? null,
+    supersededBy: value.superseded_by ?? '',
+  }
+}
+
+export const assessmentSnapshotsApi = {
+  finalizeAssessmentSnapshot: async (assessmentId: string, input: FinalizeAssessmentSnapshotInput): Promise<FinalizeAssessmentSnapshotResponse> => {
+    const value = await req(`/engagements/${id(assessmentId)}/snapshots/finalize`, {
+      method: 'POST',
+      headers: {
+        'Idempotency-Key': input.idempotencyKey ?? newIdempotencyKey(),
+        'If-Match': String(input.expectedDefaultVersion),
+      },
+      body: JSON.stringify({
+        selected_runs: input.selectedRuns.map((selection) => ({ run_id: selection.runId, lane_keys: selection.laneKeys })),
+      }),
+    })
+    return { snapshot: mapAssessmentSnapshot(value.snapshot ?? {}), defaultVersion: Number(value.default_version ?? 0) }
+  },
+
+  assessmentSnapshots: async (assessmentId: string): Promise<AssessmentSnapshotListResponse> => {
+    const value = await req(`/engagements/${id(assessmentId)}/snapshots`)
+    return {
+      items: (value.items ?? []).map(mapAssessmentSnapshot),
+      defaultSnapshotId: value.default_snapshot_id ?? '',
+      defaultVersion: Number(value.default_version ?? 0),
+    }
+  },
+
+  assessmentSnapshot: async (snapshotId: string): Promise<AssessmentSnapshot> =>
+    mapAssessmentSnapshot(await req(`/assessment-snapshots/${id(snapshotId)}`)),
+}

--- a/web/src/lib/api/assessment-snapshots.ts
+++ b/web/src/lib/api/assessment-snapshots.ts
@@ -87,10 +87,12 @@ export const assessmentSnapshotsApi = {
     return { snapshot: mapAssessmentSnapshot(value.snapshot ?? {}), defaultVersion: Number(value.default_version ?? 0) }
   },
 
-  assessmentSnapshots: async (assessmentId: string): Promise<AssessmentSnapshotListResponse> => {
-    const value = await req(`/engagements/${id(assessmentId)}/snapshots`)
+  assessmentSnapshots: async (assessmentId: string, cursor = ''): Promise<AssessmentSnapshotListResponse> => {
+    const query = cursor ? `?cursor=${encodeURIComponent(cursor)}` : ''
+    const value = await req(`/engagements/${id(assessmentId)}/snapshots${query}`)
     return {
       items: (value.items ?? []).map(mapAssessmentSnapshot),
+      nextCursor: value.next_cursor ?? '',
       defaultSnapshotId: value.default_snapshot_id ?? '',
       defaultVersion: Number(value.default_version ?? 0),
     }

--- a/web/src/lib/api/auth.ts
+++ b/web/src/lib/api/auth.ts
@@ -7,7 +7,16 @@ export const authApi = {
   acceptAup: (version: string): Promise<unknown> =>
     req('/aup/accept', { method: 'POST', body: JSON.stringify({ version }) }),
 
-  me: async (): Promise<CurrentUser> => req('/me'),
+  me: async (): Promise<CurrentUser> => {
+    const value = await req('/me')
+    return {
+      id: value.id ?? '', name: value.name ?? '', role: value.role ?? '',
+      features: value.features ? {
+        assessmentLifecycleRead: Boolean(value.features.assessment_lifecycle_read),
+        assessmentLifecycleUIDefault: Boolean(value.features.assessment_lifecycle_ui_default),
+      } : undefined,
+    }
+  },
 }
 
 export const teamApi = {

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -33,6 +33,13 @@ export function getOnUnauthorized(): (() => void) | null {
   return onUnauthorized
 }
 
+export function newIdempotencyKey(): string {
+  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID()
+  const bytes = new Uint8Array(16)
+  globalThis.crypto.getRandomValues(bytes)
+  return Array.from(bytes, (value) => value.toString(16).padStart(2, '0')).join('')
+}
+
 export type BFFSession = { authenticated: boolean; csrfToken: string }
 
 function apiRequestInit(init: RequestInit = {}, json = true): RequestInit {

--- a/web/src/lib/api/engagements.ts
+++ b/web/src/lib/api/engagements.ts
@@ -4,7 +4,7 @@ import type {
   ScopeTarget,
   UploadedSourcePackage,
 } from '../types'
-import { req } from './client'
+import { newIdempotencyKey, req } from './client'
 
 function createRequest(input: CreateEngagementInput) {
   return {
@@ -36,6 +36,7 @@ function mapEngagement(r: any): Engagement {
       blackouts: (r.RoE?.blackouts ?? []).map((b: any) => ({ from: b.from ?? '', to: b.to ?? '' })),
     },
     liveReconEnabled: r.LiveReconEnabled ?? false,
+    requiresExplicitExecutionAuthorization: r.RequiresExplicitExecutionAuthorization ?? false,
     createdAt: r.Audit?.CreatedAt ?? null,
     businessAssetId: r.BusinessAssetID ?? '',
     // Optional list-view enrichment; stays undefined when the API omits it.
@@ -62,6 +63,7 @@ export const engagementsApi = {
     mapEngagement(
       await req('/engagements', {
         method: 'POST',
+        headers: { 'Idempotency-Key': newIdempotencyKey() },
         body: JSON.stringify(createRequest(input)),
       }),
     ),
@@ -72,6 +74,7 @@ export const engagementsApi = {
     form.append('source', source)
     return mapEngagement(await req('/engagements', {
       method: 'POST',
+      headers: { 'Idempotency-Key': newIdempotencyKey() },
       body: form,
     }))
   },

--- a/web/src/lib/api/engagements.ts
+++ b/web/src/lib/api/engagements.ts
@@ -4,7 +4,7 @@ import type {
   ScopeTarget,
   UploadedSourcePackage,
 } from '../types'
-import { newIdempotencyKey, req } from './client'
+import { req } from './client'
 
 function createRequest(input: CreateEngagementInput) {
   return {
@@ -59,22 +59,22 @@ export const engagementsApi = {
   listEngagements: async (): Promise<Engagement[]> =>
     ((await req('/engagements')) ?? []).map(mapEngagement),
 
-  createEngagement: async (input: CreateEngagementInput): Promise<Engagement> =>
+  createEngagement: async (input: CreateEngagementInput, idempotencyKey: string): Promise<Engagement> =>
     mapEngagement(
       await req('/engagements', {
         method: 'POST',
-        headers: { 'Idempotency-Key': newIdempotencyKey() },
+        headers: { 'Idempotency-Key': idempotencyKey },
         body: JSON.stringify(createRequest(input)),
       }),
     ),
 
-  createEngagementFromSource: async (input: CreateEngagementInput, source: File): Promise<Engagement> => {
+  createEngagementFromSource: async (input: CreateEngagementInput, source: File, idempotencyKey: string): Promise<Engagement> => {
     const form = new FormData()
     form.append('metadata', JSON.stringify(createRequest(input)))
     form.append('source', source)
     return mapEngagement(await req('/engagements', {
       method: 'POST',
-      headers: { 'Idempotency-Key': newIdempotencyKey() },
+      headers: { 'Idempotency-Key': idempotencyKey },
       body: form,
     }))
   },

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -23,6 +23,8 @@ import { assetsApi } from './assets'
 import { vulnerabilityApi } from './vulnerability'
 import { aiTriageApi } from './ai-triage'
 import { dashboardApi } from './dashboard'
+import { assessmentCyclesApi } from './assessment-cycles'
+import { assessmentSnapshotsApi } from './assessment-snapshots'
 
 // projectMeasures was a standalone export in the old api.ts
 export const projectMeasures = codeQualityApi.projectMeasures
@@ -53,4 +55,6 @@ export const api = {
   ...vulnerabilityApi,
   ...aiTriageApi,
   ...dashboardApi,
+  ...assessmentCyclesApi,
+  ...assessmentSnapshotsApi,
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -38,6 +38,7 @@ export interface Engagement {
   authorizedTo: string | null
   roe: RoE
   liveReconEnabled: boolean
+  requiresExplicitExecutionAuthorization: boolean
   createdAt: string | null
   businessAssetId: string
   /** List-view enrichment. Absent unless the API includes it; the Engagements
@@ -73,6 +74,208 @@ export interface UploadedSourcePackage {
   target: string
   uploadedBy: string
   uploadedAt: string | null
+}
+
+export type AssessmentCycleBoundaryKind = 'standalone' | 'asset' | 'project' | 'asset_project'
+export type AssessmentCycleStatus = 'open' | 'completed' | 'archived'
+export type AssessmentStatus = 'draft' | 'active' | 'completed' | 'archived'
+export type AssessmentCycleScanStaleness = 'fresh' | 'stale' | 'missing'
+
+export interface AssessmentCycleListFilters {
+  status?: AssessmentCycleStatus
+  boundaryKind?: AssessmentCycleBoundaryKind
+  assessmentStatus?: AssessmentStatus
+  selectedHeadAssessmentId?: string
+  assessmentType?: AssessmentCycleMember['assessmentType']
+  scanStaleness?: AssessmentCycleScanStaleness
+  search?: string
+  cursor?: string
+  limit?: number
+}
+
+export interface AssessmentCycleMember {
+  assessmentId: string
+  assessmentType: 'initial' | 'retest'
+  predecessorAssessmentId: string
+  retestNumber: number
+  relationshipVersion: number
+  createdAt: string
+  createdBy: string
+  archivedAt: string | null
+}
+
+export interface AssessmentCycle {
+  id: string
+  name: string
+  boundaryKind: AssessmentCycleBoundaryKind
+  businessAssetId: string
+  projectId: string
+  status: AssessmentCycleStatus
+  rootAssessmentId: string
+  selectedHeadAssessmentId: string
+  nextRetestNumber: number
+  version: number
+  createdAt: string
+  updatedAt: string
+  createdBy: string
+  updatedBy: string
+}
+
+export interface AssessmentCycleDetail {
+  cycle: AssessmentCycle
+  members: AssessmentCycleMember[]
+  branchHeads: AssessmentCycleMember[]
+}
+
+export interface AssessmentLifecycle extends AssessmentCycleDetail {
+  assessmentId: string
+}
+
+export interface AssessmentCycleSummary extends AssessmentCycle {
+  memberCount: number
+  activeBranchCount: number
+  latestAssessmentId: string
+  latestRetestNumber: number
+  members: AssessmentCycleMember[]
+  membersNextCursor: string
+  rootSnapshotId: string
+  currentSnapshotId: string
+  selectedHeadLastScanAt: string | null
+  scanStaleness: AssessmentCycleScanStaleness
+}
+
+export interface AssessmentCyclePage {
+  items: AssessmentCycleSummary[]
+  nextCursor: string
+  migrationPending: AssessmentCycleMigrationPending[]
+  migrationPendingTotal: number
+}
+
+export interface AssessmentCycleMemberPage {
+  items: AssessmentCycleMember[]
+  nextCursor: string
+}
+
+export interface AssessmentCycleMigrationPending {
+  assessmentId: string
+  name: string
+  status: string
+  boundaryKind: AssessmentCycleBoundaryKind
+  businessAssetId: string
+  updatedAt: string
+}
+
+export interface CreateAssessmentRetestInput {
+  name?: string
+  predecessorAssessmentId?: string
+  scopeStrategy?: 'copy' | 'empty'
+  profileStrategy?: 'none'
+  authorizedFrom?: string
+  authorizedTo?: string
+  timezone?: string
+  roe?: RoE
+  idempotencyKey?: string
+}
+
+export interface CreateAssessmentRetestResponse {
+  engagement: Engagement
+  cycle: AssessmentCycle
+  member: AssessmentCycleMember
+  inheritanceDiff: { scope: 'copy' | 'empty'; authorization: 'explicit_only'; roe: 'explicit_only'; scannerProfile: 'none' }
+  warnings: Array<'authorization_not_inherited' | 'roe_not_inherited' | 'scanner_profile_not_inherited'>
+}
+
+export type AssessmentSnapshotLifecycle = 'finalized' | 'superseded'
+export type AssessmentSnapshotProvenance = 'native' | 'legacy'
+export type AssessmentSnapshotCoverageState = 'complete' | 'partial' | 'unknown'
+export type AssessmentSnapshotTargetKind = 'repository' | 'oci' | 'host' | 'url' | 'cloud_resource'
+export type AssessmentSnapshotVersionKind = 'tool' | 'scanner' | 'profile' | 'rule_pack' | 'advisory_database' | 'correlation' | 'schema'
+
+export interface AssessmentSnapshotBoundary {
+  boundaryKind: AssessmentCycleBoundaryKind
+  businessAssetId: string
+  projectId: string
+}
+
+export interface AssessmentSnapshotLaneReference {
+  laneKey: string
+  manifestHash: string
+}
+
+export interface AssessmentSnapshotRunReference {
+  runId: string
+  manifestHash: string
+  laneReferences: AssessmentSnapshotLaneReference[]
+}
+
+export interface AssessmentSnapshotTarget {
+  kind: AssessmentSnapshotTargetKind
+  schemaVersion: number
+  canonical: string
+  evaluatedRevision: string
+}
+
+export interface AssessmentSnapshotVersion {
+  kind: AssessmentSnapshotVersionKind
+  name: string
+  version: string
+  digest: string
+}
+
+export interface AssessmentSnapshotDimension {
+  runId: string
+  laneKey: string
+  laneManifestHash: string
+  producer: string
+  findingKind: string
+  target: AssessmentSnapshotTarget
+  state: AssessmentSnapshotCoverageState
+  reasonCode: string
+  includedScope: string[]
+  excludedScope: string[]
+  versions: AssessmentSnapshotVersion[]
+}
+
+export interface AssessmentSnapshot {
+  id: string
+  cycleId: string
+  assessmentId: string
+  snapshotNumber: number
+  lifecycle: AssessmentSnapshotLifecycle
+  provenance: AssessmentSnapshotProvenance
+  boundary: AssessmentSnapshotBoundary
+  runReferences: AssessmentSnapshotRunReference[]
+  dimensions: AssessmentSnapshotDimension[]
+  schemaVersion: number
+  contentHash: string
+  createdAt: string
+  createdBy: string
+  finalizedAt: string
+  finalizedBy: string
+  supersededAt: string | null
+  supersededBy: string
+}
+
+export interface AssessmentSnapshotRunSelection {
+  runId: string
+  laneKeys?: string[]
+}
+
+export interface FinalizeAssessmentSnapshotInput {
+  selectedRuns: AssessmentSnapshotRunSelection[]
+  expectedDefaultVersion: number
+  idempotencyKey?: string
+}
+
+export interface FinalizeAssessmentSnapshotResponse {
+  snapshot: AssessmentSnapshot
+  defaultVersion: number
+}
+
+export interface AssessmentSnapshotListResponse {
+  items: AssessmentSnapshot[]
+  defaultSnapshotId: string
+  defaultVersion: number
 }
 
 export type BusinessAssetType = 'product' | 'application' | 'system' | 'business_service'
@@ -675,6 +878,10 @@ export interface CurrentUser {
   id: string
   name: string
   role: string
+  features?: {
+    assessmentLifecycleRead: boolean
+    assessmentLifecycleUIDefault: boolean
+  }
 }
 
 // Audit: one append-only, attributable audit record.

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -274,6 +274,7 @@ export interface FinalizeAssessmentSnapshotResponse {
 
 export interface AssessmentSnapshotListResponse {
   items: AssessmentSnapshot[]
+  nextCursor: string
   defaultSnapshotId: string
   defaultVersion: number
 }

--- a/web/src/pages/AssessmentCycles/AssessmentCyclesPage.test.tsx
+++ b/web/src/pages/AssessmentCycles/AssessmentCyclesPage.test.tsx
@@ -1,0 +1,67 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import type { AssessmentCycleSummary } from '../../lib/types'
+import { AssessmentCyclesPage } from './AssessmentCyclesPage'
+
+vi.mock('../../lib/api', () => ({ api: { listAssessmentCycles: vi.fn(), listAssessmentCycleMembers: vi.fn() } }))
+
+const cycle: AssessmentCycleSummary = {
+  id: 'cycle-1', name: 'Payments Cycle', boundaryKind: 'asset', businessAssetId: 'asset-1', projectId: '', status: 'open',
+  rootAssessmentId: 'assessment-root', selectedHeadAssessmentId: 'assessment-head', nextRetestNumber: 3, version: 4,
+  createdAt: '2026-08-01T00:00:00Z', updatedAt: '2026-08-03T00:00:00Z', createdBy: 'alice', updatedBy: 'alice',
+  memberCount: 3, activeBranchCount: 2, latestAssessmentId: 'assessment-head', latestRetestNumber: 2,
+  members: [
+    { assessmentId: 'assessment-root', assessmentType: 'initial', predecessorAssessmentId: '', retestNumber: 0, relationshipVersion: 1, createdAt: '2026-08-01T00:00:00Z', createdBy: 'alice', archivedAt: null },
+    { assessmentId: 'assessment-head', assessmentType: 'retest', predecessorAssessmentId: 'assessment-root', retestNumber: 1, relationshipVersion: 1, createdAt: '2026-08-02T00:00:00Z', createdBy: 'alice', archivedAt: null },
+  ],
+  membersNextCursor: 'member-cursor', rootSnapshotId: '', currentSnapshotId: '',
+  selectedHeadLastScanAt: null, scanStaleness: 'missing',
+}
+
+describe('AssessmentCyclesPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(api.listAssessmentCycles).mockResolvedValue({
+      items: [cycle], nextCursor: '', migrationPendingTotal: 1,
+      migrationPending: [{ assessmentId: 'legacy-1', name: 'Legacy Assessment', status: 'completed', boundaryKind: 'standalone', businessAssetId: '', updatedAt: '2026-08-04T00:00:00Z' }],
+    })
+    vi.mocked(api.listAssessmentCycleMembers).mockResolvedValue({
+      items: [{ assessmentId: 'assessment-archived', assessmentType: 'retest', predecessorAssessmentId: 'assessment-root', retestNumber: 2, relationshipVersion: 1, createdAt: '2026-08-03T00:00:00Z', createdBy: 'alice', archivedAt: '2026-08-04T00:00:00Z' }],
+      nextCursor: '',
+    })
+  })
+
+  it('renders N/A metrics, expands members, and continues the member cursor', async () => {
+    render(<MemoryRouter initialEntries={['/assessment-cycles?expanded=cycle-1']}><AssessmentCyclesPage /></MemoryRouter>)
+
+    expect(await screen.findByText('Payments Cycle')).toBeInTheDocument()
+    expect(screen.getAllByText('N/A').length).toBeGreaterThan(0)
+    expect(screen.getByText('Initial')).toBeInTheDocument()
+    expect(screen.getByText('Selected head')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Load more members' }))
+    await waitFor(() => expect(api.listAssessmentCycleMembers).toHaveBeenCalledWith('cycle-1', 'member-cursor', 25))
+    expect(await screen.findByText('Archived')).toBeInTheDocument()
+  })
+
+  it('renders migration-pending assessments without fabricating a Cycle', async () => {
+    render(<MemoryRouter initialEntries={['/assessment-cycles']}><AssessmentCyclesPage /></MemoryRouter>)
+
+    expect(await screen.findByText('Migration pending · 1')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Legacy Assessment/ })).toHaveAttribute('href', '/engagements/legacy-1')
+    expect(screen.getByText('Migration pending')).toBeInTheDocument()
+  })
+
+  it('persists bounded filters in the URL-backed API query and clears them', async () => {
+    render(<MemoryRouter initialEntries={['/assessment-cycles?assessment_status=active&assessment_type=retest&selected_head=assessment-head&scan=stale&q=payments']}><AssessmentCyclesPage /></MemoryRouter>)
+
+    await waitFor(() => expect(api.listAssessmentCycles).toHaveBeenCalledWith(expect.objectContaining({
+      assessmentStatus: 'active', assessmentType: 'retest', selectedHeadAssessmentId: 'assessment-head', scanStaleness: 'stale', search: 'payments',
+    })))
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }))
+    await waitFor(() => expect(api.listAssessmentCycles).toHaveBeenLastCalledWith(expect.objectContaining({
+      assessmentStatus: undefined, assessmentType: undefined, selectedHeadAssessmentId: undefined, scanStaleness: undefined, search: undefined,
+    })))
+  })
+})

--- a/web/src/pages/AssessmentCycles/AssessmentCyclesPage.tsx
+++ b/web/src/pages/AssessmentCycles/AssessmentCyclesPage.tsx
@@ -1,0 +1,100 @@
+import { ChevronDown, GitBranch01, RefreshCw01, SearchLg } from '@untitledui/icons'
+import { useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { Button, Card, EmptyState, ErrorState, Input, Pill, Select, Spinner, cn } from '../../components/ui'
+import { useFetch } from '../../hooks'
+import { api } from '../../lib/api'
+import type {
+  AssessmentCycleBoundaryKind,
+  AssessmentCycleMember,
+  AssessmentCycleScanStaleness,
+  AssessmentCycleStatus,
+  AssessmentCycleSummary,
+  AssessmentStatus,
+} from '../../lib/types'
+
+export function AssessmentCyclesPage() {
+  const [params, setParams] = useSearchParams()
+  const status = (params.get('status') ?? '') as AssessmentCycleStatus | ''
+  const boundaryKind = (params.get('boundary') ?? '') as AssessmentCycleBoundaryKind | ''
+  const assessmentStatus = (params.get('assessment_status') ?? '') as AssessmentStatus | ''
+  const assessmentType = (params.get('assessment_type') ?? '') as AssessmentCycleMember['assessmentType'] | ''
+  const scanStaleness = (params.get('scan') ?? '') as AssessmentCycleScanStaleness | ''
+  const selectedHeadAssessmentId = params.get('selected_head') ?? ''
+  const cursor = params.get('cursor') ?? ''
+  const search = params.get('q') ?? ''
+  const expanded = new Set((params.get('expanded') ?? '').split(',').filter(Boolean))
+  const filterValues = [status, boundaryKind, assessmentStatus, assessmentType, scanStaleness, selectedHeadAssessmentId, search]
+  const cyclesFetch = useFetch(() => api.listAssessmentCycles({
+    status: status || undefined,
+    boundaryKind: boundaryKind || undefined,
+    assessmentStatus: assessmentStatus || undefined,
+    selectedHeadAssessmentId: selectedHeadAssessmentId || undefined,
+    assessmentType: assessmentType || undefined,
+    scanStaleness: scanStaleness || undefined,
+    search: search || undefined,
+    cursor,
+    limit: 50,
+  }), { deps: [...filterValues, cursor] })
+  const [extraMembers, setExtraMembers] = useState<Record<string, AssessmentCycleMember[]>>({})
+  const [memberCursors, setMemberCursors] = useState<Record<string, string>>({})
+  const [memberLoading, setMemberLoading] = useState('')
+  const [memberErrors, setMemberErrors] = useState<Record<string, string>>({})
+
+  function update(next: Record<string, string>, replace = true) {
+    const values = new URLSearchParams(params)
+    for (const [key, value] of Object.entries(next)) value ? values.set(key, value) : values.delete(key)
+    setParams(values, { replace })
+  }
+
+  function toggle(cycleId: string) {
+    const next = new Set(expanded)
+    next.has(cycleId) ? next.delete(cycleId) : next.add(cycleId)
+    update({ expanded: [...next].sort().join(',') })
+  }
+
+  async function loadMore(cycle: AssessmentCycleSummary) {
+    const nextCursor = memberCursors[cycle.id] ?? cycle.membersNextCursor
+    if (!nextCursor) return
+    setMemberLoading(cycle.id)
+    setMemberErrors((current) => ({ ...current, [cycle.id]: '' }))
+    try {
+      const page = await api.listAssessmentCycleMembers(cycle.id, nextCursor, 25)
+      setExtraMembers((current) => ({ ...current, [cycle.id]: [...(current[cycle.id] ?? []), ...page.items] }))
+      setMemberCursors((current) => ({ ...current, [cycle.id]: page.nextCursor }))
+    } catch (cause) {
+      setMemberErrors((current) => ({ ...current, [cycle.id]: cause instanceof Error ? cause.message : 'Member page failed.' }))
+    } finally {
+      setMemberLoading('')
+    }
+  }
+
+  const items = cyclesFetch.data?.items ?? []
+  return <div className="mx-auto max-w-[1600px] animate-fade-in space-y-6">
+    <header className="flex flex-wrap items-end justify-between gap-4"><div><p className="text-xs font-semibold uppercase tracking-wider text-brand-secondary">Assessment lifecycle</p><h1 className="mt-1 text-2xl font-bold tracking-tight text-primary">Assessment Cycles</h1><p className="mt-1 text-sm text-tertiary">Root-to-selected/final projections only. Display latest never changes semantic precedence.</p></div><Button variant="secondary" onClick={cyclesFetch.refetch}><RefreshCw01 className="size-4" aria-hidden="true" />Refresh</Button></header>
+    <Card bodyClass="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      <div className="relative sm:col-span-2"><SearchLg className="pointer-events-none absolute left-3 top-3 size-4 text-quaternary" aria-hidden="true" /><Input aria-label="Search Assessment Cycles" value={search} onChange={(event) => update({ q: event.target.value, cursor: '' })} className="pl-9" placeholder="Search Cycle, root, or selected head" /></div>
+      <Select ariaLabel="Cycle status" value={status} onValueChange={(value) => update({ status: value, cursor: '' })} placeholder="All Cycle statuses" options={[{ value: 'open', label: 'Open' }, { value: 'completed', label: 'Completed' }, { value: 'archived', label: 'Archived' }]} className="w-full" />
+      <Select ariaLabel="Boundary kind" value={boundaryKind} onValueChange={(value) => update({ boundary: value, cursor: '' })} placeholder="All boundaries" options={[{ value: 'standalone', label: 'Standalone' }, { value: 'asset', label: 'Asset' }, { value: 'project', label: 'Project' }, { value: 'asset_project', label: 'Asset + Project' }]} className="w-full" />
+      <Select ariaLabel="Selected-head Assessment status" value={assessmentStatus} onValueChange={(value) => update({ assessment_status: value, cursor: '' })} placeholder="All Assessment statuses" options={[{ value: 'draft', label: 'Draft' }, { value: 'active', label: 'Active' }, { value: 'completed', label: 'Completed' }, { value: 'archived', label: 'Archived' }]} className="w-full" />
+      <Select ariaLabel="Assessment member type" value={assessmentType} onValueChange={(value) => update({ assessment_type: value, cursor: '' })} placeholder="Initial or Re-test" options={[{ value: 'initial', label: 'Initial' }, { value: 'retest', label: 'Re-test' }]} className="w-full" />
+      <Input aria-label="Selected head Assessment ID" value={selectedHeadAssessmentId} onChange={(event) => update({ selected_head: event.target.value, cursor: '' })} placeholder="Selected head ID" />
+      <Select ariaLabel="Selected-head scan staleness" value={scanStaleness} onValueChange={(value) => update({ scan: value, cursor: '' })} placeholder="Any scan freshness" options={[{ value: 'fresh', label: 'Fresh ≤ 24h' }, { value: 'stale', label: 'Stale > 24h' }, { value: 'missing', label: 'No trustworthy scan' }]} className="w-full" />
+      {filterValues.some(Boolean) ? <Button variant="secondary" onClick={() => setParams(new URLSearchParams(), { replace: true })}>Clear filters</Button> : null}
+    </Card>
+    {cyclesFetch.loading && !cyclesFetch.data ? <Spinner label="Loading Assessment Cycles…" /> : null}
+    {cyclesFetch.error ? <ErrorState message={cyclesFetch.error} /> : null}
+    {!cyclesFetch.loading && !cyclesFetch.error && items.length === 0 && !(cyclesFetch.data?.migrationPendingTotal) ? <EmptyState icon={GitBranch01} title="No Assessment Cycles" hint="No Cycle or migration-pending Assessment matches these filters." /> : null}
+    <div className="space-y-3">{items.map((cycle) => <CycleRow key={cycle.id} cycle={cycle} expanded={expanded.has(cycle.id)} extraMembers={extraMembers[cycle.id] ?? []} nextMemberCursor={memberCursors[cycle.id] ?? cycle.membersNextCursor} loading={memberLoading === cycle.id} error={memberErrors[cycle.id] ?? ''} onToggle={() => toggle(cycle.id)} onLoadMore={() => loadMore(cycle)} />)}</div>
+    {cyclesFetch.data?.nextCursor ? <div className="flex justify-end"><Button variant="secondary" onClick={() => update({ cursor: cyclesFetch.data?.nextCursor ?? '' }, false)}>Next Cycle page</Button></div> : null}
+    {cyclesFetch.data?.migrationPendingTotal ? <Card title={`Migration pending · ${cyclesFetch.data.migrationPendingTotal}`}>{cyclesFetch.data.migrationPending.length ? <div className="space-y-2">{cyclesFetch.data.migrationPending.map((assessment) => <Link key={assessment.assessmentId} to={`/engagements/${encodeURIComponent(assessment.assessmentId)}`} className="flex flex-wrap items-center gap-2 rounded-lg border border-warning/30 bg-warning/5 px-4 py-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"><span className="font-semibold text-primary">{assessment.name}</span><span className="font-mono text-xs text-tertiary">{assessment.assessmentId}</span><Pill className="text-warning">Migration pending</Pill><Pill>{assessment.status} Assessment</Pill><span className="ml-auto text-xs text-tertiary">{formatDate(assessment.updatedAt)}</span></Link>)}</div> : <p className="text-sm text-tertiary">Pending legacy Assessments exist but are excluded by Cycle-only filters. Clear filters to inspect them.</p>}</Card> : null}
+  </div>
+}
+
+function CycleRow({ cycle, expanded, extraMembers, nextMemberCursor, loading, error, onToggle, onLoadMore }: { cycle: AssessmentCycleSummary; expanded: boolean; extraMembers: AssessmentCycleMember[]; nextMemberCursor: string; loading: boolean; error: string; onToggle: () => void; onLoadMore: () => void }) {
+  const members = [...cycle.members, ...extraMembers]
+  return <Card bodyClass="p-0"><button type="button" aria-expanded={expanded} aria-controls={`cycle-${cycle.id}`} onClick={onToggle} className="grid w-full gap-3 px-5 py-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand md:grid-cols-[minmax(240px,1.4fr)_repeat(3,minmax(110px,.6fr))_auto] md:items-center"><span><span className="flex flex-wrap items-center gap-2"><strong className="text-sm text-primary">{cycle.name}</strong><Pill>{cycle.status} Cycle</Pill></span><span className="mt-1 block font-mono text-xs text-tertiary">{cycle.id}</span></span><Stat label="Members / branches" value={`${cycle.memberCount} / ${cycle.activeBranchCount}`} /><Stat label="Latest member" value={cycle.latestRetestNumber > 0 ? `Re-test #${cycle.latestRetestNumber}` : 'Initial'} /><Stat label="Selected-head scan" value={cycle.scanStaleness} /><ChevronDown className={cn('size-4 text-tertiary transition-transform', expanded && 'rotate-180')} aria-hidden="true" /></button>{expanded ? <div id={`cycle-${cycle.id}`} className="border-t border-secondary px-5 py-4"><div className="mb-3 grid gap-2 text-xs text-tertiary sm:grid-cols-2 lg:grid-cols-4"><span><strong>Root snapshot:</strong> {cycle.rootSnapshotId || 'N/A'}</span><span><strong>Current snapshot:</strong> {cycle.currentSnapshotId || 'N/A'}</span><span><strong>Display latest:</strong> {cycle.latestAssessmentId || 'N/A'}</span><span><strong>Last trusted scan:</strong> {cycle.selectedHeadLastScanAt ? formatDate(cycle.selectedHeadLastScanAt) : 'N/A'}</span></div><ul aria-label={`${cycle.name} members`} className="space-y-2">{members.map((member) => <li key={member.assessmentId}><Link to={`/engagements/${encodeURIComponent(member.assessmentId)}`} className="flex flex-wrap items-center gap-2 rounded-lg border border-secondary px-3 py-2 text-sm hover:border-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"><span className="font-semibold text-primary">{member.assessmentType === 'retest' ? `Re-test #${member.retestNumber}` : 'Initial'}</span><span className="font-mono text-xs text-tertiary">{member.assessmentId}</span>{member.assessmentId === cycle.selectedHeadAssessmentId ? <Pill className="text-brand-secondary">Selected head</Pill> : null}{member.assessmentId === cycle.latestAssessmentId ? <Pill className="text-brand-secondary">Display latest</Pill> : null}{member.archivedAt ? <Pill className="text-warning">Archived</Pill> : null}<span className="ml-auto text-xs text-tertiary">{formatDate(member.createdAt)}</span></Link></li>)}</ul>{error ? <ErrorState className="mt-3" message={error} /> : null}{nextMemberCursor ? <Button className="mt-3" variant="secondary" loading={loading} onClick={onLoadMore}>Load more members</Button> : null}</div> : null}</Card>
+}
+
+function Stat({ label, value }: { label: string; value: string }) { return <span><span className="block text-[11px] font-semibold uppercase tracking-wide text-quaternary">{label}</span><span className="mt-1 block text-sm font-semibold capitalize text-primary">{value}</span></span> }
+function formatDate(value: string) { return value ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(value)) : 'Unknown' }

--- a/web/src/pages/Dashboard/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard/Dashboard.test.tsx
@@ -28,10 +28,10 @@ const assets: BusinessAsset[] = [
 
 const engagements: Engagement[] = [
   {
-    id: 'eng-active', name: 'Payment API Review', client: 'Internal', status: 'active', inScope: [{ kind: 'repo', value: 'payments' }], outOfScope: [], authorizedFrom: null, authorizedTo: null, roe: { allowedToolClasses: [], blackouts: [] }, liveReconEnabled: false, createdAt: '2026-08-01T00:00:00Z', businessAssetId: 'asset-critical',
+    id: 'eng-active', name: 'Payment API Review', client: 'Internal', status: 'active', inScope: [{ kind: 'repo', value: 'payments' }], outOfScope: [], authorizedFrom: null, authorizedTo: null, roe: { allowedToolClasses: [], blackouts: [] }, liveReconEnabled: false, requiresExplicitExecutionAuthorization: false, createdAt: '2026-08-01T00:00:00Z', businessAssetId: 'asset-critical',
   },
   {
-    id: 'eng-unassigned', name: 'New Service Review', client: 'Internal', status: 'draft', inScope: [{ kind: 'service', value: 'new-service' }], outOfScope: [], authorizedFrom: null, authorizedTo: null, roe: { allowedToolClasses: [], blackouts: [] }, liveReconEnabled: false, createdAt: '2026-08-02T00:00:00Z', businessAssetId: '',
+    id: 'eng-unassigned', name: 'New Service Review', client: 'Internal', status: 'draft', inScope: [{ kind: 'service', value: 'new-service' }], outOfScope: [], authorizedFrom: null, authorizedTo: null, roe: { allowedToolClasses: [], blackouts: [] }, liveReconEnabled: false, requiresExplicitExecutionAuthorization: false, createdAt: '2026-08-02T00:00:00Z', businessAssetId: '',
   },
 ]
 

--- a/web/src/pages/EngagementDetail/EngagementDetail.test.tsx
+++ b/web/src/pages/EngagementDetail/EngagementDetail.test.tsx
@@ -37,6 +37,7 @@ const mockEngagement = {
   authorizedTo: null,
   roe: { allowedToolClasses: [], blackouts: [] },
   liveReconEnabled: false,
+  requiresExplicitExecutionAuthorization: false,
   createdAt: '2026-08-15T00:00:00Z',
   businessAssetId: '',
 }

--- a/web/src/pages/Engagements/Engagements.test.tsx
+++ b/web/src/pages/Engagements/Engagements.test.tsx
@@ -91,7 +91,7 @@ describe('Engagements', () => {
       id: 'eng-upload', name: 'Uploaded assessment', client: '', status: 'draft',
       inScope: [{ kind: 'repo', value: `uploaded-source/sha256/${'b'.repeat(64)}` }], outOfScope: [],
       authorizedFrom: null, authorizedTo: null, roe: { allowedToolClasses: [], blackouts: [] },
-      liveReconEnabled: false, createdAt: '2026-08-28T00:00:00Z', businessAssetId: '',
+      liveReconEnabled: false, requiresExplicitExecutionAuthorization: false, createdAt: '2026-08-28T00:00:00Z', businessAssetId: '',
     }
     vi.mocked(api.createEngagementFromSource).mockResolvedValue(created)
     vi.mocked(api.startScan).mockResolvedValue({
@@ -133,6 +133,7 @@ describe('Engagements', () => {
         authorizedTo: null,
         roe: { allowedToolClasses: [], blackouts: [] },
         liveReconEnabled: false,
+        requiresExplicitExecutionAuthorization: false,
         createdAt: '2026-08-20T10:00:00Z',
         businessAssetId: 'a1',
       },
@@ -147,6 +148,7 @@ describe('Engagements', () => {
         authorizedTo: null,
         roe: { allowedToolClasses: [], blackouts: [] },
         liveReconEnabled: false,
+        requiresExplicitExecutionAuthorization: false,
         createdAt: '2026-08-10T10:00:00Z',
         businessAssetId: '',
       },

--- a/web/src/pages/Engagements/NewEngagementPage.tsx
+++ b/web/src/pages/Engagements/NewEngagementPage.tsx
@@ -31,11 +31,15 @@ export const NewEngagementPage: FC = () => {
       {/* Form */}
       <CreateEngagementForm
         initialAssetId={initialAssetId}
-        onCreated={(engagement, sourceMode, scanStartError) => {
-          if (sourceMode === 'upload') {
+        onCreated={(engagement, creationKind, scanStartError) => {
+          if (creationKind === 'upload') {
             navigate(`/engagements/${encodeURIComponent(engagement.id)}`, {
               state: scanStartError ? { scanStartError } : undefined,
             })
+            return
+          }
+          if (creationKind === 'retest') {
+            navigate(`/engagements/${encodeURIComponent(engagement.id)}`)
             return
           }
           navigate('/engagements')

--- a/web/src/pages/Engagements/NewEngagementPage.tsx
+++ b/web/src/pages/Engagements/NewEngagementPage.tsx
@@ -1,10 +1,12 @@
 import type { FC } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { useOptionalAuth } from '../../auth/AuthContext'
 import { CreateEngagementForm } from './components/CreateEngagementForm'
 
 export const NewEngagementPage: FC = () => {
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
+  const auth = useOptionalAuth()
   const initialAssetId = searchParams.get('assetId') ?? ''
 
   return (
@@ -31,6 +33,7 @@ export const NewEngagementPage: FC = () => {
       {/* Form */}
       <CreateEngagementForm
         initialAssetId={initialAssetId}
+        assessmentLifecycleEnabled={auth?.currentUser?.features?.assessmentLifecycleUIDefault === true}
         onCreated={(engagement, creationKind, scanStartError) => {
           if (creationKind === 'upload') {
             navigate(`/engagements/${encodeURIComponent(engagement.id)}`, {

--- a/web/src/pages/Engagements/components/CreateEngagementForm.test.tsx
+++ b/web/src/pages/Engagements/components/CreateEngagementForm.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../../lib/api'
+import type { AssessmentCycleSummary } from '../../../lib/types'
+import { CreateEngagementForm } from './CreateEngagementForm'
+
+vi.mock('../../../lib/api', () => ({
+  api: {
+    listBusinessAssets: vi.fn(),
+    listAssessmentCycles: vi.fn(),
+    createRetest: vi.fn(),
+    createEngagement: vi.fn(),
+    createEngagementFromSource: vi.fn(),
+    startScan: vi.fn(),
+  },
+}))
+
+const cycle: AssessmentCycleSummary = {
+  id: 'cycle-1', name: 'Payments Cycle', boundaryKind: 'asset_project', businessAssetId: 'asset-1', projectId: 'project-1', status: 'open',
+  rootAssessmentId: 'assessment-0', selectedHeadAssessmentId: 'assessment-1',
+  nextRetestNumber: 2, version: 3, createdAt: '2026-08-20T00:00:00Z', updatedAt: '2026-09-01T00:00:00Z', createdBy: 'operator', updatedBy: 'operator',
+  memberCount: 2, activeBranchCount: 1, latestAssessmentId: 'assessment-1', latestRetestNumber: 1,
+  members: [
+    { assessmentId: 'assessment-0', assessmentType: 'initial', predecessorAssessmentId: '', retestNumber: 0, relationshipVersion: 1, createdAt: '2026-08-20T00:00:00Z', createdBy: 'operator', archivedAt: null },
+    { assessmentId: 'assessment-1', assessmentType: 'retest', predecessorAssessmentId: 'assessment-0', retestNumber: 1, relationshipVersion: 1, createdAt: '2026-08-25T00:00:00Z', createdBy: 'operator', archivedAt: null },
+  ],
+  membersNextCursor: '', rootSnapshotId: 'snapshot-0', currentSnapshotId: 'snapshot-1',
+  selectedHeadLastScanAt: '2026-09-01T00:00:00Z', scanStaleness: 'fresh',
+}
+
+describe('CreateEngagementForm Re-test purpose', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(api.listBusinessAssets).mockResolvedValue({ items: [], total: 0, limit: 200, offset: 0 })
+    vi.mocked(api.listAssessmentCycles).mockResolvedValue({ items: [cycle], nextCursor: '', migrationPending: [], migrationPendingTotal: 0 })
+  })
+
+  it('submits only lifecycle input and reuses the idempotency key for a draft retry', async () => {
+    vi.mocked(api.createRetest).mockRejectedValue(new Error('temporary network failure'))
+    render(<CreateEngagementForm onCreated={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('radio', { name: /Re-test existing assessment/ }))
+    expect(await screen.findByRole('combobox', { name: 'Based on Assessment' })).toHaveTextContent('Payments Cycle · Re-test #1')
+    fireEvent.change(screen.getByRole('textbox', { name: /Name/ }), { target: { value: 'Payments verification' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save non-executable draft' }))
+    expect(await screen.findByText('temporary network failure')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Save non-executable draft' }))
+
+    await waitFor(() => expect(api.createRetest).toHaveBeenCalledTimes(2))
+    const first = vi.mocked(api.createRetest).mock.calls[0]
+    const second = vi.mocked(api.createRetest).mock.calls[1]
+    expect(first?.[0]).toBe('assessment-1')
+    expect(first?.[1]).toMatchObject({ name: 'Payments verification', predecessorAssessmentId: 'assessment-1', scopeStrategy: 'copy', profileStrategy: 'none', authorizedFrom: '', authorizedTo: '', roe: undefined })
+    expect(first?.[1]?.idempotencyKey).toBeTruthy()
+    expect(second?.[1]?.idempotencyKey).toBe(first?.[1]?.idempotencyKey)
+    expect(first?.[1]).not.toHaveProperty('cycleId')
+    expect(first?.[1]).not.toHaveProperty('boundaryKind')
+  })
+})

--- a/web/src/pages/Engagements/components/CreateEngagementForm.test.tsx
+++ b/web/src/pages/Engagements/components/CreateEngagementForm.test.tsx
@@ -37,7 +37,7 @@ describe('CreateEngagementForm Re-test purpose', () => {
 
   it('submits only lifecycle input and reuses the idempotency key for a draft retry', async () => {
     vi.mocked(api.createRetest).mockRejectedValue(new Error('temporary network failure'))
-    render(<CreateEngagementForm onCreated={vi.fn()} />)
+    render(<CreateEngagementForm assessmentLifecycleEnabled onCreated={vi.fn()} />)
 
     fireEvent.click(screen.getByRole('radio', { name: /Re-test existing assessment/ }))
     expect(await screen.findByRole('combobox', { name: 'Based on Assessment' })).toHaveTextContent('Payments Cycle · Re-test #1')
@@ -55,5 +55,27 @@ describe('CreateEngagementForm Re-test purpose', () => {
     expect(second?.[1]?.idempotencyKey).toBe(first?.[1]?.idempotencyKey)
     expect(first?.[1]).not.toHaveProperty('cycleId')
     expect(first?.[1]).not.toHaveProperty('boundaryKind')
+  })
+
+  it('hides Re-test controls outside the tenant lifecycle rollout', () => {
+    render(<CreateEngagementForm onCreated={vi.fn()} />)
+    expect(screen.queryByRole('radio', { name: /Re-test existing assessment/ })).not.toBeInTheDocument()
+  })
+
+  it('reuses one idempotency key when an initial Assessment request is retried', async () => {
+    vi.mocked(api.createEngagement).mockRejectedValue(new Error('temporary network failure'))
+    render(<CreateEngagementForm onCreated={vi.fn()} />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: /Name/ }), { target: { value: 'Initial assessment' } })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Target value for row 1' }), { target: { value: 'app.example.com' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create Engagement' }))
+    expect(await screen.findByText('temporary network failure')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Create Engagement' }))
+
+    await waitFor(() => expect(api.createEngagement).toHaveBeenCalledTimes(2))
+    const firstKey = vi.mocked(api.createEngagement).mock.calls[0]?.[1]
+    const secondKey = vi.mocked(api.createEngagement).mock.calls[1]?.[1]
+    expect(firstKey).toBeTruthy()
+    expect(secondKey).toBe(firstKey)
   })
 })

--- a/web/src/pages/Engagements/components/CreateEngagementForm.tsx
+++ b/web/src/pages/Engagements/components/CreateEngagementForm.tsx
@@ -1,17 +1,19 @@
 import { useEffect, useMemo, useState, type FC, type FormEvent } from 'react'
 import { Check, Link01, Plus, Trash01, Upload01 } from '@untitledui/icons'
 import { api } from '../../../lib/api'
+import { newIdempotencyKey } from '../../../lib/api/client'
 import { kindLabel } from '../../../lib/format'
-import type { BusinessAsset, Engagement, ScopeTarget } from '../../../lib/types'
+import type { AssessmentCycleSummary, BusinessAsset, Engagement, ScopeTarget } from '../../../lib/types'
 import { Select } from '../../../components/ui'
 
 const KINDS = ['repo', 'domain', 'host', 'url', 'image', 'cidr']
 const MAX_SOURCE_BYTES = 512 * 1024 * 1024
 type SourceMode = 'linked' | 'upload'
+type CreationKind = SourceMode | 'retest'
 
 export interface CreateEngagementFormProps {
   initialAssetId?: string
-  onCreated: (engagement: Engagement, sourceMode: SourceMode, scanStartError?: string) => void
+  onCreated: (engagement: Engagement, creationKind: CreationKind, scanStartError?: string) => void
 }
 
 export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
@@ -20,6 +22,7 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
 }) => {
   const [name, setName] = useState('')
   const [client, setClient] = useState('')
+  const [purpose, setPurpose] = useState<'initial' | 'retest'>('initial')
   const [sourceMode, setSourceMode] = useState<SourceMode>('linked')
   const [sourceFile, setSourceFile] = useState<File | null>(null)
   const [scope, setScope] = useState<ScopeTarget[]>([{ kind: 'repo', value: '' }])
@@ -29,6 +32,12 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
   const [error, setError] = useState<string | null>(null)
   const [assets, setAssets] = useState<BusinessAsset[]>([])
   const [assetId, setAssetId] = useState(initialAssetId ?? '')
+  const [eligibleCycles, setEligibleCycles] = useState<AssessmentCycleSummary[]>([])
+  const [eligibleLoading, setEligibleLoading] = useState(false)
+  const [eligibleError, setEligibleError] = useState('')
+  const [basedOnAssessmentId, setBasedOnAssessmentId] = useState('')
+  const [toolClasses, setToolClasses] = useState('')
+  const [retestIdempotencyKey] = useState(newIdempotencyKey)
 
   useEffect(() => {
     let live = true
@@ -51,6 +60,28 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
     }
   }, [initialAssetId])
 
+  useEffect(() => {
+    if (purpose !== 'retest') return
+    let live = true
+    setEligibleLoading(true)
+    setEligibleError('')
+    api.listAssessmentCycles({ status: 'open', assessmentStatus: 'completed', limit: 50 })
+      .then((result) => {
+        if (!live) return
+        setEligibleCycles(result.items)
+        const ids = result.items.flatMap((cycle) => cycle.members.filter((member) => !member.archivedAt).map((member) => member.assessmentId))
+        setBasedOnAssessmentId((current) => (ids.includes(current) ? current : result.items[0]?.selectedHeadAssessmentId ?? ids[0] ?? ''))
+      })
+      .catch((cause) => {
+        if (!live) return
+        setEligibleCycles([])
+        setBasedOnAssessmentId('')
+        setEligibleError(cause instanceof Error ? cause.message : 'Eligible Assessment lookup failed.')
+      })
+      .finally(() => { if (live) setEligibleLoading(false) })
+    return () => { live = false }
+  }, [purpose])
+
   const assetOptions = useMemo(() => [
     { value: '__unassigned__', label: 'Unassigned' },
     ...assets.map((asset) => ({
@@ -63,6 +94,13 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
     value: kind,
     label: kindLabel(kind),
   })), [])
+  const predecessorOptions = useMemo(() => {
+    const seen = new Set<string>()
+    return eligibleCycles.flatMap((cycle) => cycle.members.filter((member) => !member.archivedAt && !seen.has(member.assessmentId)).map((member) => {
+      seen.add(member.assessmentId)
+      return { value: member.assessmentId, label: `${cycle.name} · ${member.assessmentType === 'retest' ? `Re-test #${member.retestNumber}` : 'Initial'} · ${member.assessmentId}` }
+    }))
+  }, [eligibleCycles])
 
   function setRow(index: number, patch: Partial<ScopeTarget>) {
     setScope((rows) => rows.map((row, rowIndex) => (rowIndex === index ? { ...row, ...patch } : row)))
@@ -86,20 +124,28 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
 
   async function handleSubmit(event: FormEvent) {
     event.preventDefault()
+    await submit(false)
+  }
+
+  async function submit(draft: boolean) {
     const inScope = sourceMode === 'linked' ? scope.filter((row) => row.value.trim() !== '') : []
     if (!name.trim()) {
       setError('Name is required.')
       return
     }
-    if (sourceMode === 'linked' && inScope.length === 0) {
+    if (purpose === 'retest' && !basedOnAssessmentId) {
+      setError('Choose an eligible completed Assessment in an open Cycle.')
+      return
+    }
+    if (purpose === 'initial' && sourceMode === 'linked' && inScope.length === 0) {
       setError('Add at least one in-scope target.')
       return
     }
-    if (sourceMode === 'upload' && !sourceFile) {
+    if (purpose === 'initial' && sourceMode === 'upload' && !sourceFile) {
       setError('Choose a source package to upload.')
       return
     }
-    if (assetId && !assets.some((asset) => asset.id === assetId)) {
+    if (purpose === 'initial' && assetId && !assets.some((asset) => asset.id === assetId)) {
       setError('Select a valid Asset.')
       return
     }
@@ -114,6 +160,16 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
     setSubmitting(true)
     setError(null)
     try {
+      if (purpose === 'retest') {
+        const result = await api.createRetest(basedOnAssessmentId, {
+          name: name.trim(), predecessorAssessmentId: basedOnAssessmentId, scopeStrategy: 'copy', profileStrategy: 'none',
+          authorizedFrom: draft ? '' : from ?? '', authorizedTo: draft ? '' : to ?? '', timezone: timezone || 'UTC',
+          roe: draft ? undefined : { allowedToolClasses: toolClasses.split(',').map((value) => value.trim()).filter(Boolean), blackouts: [] },
+          idempotencyKey: retestIdempotencyKey,
+        })
+        onCreated(result.engagement, 'retest')
+        return
+      }
       const input = {
         name: name.trim(),
         client: client.trim(),
@@ -162,6 +218,16 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
             </span>
             Assessment context
           </div>
+          <div role="radiogroup" aria-label="Assessment purpose" className="mb-4 grid gap-3 sm:grid-cols-2">
+            <label className="flex cursor-pointer gap-3 rounded-xl border border-secondary bg-secondary/30 p-4">
+              <input type="radio" name="assessment-purpose" checked={purpose === 'initial'} disabled={submitting} onChange={() => { setPurpose('initial'); setError(null) }} className="mt-1 size-4 accent-brand-solid" />
+              <span><span className="block text-sm font-semibold text-primary">Initial assessment</span><span className="mt-1 block text-xs text-tertiary">Create a new standalone or Asset-bound Cycle.</span></span>
+            </label>
+            <label className="flex cursor-pointer gap-3 rounded-xl border border-secondary bg-secondary/30 p-4">
+              <input type="radio" name="assessment-purpose" checked={purpose === 'retest'} disabled={submitting} onChange={() => { setPurpose('retest'); setError(null) }} className="mt-1 size-4 accent-brand-solid" />
+              <span><span className="block text-sm font-semibold text-primary">Re-test existing assessment</span><span className="mt-1 block text-xs text-tertiary">Cycle, boundary, type, scope, and profile are server-derived.</span></span>
+            </label>
+          </div>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
             <div>
               <label htmlFor="engagement-name-input" className="block text-xs font-medium text-secondary">
@@ -180,6 +246,7 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
               />
             </div>
 
+            {purpose === 'initial' ? <>
             <div>
               <label htmlFor="engagement-client-input" className="block text-xs font-medium text-secondary">
                 Client <span className="text-tertiary">(Optional)</span>
@@ -208,11 +275,18 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
                 className="mt-1.5 h-10 w-full border-primary bg-primary shadow-xs"
               />
             </div>
+            </> : <div className="sm:col-span-1 xl:col-span-2">
+              <label className="block text-xs font-medium text-secondary">Based on Assessment <span className="text-utility-red-600">*</span></label>
+              {predecessorOptions.length ? <Select ariaLabel="Based on Assessment" disabled={submitting || eligibleLoading} value={basedOnAssessmentId || predecessorOptions[0]!.value} onValueChange={setBasedOnAssessmentId} options={predecessorOptions} className="mt-1.5 h-10 w-full border-primary bg-primary shadow-xs" /> : null}
+              {eligibleLoading ? <p role="status" className="mt-1.5 text-xs text-tertiary">Loading eligible completed Assessments…</p> : null}
+              {!eligibleLoading && !eligibleError && predecessorOptions.length === 0 ? <p role="status" className="mt-1.5 text-xs text-warning">No eligible completed Assessment exists in an open Cycle. Reopen the Cycle first if it is completed.</p> : null}
+              {eligibleError ? <p role="alert" className="mt-1.5 text-xs text-error-primary">{eligibleError}</p> : null}
+            </div>}
           </div>
         </div>
 
         {/* Step 2: Source */}
-        <div className="border-t border-secondary pt-6">
+        {purpose === 'initial' ? <div className="border-t border-secondary pt-6">
           <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-primary">
             <span className="flex size-6 items-center justify-center rounded-full bg-brand-solid text-xs font-bold text-white">
               2
@@ -334,7 +408,7 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
               </div>
             )}
           </div>
-        </div>
+        </div> : <div className="border-t border-secondary pt-6"><div className="mb-3 flex items-center gap-2 text-sm font-semibold text-primary"><span className="flex size-6 items-center justify-center rounded-full bg-brand-solid text-xs font-bold text-white">2</span>Derived lifecycle context</div><div className="rounded-xl border border-secondary bg-secondary/30 p-4 text-sm text-secondary"><p><strong>Assessment type:</strong> Re-test</p><p className="mt-1"><strong>Scope/profile:</strong> copied only by the server contract; no Cycle or boundary selector is writable.</p></div></div>}
 
         {/* Step 3: Authorization Window */}
         <div className="border-t border-secondary pt-6">
@@ -373,6 +447,7 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
                 className="mt-1.5 w-full rounded-lg border border-primary bg-primary px-3.5 py-2 text-sm text-primary shadow-xs outline-none focus:border-brand focus:ring-2 focus:ring-brand/20 disabled:cursor-not-allowed disabled:opacity-50"
               />
             </div>
+            {purpose === 'retest' ? <div className="sm:col-span-2"><label htmlFor="retest-tool-classes" className="block text-xs font-medium text-secondary">Allowed tool classes <span className="text-tertiary">(Required for executable authorization)</span></label><input id="retest-tool-classes" value={toolClasses} disabled={submitting} onChange={(event) => setToolClasses(event.target.value)} placeholder="sca, sast" className="mt-1.5 w-full rounded-lg border border-primary bg-primary px-3.5 py-2 text-sm text-primary shadow-xs outline-none focus:border-brand focus:ring-2 focus:ring-brand/20 disabled:cursor-not-allowed disabled:opacity-50" /><p className="mt-1.5 text-xs text-tertiary">Planned dates never authorize execution. Missing, expired, reversed, or invalid authorization/RoE remains a non-executable draft.</p></div> : null}
           </div>
         </div>
 
@@ -382,7 +457,8 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
           </div>
         )}
 
-        <div className="flex items-center justify-end gap-3 border-t border-secondary pt-6">
+        <div className="flex flex-wrap items-center justify-end gap-3 border-t border-secondary pt-6">
+          {purpose === 'retest' ? <button type="button" disabled={submitting || eligibleLoading} onClick={() => submit(true)} className="inline-flex items-center justify-center rounded-lg border border-secondary bg-primary px-4 py-2.5 text-sm font-semibold text-secondary shadow-xs transition hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-brand/30 disabled:cursor-not-allowed disabled:opacity-50">Save non-executable draft</button> : null}
           <button
             type="submit"
             disabled={submitting}
@@ -393,7 +469,7 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
             ) : (
               <Check className="size-4" />
             )}
-            {sourceMode === 'upload' ? 'Create & Scan' : 'Create Engagement'}
+            {purpose === 'retest' ? 'Create Re-test' : sourceMode === 'upload' ? 'Create & Scan' : 'Create Engagement'}
           </button>
         </div>
       </form>

--- a/web/src/pages/Engagements/components/CreateEngagementForm.tsx
+++ b/web/src/pages/Engagements/components/CreateEngagementForm.tsx
@@ -13,11 +13,13 @@ type CreationKind = SourceMode | 'retest'
 
 export interface CreateEngagementFormProps {
   initialAssetId?: string
+  assessmentLifecycleEnabled?: boolean
   onCreated: (engagement: Engagement, creationKind: CreationKind, scanStartError?: string) => void
 }
 
 export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
   initialAssetId,
+  assessmentLifecycleEnabled = false,
   onCreated,
 }) => {
   const [name, setName] = useState('')
@@ -37,6 +39,7 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
   const [eligibleError, setEligibleError] = useState('')
   const [basedOnAssessmentId, setBasedOnAssessmentId] = useState('')
   const [toolClasses, setToolClasses] = useState('')
+  const [initialIdempotencyKey] = useState(newIdempotencyKey)
   const [retestIdempotencyKey] = useState(newIdempotencyKey)
 
   useEffect(() => {
@@ -181,8 +184,8 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
         assetId,
       }
       const engagement = sourceMode === 'upload'
-        ? await api.createEngagementFromSource(input, sourceFile!)
-        : await api.createEngagement(input)
+        ? await api.createEngagementFromSource(input, sourceFile!, initialIdempotencyKey)
+        : await api.createEngagement(input, initialIdempotencyKey)
       if (sourceMode === 'upload') {
         try {
           await api.startScan(engagement.id, '', 'upload')
@@ -223,10 +226,10 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
               <input type="radio" name="assessment-purpose" checked={purpose === 'initial'} disabled={submitting} onChange={() => { setPurpose('initial'); setError(null) }} className="mt-1 size-4 accent-brand-solid" />
               <span><span className="block text-sm font-semibold text-primary">Initial assessment</span><span className="mt-1 block text-xs text-tertiary">Create a new standalone or Asset-bound Cycle.</span></span>
             </label>
-            <label className="flex cursor-pointer gap-3 rounded-xl border border-secondary bg-secondary/30 p-4">
+            {assessmentLifecycleEnabled ? <label className="flex cursor-pointer gap-3 rounded-xl border border-secondary bg-secondary/30 p-4">
               <input type="radio" name="assessment-purpose" checked={purpose === 'retest'} disabled={submitting} onChange={() => { setPurpose('retest'); setError(null) }} className="mt-1 size-4 accent-brand-solid" />
               <span><span className="block text-sm font-semibold text-primary">Re-test existing assessment</span><span className="mt-1 block text-xs text-tertiary">Cycle, boundary, type, scope, and profile are server-derived.</span></span>
-            </label>
+            </label> : null}
           </div>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
             <div>


### PR DESCRIPTION
Split from #811 in response to the requested decomposition.

Depends on #779 and intentionally uses its ScanRun provenance model. Because #779 comes from a fork, this PR temporarily targets codex/pr-779-base, which is an exact mirror of the current #779 head SHA. Retarget this PR to main immediately after #779 merges. The duplicate ScanRun implementation and migration from #811 are not present in this diff.

Scope
- Assessment Cycle and Re-test lifecycle API, immutable Snapshot finalization, UI, and OpenAPI contracts.
- Resumable Cycle and Snapshot backfills plus the read-only integrity verifier.
- Default-off rollout gates and tenant allowlists.
- Migrations 0131 through 0135, following #779 migration 0129 and the reserved Integrations migration 0130.

Review fixes included
- Legacy completion remains compatible while Snapshot enforcement is disabled; enabled enforcement fails closed.
- Backfill and integrity publication use unique lease-token fencing with transactional item and business writes.
- Resume rejects schema, dry-run, or batch-size mismatches.
- Snapshot ETags return the real default-pointer CAS version and legacy-only history lists with version zero.
- Tenant ownership, forced RLS, immutable hashes, idempotency, and optimistic concurrency are preserved.

Validation
- Focused Cycle, Snapshot, backfill, integrity, HTTP, Postgres, and migration tests pass.
- Race checks for the Assessment, persistence, HTTP, and observability packages pass.

Please review this PR as the Cycle/Snapshot slice only; Finding Lineage and Comparison/Closure are stacked separately.