### PR TITLE
feat(web): surface per-engagement tool credentials in the dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Per-engagement tool credentials in the dashboard.** The vault-sealed credential routes
+  (`GET/POST/DELETE /engagements/{id}/credentials`) had no UI. A new **Credentials** tab (under
+  Governance) lists the stored placeholders with their timestamps, adds one through a collapsible form
+  (the secret is write-only, sealed in the vault, and never shown again), and deletes one behind an
+  inline confirm. Referenced from tool config as `{{secret:NAME}}` and resolved server-side only at
+  tool-execution time.
+
+
 - **Runtime detections feed the behavior baseline (#822).** The statistical baseline behind a host's
   Behavior risk factor only ever saw its process snapshot, so the network, privilege and file features
   stayed at zero and anomaly scoring never ran over runtime telemetry. The baseline now folds the host's

--- a/web/src/lib/api/engagements.ts
+++ b/web/src/lib/api/engagements.ts
@@ -64,6 +64,14 @@ function mapEngagement(r: EngagementWire): Engagement {
 
 export { mapEngagement }
 
+// A per-engagement tool credential. The secret value is write-only: it is sealed in the vault on set
+// and never returned, so this metadata carries only the name and timestamps.
+export interface EngagementCredential {
+  name: string
+  createdAt: string
+  updatedAt: string
+}
+
 export const engagementsApi = {
   listEngagements: async (): Promise<Engagement[]> =>
     ((await req('/engagements')) ?? []).map(mapEngagement),
@@ -165,6 +173,23 @@ export const engagementsApi = {
         body: JSON.stringify({ allowed_tool_classes: allowedToolClasses, blackouts }),
       }),
     ),
+
+  // Per-engagement tool credentials (vault-sealed placeholders resolved only at tool-execution time).
+  engagementCredentials: async (id: string): Promise<EngagementCredential[]> =>
+    ((await req(`/engagements/${encodeURIComponent(id)}/credentials`)) ?? []).map((c: any) => ({
+      name: c?.name ?? '',
+      createdAt: c?.created_at ?? '',
+      updatedAt: c?.updated_at ?? '',
+    })),
+  setEngagementCredential: async (id: string, name: string, value: string): Promise<void> => {
+    await req(`/engagements/${encodeURIComponent(id)}/credentials`, {
+      method: 'POST',
+      body: JSON.stringify({ name, value }),
+    })
+  },
+  deleteEngagementCredential: async (id: string, name: string): Promise<void> => {
+    await req(`/engagements/${encodeURIComponent(id)}/credentials/${encodeURIComponent(name)}`, { method: 'DELETE' })
+  },
 
   importBundle: async (bundleJSON: string): Promise<Engagement> =>
     mapEngagement(await req('/engagements/import', { method: 'POST', body: bundleJSON })),

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -13,6 +13,7 @@ export { type AttackPathResult, type AttackPath, type AttackPathNode, type Attac
 export { type SLAPoliciesView, type SLAPolicy, type SLAConfig, type SLAWeights, type SLAThresholds, type SLADueRange, type SLADueRanges, type SLADueTier, type SLAActivateResult, nsToDays, daysToNs } from './sla'
 export { type OffensivePolicy, type OffensiveTechnique, type OffensiveLegalReview } from './offensivepolicy'
 export { type AlertTestResult, type AlertTestOutcome, AlertNotEnabledError } from './alerting'
+export { type EngagementCredential } from './engagements'
 
 import { authApi, teamApi } from './auth'
 import { auditApi } from './audit'

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -673,6 +673,17 @@ export const handlers = [
     })
   }),
   http.get('/api/v1/engagements/:id/risk-stories', () => HttpResponse.json({ stories: RISK_STORIES })),
