### PR TITLE
feat(web): surface five wired-but-unshown capabilities in the dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Per-engagement vulnerability posture in the dashboard.** The reconciled advisory occurrences and the
+  governed action queue for an engagement (`GET /engagements/{id}/vulnerability/occurrences` and
+  `.../vulnerability/actions`, with `.../actions/{aid}/acknowledge` and `/resolve`) had no UI. A new
+  **Vuln Posture** tab (under Findings) lists the action queue with in-place acknowledge/resolve and the
+  reconciled occurrences with fix version and reachability, surfaced where the operator works the engagement.
+
+- **Reconciliation run results in the dashboard.** A tenant could start a vulnerability reconciliation
+  but could not see its outcome. Starting a full reconciliation now opens a run panel that polls the run
+  to completion and shows its counts (processed/added/updated/unchanged/unmatchable/retired) and its
+  per-item diffs, filterable by class (missing/changed/stale/in-sync) with cursor paging.
+
+- **Per-asset risk stories in the dashboard.** The server assembles one correlated risk narrative per
+  asset (`GET /engagements/{id}/risk-stories`), joining identity, exposure, findings, attack paths and
+  detections into a single ranked score, but no UI consumed it. A new **Risk Stories** tab (under
+  Findings) shows one card per asset ranked by risk, with each finding's corroboration (reachable, on an
+  attack path, seen under attack) that raised it.
+
+- **Purple-team detection coverage in the dashboard.** The server computes, for each executed attack
+  technique, whether its expected detection fired (`GET /engagements/{id}/purple-coverage`, and
+  `?run=<id>` for a run's gap work items), but no dashboard surface consumed it. A new **Purple
+  Coverage** tab (under Offensive) shows the latest emulation run's coverage percentage and its
+  covered/gap/not-run/out-of-reach breakdown, a per-run coverage trend, and the detection gaps (one
+  work item per executed-but-undetected technique) to close.
+
+- **Scan-run history and run-to-run drift in the dashboard.** Every SCA scan already sealed a manifest
+  of its inputs (tool and database versions, the SBOM hash, a reproducibility score) and the finding
+  keys it produced, and the server exposed `GET /engagements/{id}/scan-runs` and
+  `.../scan-runs/compare?a=&b=`, but no dashboard surface consumed them. A new **Scan Runs** tab (under
+  Supply Chain) lists the history with each run's reproducibility score and pinned/live inputs, and
+  comparing two runs shows which finding keys were added or removed, how many are unchanged, and the
+  manifest deltas (grype-db, vuln-db snapshot, tool versions) that explain a legitimate change.
+
 - **One artifact deploys to native hosts and Kubernetes via `execution.mode`.** The Helm chart gained a
   top-level `execution.mode`: `controlPlaneOnly` (default — offline scanner console that boots on any node,
   including managed EKS and `kind`), `externalNative` (production control plane on k8s, execution tier on
@@ -109,6 +141,11 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
   tool, version, location and provenance.
 
 ### Changed
+
+- **Dashboard theme fidelity.** The Code Quality measures table now labels bug, vulnerability, code-smell
+  and hotspot columns with icons instead of emoji; the project-activity trend chart, the code-viewer
+  syntax highlighter, the modern badge addon, and the dependency-graph minimap now draw from semantic
+  theme tokens so they render correctly in both light and dark themes.
 
 - **Console pages read as one operational surface.** The Hosts list is a dense table (host, OS,
   packages, open findings by severity, fixable, KEV, scan state, recorded) with a filter row; the host

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -1480,7 +1480,7 @@ func main() {
 	var judgmentSvc *analysisuc.Service                   // shared by the HTTP verify/accept routes + the agent propose tool
 	var promotionEval *promotionuc.Evaluator              // optional source-signal reevaluator; proposes only
 	var promotionRunner *promotionuc.ReconciliationRunner // server-only promotion recovery
-	if cfg.JudgmentsEnabled {                             // AI judgment lifecycle (verify/accept/list); off by default
+	if cfg.JudgmentsEnabled {                             // AI judgment lifecycle (verify/accept/list); on by default
 		svc, aerr := analysisuc.NewService(judgmentStore, evidenceService, auditLog, clock, ids)
 		if aerr != nil {
 			log.Error("analysis (judgment) service init failed", "err", aerr)

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -67,6 +67,22 @@ docker compose -f deploy/docker-compose.full.yml up --build
 
 See [Deployment](deployment.md) for the image targets and a production checklist.
 
+### With Kubernetes (Helm)
+
+The chart in `deploy/helm/synapse` installs the control plane on any cluster. Its `execution.mode`
+selects the shape: `controlPlaneOnly` (the offline scanner console, boots on managed EKS/GKE and
+`kind`), `externalNative` (production control plane on Kubernetes with a native execution tier per
+ADR 0008), and `inClusterBroker` (in-cluster execution via an opt-in privileged egress-broker
+DaemonSet). Try it against a local `kind` cluster:
+
+```bash
+make kind-smoke       # deploy execution.mode=controlPlaneOnly and assert the control plane serves
+```
+
+The runtime database role must be `NOSUPERUSER NOBYPASSRLS`; Synapse refuses to serve on a superuser
+role because it bypasses the row-level security that isolates tenants. See
+[Deployment](deployment.md) for the mode matrix, the egress placements, and the production checklist.
+
 ## Verify
 
 ```bash

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -281,7 +281,7 @@ type Config struct {
 	PromotionReconcileInterval      time.Duration
 	FleetDetectionReconcileInterval time.Duration
 
-	// JudgmentsEnabled turns on the AI judgment lifecycle HTTP routes; off by default.
+	// JudgmentsEnabled turns on the AI judgment lifecycle HTTP routes; on by default.
 	JudgmentsEnabled bool
 	// FleetAssetsEnabled turns on the multi-tenant fleet asset model (assets, edges, business
 	// services) and its HTTP routes; off by default. When on with Postgres, startup refuses to

--- a/web/src/components/base/badges/badges.tsx
+++ b/web/src/components/base/badges/badges.tsx
@@ -87,7 +87,7 @@ const withPillTypes = {
         styles: {
             gray: {
                 root: "bg-primary text-secondary ring-primary",
-                addon: "text-neutral-500",
+                addon: "text-quaternary",
                 addonButton: "hover:bg-utility-neutral-100 text-utility-neutral-400 hover:text-utility-neutral-500",
             },
         },

--- a/web/src/components/codequality/ProjectActivityView.tsx
+++ b/web/src/components/codequality/ProjectActivityView.tsx
@@ -465,8 +465,8 @@ function Trend({ metric, points }: { metric: MetricKey; points: TrendPoint[] }) 
 
           <defs>
             <linearGradient id="githubTrackGrad" x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor="#1570EF" stopOpacity="0.25" />
-              <stop offset="100%" stopColor="#1570EF" stopOpacity="0.02" />
+              <stop offset="0%" stopColor="var(--color-utility-blue-600)" stopOpacity="0.25" />
+              <stop offset="100%" stopColor="var(--color-utility-blue-600)" stopOpacity="0.02" />
             </linearGradient>
           </defs>
 
@@ -514,7 +514,7 @@ function Trend({ metric, points }: { metric: MetricKey; points: TrendPoint[] }) 
                 y1={baselineY}
                 x2={coord.x}
                 y2={coord.y}
-                stroke="#1570EF"
+                stroke="var(--color-utility-blue-600)"
                 strokeDasharray="3 3"
                 strokeWidth="1.5"
               />
@@ -523,7 +523,7 @@ function Trend({ metric, points }: { metric: MetricKey; points: TrendPoint[] }) 
                 cx={coord.x}
                 cy={baselineY}
                 r="3.5"
-                fill="#1570EF"
+                fill="var(--color-utility-blue-600)"
               />
             </g>
           ))}
@@ -535,7 +535,7 @@ function Trend({ metric, points }: { metric: MetricKey; points: TrendPoint[] }) 
           {coords.length > 1 && (
             <polyline
               fill="none"
-              stroke="#1570EF"
+              stroke="var(--color-utility-blue-600)"
               strokeWidth="2.5"
               strokeLinecap="round"
               strokeLinejoin="round"
@@ -577,8 +577,8 @@ function Trend({ metric, points }: { metric: MetricKey; points: TrendPoint[] }) 
                   cx={coord.x}
                   cy={coord.y}
                   r="8"
-                  fill="#EFF8FF"
-                  stroke="#1570EF"
+                  fill="var(--color-utility-blue-50)"
+                  stroke="var(--color-utility-blue-600)"
                   strokeWidth="2.5"
                 />
 
@@ -587,7 +587,7 @@ function Trend({ metric, points }: { metric: MetricKey; points: TrendPoint[] }) 
                   cx={coord.x}
                   cy={coord.y}
                   r="3.5"
-                  fill="#1570EF"
+                  fill="var(--color-utility-blue-600)"
                 >
                   <title>
                     {p.label}: {p.display}
@@ -603,20 +603,20 @@ function Trend({ metric, points }: { metric: MetricKey; points: TrendPoint[] }) 
                     width="48"
                     height="18"
                     rx="4"
-                    fill="#1570EF"
-                    stroke="#175CD3"
+                    fill="var(--color-utility-blue-600)"
+                    stroke="var(--color-utility-blue-700)"
                     strokeWidth="1"
                   />
                   <polygon
                     points="0,-1 -3,-4 3,-4"
-                    fill="#1570EF"
+                    fill="var(--color-utility-blue-600)"
                   />
                   <text
                     x="0"
                     y="-2"
                     textAnchor="middle"
                     dominantBaseline="middle"
-                    fill="#FFFFFF"
+                    fill="var(--color-text-white)"
                     className="font-mono font-bold text-[10px]"
                   >
                     {p.display}

--- a/web/src/components/codequality/ProjectCodeWorkspace/syntaxHighlighter.tsx
+++ b/web/src/components/codequality/ProjectCodeWorkspace/syntaxHighlighter.tsx
@@ -182,21 +182,21 @@ export function tokenizeLine(line: string, filename: string): Token[] {
 function tokenClass(type: TokenType): string {
   switch (type) {
     case 'keyword':
-      return 'text-[#9333ea] dark:text-[#c084fc] font-semibold'
+      return 'text-utility-purple-600 font-semibold'
     case 'key':
-      return 'text-[#7c3aed] dark:text-[#d8b4fe] font-semibold'
+      return 'text-utility-indigo-600 font-semibold'
     case 'string':
-      return 'text-[#16a34a] dark:text-[#4ade80]'
+      return 'text-utility-green-600'
     case 'number':
-      return 'text-[#ea580c] dark:text-[#fb923c] font-mono'
+      return 'text-utility-orange-600 font-mono'
     case 'function':
-      return 'text-[#0284c7] dark:text-[#38bdf8] font-medium'
+      return 'text-utility-sky-600 font-medium'
     case 'type':
-      return 'text-[#d97706] dark:text-[#facc15]'
+      return 'text-utility-amber-600'
     case 'comment':
       return 'text-tertiary italic select-none'
     case 'operator':
-      return 'text-[#ec4899] dark:text-[#f472b6]'
+      return 'text-utility-pink-600'
     case 'punctuation':
       return 'text-secondary'
     case 'text':

--- a/web/src/components/synapse/VirtualTable.tsx
+++ b/web/src/components/synapse/VirtualTable.tsx
@@ -3,7 +3,7 @@ import { useRef, type KeyboardEvent, type ReactNode } from 'react'
 import { cn } from '../ui'
 
 export interface Column<T> {
-  header: string
+  header: ReactNode
   /** Width/grow/alignment classes, applied to both the header and the cells. */
   className?: string
   cell: (item: T) => ReactNode

--- a/web/src/lib/api/blueteam.ts
+++ b/web/src/lib/api/blueteam.ts
@@ -66,6 +66,51 @@ export interface ApplyOutcome {
   pending: boolean // 202: recorded, awaiting a second human approval
 }
 
+// Purple-team coverage (#426): for each executed attack technique, whether the expected detection fired.
+// covered = executed and detected; gap = executed but undetected (produces a work item); unknown = not
+// executed this run; out_of_reach = the platform cannot emulate it.
+export type PurpleVerdict = 'out_of_reach' | 'unknown' | 'covered' | 'gap'
+
+export interface PurpleCoverageRow {
+  runId: string
+  assetId: string
+  techniqueId: string
+  taxonomyRef: string
+  expected: string
+  actual: string[]
+  verdict: PurpleVerdict
+  computedAt: string
+}
+
+export interface PurpleWorkItem {
+  techniqueId: string
+  taxonomyRef: string
+  missingDetection: string
+}
+
+// The coverage records carry no JSON tags server-side, so the wire keys are PascalCase; tolerate a
+// snake_case shape too in case tags are added later.
+function mapPurpleRow(r: any): PurpleCoverageRow {
+  return {
+    runId: r?.RunID ?? r?.run_id ?? '',
+    assetId: r?.AssetID ?? r?.asset_id ?? '',
+    techniqueId: r?.TechniqueID ?? r?.technique_id ?? '',
+    taxonomyRef: r?.TaxonomyRef ?? r?.taxonomy_ref ?? '',
+    expected: r?.Expected ?? r?.expected ?? '',
+    actual: Array.isArray(r?.Actual) ? r.Actual : Array.isArray(r?.actual) ? r.actual : [],
+    verdict: (r?.Verdict ?? r?.verdict ?? 'unknown') as PurpleVerdict,
+    computedAt: r?.ComputedAt ?? r?.computed_at ?? '',
+  }
+}
+
+function mapPurpleWorkItem(r: any): PurpleWorkItem {
+  return {
+    techniqueId: r?.TechniqueID ?? r?.technique_id ?? '',
+    taxonomyRef: r?.TaxonomyRef ?? r?.taxonomy_ref ?? '',
+    missingDetection: r?.MissingDetection ?? r?.missing_detection ?? '',
+  }
+}
+
 export const blueteamApi = {
   /** null when the deployment does not expose governed response (route 404). */
   listResponses: async (state?: ResponseState): Promise<ResponseRecord[] | null> => {
@@ -88,6 +133,19 @@ export const blueteamApi = {
   },
   revertResponse: async (id: string, body: { target: string; target_kind?: string }): Promise<ResponseRecord> =>
     mapRecord(await req(`/blueteam/response/${encodeURIComponent(id)}/revert`, { method: 'POST', body: JSON.stringify(body) })),
+  // Purple-team coverage trend for an engagement (all coverage records across runs). Returns [] when the
+  // feature is not enabled (the route answers an empty set rather than 404).
+  purpleCoverage: async (engagementId: string): Promise<PurpleCoverageRow[]> => {
+    const r = await req(`/engagements/${encodeURIComponent(engagementId)}/purple-coverage`)
+    return Array.isArray(r?.coverage) ? r.coverage.map(mapPurpleRow) : []
+  },
+  // The gap work items (one per undetected technique) for a single run.
+  purpleWorkItems: async (engagementId: string, runId: string): Promise<PurpleWorkItem[]> => {
+    const r = await req(
+      `/engagements/${encodeURIComponent(engagementId)}/purple-coverage?run=${encodeURIComponent(runId)}`,
+    )
+    return Array.isArray(r?.work_items) ? r.work_items.map(mapPurpleWorkItem) : []
+  },
   /** Halt every offensive path fleet-wide (kill switch). PermAdminister. */
   haltOffensive: async (reason: string): Promise<HaltResult> => {
     const r = await req('/redteam/halt', { method: 'POST', body: JSON.stringify({ reason }) })

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -6,7 +6,9 @@ export { type ReportType, type ReportBuildOptions } from './evidence'
 export { type ReconLogEvent, streamReconLogs } from './recon'
 export { type AgentStreamEvent, streamAgentSession } from './agent'
 export { type Connector, type ConnectorCreate, type ConnectorProvider } from './connectors'
-export { type ResponseRecord, type ResponsePlan, type ResponseKind, type ResponseState, type HaltResult } from './blueteam'
+export { type ResponseRecord, type ResponsePlan, type ResponseKind, type ResponseState, type HaltResult, type PurpleVerdict, type PurpleCoverageRow, type PurpleWorkItem } from './blueteam'
+export { type RiskStory, type RiskFinding, type RiskExposure, type RiskPath, type RiskDetection, type RiskAssetFacts } from './riskstory'
+export { type ReconcileRun, type ReconcileCounts, type ReconcileState, type ReconcileDiff, type ReconcileDiffClass, type ReconcileDiffCursor, type ReconcileDiffPage } from './vulnerability'
 
 import { authApi, teamApi } from './auth'
 import { auditApi } from './audit'
@@ -28,6 +30,7 @@ import { dashboardApi } from './dashboard'
 import { capabilitiesApi } from './capabilities'
 import { connectorsApi } from './connectors'
 import { blueteamApi } from './blueteam'
+import { riskStoryApi } from './riskstory'
 
 // projectMeasures was a standalone export in the old api.ts
 export const projectMeasures = codeQualityApi.projectMeasures
@@ -61,4 +64,5 @@ export const api = {
   ...capabilitiesApi,
   ...connectorsApi,
   ...blueteamApi,
+  ...riskStoryApi,
 }

--- a/web/src/lib/api/riskstory.ts
+++ b/web/src/lib/api/riskstory.ts
@@ -1,0 +1,107 @@
+import { req } from './client'
+
+/**
+ * Unified per-asset risk story (#427): one narrative per asset that correlates the asset's identity,
+ * exposure, findings (with corroboration from reachability, attack paths, and detections), attack paths,
+ * and runtime detections into a single ranked score. The read route reports an empty set when the
+ * correlation view is not enabled, so the client treats [] as "not enabled".
+ */
+export interface RiskAssetFacts {
+  kind: string
+  key: string
+  name: string
+}
+
+export interface RiskExposure {
+  description: string
+  confidence: string
+  qualifiers: string[]
+}
+
+export interface RiskFinding {
+  findingId: string
+  title: string
+  severity: string
+  priority: number // 1..5 (1 = act now); 0 = unset
+  riskScore: number
+  kev: boolean
+  reachability: string
+  reachable: boolean
+  onAttackPath: boolean
+  seenUnderAttack: boolean
+  corroboration: string[]
+  rankReason: string
+  lastObserved: string
+  stale: boolean
+}
+
+export interface RiskPath {
+  summary: string
+  confidence: string
+  qualifiers: string[]
+}
+
+export interface RiskDetection {
+  ruleId: string
+  severity: string
+  observed: string
+  stale: boolean
+  qualifiers: string[]
+}
+
+export interface RiskStory {
+  assetId: string
+  identity: RiskAssetFacts
+  exposure: RiskExposure[]
+  findings: RiskFinding[]
+  paths: RiskPath[]
+  detections: RiskDetection[]
+  score: number
+  qualifiers: string[]
+  generatedAt: string
+}
+
+function arr<T>(v: any, map: (x: any) => T): T[] {
+  return Array.isArray(v) ? v.map(map) : []
+}
+
+function mapFinding(f: any): RiskFinding {
+  return {
+    findingId: f?.finding_id ?? '',
+    title: f?.title ?? '',
+    severity: f?.severity ?? '',
+    priority: f?.priority ?? 0,
+    riskScore: f?.risk_score ?? 0,
+    kev: f?.kev === true,
+    reachability: f?.reachability ?? '',
+    reachable: f?.reachable === true,
+    onAttackPath: f?.on_attack_path === true,
+    seenUnderAttack: f?.seen_under_attack === true,
+    corroboration: Array.isArray(f?.corroboration) ? f.corroboration : [],
+    rankReason: f?.rank_reason ?? '',
+    lastObserved: f?.last_observed ?? '',
+    stale: f?.stale === true,
+  }
+}
+
+function mapStory(s: any): RiskStory {
+  return {
+    assetId: s?.asset_id ?? '',
+    identity: { kind: s?.identity?.kind ?? '', key: s?.identity?.key ?? '', name: s?.identity?.name ?? '' },
+    exposure: arr(s?.exposure, (e) => ({ description: e?.description ?? '', confidence: e?.confidence ?? '', qualifiers: Array.isArray(e?.qualifiers) ? e.qualifiers : [] })),
+    findings: arr(s?.findings, mapFinding),
+    paths: arr(s?.paths, (p) => ({ summary: p?.summary ?? '', confidence: p?.confidence ?? '', qualifiers: Array.isArray(p?.qualifiers) ? p.qualifiers : [] })),
+    detections: arr(s?.detections, (d) => ({ ruleId: d?.rule_id ?? '', severity: d?.severity ?? '', observed: d?.observed ?? '', stale: d?.stale === true, qualifiers: Array.isArray(d?.qualifiers) ? d.qualifiers : [] })),
+    score: s?.score ?? 0,
+    qualifiers: Array.isArray(s?.qualifiers) ? s.qualifiers : [],
+    generatedAt: s?.generated_at ?? '',
+  }
+}
+
+export const riskStoryApi = {
+  // One assembled risk story per asset in the engagement. Returns [] when the correlation view is off.
+  riskStories: async (engagementId: string): Promise<RiskStory[]> => {
+    const r = await req(`/engagements/${encodeURIComponent(engagementId)}/risk-stories`)
+    return arr(r?.stories, mapStory)
+  },
+}

--- a/web/src/lib/api/scan.ts
+++ b/web/src/lib/api/scan.ts
@@ -4,8 +4,11 @@ import type {
   CodeRating,
   Component,
   ImportedSBOMMetadata,
+  ScanDrift,
   ScanJob,
+  ScanManifest,
   ScanResult,
+  ScanRun,
   Vulnerability,
   Writeup,
 } from '../types'
@@ -279,6 +282,40 @@ function mapScanResult(r: any): ScanResult {
   }
 }
 
+function mapScanManifest(m: any): ScanManifest {
+  return {
+    toolVersions: m?.tool_versions ?? {},
+    vulnDBSnapshot: m?.vuln_db_snapshot ?? '',
+    grypeDBVersion: m?.grype_db_version ?? '',
+    correlationVersion: m?.correlation_version ?? 0,
+    sbomSha256: m?.sbom_sha256 ?? '',
+    reproScore: m?.repro_score ?? 0,
+    pinnedInputs: m?.pinned_inputs ?? [],
+    unpinnedInputs: m?.unpinned_inputs ?? [],
+  }
+}
+
+function mapScanRun(r: any): ScanRun {
+  return {
+    id: r?.id ?? '',
+    engagementId: r?.engagement_id ?? '',
+    createdAt: r?.created_at ?? '',
+    manifest: mapScanManifest(r?.manifest),
+    findingKeys: r?.finding_keys ?? [],
+  }
+}
+
+function mapScanDrift(r: any): ScanDrift {
+  return {
+    runA: mapScanRun(r?.run_a),
+    runB: mapScanRun(r?.run_b),
+    added: r?.added ?? [],
+    removed: r?.removed ?? [],
+    unchanged: r?.unchanged ?? 0,
+    explanation: r?.explanation ?? [],
+  }
+}
+
 export const scanApi = {
   startScan: async (engagementId: string, target: string, kind: string, ref = '', mode = 'full', codeQuality = false): Promise<ScanJob> => {
     const r = await req('/sca/scans', {
@@ -286,6 +323,22 @@ export const scanApi = {
       body: JSON.stringify({ engagement_id: engagementId, target, kind, ref, mode, code_quality: codeQuality }),
     })
     return mapScanJob(r)
+  },
+
+  // Scan-run history: the manifest + finding-key snapshot of every persisted scan,
+  // for reproducibility and run-to-run drift (chain of custody).
+  scanRuns: async (engagementId: string): Promise<ScanRun[]> => {
+    const r = await req(`/engagements/${encodeURIComponent(engagementId)}/scan-runs`)
+    return Array.isArray(r) ? r.map(mapScanRun) : []
+  },
+
+  // Drift between two scan runs: which finding keys appeared/disappeared and the
+  // manifest deltas that explain a legitimate change.
+  compareScanRuns: async (engagementId: string, a: string, b: string): Promise<ScanDrift> => {
+    const r = await req(
+      `/engagements/${encodeURIComponent(engagementId)}/scan-runs/compare?a=${encodeURIComponent(a)}&b=${encodeURIComponent(b)}`,
+    )
+    return mapScanDrift(r)
   },
 
   scanStatus: async (engagementId: string): Promise<ScanJob | null> => {

--- a/web/src/lib/api/vulnerability.ts
+++ b/web/src/lib/api/vulnerability.ts
@@ -162,6 +162,93 @@ function vulnerabilitySourceBody(input: VulnerabilitySourceInput) {
   }
 }
 
+// Vulnerability reconciliation run + diffs (#... reconcile-runs). A reconciliation re-evaluates the
+// current advisory corpus against recorded occurrences; the run reports counts and per-item diffs.
+export interface ReconcileCounts {
+  processed: number
+  added: number
+  updated: number
+  unchanged: number
+  unmatchable: number
+  retired: number
+}
+
+export type ReconcileState = 'queued' | 'running' | 'succeeded' | 'failed'
+
+export interface ReconcileRun {
+  id: string
+  scope: string
+  advisoryId: string
+  dryRun: boolean
+  state: ReconcileState
+  counts: ReconcileCounts
+  errorSamples: string[]
+  snapshotAt: string
+  startedAt: string | null
+  finishedAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type ReconcileDiffClass = 'missing_occurrence' | 'changed_occurrence' | 'in_sync' | 'stale_occurrence'
+
+export interface ReconcileDiff {
+  runId: string
+  engagementId: string
+  advisoryId: string
+  componentFingerprint: string
+  class: ReconcileDiffClass
+  createdAt: string
+}
+
+export interface ReconcileDiffCursor {
+  class: string
+  engagementId: string
+  advisoryId: string
+  componentFingerprint: string
+}
+
+export interface ReconcileDiffPage {
+  items: ReconcileDiff[]
+  next: ReconcileDiffCursor | null
+}
+
+function mapReconcileRun(r: any): ReconcileRun {
+  const c = r?.counts ?? {}
+  return {
+    id: r?.id ?? '',
+    scope: r?.scope ?? '',
+    advisoryId: r?.advisory_id ?? '',
+    dryRun: r?.dry_run === true,
+    state: (r?.state ?? 'queued') as ReconcileState,
+    counts: {
+      processed: c?.processed ?? 0,
+      added: c?.added ?? 0,
+      updated: c?.updated ?? 0,
+      unchanged: c?.unchanged ?? 0,
+      unmatchable: c?.unmatchable ?? 0,
+      retired: c?.retired ?? 0,
+    },
+    errorSamples: Array.isArray(r?.error_samples) ? r.error_samples : [],
+    snapshotAt: r?.snapshot_at ?? '',
+    startedAt: r?.started_at ?? null,
+    finishedAt: r?.finished_at ?? null,
+    createdAt: r?.created_at ?? '',
+    updatedAt: r?.updated_at ?? '',
+  }
+}
+
+function mapReconcileDiff(d: any): ReconcileDiff {
+  return {
+    runId: d?.run_id ?? '',
+    engagementId: d?.engagement_id ?? '',
+    advisoryId: d?.advisory_id ?? '',
+    componentFingerprint: d?.component_fingerprint ?? '',
+    class: (d?.class ?? 'in_sync') as ReconcileDiffClass,
+    createdAt: d?.created_at ?? '',
+  }
+}
+
 export const vulnerabilityApi = {
   vulnerabilityOverview: async (signal?: AbortSignal): Promise<VulnerabilityIntelligenceOverview> => {
     const raw = await req('/vulnerability/overview', { signal })
@@ -306,4 +393,53 @@ export const vulnerabilityApi = {
     const raw = await req(`/vulnerability/advisories/${encodeURIComponent(advisoryId)}/reconcile`, { method: 'POST', body: JSON.stringify({ client_idempotency_key: idempotencyKey }) })
     return { runId: raw?.run_id ?? '', jobId: raw?.job_id ?? '', scope: raw?.scope ?? 'advisory', advisoryId: raw?.advisory_id ?? advisoryId, state: raw?.state ?? 'queued', created: raw?.created === true }
   },
+
+  // Read a reconciliation run's state + counts (poll until state is terminal).
+  reconcileRun: async (id: string, signal?: AbortSignal): Promise<ReconcileRun> =>
+    mapReconcileRun(await req(`/vulnerability/reconcile-runs/${encodeURIComponent(id)}`, { signal })),
+
+  // A page of a reconciliation run's diffs, optionally filtered by class. The cursor's four fields are
+  // sent together (the API requires a complete cursor or none).
+  reconcileDiffs: async (
+    id: string,
+    opts?: { class?: ReconcileDiffClass; limit?: number; cursor?: ReconcileDiffCursor },
+  ): Promise<ReconcileDiffPage> => {
+    const p = new URLSearchParams()
+    if (opts?.class) p.set('class', opts.class)
+    if (opts?.limit) p.set('limit', String(opts.limit))
+    if (opts?.cursor) {
+      p.set('after_class', opts.cursor.class)
+      p.set('after_engagement_id', opts.cursor.engagementId)
+      p.set('after_advisory_id', opts.cursor.advisoryId)
+      p.set('after_component_fingerprint', opts.cursor.componentFingerprint)
+    }
+    const qs = p.toString()
+    const raw = await req(`/vulnerability/reconcile-runs/${encodeURIComponent(id)}/diffs${qs ? `?${qs}` : ''}`)
+    return {
+      items: Array.isArray(raw?.items) ? raw.items.map(mapReconcileDiff) : [],
+      next: raw?.next
+        ? {
+            class: raw.next.class ?? '',
+            engagementId: raw.next.engagement_id ?? '',
+            advisoryId: raw.next.advisory_id ?? '',
+            componentFingerprint: raw.next.component_fingerprint ?? '',
+          }
+        : null,
+    }
+  },
+
+  // Per-engagement reconciled vulnerability posture: the occurrences matched to this engagement and the
+  // governed action queue (acknowledge / resolve), surfaced where the operator works the engagement.
+  engagementVulnerabilityOccurrences: async (engagementId: string, signal?: AbortSignal): Promise<VulnerabilityOccurrence[]> => {
+    const raw = await req(`/engagements/${encodeURIComponent(engagementId)}/vulnerability/occurrences`, { signal })
+    return (raw?.items ?? []).map(mapVulnerabilityOccurrence)
+  },
+  engagementVulnerabilityActions: async (engagementId: string, signal?: AbortSignal): Promise<VulnerabilityAction[]> => {
+    const raw = await req(`/engagements/${encodeURIComponent(engagementId)}/vulnerability/actions`, { signal })
+    return (raw?.items ?? []).map(mapVulnerabilityAction)
+  },
+  acknowledgeVulnerabilityAction: async (engagementId: string, actionId: string): Promise<VulnerabilityAction> =>
+    mapVulnerabilityAction(await req(`/engagements/${encodeURIComponent(engagementId)}/vulnerability/actions/${encodeURIComponent(actionId)}/acknowledge`, { method: 'POST' })),
+  resolveVulnerabilityAction: async (engagementId: string, actionId: string): Promise<VulnerabilityAction> =>
+    mapVulnerabilityAction(await req(`/engagements/${encodeURIComponent(engagementId)}/vulnerability/actions/${encodeURIComponent(actionId)}/resolve`, { method: 'POST' })),
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -408,6 +408,27 @@ export interface ScanManifest {
   unpinnedInputs: string[]
 }
 
+// One persisted scan execution: its manifest (reproducibility inputs) plus the
+// finding identity keys present in the run, enough to list history and compute drift.
+export interface ScanRun {
+  id: string
+  engagementId: string
+  createdAt: string
+  manifest: ScanManifest
+  findingKeys: string[]
+}
+
+// The difference between two scan runs: which finding keys appeared or disappeared,
+// and the manifest deltas that explain why a result legitimately changed.
+export interface ScanDrift {
+  runA: ScanRun
+  runB: ScanRun
+  added: string[]
+  removed: string[]
+  unchanged: number
+  explanation: string[]
+}
+
 export interface LicenseFinding {
   license: string
   category: LicenseCategory

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -9,6 +9,123 @@ const DAY_AGO = new Date(Date.now() - 86400_000).toISOString()
 const WEEK_AGO = new Date(Date.now() - 7 * 86400_000).toISOString()
 const MONTH_AGO = new Date(Date.now() - 30 * 86400_000).toISOString()
 
+const SCAN_RUNS = [
+  {
+    id: 'run-2026-02',
+    engagement_id: 'eng-001',
+    created_at: WEEK_AGO,
+    manifest: {
+      tool_versions: { syft: '1.18.1', grype: '0.86.1', synapse: 'dev' },
+      vuln_db_snapshot: 'osv.dev@2026-02-20T00:00:00Z',
+      grype_db_version: 'v5@2026-02-20',
+      correlation_version: 7,
+      sbom_sha256: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+      repro_score: 82,
+      pinned_inputs: ['syft', 'grype', 'grype-db'],
+      unpinned_inputs: ['osv.dev'],
+    },
+    finding_keys: [
+      'pkg:npm/lodash@4.17.20|CVE-2021-23337',
+      'pkg:golang/github.com/gogo/protobuf@1.3.1|CVE-2021-3121',
+      'pkg:pypi/pyyaml@5.3.1|CVE-2020-14343',
+    ],
+  },
+  {
+    id: 'run-2026-01',
+    engagement_id: 'eng-001',
+    created_at: MONTH_AGO,
+    manifest: {
+      tool_versions: { syft: '1.17.0', grype: '0.85.0', synapse: 'dev' },
+      vuln_db_snapshot: 'osv.dev@2026-01-20T00:00:00Z',
+      grype_db_version: 'v5@2026-01-20',
+      correlation_version: 7,
+      sbom_sha256: '00998877665544332211aabbccddeeff00112233445566778899aabbccddeeff',
+      repro_score: 82,
+      pinned_inputs: ['syft', 'grype', 'grype-db'],
+      unpinned_inputs: ['osv.dev'],
+    },
+    finding_keys: [
+      'pkg:golang/github.com/gogo/protobuf@1.3.1|CVE-2021-3121',
+      'pkg:pypi/pyyaml@5.3.1|CVE-2020-14343',
+    ],
+  },
+]
+
+// Purple-coverage records carry no JSON tags server-side, so the mock uses PascalCase keys.
+const PURPLE_COVERAGE = [
+  { RunID: 'emu-feb', AssetID: 'asset-1', TechniqueID: 'T1059.001', TaxonomyRef: 'attack:T1059.001', Expected: 'det-powershell', Actual: ['det-powershell'], Verdict: 'covered', ComputedAt: WEEK_AGO },
+  { RunID: 'emu-feb', AssetID: 'asset-1', TechniqueID: 'T1053.005', TaxonomyRef: 'attack:T1053.005', Expected: 'det-schtask', Actual: [], Verdict: 'gap', ComputedAt: WEEK_AGO },
+  { RunID: 'emu-feb', AssetID: 'asset-1', TechniqueID: 'T1021.001', TaxonomyRef: 'attack:T1021.001', Expected: 'det-rdp', Actual: [], Verdict: 'unknown', ComputedAt: WEEK_AGO },
+  { RunID: 'emu-feb', AssetID: 'asset-1', TechniqueID: 'T1552.001', TaxonomyRef: 'attack:T1552.001', Expected: '', Actual: [], Verdict: 'out_of_reach', ComputedAt: WEEK_AGO },
+  { RunID: 'emu-jan', AssetID: 'asset-1', TechniqueID: 'T1059.001', TaxonomyRef: 'attack:T1059.001', Expected: 'det-powershell', Actual: [], Verdict: 'gap', ComputedAt: MONTH_AGO },
+  { RunID: 'emu-jan', AssetID: 'asset-1', TechniqueID: 'T1053.005', TaxonomyRef: 'attack:T1053.005', Expected: 'det-schtask', Actual: [], Verdict: 'gap', ComputedAt: MONTH_AGO },
+]
+
+const PURPLE_WORK_ITEMS = [
+  { TechniqueID: 'T1053.005', TaxonomyRef: 'attack:T1053.005', MissingDetection: 'det-schtask' },
+]
+
+const RECONCILE_RUN = {
+  tenant_id: 't-1',
+  id: 'rec-001',
+  scope: 'tenant',
+  advisory_id: '',
+  dry_run: false,
+  durable_job_id: 'job-rec-001',
+  counts: { processed: 1284, added: 12, updated: 37, unchanged: 1201, unmatchable: 28, retired: 6 },
+  error_samples: [],
+  state: 'succeeded',
+  snapshot_at: HOUR_AGO,
+  started_at: HOUR_AGO,
+  finished_at: NOW,
+  created_at: HOUR_AGO,
+  updated_at: NOW,
+}
+
+const RECONCILE_DIFFS = [
+  { run_id: 'rec-001', engagement_id: 'eng-001', advisory_id: 'CVE-2021-23337', component_fingerprint: 'pkg:npm/lodash@4.17.20', class: 'missing_occurrence', details: {}, created_at: NOW },
+  { run_id: 'rec-001', engagement_id: 'eng-001', advisory_id: 'CVE-2020-14343', component_fingerprint: 'pkg:pypi/pyyaml@5.3.1', class: 'changed_occurrence', details: {}, created_at: NOW },
+  { run_id: 'rec-001', engagement_id: 'eng-002', advisory_id: 'CVE-2021-3121', component_fingerprint: 'pkg:golang/github.com/gogo/protobuf@1.3.1', class: 'stale_occurrence', details: {}, created_at: NOW },
+]
+
+const ENG_VULN_OCCURRENCES = [
+  { id: 'occ-1', engagement_id: 'eng-001', advisory_id: 'CVE-2021-23337', package_name: 'lodash', component_version: '4.17.20', ecosystem: 'npm', state: 'open', reachability: 'reachable', fixed_version: '4.17.21' },
+  { id: 'occ-2', engagement_id: 'eng-001', advisory_id: 'CVE-2020-14343', package_name: 'pyyaml', component_version: '5.3.1', ecosystem: 'pypi', state: 'open', reachability: 'unknown', fixed_version: '5.4' },
+]
+
+const ENG_VULN_ACTIONS = [
+  { id: 'act-1', engagement_id: 'eng-001', occurrence_id: 'occ-1', finding_id: 'f-1', type: 'remediate', status: 'open', title: 'Upgrade lodash to 4.17.21', reason_codes: ['reachable', 'has_fix'], created_at: DAY_AGO, updated_at: DAY_AGO },
+  { id: 'act-2', engagement_id: 'eng-001', occurrence_id: 'occ-2', finding_id: 'f-2', type: 'triage', status: 'acknowledged', title: 'Assess pyyaml unsafe load exposure', reason_codes: ['no_reachability'], created_at: WEEK_AGO, updated_at: DAY_AGO },
+]
+
+const RISK_STORIES = [
+  {
+    asset_id: 'asset-web-01',
+    identity: { kind: 'host', key: 'web-01', name: 'web-01.prod' },
+    exposure: [{ description: 'internet-facing via edge LB', confidence: 'observed', qualifiers: ['public'] }],
+    findings: [
+      { finding_id: 'f-1', title: 'lodash prototype pollution (CVE-2021-23337)', severity: 'high', priority: 1, risk_score: 8.4, kev: false, reachability: 'reachable', reachable: true, on_attack_path: true, seen_under_attack: false, corroboration: ['reachable', 'on_attack_path'], rank_reason: 'raised by corroboration: reachable + on_attack_path', last_observed: WEEK_AGO, stale: false },
+      { finding_id: 'f-2', title: 'pyyaml unsafe load (CVE-2020-14343)', severity: 'medium', priority: 3, risk_score: 5.1, kev: false, reachability: 'unknown', reachable: false, on_attack_path: false, seen_under_attack: false, corroboration: [], rank_reason: 'base priority; no corroborating signals', last_observed: MONTH_AGO, stale: true },
+    ],
+    paths: [{ summary: 'edge LB -> web-01 -> db-01', confidence: 'inferred', qualifiers: [] }],
+    detections: [{ rule_id: 'proc.suspicious_shell', severity: 'high', observed: DAY_AGO, stale: false, qualifiers: [] }],
+    score: 1,
+    qualifiers: ['internet_facing', 'under_active_attack_path'],
+    generated_at: NOW,
+  },
+  {
+    asset_id: 'asset-db-01',
+    identity: { kind: 'host', key: 'db-01', name: 'db-01.prod' },
+    exposure: [],
+    findings: [],
+    paths: [],
+    detections: [],
+    score: 0,
+    qualifiers: [],
+    generated_at: NOW,
+  },
+]
+
 // ============================================================================
 // MOCK DATA
 // ============================================================================
@@ -416,6 +533,40 @@ export const handlers = [
   // 404 matches the real backend (ErrNotFound) when no job exists. A 200 with a
   // null body made mapScanJob(null) throw on every poll tick.
   http.get('/api/v1/engagements/:id/scan-status', () => new HttpResponse(null, { status: 404 })),
+  http.get('/api/v1/engagements/:id/scan-runs/compare', () =>
+    HttpResponse.json({
+      run_a: SCAN_RUNS[0],
+      run_b: SCAN_RUNS[1],
+      added: [],
+      removed: ['pkg:npm/lodash@4.17.20|CVE-2021-23337'],
+      unchanged: 2,
+      explanation: [
+        'grype-db changed: "v5@2026-02-20" -> "v5@2026-01-20"',
+        'vuln-db snapshot changed: "osv.dev@2026-02-20T00:00:00Z" -> "osv.dev@2026-01-20T00:00:00Z"',
+      ],
+    }),
+  ),
+  http.get('/api/v1/engagements/:id/scan-runs', () => HttpResponse.json(SCAN_RUNS)),
+  http.get('/api/v1/engagements/:id/purple-coverage', ({ request }) => {
+    const url = new URL(request.url)
+    if (url.searchParams.get('run')) return HttpResponse.json({ work_items: PURPLE_WORK_ITEMS })
+    return HttpResponse.json({ coverage: PURPLE_COVERAGE })
+  }),
+  http.get('/api/v1/engagements/:id/risk-stories', () => HttpResponse.json({ stories: RISK_STORIES })),
+  http.get('/api/v1/vulnerability/reconcile-runs/:id', () => HttpResponse.json(RECONCILE_RUN)),
+  http.get('/api/v1/vulnerability/reconcile-runs/:id/diffs', ({ request }) => {
+    const cls = new URL(request.url).searchParams.get('class')
+    const items = cls ? RECONCILE_DIFFS.filter((d) => d.class === cls) : RECONCILE_DIFFS
+    return HttpResponse.json({ items, next: null })
+  }),
+  http.get('/api/v1/engagements/:id/vulnerability/occurrences', () => HttpResponse.json({ items: ENG_VULN_OCCURRENCES, next: null })),
+  http.get('/api/v1/engagements/:id/vulnerability/actions', () => HttpResponse.json({ items: ENG_VULN_ACTIONS, next: null })),
+  http.post('/api/v1/engagements/:id/vulnerability/actions/:aid/acknowledge', ({ params }) =>
+    HttpResponse.json({ ...(ENG_VULN_ACTIONS.find((a) => a.id === params.aid) ?? ENG_VULN_ACTIONS[0]), id: params.aid, status: 'acknowledged' }),
+  ),
+  http.post('/api/v1/engagements/:id/vulnerability/actions/:aid/resolve', ({ params }) =>
+    HttpResponse.json({ ...(ENG_VULN_ACTIONS.find((a) => a.id === params.aid) ?? ENG_VULN_ACTIONS[0]), id: params.aid, status: 'resolved' }),
+  ),
   http.get('/api/v1/engagements/:id/scan', () => HttpResponse.json(SCAN_RESULT)),
   http.post('/api/v1/sca/scans', () => HttpResponse.json({ id: 'job-mock', engagement_id: 'eng-001', target: 'https://github.com/KKloudTarus/synapse-ce.git', kind: 'git', status: 'complete', stage: 'done', progress: 100, error: '', started_at: new Date(Date.now() - 300000).toISOString(), finished_at: NOW, debug_events: SCAN_RESULT.debug_events })),
 

--- a/web/src/pages/CodeQuality/ProjectMeasuresPage/index.tsx
+++ b/web/src/pages/CodeQuality/ProjectMeasuresPage/index.tsx
@@ -332,8 +332,8 @@ export function ProjectMeasuresPage() {
               <table className="min-w-full text-left text-sm whitespace-nowrap">
                 <thead className="bg-secondary/40 text-[10px] uppercase tracking-wider text-tertiary border-b border-secondary sticky top-0 font-bold font-sans">
                   <tr>
-                    {cols.map((c) => (
-                      <th key={c.header} scope="col" className={cn('px-4 py-2.5 font-bold', c.className)}>
+                    {cols.map((c, ci) => (
+                      <th key={ci} scope="col" className={cn('px-4 py-2.5 font-bold', c.className)}>
                         {c.header}
                       </th>
                     ))}
@@ -342,8 +342,8 @@ export function ProjectMeasuresPage() {
                 <tbody className="divide-y divide-secondary/40 font-sans text-xs">
                   {sortedAndFilteredItems.map((item) => (
                     <tr key={item.path} className="hover:bg-secondary/40 transition-colors group">
-                      {cols.map((c) => (
-                        <td key={c.header} className={cn('px-4 py-2.5 min-w-0 truncate', c.className)}>
+                      {cols.map((c, ci) => (
+                        <td key={ci} className={cn('px-4 py-2.5 min-w-0 truncate', c.className)}>
                           {c.cell(item)}
                         </td>
                       ))}

--- a/web/src/pages/CodeQuality/ProjectMeasuresPage/measureColumns.tsx
+++ b/web/src/pages/CodeQuality/ProjectMeasuresPage/measureColumns.tsx
@@ -249,7 +249,12 @@ export function getDomainColumns(
         return [
           ...base,
           {
-            header: '🐞 Bugs',
+            header: (
+              <span className="inline-flex items-center gap-1.5">
+                <Virus className="size-3.5 text-warning-primary" aria-hidden />
+                Bugs
+              </span>
+            ),
             cell: (i) => {
               const count = i.issues?.byType['bug']?.value
               return count && count > 0 ? (
@@ -262,7 +267,12 @@ export function getDomainColumns(
             },
           },
           {
-            header: '🛡️ Vulnerabilities',
+            header: (
+              <span className="inline-flex items-center gap-1.5">
+                <ShieldTick className="size-3.5 text-error-primary" aria-hidden />
+                Vulnerabilities
+              </span>
+            ),
             cell: (i) => {
               const count = i.issues?.byType['vulnerability']?.value
               return count && count > 0 ? (
@@ -275,7 +285,12 @@ export function getDomainColumns(
             },
           },
           {
-            header: '🔧 Code Smells',
+            header: (
+              <span className="inline-flex items-center gap-1.5">
+                <Tool01 className="size-3.5 text-utility-blue-600 dark:text-utility-blue-400" aria-hidden />
+                Code Smells
+              </span>
+            ),
             cell: (i) => {
               const count = i.issues?.byType['code_smell']?.value
               return count && count > 0 ? (
@@ -288,7 +303,12 @@ export function getDomainColumns(
             },
           },
           {
-            header: '🔥 Hotspots',
+            header: (
+              <span className="inline-flex items-center gap-1.5">
+                <Zap className="size-3.5 text-warning-primary" aria-hidden />
+                Hotspots
+              </span>
+            ),
             cell: (i) => {
               const count = i.issues?.byType['security_hotspot']?.value
               return count && count > 0 ? (

--- a/web/src/pages/DependencyGraph/index.tsx
+++ b/web/src/pages/DependencyGraph/index.tsx
@@ -144,7 +144,12 @@ function GraphCanvas({
           <Background color="var(--color-border)" gap={22} />
           <Controls showInteractive={false} />
           {flow.nodes.length > 40 && (
-            <MiniMap pannable zoomable style={{ background: 'var(--color-surface)' }} maskColor="rgba(0,0,0,0.5)" />
+            <MiniMap
+              pannable
+              zoomable
+              style={{ background: 'var(--color-surface)' }}
+              maskColor="color-mix(in srgb, var(--color-bg-overlay) 50%, transparent)"
+            />
           )}
         </ReactFlow>
       </div>

--- a/web/src/pages/EngagementDetail/PurpleCoverageTab.test.tsx
+++ b/web/src/pages/EngagementDetail/PurpleCoverageTab.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import type { PurpleCoverageRow } from '../../lib/api'
+import { PurpleCoverageTab } from './PurpleCoverageTab'
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    purpleCoverage: vi.fn(),
+    purpleWorkItems: vi.fn(),
+  },
+}))
+
+function row(runId: string, technique: string, verdict: PurpleCoverageRow['verdict'], at: string): PurpleCoverageRow {
+  return { runId, assetId: 'a1', techniqueId: technique, taxonomyRef: `attack:${technique}`, expected: 'det', actual: [], verdict, computedAt: at }
+}
+
+describe('PurpleCoverageTab', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('summarizes the latest run and lists its detection gaps', async () => {
+    vi.mocked(api.purpleCoverage).mockResolvedValue([
+      row('emu-feb', 'T1059.001', 'covered', '2026-02-20T00:00:00Z'),
+      row('emu-feb', 'T1053.005', 'gap', '2026-02-20T00:00:00Z'),
+      row('emu-feb', 'T1021.001', 'unknown', '2026-02-20T00:00:00Z'),
+      row('emu-jan', 'T1059.001', 'gap', '2026-01-20T00:00:00Z'),
+    ])
+    vi.mocked(api.purpleWorkItems).mockResolvedValue([
+      { techniqueId: 'T1053.005', taxonomyRef: 'attack:T1053.005', missingDetection: 'det-schtask' },
+    ])
+
+    render(<PurpleCoverageTab engagementId="eng-001" />)
+
+    // covered=1, gap=1 over the latest run => 1/(1+1) = 50% (shown in the summary and the run row).
+    expect((await screen.findAllByText('50%')).length).toBeGreaterThan(0)
+    // The latest run (emu-feb) is auto-selected, so its gap work items load.
+    await waitFor(() => expect(api.purpleWorkItems).toHaveBeenCalledWith('eng-001', 'emu-feb'))
+    expect(await screen.findByText('T1053.005')).toBeInTheDocument()
+    expect(screen.getByText(/write detection: det-schtask/)).toBeInTheDocument()
+  })
+
+  it('shows an empty state when no emulation has run', async () => {
+    vi.mocked(api.purpleCoverage).mockResolvedValue([])
+    render(<PurpleCoverageTab engagementId="eng-001" />)
+    expect(await screen.findByText('No purple-team coverage yet')).toBeInTheDocument()
+    expect(api.purpleWorkItems).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/pages/EngagementDetail/PurpleCoverageTab.tsx
+++ b/web/src/pages/EngagementDetail/PurpleCoverageTab.tsx
@@ -1,0 +1,275 @@
+import { useEffect, useMemo, useState } from 'react'
+import {
+  AlertTriangle,
+  CheckCircle,
+  HelpCircle,
+  ShieldTick,
+  SlashCircle01,
+  Target04,
+} from '@untitledui/icons'
+import { Card, EmptyState, ErrorState, Pill, Spinner, cn } from '../../components/ui'
+import { useParallelFetch } from '../../hooks'
+import { api } from '../../lib/api'
+import type { PurpleCoverageRow, PurpleWorkItem } from '../../lib/api'
+
+interface RunSummary {
+  runId: string
+  computedAt: string
+  covered: number
+  gap: number
+  unknown: number
+  outOfReach: number
+  total: number
+  executed: number
+  // Coverage is measured over EXECUTED checks only: covered / (covered + gap). It is null when nothing
+  // executed (all unknown/out_of_reach), which is "not applicable", not 0%.
+  coveragePct: number | null
+}
+
+function summarize(rows: PurpleCoverageRow[]): RunSummary[] {
+  const byRun = new Map<string, RunSummary>()
+  for (const r of rows) {
+    let s = byRun.get(r.runId)
+    if (!s) {
+      s = { runId: r.runId, computedAt: r.computedAt, covered: 0, gap: 0, unknown: 0, outOfReach: 0, total: 0, executed: 0, coveragePct: null }
+      byRun.set(r.runId, s)
+    }
+    s.total += 1
+    if (r.computedAt > s.computedAt) s.computedAt = r.computedAt
+    if (r.verdict === 'covered') s.covered += 1
+    else if (r.verdict === 'gap') s.gap += 1
+    else if (r.verdict === 'unknown') s.unknown += 1
+    else if (r.verdict === 'out_of_reach') s.outOfReach += 1
+  }
+  const list = [...byRun.values()]
+  for (const s of list) {
+    s.executed = s.covered + s.gap
+    // floor, never round: 199/200 must read 99%, not a false 100%. Exactly-covered stays 100.
+    s.coveragePct = s.executed === 0 ? null : Math.floor((s.covered / s.executed) * 100)
+  }
+  return list.sort((a, b) => (a.computedAt < b.computedAt ? 1 : -1))
+}
+
+function textTone(pct: number | null): string {
+  if (pct === null) return 'text-tertiary'
+  if (pct >= 80) return 'text-success-primary'
+  if (pct >= 50) return 'text-warning-primary'
+  return 'text-error-primary'
+}
+
+function badgeTone(pct: number | null): string {
+  if (pct === null) return 'text-tertiary bg-secondary border-secondary'
+  if (pct >= 80) return 'text-success-primary bg-success-primary/10 border-success-primary/25'
+  if (pct >= 50) return 'text-warning-primary bg-warning-primary/10 border-warning-primary/25'
+  return 'text-error-primary bg-error-primary/10 border-error-primary/25'
+}
+
+function pctLabel(pct: number | null): string {
+  return pct === null ? 'N/A' : `${pct}%`
+}
+
+function shortId(id: string): string {
+  return id.length > 10 ? `${id.slice(0, 8)}…` : id
+}
+
+function formatWhen(iso: string): string {
+  if (!iso) return 'unknown time'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+
+function VerdictCount({
+  icon: Icon,
+  count,
+  label,
+  tone,
+}: {
+  icon: typeof CheckCircle
+  count: number
+  label: string
+  tone: string
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <Icon className={cn('size-4 shrink-0', tone)} aria-hidden />
+      <span className="text-sm font-semibold text-primary">{count}</span>
+      <span className="text-xs text-tertiary">{label}</span>
+    </div>
+  )
+}
+
+function SummaryCard({ latest }: { latest: RunSummary }) {
+  return (
+    <Card title="Detection coverage" titleClassName="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-x-8 gap-y-4">
+        <div className="flex items-baseline gap-2">
+          <span className={cn('text-4xl font-bold tabular-nums', textTone(latest.coveragePct))}>
+            {pctLabel(latest.coveragePct)}
+          </span>
+          <span className="text-sm text-tertiary">
+            {latest.executed > 0
+              ? `of ${latest.executed} executed check${latest.executed === 1 ? '' : 's'} detected`
+              : 'no checks executed this run'}
+          </span>
+        </div>
+        <div className="grid grid-cols-2 gap-x-6 gap-y-2">
+          <VerdictCount icon={CheckCircle} count={latest.covered} label="covered" tone="text-success-primary" />
+          <VerdictCount icon={AlertTriangle} count={latest.gap} label="gaps" tone="text-error-primary" />
+          <VerdictCount icon={HelpCircle} count={latest.unknown} label="not run" tone="text-quaternary" />
+          <VerdictCount icon={SlashCircle01} count={latest.outOfReach} label="out of reach" tone="text-quaternary" />
+        </div>
+      </div>
+      <p className="mt-4 text-xs text-tertiary">
+        Coverage is measured over executed checks only (one per attack technique per asset). A gap is a
+        check that ran without its expected detection firing; it becomes a work item below. Checks that did
+        not run or cannot be emulated are shown but excluded from the percentage.
+      </p>
+    </Card>
+  )
+}
+
+function RunRow({
+  run,
+  selected,
+  disabled,
+  onSelect,
+}: {
+  run: RunSummary
+  selected: boolean
+  disabled: boolean
+  onSelect: () => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      disabled={disabled}
+      aria-current={selected}
+      aria-label={`Emulation run ${shortId(run.runId)}, ${pctLabel(run.coveragePct)} coverage`}
+      className={cn(
+        'flex w-full flex-wrap items-center gap-x-4 gap-y-2 rounded-lg border px-4 py-3 text-left transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand disabled:cursor-not-allowed disabled:opacity-60',
+        selected
+          ? 'border-brand-solid bg-brand-primary/5 ring-1 ring-inset ring-brand/25'
+          : 'border-secondary bg-primary hover:bg-secondary/40',
+      )}
+    >
+      <span className="inline-flex items-center gap-1.5 font-mono text-xs text-secondary">
+        <Target04 className="size-3.5 text-quaternary" aria-hidden />
+        {shortId(run.runId)}
+      </span>
+      <span className="text-xs text-tertiary">{formatWhen(run.computedAt)}</span>
+      <span className={cn('inline-flex items-center rounded border px-1.5 py-0.5 font-mono text-xs font-bold', badgeTone(run.coveragePct))}>
+        {pctLabel(run.coveragePct)}
+      </span>
+      <span className="ml-auto flex flex-wrap items-center gap-1.5 text-xs">
+        <Pill className="text-success-primary">{run.covered} covered</Pill>
+        {run.gap > 0 && <Pill className="text-error-primary">{run.gap} gaps</Pill>}
+        {run.unknown > 0 && <Pill>{run.unknown} not run</Pill>}
+      </span>
+    </button>
+  )
+}
+
+function GapList({ items, loading, error }: { items: PurpleWorkItem[]; loading: boolean; error: string }) {
+  return (
+    <Card title="Detection gaps to close" titleClassName="flex items-center gap-2">
+      {loading ? (
+        <Spinner label="Loading gaps…" />
+      ) : error ? (
+        <ErrorState message={error} />
+      ) : items.length === 0 ? (
+        <div className="flex items-center gap-2 text-sm text-tertiary">
+          <CheckCircle className="size-4 text-success-primary" aria-hidden />
+          No detection gaps recorded for this run.
+        </div>
+      ) : (
+        <ul className="space-y-2">
+          {items.map((w) => (
+            <li
+              key={`${w.techniqueId}:${w.missingDetection}`}
+              className="flex flex-wrap items-center gap-x-3 gap-y-1 rounded-lg border border-secondary bg-secondary/20 px-3 py-2"
+            >
+              <AlertTriangle className="size-4 shrink-0 text-error-primary" aria-hidden />
+              <span className="font-mono text-sm font-semibold text-primary">{w.techniqueId}</span>
+              {w.taxonomyRef && <Pill className="font-mono">{w.taxonomyRef}</Pill>}
+              <span className="text-xs text-tertiary">
+                write detection{w.missingDetection ? `: ${w.missingDetection}` : ''}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  )
+}
+
+export function PurpleCoverageTab({ engagementId }: { engagementId: string }) {
+  const { data, loading, error } = useParallelFetch<[PurpleCoverageRow[]]>(
+    () => Promise.all([api.purpleCoverage(engagementId)]),
+    { deps: [engagementId] },
+  )
+
+  const runs = useMemo(() => summarize(data?.[0] ?? []), [data])
+  const [selectedRun, setSelectedRun] = useState<string | null>(null)
+  const [items, setItems] = useState<PurpleWorkItem[]>([])
+  const [itemsLoading, setItemsLoading] = useState(false)
+  const [itemsErr, setItemsErr] = useState('')
+
+  // Default to the most recent run, and never point at a run that is no longer in the list.
+  const activeRun = (selectedRun && runs.some((r) => r.runId === selectedRun) ? selectedRun : runs[0]?.runId) ?? null
+
+  useEffect(() => {
+    if (!activeRun) return
+    let alive = true
+    setItemsLoading(true)
+    setItemsErr('')
+    api
+      .purpleWorkItems(engagementId, activeRun)
+      .then((w) => {
+        if (alive) setItems(w)
+      })
+      .catch((e) => {
+        if (alive) setItemsErr(e instanceof Error ? e.message : 'failed to load gaps')
+      })
+      .finally(() => {
+        if (alive) setItemsLoading(false)
+      })
+    return () => {
+      alive = false
+    }
+  }, [engagementId, activeRun])
+
+  if (loading) return <Spinner label="Loading purple coverage…" />
+  if (error) return <ErrorState message={error} />
+  if (runs.length === 0)
+    return (
+      <EmptyState
+        icon={ShieldTick}
+        title="No purple-team coverage yet"
+        hint="Run an adversary emulation on an enrolled asset; coverage joins each executed technique with the detections that fired."
+      />
+    )
+
+  return (
+    <div className="space-y-6">
+      <SummaryCard latest={runs[0]} />
+      {runs.length > 1 && (
+        <Card title="Coverage by emulation run">
+          <div className="space-y-2" role="group" aria-label="Emulation runs">
+            {runs.map((r) => (
+              <RunRow
+                key={r.runId}
+                run={r}
+                selected={r.runId === activeRun}
+                disabled={itemsLoading}
+                onSelect={() => setSelectedRun(r.runId)}
+              />
+            ))}
+          </div>
+        </Card>
+      )}
+      <GapList items={items} loading={itemsLoading} error={itemsErr} />
+    </div>
+  )
+}

--- a/web/src/pages/EngagementDetail/RiskStoriesTab.test.tsx
+++ b/web/src/pages/EngagementDetail/RiskStoriesTab.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import type { RiskStory } from '../../lib/api'
+import { RiskStoriesTab } from './RiskStoriesTab'
+
+vi.mock('../../lib/api', () => ({
+  api: { riskStories: vi.fn() },
+}))
+
+function story(id: string, name: string, score: number, findings: RiskStory['findings']): RiskStory {
+  return {
+    assetId: id,
+    identity: { kind: 'host', key: name, name: `${name}.prod` },
+    exposure: [],
+    findings,
+    paths: [],
+    detections: [],
+    score,
+    qualifiers: [],
+    generatedAt: '2026-02-20T00:00:00Z',
+  }
+}
+
+describe('RiskStoriesTab', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('ranks assets by score and surfaces corroboration on findings', async () => {
+    vi.mocked(api.riskStories).mockResolvedValue([
+      story('db-01', 'db-01', 0, []),
+      story('web-01', 'web-01', 1, [
+        {
+          findingId: 'f-1',
+          title: 'lodash prototype pollution',
+          severity: 'high',
+          priority: 1,
+          riskScore: 8.4,
+          kev: false,
+          reachability: 'reachable',
+          reachable: true,
+          onAttackPath: true,
+          seenUnderAttack: false,
+          corroboration: ['reachable', 'on_attack_path'],
+          rankReason: 'raised by corroboration',
+          lastObserved: '2026-02-13T00:00:00Z',
+          stale: false,
+        },
+      ]),
+    ])
+
+    render(<RiskStoriesTab engagementId="eng-001" />)
+
+    expect(await screen.findByText('web-01.prod')).toBeInTheDocument()
+    expect(screen.getByText('db-01.prod')).toBeInTheDocument()
+    expect(screen.getByText('lodash prototype pollution')).toBeInTheDocument()
+    // Corroboration signals surface as badges.
+    expect(screen.getByText('reachable')).toBeInTheDocument()
+    expect(screen.getByText('on attack path')).toBeInTheDocument()
+    // The asset with no findings says so rather than rendering an empty list.
+    expect(screen.getByText('No findings correlated to this asset.')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when no stories correlate', async () => {
+    vi.mocked(api.riskStories).mockResolvedValue([])
+    render(<RiskStoriesTab engagementId="eng-001" />)
+    expect(await screen.findByText('No correlated risk stories yet')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/EngagementDetail/RiskStoriesTab.tsx
+++ b/web/src/pages/EngagementDetail/RiskStoriesTab.tsx
@@ -1,0 +1,159 @@
+import { useMemo } from 'react'
+import { Cube01, GitBranch01, ShieldZap, Target04, Activity } from '@untitledui/icons'
+import { Card, EmptyState, ErrorState, Pill, Spinner, cn } from '../../components/ui'
+import { useParallelFetch } from '../../hooks'
+import { api } from '../../lib/api'
+import type { RiskFinding, RiskStory } from '../../lib/api'
+
+function severityTone(sev: string): string {
+  const s = sev.toLowerCase()
+  if (s === 'critical' || s === 'high') return 'bg-error-solid'
+  if (s === 'medium') return 'bg-warning-solid'
+  if (s === 'low') return 'bg-utility-blue-500'
+  return 'bg-quaternary'
+}
+
+function priorityLabel(p: number): string {
+  return p >= 1 && p <= 5 ? `P${p}` : '—'
+}
+
+// story.score is the best (most urgent) finding priority: 1 = act now, 5 = low, 0 = no findings.
+function urgencyRank(score: number): number {
+  return score >= 1 && score <= 5 ? score : 99 // 0 / no findings sorts last
+}
+
+function scoreTone(score: number): string {
+  if (score === 1) return 'text-error-primary bg-error-primary/10 border-error-primary/25'
+  if (score === 2 || score === 3) return 'text-warning-primary bg-warning-primary/10 border-warning-primary/25'
+  if (score >= 4) return 'text-utility-blue-600 dark:text-utility-blue-400 bg-utility-blue-500/10 border-utility-blue-500/25'
+  return 'text-tertiary bg-secondary border-secondary'
+}
+
+function scoreLabel(score: number): string {
+  if (score === 0) return 'no findings'
+  if (score === 1) return 'P1 · act now'
+  return `P${score}`
+}
+
+function SignalBadges({ f }: { f: RiskFinding }) {
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1">
+      {f.kev && <Pill className="text-error-primary">KEV</Pill>}
+      {f.reachable && (
+        <Pill className="text-error-primary">
+          <Target04 className="size-3" aria-hidden />
+          reachable
+        </Pill>
+      )}
+      {f.onAttackPath && (
+        <Pill className="text-warning-primary">
+          <GitBranch01 className="size-3" aria-hidden />
+          on attack path
+        </Pill>
+      )}
+      {f.seenUnderAttack && (
+        <Pill className="text-error-primary">
+          <Activity className="size-3" aria-hidden />
+          seen under attack
+        </Pill>
+      )}
+    </span>
+  )
+}
+
+function FindingRow({ f }: { f: RiskFinding }) {
+  return (
+    <li className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-secondary/60 py-2 first:border-t-0">
+      <span className={cn('size-2 shrink-0 rounded-full', severityTone(f.severity))} aria-hidden title={f.severity} />
+      {f.severity && <span className="sr-only">{f.severity} severity: </span>}
+      <span className="min-w-0 flex-1 truncate text-sm text-primary" title={f.title}>
+        {f.title || f.findingId}
+      </span>
+      <span className="font-mono text-xs font-semibold text-tertiary">{priorityLabel(f.priority)}</span>
+      <SignalBadges f={f} />
+    </li>
+  )
+}
+
+function StoryCard({ story }: { story: RiskStory }) {
+  const name = story.identity.name || story.identity.key || story.assetId
+  const topFindings = story.findings.slice(0, 6)
+  const moreFindings = story.findings.length - topFindings.length
+  return (
+    <Card
+      title={
+        <span className="inline-flex items-center gap-2">
+          <Cube01 className="size-4 text-quaternary" aria-hidden />
+          <span className="truncate">{name}</span>
+          {story.identity.kind && <Pill className="font-mono">{story.identity.kind}</Pill>}
+        </span>
+      }
+      actions={
+        <span className={cn('inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-bold', scoreTone(story.score))}>
+          <ShieldZap className="size-3.5" aria-hidden />
+          {scoreLabel(story.score)}
+        </span>
+      }
+    >
+      {story.qualifiers.length > 0 && (
+        <div className="mb-3 flex flex-wrap gap-1.5">
+          {story.qualifiers.map((q) => (
+            <Pill key={q}>{q}</Pill>
+          ))}
+        </div>
+      )}
+      {story.findings.length > 0 ? (
+        <ul>
+          {topFindings.map((f) => (
+            <FindingRow key={f.findingId} f={f} />
+          ))}
+          {moreFindings > 0 && <li className="pt-2 text-xs text-tertiary">and {moreFindings} more finding{moreFindings === 1 ? '' : 's'}</li>}
+        </ul>
+      ) : (
+        <p className="text-sm text-tertiary">No findings correlated to this asset.</p>
+      )}
+      <div className="mt-4 flex flex-wrap gap-x-6 gap-y-1 border-t border-secondary/60 pt-3 text-xs text-tertiary">
+        <span>{story.exposure.length} exposure element{story.exposure.length === 1 ? '' : 's'}</span>
+        <span>{story.paths.length} attack path{story.paths.length === 1 ? '' : 's'}</span>
+        <span>{story.detections.length} detection{story.detections.length === 1 ? '' : 's'}</span>
+      </div>
+    </Card>
+  )
+}
+
+export function RiskStoriesTab({ engagementId }: { engagementId: string }) {
+  const { data, loading, error } = useParallelFetch<[RiskStory[]]>(
+    () => Promise.all([api.riskStories(engagementId)]),
+    { deps: [engagementId] },
+  )
+
+  const stories = useMemo(() => {
+    const list = data?.[0] ?? []
+    // Most urgent first: priority 1 (act now) leads; assets with no findings (score 0) sort last.
+    return [...list].sort((a, b) => urgencyRank(a.score) - urgencyRank(b.score))
+  }, [data])
+
+  if (loading) return <Spinner label="Loading risk stories…" />
+  if (error) return <ErrorState message={error} />
+  if (stories.length === 0)
+    return (
+      <EmptyState
+        icon={Cube01}
+        title="No correlated risk stories yet"
+        hint="A risk story is assembled per asset once findings, exposure, attack paths, or detections correlate to it. Run scans and enroll assets to populate this view."
+      />
+    )
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-tertiary">
+        One story per asset, ranked by correlated risk. A finding is raised when it is reachable, on an
+        attack path, or seen under attack; those signals order it above an equal-priority finding without
+        them.
+      </p>
+      {stories.map((s) => (
+        <StoryCard key={s.assetId} story={s} />
+      ))}
+    </div>
+  )
+}

--- a/web/src/pages/EngagementDetail/ScanRunsTab.test.tsx
+++ b/web/src/pages/EngagementDetail/ScanRunsTab.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import type { ScanRun } from '../../lib/types'
+import { ScanRunsTab } from './ScanRunsTab'
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    scanRuns: vi.fn(),
+    compareScanRuns: vi.fn(),
+  },
+}))
+
+function run(id: string, createdAt: string, repro: number, keys: string[], grypeDB = 'v5@2026-02-20'): ScanRun {
+  return {
+    id,
+    engagementId: 'eng-001',
+    createdAt,
+    manifest: {
+      toolVersions: { syft: '1.18.1' },
+      vulnDBSnapshot: 'osv.dev@2026-02-20',
+      grypeDBVersion: grypeDB,
+      correlationVersion: 7,
+      sbomSha256: 'abc',
+      reproScore: repro,
+      pinnedInputs: ['syft', 'grype'],
+      unpinnedInputs: ['osv.dev'],
+    },
+    findingKeys: keys,
+  }
+}
+
+describe('ScanRunsTab', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('lists runs newest-first and compares two selected runs', async () => {
+    vi.mocked(api.scanRuns).mockResolvedValue([
+      run('run-jan', '2026-01-20T00:00:00Z', 82, ['k1', 'k2']),
+      run('run-feb', '2026-02-20T00:00:00Z', 82, ['k1', 'k2', 'k3']),
+    ])
+    vi.mocked(api.compareScanRuns).mockResolvedValue({
+      runA: run('run-feb', '2026-02-20T00:00:00Z', 82, ['k1', 'k2', 'k3']),
+      runB: run('run-jan', '2026-01-20T00:00:00Z', 82, ['k1', 'k2']),
+      added: [],
+      removed: ['k3'],
+      unchanged: 2,
+      explanation: ['grype-db changed: "v5@2026-02-20" -> "v5@2026-01-20"'],
+    })
+
+    render(<ScanRunsTab engagementId="eng-001" />)
+
+    // Both runs render; the reproducibility score is surfaced.
+    expect(await screen.findByText(/run-feb/)).toBeInTheDocument()
+    expect(screen.getByText(/run-jan/)).toBeInTheDocument()
+    expect(screen.getByText('Select two runs to compare')).toBeInTheDocument()
+
+    const rows = screen.getAllByRole('button', { pressed: false })
+    await userEvent.click(rows[0])
+    await userEvent.click(rows[1])
+
+    const compareBtn = await screen.findByRole('button', { name: /Compare A and B/ })
+    await userEvent.click(compareBtn)
+
+    await waitFor(() => expect(api.compareScanRuns).toHaveBeenCalledWith('eng-001', 'run-feb', 'run-jan'))
+    expect(await screen.findByText('1 removed')).toBeInTheDocument()
+    expect(screen.getByText('2 unchanged')).toBeInTheDocument()
+    expect(screen.getByText(/grype-db changed/)).toBeInTheDocument()
+  })
+
+  it('shows an empty state when there is no scan history', async () => {
+    vi.mocked(api.scanRuns).mockResolvedValue([])
+    render(<ScanRunsTab engagementId="eng-001" />)
+    expect(await screen.findByText('No scan runs yet')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/EngagementDetail/ScanRunsTab.tsx
+++ b/web/src/pages/EngagementDetail/ScanRunsTab.tsx
@@ -1,0 +1,274 @@
+import { useMemo, useState } from 'react'
+import {
+  ArrowRight,
+  Clock,
+  Database01,
+  Fingerprint02,
+  Minus,
+  Package,
+  Percent01,
+  Plus,
+} from '@untitledui/icons'
+import { Button, Card, EmptyState, ErrorState, Pill, Spinner, cn } from '../../components/ui'
+import { useParallelFetch } from '../../hooks'
+import { api } from '../../lib/api'
+import type { ScanDrift, ScanRun } from '../../lib/types'
+
+// A scan run's reproducibility score maps to a semantic tone: a run built entirely
+// from pinned inputs (100) is reproducible; a run with live inputs (osv.dev) is not.
+function reproTone(score: number): string {
+  if (score >= 90) return 'text-success-primary bg-success-primary/10 border-success-primary/25'
+  if (score >= 60) return 'text-warning-primary bg-warning-primary/10 border-warning-primary/25'
+  return 'text-error-primary bg-error-primary/10 border-error-primary/25'
+}
+
+function shortId(id: string): string {
+  return id.length > 10 ? `${id.slice(0, 8)}…` : id
+}
+
+function formatWhen(iso: string): string {
+  if (!iso) return 'unknown time'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+
+function RunRow({
+  run,
+  order,
+  selected,
+  disabled,
+  onToggle,
+}: {
+  run: ScanRun
+  order: number | null
+  selected: boolean
+  disabled: boolean
+  onToggle: () => void
+}) {
+  const findings = run.findingKeys.length
+  const pinned = run.manifest.pinnedInputs.length
+  const unpinned = run.manifest.unpinnedInputs.length
+  const role = order === 1 ? 'A' : order === 2 ? 'B' : null
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      disabled={disabled}
+      aria-pressed={selected}
+      aria-label={`Scan run ${shortId(run.id)}${role ? `, selected as comparison run ${role}` : ''}`}
+      className={cn(
+        'disabled:cursor-not-allowed disabled:opacity-60',
+        'flex w-full flex-wrap items-center gap-x-4 gap-y-2 rounded-lg border px-4 py-3 text-left transition-colors',
+        selected
+          ? 'border-brand-solid bg-brand-primary/5 ring-1 ring-inset ring-brand/25'
+          : 'border-secondary bg-primary hover:bg-secondary/40',
+      )}
+    >
+      <span
+        className={cn(
+          'inline-flex size-6 shrink-0 items-center justify-center rounded-md border text-[11px] font-bold',
+          selected ? 'border-brand-solid text-brand-secondary' : 'border-secondary text-quaternary',
+        )}
+        aria-hidden
+      >
+        {order ? (order === 1 ? 'A' : 'B') : ''}
+      </span>
+      <span className="inline-flex items-center gap-1.5 font-mono text-xs text-secondary">
+        <Package className="size-3.5 text-quaternary" aria-hidden />
+        {shortId(run.id)}
+      </span>
+      <span className="inline-flex items-center gap-1.5 text-xs text-tertiary">
+        <Clock className="size-3.5" aria-hidden />
+        {formatWhen(run.createdAt)}
+      </span>
+      <span
+        className={cn(
+          'inline-flex items-center gap-1 rounded border px-1.5 py-0.5 font-mono text-xs font-bold',
+          reproTone(run.manifest.reproScore),
+        )}
+        title="Reproducibility score: fraction of scan inputs that are version-pinned"
+      >
+        <Percent01 className="size-3" aria-hidden />
+        {run.manifest.reproScore}
+      </span>
+      <span className="inline-flex items-center gap-1.5 text-xs text-tertiary">
+        <Fingerprint02 className="size-3.5" aria-hidden />
+        {findings} finding{findings === 1 ? '' : 's'}
+      </span>
+      <span className="ml-auto flex flex-wrap items-center gap-1.5">
+        {run.manifest.grypeDBVersion && (
+          <Pill className="font-mono">
+            <Database01 className="size-3" aria-hidden />
+            {run.manifest.grypeDBVersion}
+          </Pill>
+        )}
+        <Pill>{pinned} pinned</Pill>
+        {unpinned > 0 && <Pill className="text-warning-primary">{unpinned} live</Pill>}
+      </span>
+    </button>
+  )
+}
+
+function KeyList({ keys, cap = 25 }: { keys: string[]; cap?: number }) {
+  const shown = keys.slice(0, cap)
+  const rest = keys.length - shown.length
+  return (
+    <ul className="mt-2 space-y-1">
+      {shown.map((k) => (
+        <li key={k} className="truncate font-mono text-xs text-secondary" title={k}>
+          {k}
+        </li>
+      ))}
+      {rest > 0 && <li className="text-xs text-tertiary">and {rest} more…</li>}
+    </ul>
+  )
+}
+
+function DriftPanel({ drift }: { drift: ScanDrift }) {
+  return (
+    <Card
+      title={
+        <span className="inline-flex items-center gap-2">
+          Drift
+          <span className="inline-flex items-center gap-1.5 font-mono text-xs font-normal text-tertiary">
+            {shortId(drift.runA.id)}
+            <ArrowRight className="size-3.5" aria-hidden />
+            {shortId(drift.runB.id)}
+          </span>
+        </span>
+      }
+    >
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <div className="rounded-lg border border-success-primary/25 bg-success-primary/5 p-4">
+          <div className="flex items-center gap-2 text-sm font-semibold text-success-primary">
+            <Plus className="size-4" aria-hidden />
+            {drift.added.length} added
+          </div>
+          <p className="mt-1 text-xs text-tertiary">Finding keys present in B but not A.</p>
+          {drift.added.length > 0 && <KeyList keys={drift.added} />}
+        </div>
+        <div className="rounded-lg border border-error-primary/25 bg-error-primary/5 p-4">
+          <div className="flex items-center gap-2 text-sm font-semibold text-error-primary">
+            <Minus className="size-4" aria-hidden />
+            {drift.removed.length} removed
+          </div>
+          <p className="mt-1 text-xs text-tertiary">Finding keys present in A but not B.</p>
+          {drift.removed.length > 0 && <KeyList keys={drift.removed} />}
+        </div>
+        <div className="rounded-lg border border-secondary bg-secondary/30 p-4">
+          <div className="text-sm font-semibold text-primary">{drift.unchanged} unchanged</div>
+          <p className="mt-1 text-xs text-tertiary">Finding keys present in both runs.</p>
+        </div>
+      </div>
+      <div className="mt-4">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-tertiary">Why the result changed</h3>
+        {drift.explanation.length > 0 ? (
+          <ul className="mt-2 space-y-1.5">
+            {drift.explanation.map((e) => (
+              <li key={e} className="flex items-start gap-2 text-sm text-secondary">
+                <ArrowRight className="mt-0.5 size-3.5 shrink-0 text-quaternary" aria-hidden />
+                <span className="font-mono text-xs">{e}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="mt-2 text-sm text-tertiary">
+            No manifest deltas were recorded for these runs. Any change in findings then comes from the
+            target rather than a reported change in the scanner or its databases.
+          </p>
+        )}
+      </div>
+    </Card>
+  )
+}
+
+export function ScanRunsTab({ engagementId }: { engagementId: string }) {
+  const { data, loading, error } = useParallelFetch<[ScanRun[]]>(
+    () => Promise.all([api.scanRuns(engagementId)]),
+    { deps: [engagementId] },
+  )
+
+  const runs = useMemo(() => {
+    const list = data?.[0] ?? []
+    return [...list].sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1))
+  }, [data])
+
+  const [selected, setSelected] = useState<string[]>([])
+  const [drift, setDrift] = useState<ScanDrift | null>(null)
+  const [comparing, setComparing] = useState(false)
+  const [compareErr, setCompareErr] = useState('')
+
+  function toggle(id: string) {
+    setDrift(null)
+    setCompareErr('')
+    setSelected((prev) => {
+      if (prev.includes(id)) return prev.filter((x) => x !== id)
+      if (prev.length >= 2) return [prev[1], id]
+      return [...prev, id]
+    })
+  }
+
+  async function compare() {
+    if (selected.length !== 2) return
+    setComparing(true)
+    setCompareErr('')
+    try {
+      setDrift(await api.compareScanRuns(engagementId, selected[0], selected[1]))
+    } catch (e) {
+      setCompareErr(e instanceof Error ? e.message : 'comparison failed')
+    } finally {
+      setComparing(false)
+    }
+  }
+
+  if (loading) return <Spinner label="Loading scan runs…" />
+  if (error) return <ErrorState message={error} />
+  if (runs.length === 0)
+    return (
+      <EmptyState
+        icon={Package}
+        title="No scan runs yet"
+        hint="Run an SCA scan to build a reproducibility history and compare results run to run."
+      />
+    )
+
+  return (
+    <div className="space-y-6">
+      <Card
+        title="Scan runs"
+        actions={
+          selected.length === 2 ? (
+            <Button variant="primary" onClick={compare} disabled={comparing} className="px-3 py-1.5">
+              Compare A and B
+            </Button>
+          ) : (
+            <span className="text-xs text-tertiary">Select two runs to compare</span>
+          )
+        }
+      >
+        <p className="mb-4 text-sm text-tertiary">
+          Every SCA scan seals a manifest of its inputs (tool and database versions, the SBOM hash) and the
+          finding keys it produced. Pick two runs to see what changed and why.
+        </p>
+        <div className="space-y-2">
+          {runs.map((r) => {
+            const idx = selected.indexOf(r.id)
+            return (
+              <RunRow
+                key={r.id}
+                run={r}
+                order={idx === -1 ? null : idx + 1}
+                selected={idx !== -1}
+                disabled={comparing}
+                onToggle={() => toggle(r.id)}
+              />
+            )
+          })}
+        </div>
+      </Card>
+      {compareErr && <ErrorState message={compareErr} />}
+      {comparing && <Spinner label="Comparing runs…" />}
+      {drift && <DriftPanel drift={drift} />}
+    </div>
+  )
+}

--- a/web/src/pages/EngagementDetail/VulnPostureTab.test.tsx
+++ b/web/src/pages/EngagementDetail/VulnPostureTab.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import type { VulnerabilityAction, VulnerabilityOccurrence } from '../../lib/types'
+import { VulnPostureTab } from './VulnPostureTab'
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    engagementVulnerabilityActions: vi.fn(),
+    engagementVulnerabilityOccurrences: vi.fn(),
+    acknowledgeVulnerabilityAction: vi.fn(),
+    resolveVulnerabilityAction: vi.fn(),
+  },
+}))
+
+function action(id: string, status: string, title: string): VulnerabilityAction {
+  return { id, engagementId: 'eng-001', occurrenceId: 'occ-1', findingId: 'f-1', type: 'remediate', status, title, reasonCodes: ['reachable'], createdAt: '', updatedAt: '' }
+}
+
+function occ(id: string, advisory: string, pkg: string): VulnerabilityOccurrence {
+  return {
+    id, engagementId: 'eng-001', advisoryId: advisory, advisoryRevision: 1, componentId: 'c1', componentFingerprint: `pkg:npm/${pkg}`, ecosystem: 'npm',
+    packageName: pkg, componentVersion: '4.17.20', componentCpe: '', fixedVersion: '4.17.21', matchMethod: '', confidence: '', scope: '', reachability: 'reachable',
+    state: 'open', firstDetectedAt: '', lastDetectedAt: '', lastEvaluatedAt: '', updatedAt: '',
+  }
+}
+
+describe('VulnPostureTab', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('shows the action queue and resolves an action in place', async () => {
+    vi.mocked(api.engagementVulnerabilityActions).mockResolvedValue([action('act-1', 'open', 'Upgrade lodash to 4.17.21')])
+    vi.mocked(api.engagementVulnerabilityOccurrences).mockResolvedValue([occ('occ-1', 'CVE-2021-23337', 'lodash')])
+    vi.mocked(api.resolveVulnerabilityAction).mockResolvedValue(action('act-1', 'resolved', 'Upgrade lodash to 4.17.21'))
+
+    render(<VulnPostureTab engagementId="eng-001" />)
+
+    expect(await screen.findByText('Upgrade lodash to 4.17.21')).toBeInTheDocument()
+    expect(screen.getByText('CVE-2021-23337')).toBeInTheDocument()
+    expect(screen.getByText('1 open')).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole('button', { name: 'Resolve' }))
+    await waitFor(() => expect(api.resolveVulnerabilityAction).toHaveBeenCalledWith('eng-001', 'act-1'))
+    // After resolving, the open counter drops and the Resolve button disappears for that row.
+    expect(await screen.findByText('0 open')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when nothing is reconciled', async () => {
+    vi.mocked(api.engagementVulnerabilityActions).mockResolvedValue([])
+    vi.mocked(api.engagementVulnerabilityOccurrences).mockResolvedValue([])
+    render(<VulnPostureTab engagementId="eng-001" />)
+    expect(await screen.findByText('No reconciled vulnerabilities yet')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/EngagementDetail/VulnPostureTab.tsx
+++ b/web/src/pages/EngagementDetail/VulnPostureTab.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useMemo, useState } from 'react'
+import { CheckCircle, Package, ShieldTick } from '@untitledui/icons'
+import { Button, Card, EmptyState, ErrorState, Pill, Spinner, cn } from '../../components/ui'
+import { useParallelFetch } from '../../hooks'
+import { api } from '../../lib/api'
+import type { VulnerabilityAction, VulnerabilityOccurrence } from '../../lib/types'
+
+const STATUS_ORDER: Record<string, number> = { open: 0, acknowledged: 1, resolved: 2 }
+
+function statusTone(status: string): string {
+  switch (status) {
+    case 'open':
+      return 'text-warning-primary bg-warning-primary/10 border-warning-primary/25'
+    case 'acknowledged':
+      return 'text-utility-blue-600 dark:text-utility-blue-400 bg-utility-blue-500/10 border-utility-blue-500/25'
+    case 'resolved':
+      return 'text-success-primary bg-success-primary/10 border-success-primary/25'
+    default:
+      return 'text-tertiary bg-secondary border-secondary'
+  }
+}
+
+function occStateTone(state: string): string {
+  const s = state.toLowerCase()
+  if (s === 'open' || s === 'active') return 'text-error-primary'
+  if (s === 'fixed' || s === 'resolved') return 'text-success-primary'
+  return 'text-tertiary'
+}
+
+function ActionRow({
+  action,
+  busy,
+  onAck,
+  onResolve,
+}: {
+  action: VulnerabilityAction
+  busy: boolean
+  onAck: () => void
+  onResolve: () => void
+}) {
+  return (
+    <li className="flex flex-wrap items-center gap-x-3 gap-y-2 border-t border-secondary/60 py-3 first:border-t-0">
+      <ShieldTick className="size-4 shrink-0 text-quaternary" aria-hidden />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm text-primary" title={action.title}>
+          {action.title || action.type || action.id}
+        </span>
+        {action.reasonCodes.length > 0 && (
+          <span className="mt-1 flex flex-wrap gap-1">
+            {action.reasonCodes.map((c) => (
+              <Pill key={c} className="font-mono">
+                {c}
+              </Pill>
+            ))}
+          </span>
+        )}
+      </span>
+      <span className={cn('inline-flex items-center rounded border px-1.5 py-0.5 text-xs font-bold', statusTone(action.status))}>
+        {action.status}
+      </span>
+      <span className="flex items-center gap-2">
+        {action.status === 'open' && (
+          <Button variant="secondary" onClick={onAck} loading={busy} className="px-2.5 py-1 text-xs">
+            Acknowledge
+          </Button>
+        )}
+        {action.status !== 'resolved' && (
+          <Button variant="primary" onClick={onResolve} loading={busy} className="px-2.5 py-1 text-xs">
+            Resolve
+          </Button>
+        )}
+      </span>
+    </li>
+  )
+}
+
+function OccurrenceRow({ o }: { o: VulnerabilityOccurrence }) {
+  return (
+    <li className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-secondary/60 py-2 first:border-t-0">
+      <span className="font-mono text-xs font-semibold text-primary">{o.advisoryId}</span>
+      <span className="min-w-0 flex-1 truncate font-mono text-xs text-tertiary" title={`${o.packageName}@${o.componentVersion}`}>
+        {o.packageName}
+        {o.componentVersion ? `@${o.componentVersion}` : ''}
+      </span>
+      {o.ecosystem && <Pill>{o.ecosystem}</Pill>}
+      {o.fixedVersion && <Pill className="text-success-primary">fix {o.fixedVersion}</Pill>}
+      {o.reachability && o.reachability !== 'unknown' && <Pill className="text-error-primary">{o.reachability}</Pill>}
+      <span className={cn('text-xs font-semibold', occStateTone(o.state))}>{o.state}</span>
+    </li>
+  )
+}
+
+export function VulnPostureTab({ engagementId }: { engagementId: string }) {
+  const { data, loading, error } = useParallelFetch<[VulnerabilityAction[], VulnerabilityOccurrence[]]>(
+    () => Promise.all([api.engagementVulnerabilityActions(engagementId), api.engagementVulnerabilityOccurrences(engagementId)]),
+    { deps: [engagementId] },
+  )
+
+  const [actions, setActions] = useState<VulnerabilityAction[]>([])
+  useEffect(() => {
+    if (data) setActions(data[0])
+  }, [data])
+
+  const occurrences = data?.[1] ?? []
+  const sortedActions = useMemo(
+    () => [...actions].sort((a, b) => (STATUS_ORDER[a.status] ?? 9) - (STATUS_ORDER[b.status] ?? 9)),
+    [actions],
+  )
+  const openCount = actions.filter((a) => a.status === 'open').length
+
+  const [pending, setPending] = useState<Set<string>>(() => new Set())
+  const [mutErr, setMutErr] = useState('')
+
+  async function move(action: VulnerabilityAction, kind: 'ack' | 'resolve') {
+    // Track pending per action id so two concurrent mutations do not clear each other's busy state,
+    // and both buttons on a row stay disabled until that action's own request settles.
+    setPending((prev) => new Set(prev).add(action.id))
+    setMutErr('')
+    try {
+      const updated =
+        kind === 'ack'
+          ? await api.acknowledgeVulnerabilityAction(engagementId, action.id)
+          : await api.resolveVulnerabilityAction(engagementId, action.id)
+      setActions((prev) => prev.map((x) => (x.id === updated.id ? updated : x)))
+    } catch (e) {
+      setMutErr(e instanceof Error ? e.message : 'action failed')
+    } finally {
+      setPending((prev) => {
+        const next = new Set(prev)
+        next.delete(action.id)
+        return next
+      })
+    }
+  }
+
+  if (loading) return <Spinner label="Loading vulnerability posture…" />
+  if (error) return <ErrorState message={error} />
+  if (actions.length === 0 && occurrences.length === 0)
+    return (
+      <EmptyState
+        icon={ShieldTick}
+        title="No reconciled vulnerabilities yet"
+        hint="Once vulnerability reconciliation matches advisories to this engagement's components, the occurrences and their governed action queue appear here."
+      />
+    )
+
+  return (
+    <div className="space-y-6">
+      <Card
+        title="Action queue"
+        actions={<span className="text-xs text-tertiary">{openCount} open</span>}
+      >
+        <div aria-live="polite">{mutErr && <ErrorState message={mutErr} />}</div>
+        {sortedActions.length === 0 ? (
+          <div className="flex items-center gap-2 text-sm text-tertiary">
+            <CheckCircle className="size-4 text-success-primary" aria-hidden />
+            No vulnerability actions for this engagement.
+          </div>
+        ) : (
+          <ul>
+            {sortedActions.map((a) => (
+              <ActionRow
+                key={a.id}
+                action={a}
+                busy={pending.has(a.id)}
+                onAck={() => move(a, 'ack')}
+                onResolve={() => move(a, 'resolve')}
+              />
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      <Card
+        title="Reconciled occurrences"
+        actions={<span className="inline-flex items-center gap-1.5 text-xs text-tertiary"><Package className="size-3.5" aria-hidden />{occurrences.length}</span>}
+      >
+        {occurrences.length === 0 ? (
+          <p className="text-sm text-tertiary">No reconciled occurrences matched to this engagement.</p>
+        ) : (
+          <ul>
+            {occurrences.map((o) => (
+              <OccurrenceRow key={o.id} o={o} />
+            ))}
+          </ul>
+        )}
+      </Card>
+    </div>
+  )
+}

--- a/web/src/pages/EngagementDetail/index.tsx
+++ b/web/src/pages/EngagementDetail/index.tsx
@@ -35,6 +35,10 @@ import { packageLocationMap, countVulnerabilityFindings, VulnsTab } from './Vuln
 import { LicensesTab } from './LicensesTab'
 import { ComponentsTab } from './ComponentsTab'
 import { ReconTab } from './ReconTab'
+import { ScanRunsTab } from './ScanRunsTab'
+import { PurpleCoverageTab } from './PurpleCoverageTab'
+import { RiskStoriesTab } from './RiskStoriesTab'
+import { VulnPostureTab } from './VulnPostureTab'
 import { DetectionsTab } from './DetectionsTab'
 import { ImportedFindingsTab } from './ImportedFindingsTab'
 import { DataGovernanceTab } from './DataGovernanceTab'
@@ -51,13 +55,17 @@ export type Tab =
   | 'findings'
   | 'imported'
   | 'sla'
+  | 'risk-stories'
+  | 'vuln-posture'
   | 'components'
   | 'vulns'
   | 'licenses'
   | 'graph'
+  | 'scanruns'
   | 'quality'
   | 'threats'
   | 'recon'
+  | 'purple'
   | 'agent'
   | 'detections'
   | 'reviews'
@@ -91,6 +99,8 @@ export const TAB_GROUPS: TabGroupDefinition[] = [
     sub: [
       { id: 'findings', label: 'All Findings', countKey: 'findings' },
       { id: 'imported', label: 'Imported' },
+      { id: 'risk-stories', label: 'Risk Stories' },
+      { id: 'vuln-posture', label: 'Vuln Posture' },
       { id: 'sla', label: 'Remediation SLA' },
     ],
   },
@@ -103,6 +113,7 @@ export const TAB_GROUPS: TabGroupDefinition[] = [
       { id: 'vulns', label: 'Vulnerabilities', countKey: 'vulns' },
       { id: 'licenses', label: 'Licenses', countKey: 'licenses' },
       { id: 'graph', label: 'Dependency Graph' },
+      { id: 'scanruns', label: 'Scan Runs' },
     ],
   },
   {
@@ -112,6 +123,7 @@ export const TAB_GROUPS: TabGroupDefinition[] = [
     sub: [
       { id: 'recon', label: 'Recon' },
       { id: 'threats', label: 'Threat Model' },
+      { id: 'purple', label: 'Purple Coverage' },
       { id: 'agent', label: 'Agent' },
     ],
   },
@@ -495,6 +507,8 @@ export function EngagementDetail() {
           />
         )}
         {tab === 'sla' && <SLATab key={id} engagementId={id} findings={findings} />}
+        {tab === 'risk-stories' && <RiskStoriesTab key={id} engagementId={id} />}
+        {tab === 'vuln-posture' && <VulnPostureTab key={id} engagementId={id} />}
         {tab === 'components' && <ComponentsTab scan={scan} />}
         {tab === 'vulns' && <VulnsTab scan={scan} />}
         {tab === 'graph' && (
@@ -503,9 +517,11 @@ export function EngagementDetail() {
           </Suspense>
         )}
         {tab === 'licenses' && <LicensesTab scan={scan} />}
+        {tab === 'scanruns' && <ScanRunsTab key={id} engagementId={id} />}
         {tab === 'threats' && <ThreatModelTab engagementId={id} />}
         {tab === 'quality' && <CodeQualityTab engagementId={id} />}
         {tab === 'recon' && <ReconTab eng={eng} onGoTab={setTab} />}
+        {tab === 'purple' && <PurpleCoverageTab key={id} engagementId={id} />}
         {tab === 'agent' && <AgentTab engagementId={id} />}
         {tab === 'detections' && <DetectionsTab key={id} engagementId={id} />}
         {tab === 'imported' && <ImportedFindingsTab key={id} engagementId={id} />}

--- a/web/src/pages/VulnerabilityIntelligence/ReconcileRunPanel.test.tsx
+++ b/web/src/pages/VulnerabilityIntelligence/ReconcileRunPanel.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import { ReconcileRunPanel } from './ReconcileRunPanel'
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    reconcileRun: vi.fn(),
+    reconcileDiffs: vi.fn(),
+  },
+}))
+
+const RUN = {
+  id: 'rec-001',
+  scope: 'tenant',
+  advisoryId: '',
+  dryRun: false,
+  state: 'succeeded' as const,
+  counts: { processed: 1284, added: 12, updated: 37, unchanged: 1201, unmatchable: 28, retired: 6 },
+  errorSamples: [],
+  snapshotAt: '2026-02-20T00:00:00Z',
+  startedAt: '2026-02-20T00:00:00Z',
+  finishedAt: '2026-02-20T00:05:00Z',
+  createdAt: '2026-02-20T00:00:00Z',
+  updatedAt: '2026-02-20T00:05:00Z',
+}
+
+const DIFFS = [
+  { runId: 'rec-001', engagementId: 'eng-001', advisoryId: 'CVE-2021-23337', componentFingerprint: 'pkg:npm/lodash@4.17.20', class: 'missing_occurrence' as const, createdAt: '2026-02-20T00:05:00Z' },
+]
+
+describe('ReconcileRunPanel', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('shows run state, counts, diffs, and filters by class', async () => {
+    vi.mocked(api.reconcileRun).mockResolvedValue(RUN)
+    vi.mocked(api.reconcileDiffs).mockResolvedValue({ items: DIFFS, next: null })
+
+    render(<ReconcileRunPanel runId="rec-001" onClose={() => {}} />)
+
+    expect(await screen.findByText('succeeded')).toBeInTheDocument()
+    expect(screen.getByText('1284')).toBeInTheDocument() // processed count
+    expect(await screen.findByText('CVE-2021-23337')).toBeInTheDocument()
+
+    // Filtering re-queries with the class.
+    await userEvent.click(screen.getByRole('button', { name: 'Changed' }))
+    await waitFor(() =>
+      expect(api.reconcileDiffs).toHaveBeenCalledWith('rec-001', expect.objectContaining({ class: 'changed_occurrence' })),
+    )
+  })
+})

--- a/web/src/pages/VulnerabilityIntelligence/ReconcileRunPanel.tsx
+++ b/web/src/pages/VulnerabilityIntelligence/ReconcileRunPanel.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useState } from 'react'
+import { XClose } from '@untitledui/icons'
+import { Button, Card, ErrorState, Pill, Spinner, cn } from '../../components/ui'
+import { useFetch, usePolling } from '../../hooks'
+import { api } from '../../lib/api'
+import type { ReconcileDiff, ReconcileDiffClass, ReconcileDiffCursor, ReconcileRun } from '../../lib/api'
+import { formatTime } from './shared'
+
+const DIFF_CLASSES: { id: '' | ReconcileDiffClass; label: string }[] = [
+  { id: '', label: 'All' },
+  { id: 'missing_occurrence', label: 'Missing' },
+  { id: 'changed_occurrence', label: 'Changed' },
+  { id: 'stale_occurrence', label: 'Stale' },
+  { id: 'in_sync', label: 'In sync' },
+]
+
+function stateTone(state: ReconcileRun['state']): string {
+  switch (state) {
+    case 'succeeded':
+      return 'text-success-primary bg-success-primary/10 border-success-primary/25'
+    case 'failed':
+      return 'text-error-primary bg-error-primary/10 border-error-primary/25'
+    case 'running':
+      return 'text-warning-primary bg-warning-primary/10 border-warning-primary/25'
+    default:
+      return 'text-tertiary bg-secondary border-secondary'
+  }
+}
+
+function diffClassTone(c: ReconcileDiffClass): string {
+  switch (c) {
+    case 'missing_occurrence':
+      return 'text-error-primary'
+    case 'changed_occurrence':
+      return 'text-warning-primary'
+    case 'stale_occurrence':
+      return 'text-tertiary'
+    default:
+      return 'text-success-primary'
+  }
+}
+
+function CountCell({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-secondary bg-secondary/20 px-3 py-2">
+      <div className="font-mono text-lg font-bold tabular-nums text-primary">{value}</div>
+      <div className="text-xs text-tertiary">{label}</div>
+    </div>
+  )
+}
+
+export function ReconcileRunPanel({ runId, onClose }: { runId: string; onClose: () => void }) {
+  const { data: initial, loading, error } = useFetch((s) => api.reconcileRun(runId, s), { deps: [runId] })
+  const [run, setRun] = useState<ReconcileRun | null>(null)
+  useEffect(() => {
+    if (initial) setRun(initial)
+  }, [initial])
+
+  const terminal = run?.state === 'succeeded' || run?.state === 'failed'
+  const { data: polled } = usePolling(() => api.reconcileRun(runId), {
+    interval: 2500,
+    enabled: !!run && !terminal,
+    deps: [runId, run?.state],
+  })
+  useEffect(() => {
+    if (polled) setRun(polled)
+  }, [polled])
+
+  const [diffClass, setDiffClass] = useState<'' | ReconcileDiffClass>('')
+  const [diffs, setDiffs] = useState<ReconcileDiff[]>([])
+  const [cursor, setCursor] = useState<ReconcileDiffCursor | null>(null)
+  const [diffsLoading, setDiffsLoading] = useState(false)
+  const [diffsErr, setDiffsErr] = useState('')
+
+  // Load the first page whenever the run id, the class filter, or terminal state changes.
+  useEffect(() => {
+    let alive = true
+    // Clear the previous page so stale rows and a stale cursor never show during a reload.
+    setDiffs([])
+    setCursor(null)
+    setDiffsLoading(true)
+    setDiffsErr('')
+    api
+      .reconcileDiffs(runId, { class: diffClass || undefined, limit: 50 })
+      .then((page) => {
+        if (!alive) return
+        setDiffs(page.items)
+        setCursor(page.next)
+      })
+      .catch((e) => {
+        if (alive) setDiffsErr(e instanceof Error ? e.message : 'failed to load diffs')
+      })
+      .finally(() => {
+        if (alive) setDiffsLoading(false)
+      })
+    return () => {
+      alive = false
+    }
+  }, [runId, diffClass, terminal])
+
+  async function loadMore() {
+    if (!cursor) return
+    setDiffsLoading(true)
+    setDiffsErr('')
+    try {
+      const page = await api.reconcileDiffs(runId, { class: diffClass || undefined, limit: 50, cursor })
+      setDiffs((prev) => [...prev, ...page.items])
+      setCursor(page.next)
+    } catch (e) {
+      setDiffsErr(e instanceof Error ? e.message : 'failed to load diffs')
+    } finally {
+      setDiffsLoading(false)
+    }
+  }
+
+  return (
+    <Card
+      title={
+        <span className="inline-flex items-center gap-2">
+          Reconciliation run
+          <span className="font-mono text-xs font-normal text-tertiary">{runId}</span>
+          {run && (
+            <span className={cn('inline-flex items-center rounded border px-1.5 py-0.5 text-xs font-bold', stateTone(run.state))}>
+              {run.state}
+            </span>
+          )}
+        </span>
+      }
+      actions={
+        <Button variant="ghost" onClick={onClose} className="px-2 py-1" aria-label="Close reconciliation run">
+          <XClose className="size-4" />
+        </Button>
+      }
+    >
+      {loading && !run ? (
+        <Spinner label="Loading run…" />
+      ) : error ? (
+        <ErrorState message={error} />
+      ) : run ? (
+        <div className="space-y-5">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-6">
+            <CountCell label="processed" value={run.counts.processed} />
+            <CountCell label="added" value={run.counts.added} />
+            <CountCell label="updated" value={run.counts.updated} />
+            <CountCell label="unchanged" value={run.counts.unchanged} />
+            <CountCell label="unmatchable" value={run.counts.unmatchable} />
+            <CountCell label="retired" value={run.counts.retired} />
+          </div>
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-tertiary">
+            <span>scope {run.scope}</span>
+            {run.startedAt && <span>started {formatTime(run.startedAt)}</span>}
+            {run.finishedAt && <span>finished {formatTime(run.finishedAt)}</span>}
+            {!terminal && <span className="text-warning-primary">live, polling…</span>}
+          </div>
+          {run.errorSamples.length > 0 && (
+            <div className="rounded-lg border border-error-primary/25 bg-error-primary/5 p-3">
+              <div className="text-xs font-semibold text-error-primary">Error samples</div>
+              <ul className="mt-1 space-y-0.5">
+                {run.errorSamples.slice(0, 5).map((e, i) => (
+                  <li key={i} className="font-mono text-xs text-secondary">
+                    {e}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          <div>
+            <div className="mb-2 flex flex-wrap items-center gap-1.5" role="group" aria-label="Filter diffs by class">
+              {DIFF_CLASSES.map((c) => (
+                <button
+                  key={c.id || 'all'}
+                  type="button"
+                  onClick={() => setDiffClass(c.id)}
+                  disabled={diffsLoading}
+                  aria-pressed={diffClass === c.id}
+                  className={cn(
+                    'rounded-md border px-2 py-1 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-60',
+                    diffClass === c.id
+                      ? 'border-brand-solid bg-brand-primary/5 text-brand-secondary'
+                      : 'border-secondary text-tertiary hover:bg-secondary/40',
+                  )}
+                >
+                  {c.label}
+                </button>
+              ))}
+            </div>
+            {diffsErr && <ErrorState message={diffsErr} />}
+            {diffs.length === 0 && !diffsLoading ? (
+              <p className="text-sm text-tertiary">No diffs in this run for the selected class.</p>
+            ) : (
+              <ul className="divide-y divide-secondary/60 rounded-lg border border-secondary">
+                {diffs.map((d, i) => (
+                  <li key={`${d.advisoryId}:${d.componentFingerprint}:${i}`} className="flex flex-wrap items-center gap-x-3 gap-y-1 px-3 py-2">
+                    <Pill className={cn('font-mono', diffClassTone(d.class))}>{d.class.replace('_occurrence', '')}</Pill>
+                    <span className="font-mono text-xs font-semibold text-primary">{d.advisoryId || '—'}</span>
+                    {d.componentFingerprint && <span className="truncate font-mono text-xs text-tertiary" title={d.componentFingerprint}>{d.componentFingerprint}</span>}
+                  </li>
+                ))}
+              </ul>
+            )}
+            <div className="mt-3 flex items-center gap-3">
+              {cursor && (
+                <Button variant="secondary" onClick={loadMore} loading={diffsLoading} className="px-3 py-1.5">
+                  Load more
+                </Button>
+              )}
+              {diffsLoading && !cursor && <Spinner label="Loading diffs…" />}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </Card>
+  )
+}

--- a/web/src/pages/VulnerabilityIntelligence/VulnIntelOverview.tsx
+++ b/web/src/pages/VulnerabilityIntelligence/VulnIntelOverview.tsx
@@ -13,12 +13,14 @@ import { useFetch, usePolling } from '../../hooks'
 import { api } from '../../lib/api'
 import type { VulnerabilitySyncMode } from '../../lib/types'
 import { formatTime, Metric, message, Notice, type OperatorProps } from './shared'
+import { ReconcileRunPanel } from './ReconcileRunPanel'
 
 export function OverviewTab({ canOperate, idempotencyKey, finishAction }: OperatorProps) {
   const [notice, setNotice] = useState('')
   const [busy, setBusy] = useState('')
   const [actionError, setActionError] = useState('')
   const [refresh, setRefresh] = useState(0)
+  const [reconcileRunId, setReconcileRunId] = useState<string | null>(null)
 
   const { data, error: fetchError } = useFetch(
     (signal) => api.vulnerabilityOverview(signal),
@@ -59,6 +61,7 @@ export function OverviewTab({ canOperate, idempotencyKey, finishAction }: Operat
       const accepted = await api.startVulnerabilityReconciliation('full', idempotencyKey(action))
       finishAction(action)
       setNotice(`${accepted.created ? 'Tenant reconciliation queued' : 'Existing tenant reconciliation reused'}: ${accepted.runId}.`)
+      setReconcileRunId(accepted.runId)
       setRefresh((value) => value + 1)
     } catch (value) {
       setActionError(message(value, 'Failed to queue vulnerability reconciliation'))
@@ -84,6 +87,7 @@ export function OverviewTab({ canOperate, idempotencyKey, finishAction }: Operat
       )}
       {error && <ErrorState message={error} />}
       {notice && <Notice>{notice}</Notice>}
+      {reconcileRunId && <ReconcileRunPanel runId={reconcileRunId} onClose={() => setReconcileRunId(null)} />}
       {!data ? (
         <Spinner label="Loading vulnerability overview…" />
       ) : (


### PR DESCRIPTION
## What

Wires five backend capabilities that were live (routes registered, services non-nil, returning data) but had no dashboard surface, plus dark-theme token fixes and two doc corrections.

### Features (`feat(web)`)

Each surface is reachable end to end: api adapter, component, test, and MSW mock.

- **Scan Runs** (Supply Chain tab): scan-run history with reproducibility score, and run-to-run drift over `GET /engagements/{id}/scan-runs` and `/scan-runs/compare`.
- **Purple Coverage** (Offensive tab): the latest emulation run's detection coverage, its covered / gap / not-run / out-of-reach breakdown, the per-run trend, and the gap work items.
- **Risk Stories** (Findings tab): one correlated risk story per asset, ranked by the most urgent finding priority, with each finding's corroboration (reachable, on an attack path, seen under attack).
- **Reconciliation results** (Vulnerability Intelligence): after starting a full reconciliation, a panel polls the run to completion and shows its counts and class-filtered diffs with cursor paging.
- **Vuln Posture** (Findings tab): the per-engagement action queue with in-place acknowledge/resolve, and the reconciled occurrences.

### Fixes (`fix(web)`)

- Code Quality measures headers used emoji; they now use `@untitledui/icons`.
- The project-activity trend chart, the code-viewer syntax highlighter, the modern badge addon, and the dependency-graph minimap now draw semantic theme tokens that flip with the theme, so they render correctly in dark mode.

### Docs (`docs`)

- `SYNAPSE_JUDGMENTS_ENABLED` defaults to `true`; two comments said "off by default". Corrected to match `config.go`.
- Added a Kubernetes (Helm) section to the installation guide (the three `execution.mode` shapes, `make kind-smoke`, and the `NOSUPERUSER NOBYPASSRLS` runtime-role requirement).

## Verification

- `CGO_ENABLED=0 go build ./...` passes; `go test ./...` passes except the bubblewrap live sandbox tests, which fail only in a nested container that forbids `bwrap` mount namespaces (unchanged from `main`).
- `web`: `tsc --noEmit` clean; `pnpm test` 517 passing; `pnpm build` clean.
- `go test ./docs/` drift guards pass; Helm chart render test passes across all execution modes.
- The five new surfaces were reviewed adversarially; findings on stale-response races, per-action pending state, and risk-story score semantics were applied.

## Notes

- No backend routes were added; this surfaces existing ones. Remaining wired-but-unshown routes (target credentials, detection provenance, offensive policy read, fleet privacy/coverage/processes/retro-hunt, user management actions, per-occurrence risk timeline) are follow-ups.
- SCA remote-acquisition egress, the DAST/CSPM run paths, and the response host executor remain deliberately fail-closed or simulation-only, as documented.