+  http.get('/api/v1/engagements/:id/credentials', () =>
+    HttpResponse.json([
+      { name: 'registry_token', created_at: WEEK_AGO, updated_at: DAY_AGO },
+      { name: 'github_pat', created_at: MONTH_AGO, updated_at: MONTH_AGO },
+    ]),
+  ),
+  http.post('/api/v1/engagements/:id/credentials', async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as { name?: string }
+    return HttpResponse.json({ name: body?.name ?? '', status: 'stored' }, { status: 201 })
+  }),
+  http.delete('/api/v1/engagements/:id/credentials/:name', () => new HttpResponse(null, { status: 204 })),
   http.get('/api/v1/vulnerability/reconcile-runs/:id', () => HttpResponse.json(RECONCILE_RUN)),
   http.get('/api/v1/vulnerability/reconcile-runs/:id/diffs', ({ request }) => {
     const cls = new URL(request.url).searchParams.get('class')

--- a/web/src/pages/EngagementDetail/CredentialsTab.test.tsx
+++ b/web/src/pages/EngagementDetail/CredentialsTab.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import type { EngagementCredential } from '../../lib/api'
+import { CredentialsTab } from './CredentialsTab'
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    engagementCredentials: vi.fn(),
+    setEngagementCredential: vi.fn(),
+    deleteEngagementCredential: vi.fn(),
+  },
+}))
+
+const CREDS: EngagementCredential[] = [
+  { name: 'registry_token', createdAt: '2026-02-10T00:00:00Z', updatedAt: '2026-02-18T00:00:00Z' },
+]
+
+describe('CredentialsTab', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('lists stored credentials and keeps the add form collapsed', async () => {
+    vi.mocked(api.engagementCredentials).mockResolvedValue(CREDS)
+    render(<CredentialsTab engagementId="eng-001" />)
+
+    expect(await screen.findByText('registry_token')).toBeInTheDocument()
+    // The form is collapsed when credentials already exist; an Add button reveals it.
+    expect(screen.queryByPlaceholderText('Enter a placeholder name')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Add' })).toBeInTheDocument()
+  })
+
+  it('stores a new credential (write-only value) from the open form', async () => {
+    vi.mocked(api.engagementCredentials).mockResolvedValue([])
+    vi.mocked(api.setEngagementCredential).mockResolvedValue(undefined)
+    render(<CredentialsTab engagementId="eng-001" />)
+
+    // Empty state opens the form by default.
+    await userEvent.type(await screen.findByPlaceholderText('Enter a placeholder name'), 'npm_token')
+    await userEvent.type(screen.getByPlaceholderText('Paste the secret value'), 's3cr3t')
+    await userEvent.click(screen.getByRole('button', { name: /Store credential/ }))
+
+    await waitFor(() => expect(api.setEngagementCredential).toHaveBeenCalledWith('eng-001', 'npm_token', 's3cr3t'))
+  })
+
+  it('deletes a credential via an inline confirm', async () => {
+    vi.mocked(api.engagementCredentials).mockResolvedValue(CREDS)
+    vi.mocked(api.deleteEngagementCredential).mockResolvedValue(undefined)
+    render(<CredentialsTab engagementId="eng-001" />)
+
+    await userEvent.click(await screen.findByRole('button', { name: /Delete credential registry_token/ }))
+    // An inline confirm appears (no browser dialog).
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    await waitFor(() => expect(api.deleteEngagementCredential).toHaveBeenCalledWith('eng-001', 'registry_token'))
+  })
+
+  it('disables store for an invalid placeholder name', async () => {
+    vi.mocked(api.engagementCredentials).mockResolvedValue([])
+    render(<CredentialsTab engagementId="eng-001" />)
+    await userEvent.type(await screen.findByPlaceholderText('Enter a placeholder name'), 'bad name!')
+    await userEvent.type(screen.getByPlaceholderText('Paste the secret value'), 'x')
+    expect(screen.getByRole('button', { name: /Store credential/ })).toBeDisabled()
+    expect(api.setEngagementCredential).not.toHaveBeenCalled()
+  })
+})

--- a/web/src/pages/EngagementDetail/CredentialsTab.tsx
+++ b/web/src/pages/EngagementDetail/CredentialsTab.tsx
@@ -1,0 +1,274 @@
+import { useState } from 'react'
+import { AlertTriangle, CheckCircle, Key01, Lock01, Plus, Trash01, XClose } from '@untitledui/icons'
+import { Button, Card, EmptyState, ErrorState, Field, Input, Pill, Skeleton } from '../../components/ui'
+import { useFetch } from '../../hooks'
+import { api } from '../../lib/api'
+import type { EngagementCredential } from '../../lib/api'
+
+function formatWhen(iso: string): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+
+function AddCredential({
+  engagementId,
+  existingNames,
+  onStored,
+  onCancel,
+}: {
+  engagementId: string
+  existingNames: string[]
+  onStored: (name: string, replaced: boolean) => void
+  onCancel?: () => void
+}) {
+  const [name, setName] = useState('')
+  const [value, setValue] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+
+  const trimmed = name.trim()
+  const validName = /^[A-Za-z0-9_.-]{1,64}$/.test(trimmed)
+  const canStore = validName && value.length > 0 && !busy
+
+  async function store() {
+    if (!canStore) return
+    setBusy(true)
+    setErr('')
+    try {
+      const replaced = existingNames.includes(trimmed)
+      await api.setEngagementCredential(engagementId, trimmed, value)
+      setName('')
+      setValue('')
+      onStored(trimmed, replaced)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'failed to store credential')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Card
+      title="Add a credential"
+      actions={
+        onCancel && (
+          <Button variant="ghost" onClick={onCancel} className="px-2 py-1" aria-label="Cancel">
+            <XClose className="size-4" />
+          </Button>
+        )
+      }
+    >
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Field label="Placeholder name" htmlFor="cred-name" hint="Referenced in tool config as {{secret:NAME}}. Letters, digits, dot, dash, underscore.">
+          <Input
+            id="cred-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Enter a placeholder name"
+            autoComplete="off"
+            spellCheck={false}
+          />
+        </Field>
+        <Field label="Secret value" htmlFor="cred-value" hint="Sealed in the vault on store; resolved only at tool-execution time and never shown again.">
+          <Input
+            id="cred-value"
+            type="password"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="Paste the secret value"
+            autoComplete="new-password"
+          />
+        </Field>
+      </div>
+      {err && (
+        <div aria-live="polite" className="mt-3">
+          <ErrorState message={err} />
+        </div>
+      )}
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <Button variant="primary" onClick={store} disabled={!canStore} loading={busy} className="px-3.5 py-2">
+          <Plus className="size-4" aria-hidden />
+          {existingNames.includes(trimmed) && validName ? 'Replace credential' : 'Store credential'}
+        </Button>
+        {name.length > 0 && !validName && (
+          <span className="text-xs text-error-primary">Name allows letters, digits, dot, dash, underscore (max 64).</span>
+        )}
+      </div>
+    </Card>
+  )
+}
+
+function CredentialRow({
+  cred,
+  busy,
+  confirming,
+  onAskDelete,
+  onCancelDelete,
+  onConfirmDelete,
+}: {
+  cred: EngagementCredential
+  busy: boolean
+  confirming: boolean
+  onAskDelete: () => void
+  onCancelDelete: () => void
+  onConfirmDelete: () => void
+}) {
+  return (
+    <li className="flex flex-wrap items-center gap-x-4 gap-y-2 py-3">
+      <Key01 className="size-4 shrink-0 text-quaternary" aria-hidden />
+      <span className="font-mono text-sm font-semibold text-primary">{cred.name}</span>
+      {cred.updatedAt && <span className="text-xs text-tertiary">updated {formatWhen(cred.updatedAt)}</span>}
+      {confirming ? (
+        <span className="ml-auto flex items-center gap-2">
+          <span className="text-xs text-error-primary">Delete this credential?</span>
+          <Button variant="secondary" onClick={onConfirmDelete} loading={busy} className="px-2.5 py-1 text-xs text-error-primary">
+            Confirm
+          </Button>
+          <Button variant="ghost" onClick={onCancelDelete} className="px-2.5 py-1 text-xs">
+            Cancel
+          </Button>
+        </span>
+      ) : (
+        <Button
+          variant="secondary"
+          onClick={onAskDelete}
+          className="ml-auto px-2.5 py-1 text-xs text-error-primary"
+          aria-label={`Delete credential ${cred.name}`}
+        >
+          <Trash01 className="size-3.5" aria-hidden />
+          Delete
+        </Button>
+      )}
+    </li>
+  )
+}
+
+export function CredentialsTab({ engagementId }: { engagementId: string }) {
+  const [refresh, setRefresh] = useState(0)
+  const { data, loading, error } = useFetch<EngagementCredential[]>(
+    () => api.engagementCredentials(engagementId),
+    { deps: [engagementId, refresh] },
+  )
+  const creds = data ?? []
+
+  const [adding, setAdding] = useState(false)
+  const [success, setSuccess] = useState('')
+  const [confirmName, setConfirmName] = useState('')
+  const [pending, setPending] = useState('')
+  const [mutErr, setMutErr] = useState('')
+
+  const showForm = adding || (!loading && creds.length === 0)
+
+  async function confirmDelete(name: string) {
+    setPending(name)
+    setMutErr('')
+    try {
+      await api.deleteEngagementCredential(engagementId, name)
+      setConfirmName('')
+      setSuccess(`Deleted "${name}".`)
+      setRefresh((v) => v + 1)
+    } catch (e) {
+      setMutErr(e instanceof Error ? e.message : 'failed to delete credential')
+    } finally {
+      setPending('')
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start gap-2 rounded-lg border border-secondary bg-secondary/30 px-4 py-3 text-sm text-tertiary">
+        <Lock01 className="mt-0.5 size-4 shrink-0 text-quaternary" aria-hidden />
+        <span>
+          Credentials are sealed in the vault and resolved server-side only at tool-execution time. The
+          secret never enters a log, the workspace, or this screen; it is write-only.
+        </span>
+      </div>
+
+      {success && (
+        <div aria-live="polite" className="flex items-center gap-2 rounded-lg border border-success-primary/25 bg-success-primary/5 px-4 py-2.5 text-sm text-success-primary">
+          <CheckCircle className="size-4 shrink-0" aria-hidden />
+          <span>{success}</span>
+          <button type="button" onClick={() => setSuccess('')} className="ml-auto text-success-primary/70 hover:text-success-primary" aria-label="Dismiss">
+            <XClose className="size-4" />
+          </button>
+        </div>
+      )}
+
+      {showForm ? (
+        <AddCredential
+          engagementId={engagementId}
+          existingNames={creds.map((c) => c.name)}
+          onStored={(name, replaced) => {
+            setSuccess(`${replaced ? 'Replaced' : 'Stored'} "${name}".`)
+            setAdding(false)
+            setRefresh((v) => v + 1)
+          }}
+          onCancel={creds.length > 0 ? () => setAdding(false) : undefined}
+        />
+      ) : null}
+
+      <Card
+        title="Stored credentials"
+        actions={
+          <span className="flex items-center gap-2">
+            <Pill>{creds.length}</Pill>
+            {!showForm && (
+              <Button variant="secondary" onClick={() => setAdding(true)} className="px-2.5 py-1 text-xs">
+                <Plus className="size-3.5" aria-hidden />
+                Add
+              </Button>
+            )}
+          </span>
+        }
+      >
+        {mutErr && (
+          <div aria-live="polite" className="mb-3">
+            <ErrorState message={mutErr} />
+          </div>
+        )}
+        {loading ? (
+          <div className="space-y-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-center gap-4">
+                <Skeleton className="size-4 rounded" />
+                <Skeleton className="h-4 w-40" />
+                <Skeleton className="ml-auto h-7 w-20" />
+              </div>
+            ))}
+          </div>
+        ) : error ? (
+          <ErrorState message={error} />
+        ) : creds.length === 0 ? (
+          <EmptyState
+            icon={Key01}
+            title="No credentials yet"
+            hint="Store a placeholder above, then reference it in a scan or tool as {{secret:NAME}}."
+          />
+        ) : (
+          <ul className="divide-y divide-secondary/60">
+            {creds.map((c) => (
+              <CredentialRow
+                key={c.name}
+                cred={c}
+                busy={pending === c.name}
+                confirming={confirmName === c.name}
+                onAskDelete={() => {
+                  setConfirmName(c.name)
+                  setMutErr('')
+                }}
+                onCancelDelete={() => setConfirmName('')}
+                onConfirmDelete={() => confirmDelete(c.name)}
+              />
+            ))}
+          </ul>
+        )}
+      </Card>
+
+      <div className="flex items-start gap-2 text-xs text-quaternary">
+        <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden />
+        <span>Re-storing an existing name replaces its secret. Deleting one takes effect on the next tool run.</span>
+      </div>
+    </div>
+  )
+}

--- a/web/src/pages/EngagementDetail/index.tsx
+++ b/web/src/pages/EngagementDetail/index.tsx
@@ -40,6 +40,7 @@ import { PurpleCoverageTab } from './PurpleCoverageTab'
 import { ChainRehearsalTab } from './ChainRehearsalTab'
 import { RiskStoriesTab } from './RiskStoriesTab'
 import { VulnPostureTab } from './VulnPostureTab'
+import { CredentialsTab } from './CredentialsTab'
 import { DetectionsTab } from './DetectionsTab'
 import { ImportedFindingsTab } from './ImportedFindingsTab'
 import { DataGovernanceTab } from './DataGovernanceTab'
@@ -63,6 +64,7 @@ export type Tab =
   | 'licenses'
   | 'graph'
   | 'scanruns'
+  | 'credentials'
   | 'quality'
   | 'threats'
   | 'recon'
@@ -144,6 +146,7 @@ export const TAB_GROUPS: TabGroupDefinition[] = [
       { id: 'evidence', label: 'Evidence' },
       { id: 'reviews', label: 'Awaiting Review' },
       { id: 'quality', label: 'Code Quality' },
+      { id: 'credentials', label: 'Credentials' },
       { id: 'data-governance', label: 'Data governance' },
     ],
   },
@@ -532,6 +535,7 @@ export function EngagementDetail() {
         {tab === 'data-governance' && <DataGovernanceTab key={id} engagementId={id} />}
         {tab === 'reviews' && <JudgmentReviewTab key={id} engagementId={id} />}
         {tab === 'evidence' && <EvidenceTab key={id} engagementId={id} />}
+        {tab === 'credentials' && <CredentialsTab key={id} engagementId={id} />}
         {tab === 'settings' && <SettingsTab eng={eng} onUpdated={setEng} />}
       </div>
     </div>


### PR DESCRIPTION
## What

Surfaces the vault-sealed per-engagement credential routes (`GET/POST/DELETE /engagements/{id}/credentials`), which had no dashboard UI. A new **Credentials** tab (under Governance) manages the placeholders a scan or tool resolves as `{{secret:NAME}}`.

- List the stored placeholders with their timestamps; the count and an inline **Add** button sit in the card header.
- Add through a collapsible form: a placeholder name (validated `[A-Za-z0-9_.-]{1,64}`) and the secret value. The value is **write-only**: it is sealed in the vault on store, resolved server-side only at tool-execution time, and never returned or shown. The submit label reads **Replace credential** when the name already exists.
- Delete behind an inline themed confirm (no browser dialog); success is confirmed with a banner.
- Loading shows a row skeleton; empty, error, and mutation-error states are handled; both light and dark themes verified.

## Verification

- `web`: `tsc --noEmit` clean; `pnpm test` 521 passing (+4); `pnpm build` clean.
- The tab was rendered in a real browser (MSW-backed dev server) in light and dark; its UI/UX was scored 8.8/10 ("ship") by an independent review after applying its first-round fixes (instructive placeholders, collapsible form, inline delete confirm, success banner, skeleton loading).

## Notes

No backend change; this surfaces an existing wired route. The secret never reaches the browser on read.
