### PR TITLE
feat(web): surface tenant telemetry-privacy governance in the dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Tenant telemetry-privacy governance in the dashboard.** The fleet source-privacy policy routes
+  (`GET /fleet/privacy-policies/active`, `GET/POST /fleet/privacy-policies`, `POST
+  /fleet/privacy-policies/activate`) had no UI. A new **Telemetry Privacy** settings page shows the
+  active policy as a field-by-field disposition matrix (allow/redact/hash/drop, with limits and the
+  content digest), admits a new policy from a form (with an "admit and activate" shortcut), and rolls
+  a policy out from the admission history behind a confirm. The hash salt never crosses this human plane.
+
+
 - **Per-engagement tool credentials in the dashboard.** The vault-sealed credential routes
   (`GET/POST/DELETE /engagements/{id}/credentials`) had no UI. A new **Credentials** tab (under
   Governance) lists the stored placeholders with their timestamps, adds one through a collapsible form

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -37,6 +37,7 @@ const Audit = lazy(() => import('./pages/Settings/Audit').then(m => ({ default: 
 const Settings = lazy(() => import('./pages/Settings/Settings').then(m => ({ default: m.Settings })))
 const SettingsConfig = lazy(() => import('./pages/Settings/SettingsConfig').then(m => ({ default: m.SettingsConfig })))
 const Connectors = lazy(() => import('./pages/Settings/Connectors').then(m => ({ default: m.Connectors })))
+const TelemetryPrivacy = lazy(() => import('./pages/Settings/TelemetryPrivacy').then(m => ({ default: m.TelemetryPrivacy })))
 const ResponseOps = lazy(() => import('./pages/BlueTeam/ResponseOps').then(m => ({ default: m.ResponseOps })))
 const AITriageReviews = lazy(() => import('./pages/AITriage/AITriageReviews').then(m => ({ default: m.AITriageReviews })))
 const AITriageObservability = lazy(() => import('./pages/AITriage/AITriageObservability').then(m => ({ default: m.AITriageObservability })))
@@ -112,6 +113,7 @@ function Gate() {
           <Route index element={<Audit />} />
           <Route path="team" element={<Team />} />
           <Route path="connectors" element={<Connectors />} />
+          <Route path="privacy" element={<TelemetryPrivacy />} />
           <Route path="config" element={<SettingsConfig />} />
           <Route path="sla" element={<SLAPolicy />} />
           <Route path="offensive-policy" element={<OffensivePolicy />} />

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -8,6 +8,7 @@ export { type AgentStreamEvent, streamAgentSession } from './agent'
 export { type Connector, type ConnectorCreate, type ConnectorProvider } from './connectors'
 export { type ResponseRecord, type ResponsePlan, type ResponseKind, type ResponseState, type HaltResult, type PurpleVerdict, type PurpleCoverageRow, type PurpleWorkItem } from './blueteam'
 export { type RiskStory, type RiskFinding, type RiskExposure, type RiskPath, type RiskDetection, type RiskAssetFacts } from './riskstory'
+export { type PrivacyDisposition, type PrivacyPolicy, type PrivacyAssignment, PRIVACY_CATEGORIES } from './privacy'
 export { type ReconcileRun, type ReconcileCounts, type ReconcileState, type ReconcileDiff, type ReconcileDiffClass, type ReconcileDiffCursor, type ReconcileDiffPage } from './vulnerability'
 export { type AttackPathResult, type AttackPath, type AttackPathNode, type AttackPathStep, type AttackPathBounds, type AttackPathQuery, type AttackPathNodeKind } from './attackpaths'
 export { type SLAPoliciesView, type SLAPolicy, type SLAConfig, type SLAWeights, type SLAThresholds, type SLADueRange, type SLADueRanges, type SLADueTier, type SLAActivateResult, nsToDays, daysToNs } from './sla'
@@ -40,6 +41,7 @@ import { attackPathsApi } from './attackpaths'
 import { slaApi } from './sla'
 import { offensivePolicyApi } from './offensivepolicy'
 import { alertingApi } from './alerting'
+import { privacyApi } from './privacy'
 
 // projectMeasures was a standalone export in the old api.ts
 export const projectMeasures = codeQualityApi.projectMeasures
@@ -78,4 +80,5 @@ export const api = {
   ...slaApi,
   ...offensivePolicyApi,
   ...alertingApi,
+  ...privacyApi,
 }

--- a/web/src/lib/api/privacy.ts
+++ b/web/src/lib/api/privacy.ts
@@ -1,0 +1,101 @@
+import { ApiError, req } from './client'
+
+/**
+ * Tenant source-privacy policy governance (#413 privacy plane). A policy decides how the fleet agent
+ * redacts each telemetry field category at the source before it ever leaves the host. An admitted policy
+ * is identified by its content digest; activating a digest makes it the one agents fetch. The hash salt
+ * is never returned on this human plane (only the agent plane receives it), so it is not modelled here.
+ */
+export type PrivacyDisposition = 'allow' | 'redact' | 'hash' | 'drop'
+
+// The field categories a policy reasons about, in a stable display order (domain: internal/domain/privacy).
+export const PRIVACY_CATEGORIES: { id: string; label: string }[] = [
+  { id: 'process.comm', label: 'Process name' },
+  { id: 'process.arg', label: 'Process arguments' },
+  { id: 'process.path', label: 'Process path' },
+  { id: 'process.env', label: 'Process environment' },
+  { id: 'file.path', label: 'File path' },
+  { id: 'file.comm', label: 'File process name' },
+  { id: 'network.comm', label: 'Network process name' },
+  { id: 'privilege.comm', label: 'Privilege process name' },
+]
+
+export interface PrivacyPolicy {
+  dispositions: Record<string, PrivacyDisposition>
+  redactSecrets: boolean
+  maxArgLen: number
+  maxArgCount: number
+  maxPathLen: number
+  version: string
+}
+
+export interface PrivacyAssignment {
+  tenantId: string
+  policy: PrivacyPolicy
+  digest: string
+  createdBy: string
+  createdAt: string
+}
+
+function mapPolicy(p: any): PrivacyPolicy {
+  const dispositions: Record<string, PrivacyDisposition> = {}
+  const raw = p?.dispositions ?? {}
+  for (const k of Object.keys(raw)) dispositions[k] = raw[k] as PrivacyDisposition
+  return {
+    dispositions,
+    redactSecrets: p?.redact_secrets === true,
+    maxArgLen: p?.max_arg_len ?? 0,
+    maxArgCount: p?.max_arg_count ?? 0,
+    maxPathLen: p?.max_path_len ?? 0,
+    version: p?.version ?? '',
+  }
+}
+
+function mapAssignment(a: any): PrivacyAssignment {
+  return {
+    tenantId: a?.tenant_id ?? '',
+    policy: mapPolicy(a?.policy),
+    digest: a?.digest ?? '',
+    createdBy: a?.created_by ?? '',
+    createdAt: a?.created_at ?? '',
+  }
+}
+
+function policyWire(p: PrivacyPolicy) {
+  return {
+    dispositions: p.dispositions,
+    redact_secrets: p.redactSecrets,
+    max_arg_len: p.maxArgLen,
+    max_arg_count: p.maxArgCount,
+    max_path_len: p.maxPathLen,
+    version: p.version,
+  }
+}
+
+export const privacyApi = {
+  // The currently active policy, or null when none has been activated yet.
+  activePrivacyPolicy: async (): Promise<PrivacyAssignment | null> => {
+    try {
+      const r = await req('/fleet/privacy-policies/active')
+      return r?.assignment ? mapAssignment(r.assignment) : null
+    } catch (e) {
+      if (e instanceof ApiError && (e.status === 404 || e.status === 400)) return null
+      throw e
+    }
+  },
+  privacyPolicyHistory: async (): Promise<PrivacyAssignment[]> => {
+    const r = await req('/fleet/privacy-policies')
+    return Array.isArray(r?.assignments) ? r.assignments.map(mapAssignment) : []
+  },
+  admitPrivacyPolicy: async (policy: PrivacyPolicy): Promise<{ assignment: PrivacyAssignment; created: boolean }> => {
+    const r = await req('/fleet/privacy-policies', { method: 'POST', body: JSON.stringify({ policy: policyWire(policy) }) })
+    return { assignment: mapAssignment(r?.assignment), created: r?.created === true }
+  },
+  activatePrivacyPolicy: async (digest: string, operationId: string): Promise<PrivacyAssignment> => {
+    const r = await req('/fleet/privacy-policies/activate', {
+      method: 'POST',
+      body: JSON.stringify({ digest, operation_id: operationId }),
+    })
+    return mapAssignment(r?.assignment)
+  },
+}

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -351,6 +351,20 @@ const SLA_ITEMS = [
 ]
 
 // --- Fleet ---
+const PRIVACY_POLICY_V1 = {
+  dispositions: { 'process.comm': 'allow', 'process.arg': 'redact', 'process.path': 'allow', 'process.env': 'drop', 'file.path': 'hash', 'file.comm': 'allow', 'network.comm': 'allow', 'privilege.comm': 'allow' },
+  redact_secrets: true,
+  max_arg_len: 4096,
+  max_arg_count: 64,
+  max_path_len: 1024,
+  version: 'v1',
+}
+const PRIVACY_ACTIVE = { tenant_id: 't-1', policy: PRIVACY_POLICY_V1, digest: 'sha256:aa11bb22cc33dd44ee55', created_by: 'operator', created_at: WEEK_AGO }
+const PRIVACY_HISTORY = [
+  PRIVACY_ACTIVE,
+  { tenant_id: 't-1', policy: { ...PRIVACY_POLICY_V1, dispositions: { ...PRIVACY_POLICY_V1.dispositions, 'process.arg': 'allow' } }, digest: 'sha256:ff99ee88dd77cc66', created_by: 'operator', created_at: MONTH_AGO },
+]
+
 const FLEET_AGENTS = [
   { id: 'agent-001', name: 'prod-scanner-01', platform: 'linux/amd64', agent_version: '0.9.4', state: 'healthy', last_seen: NOW, capabilities: ['scan.host', 'scan.container', 'detect.runtime'], current_work: 2 },
   { id: 'agent-002', name: 'staging-scanner', platform: 'linux/arm64', agent_version: '0.9.3', state: 'healthy', last_seen: HOUR_AGO, capabilities: ['scan.host', 'detect.runtime'], current_work: 0 },
@@ -1152,6 +1166,16 @@ export const handlers = [
   ], next: '' })),
 
   // --- Fleet ---
+  http.get('/api/v1/fleet/privacy-policies/active', () => HttpResponse.json({ assignment: PRIVACY_ACTIVE })),
+  http.get('/api/v1/fleet/privacy-policies', () => HttpResponse.json({ assignments: PRIVACY_HISTORY })),
+  http.post('/api/v1/fleet/privacy-policies', async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as { policy?: unknown }
+    return HttpResponse.json({ assignment: { ...PRIVACY_ACTIVE, digest: 'sha256:newadmitted01', policy: body?.policy ?? PRIVACY_ACTIVE.policy }, created: true }, { status: 201 })
+  }),
+  http.post('/api/v1/fleet/privacy-policies/activate', async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as { digest?: string }
+    return HttpResponse.json({ assignment: { ...PRIVACY_ACTIVE, digest: body?.digest ?? PRIVACY_ACTIVE.digest } })
+  }),
   http.get('/api/v1/fleet/coverage/summary', () => HttpResponse.json({
     agents_by_state: { healthy: 4, stale: 1, revoked: 0 },
     rows_by_verdict: { covered: 4, stale: 1, partial: 1, agent_missing: 1 },

--- a/web/src/pages/Settings/Settings.tsx
+++ b/web/src/pages/Settings/Settings.tsx
@@ -8,6 +8,7 @@ const TABS = [
   { label: 'SLA policy', to: '/settings/sla' },
   { label: 'Offensive policy', to: '/settings/offensive-policy' },
   { label: 'Alerting', to: '/settings/alerting' },
+  { label: 'Telemetry Privacy', to: '/settings/privacy' },
   { label: 'Config', to: '/settings/config' },
 ]
 

--- a/web/src/pages/Settings/TelemetryPrivacy.test.tsx
+++ b/web/src/pages/Settings/TelemetryPrivacy.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import type { PrivacyAssignment } from '../../lib/api'
+import { TelemetryPrivacy } from './TelemetryPrivacy'
+
+vi.mock('../../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/api')>('../../lib/api')
+  return {
+    ...actual,
+    api: {
+      activePrivacyPolicy: vi.fn(),
+      privacyPolicyHistory: vi.fn(),
+      admitPrivacyPolicy: vi.fn(),
+      activatePrivacyPolicy: vi.fn(),
+    },
+  }
+})
+
+const POLICY = {
+  dispositions: { 'process.arg': 'redact', 'file.path': 'hash', 'process.env': 'drop' } as Record<string, 'allow' | 'redact' | 'hash' | 'drop'>,
+  redactSecrets: true,
+  maxArgLen: 4096,
+  maxArgCount: 64,
+  maxPathLen: 1024,
+  version: 'v1',
+}
+const ACTIVE: PrivacyAssignment = { tenantId: 't1', policy: POLICY, digest: 'sha256:aa11bb22cc33', createdBy: 'operator', createdAt: '2026-02-01T00:00:00Z' }
+const OLDER: PrivacyAssignment = { ...ACTIVE, digest: 'sha256:ff99ee88dd77', createdAt: '2026-01-01T00:00:00Z' }
+
+describe('TelemetryPrivacy', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('shows the active policy and activates a historical one', async () => {
+    vi.mocked(api.activePrivacyPolicy).mockResolvedValue(ACTIVE)
+    vi.mocked(api.privacyPolicyHistory).mockResolvedValue([ACTIVE, OLDER])
+    vi.mocked(api.activatePrivacyPolicy).mockResolvedValue({ ...OLDER })
+
+    render(<TelemetryPrivacy />)
+
+    // Active policy surfaces per-category dispositions.
+    expect(await screen.findByText('redact')).toBeInTheDocument()
+    expect(screen.getByText('hash')).toBeInTheDocument()
+    expect(screen.getByText('drop')).toBeInTheDocument()
+
+    // The non-active historical policy can be activated behind an inline confirm.
+    await userEvent.click(screen.getByRole('button', { name: /Activate/ }))
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }))
+    await waitFor(() =>
+      expect(api.activatePrivacyPolicy).toHaveBeenCalledWith('sha256:ff99ee88dd77', expect.any(String)),
+    )
+  })
+
+  it('admits a new policy from the form', async () => {
+    vi.mocked(api.activePrivacyPolicy).mockResolvedValue(null)
+    vi.mocked(api.privacyPolicyHistory).mockResolvedValue([])
+    vi.mocked(api.admitPrivacyPolicy).mockResolvedValue({ assignment: { ...ACTIVE, digest: 'sha256:new' }, created: true })
+
+    render(<TelemetryPrivacy />)
+    await userEvent.click(await screen.findByRole('button', { name: 'Admit only' }))
+    await waitFor(() => expect(api.admitPrivacyPolicy).toHaveBeenCalled())
+  })
+})

--- a/web/src/pages/Settings/TelemetryPrivacy.tsx
+++ b/web/src/pages/Settings/TelemetryPrivacy.tsx
@@ -1,0 +1,337 @@
+import { useEffect, useMemo, useState } from 'react'
+import { CheckCircle, Clock, Copy01, Plus, RefreshCcw01, ShieldTick } from '@untitledui/icons'
+import { Button, Card, ErrorState, Field, Input, Pill, Select, Spinner, cn } from '../../components/ui'
+import { useParallelFetch } from '../../hooks'
+import { api } from '../../lib/api'
+import { PRIVACY_CATEGORIES, type PrivacyAssignment, type PrivacyDisposition, type PrivacyPolicy } from '../../lib/api'
+
+const DISPOSITIONS: { value: PrivacyDisposition; label: string }[] = [
+  { value: 'allow', label: 'Allow (keep)' },
+  { value: 'redact', label: 'Redact' },
+  { value: 'hash', label: 'Hash' },
+  { value: 'drop', label: 'Drop' },
+]
+
+// Tone runs from least private (allow, kept in the clear) to most private (drop, removed). The label
+// text always carries the meaning, so colour is never the only signal.
+function DispositionBadge({ d }: { d: PrivacyDisposition }) {
+  const tone: Record<PrivacyDisposition, string> = {
+    allow: 'text-warning-primary bg-warning-primary/10 border-warning-primary/25',
+    redact: 'text-utility-blue-600 dark:text-utility-blue-400 bg-utility-blue-500/10 border-utility-blue-500/25',
+    hash: 'text-utility-purple-600 dark:text-utility-purple-400 bg-utility-purple-500/10 border-utility-purple-500/25',
+    drop: 'text-success-primary bg-success-primary/10 border-success-primary/25',
+  }
+  return <span className={cn('inline-flex items-center rounded border px-1.5 py-0.5 font-mono text-xs font-semibold', tone[d])}>{d}</span>
+}
+
+function formatWhen(iso: string): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+
+function shortDigest(d: string): string {
+  return d.length > 18 ? `${d.slice(0, 16)}…` : d
+}
+
+function newOperationId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function dispositionOf(policy: PrivacyPolicy | undefined, category: string): PrivacyDisposition {
+  return (policy?.dispositions?.[category] as PrivacyDisposition) ?? 'allow'
+}
+
+function DigestChip({ digest }: { digest: string }) {
+  const [copied, setCopied] = useState(false)
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs text-tertiary">
+      <span className="uppercase tracking-wider text-quaternary">digest</span>
+      <span className="font-mono text-secondary" title={digest}>
+        {shortDigest(digest)}
+      </span>
+      <button
+        type="button"
+        onClick={() => {
+          navigator.clipboard?.writeText(digest).then(
+            () => {
+              setCopied(true)
+              setTimeout(() => setCopied(false), 1200)
+            },
+            () => {},
+          )
+        }}
+        className="text-quaternary hover:text-secondary"
+        aria-label="Copy full digest"
+      >
+        {copied ? <CheckCircle className="size-3.5 text-success-primary" /> : <Copy01 className="size-3.5" />}
+      </button>
+    </span>
+  )
+}
+
+function ActivePolicyCard({ active }: { active: PrivacyAssignment | null }) {
+  if (!active) {
+    return (
+      <Card title="Active policy" titleClassName="flex items-center gap-2">
+        <div className="flex items-center gap-2 text-sm text-tertiary">
+          <ShieldTick className="size-4 text-quaternary" aria-hidden />
+          No policy is active yet. Agents apply the built-in default (secrets redacted, argv and paths
+          bounded) until you activate one below.
+        </div>
+      </Card>
+    )
+  }
+  const p = active.policy
+  return (
+    <Card title="Active policy" titleClassName="flex items-center gap-2" actions={<DigestChip digest={active.digest} />}>
+      <div className="overflow-hidden rounded-lg border border-secondary">
+        <table className="w-full text-left text-sm">
+          <thead className="bg-secondary/40 text-[10px] uppercase tracking-wider text-tertiary">
+            <tr>
+              <th className="px-4 py-2 font-bold">Telemetry field</th>
+              <th className="px-4 py-2 font-bold">Disposition</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-secondary/50">
+            {PRIVACY_CATEGORIES.map((c) => (
+              <tr key={c.id}>
+                <td className="px-4 py-2 text-secondary">{c.label}</td>
+                <td className="px-4 py-2">
+                  <DispositionBadge d={dispositionOf(p, c.id)} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-tertiary">
+        <span>redact secrets: {p.redactSecrets ? 'on' : 'off'}</span>
+        <span>max arg len {p.maxArgLen || 'unlimited'}</span>
+        <span>max arg count {p.maxArgCount || 'unlimited'}</span>
+        <span>max path len {p.maxPathLen || 'unlimited'}</span>
+        {active.createdBy && <span>admitted by {active.createdBy}</span>}
+        {active.createdAt && <span>{formatWhen(active.createdAt)}</span>}
+      </div>
+    </Card>
+  )
+}
+
+export function TelemetryPrivacy() {
+  const [refresh, setRefresh] = useState(0)
+  const { data, loading, error } = useParallelFetch<[PrivacyAssignment | null, PrivacyAssignment[]]>(
+    () => Promise.all([api.activePrivacyPolicy(), api.privacyPolicyHistory()]),
+    { deps: [refresh] },
+  )
+  const active = data?.[0] ?? null
+  const history = useMemo(() => data?.[1] ?? [], [data])
+
+  const [dispositions, setDispositions] = useState<Record<string, PrivacyDisposition>>({})
+  const [redactSecrets, setRedactSecrets] = useState(true)
+  const [maxArgLen, setMaxArgLen] = useState(4096)
+  const [maxArgCount, setMaxArgCount] = useState(64)
+  const [maxPathLen, setMaxPathLen] = useState(1024)
+  const [seeded, setSeeded] = useState(false)
+  useEffect(() => {
+    if (seeded || !data) return
+    const seed: Record<string, PrivacyDisposition> = {}
+    for (const c of PRIVACY_CATEGORIES) seed[c.id] = dispositionOf(active?.policy, c.id)
+    setDispositions(seed)
+    if (active?.policy) {
+      setRedactSecrets(active.policy.redactSecrets)
+      setMaxArgLen(active.policy.maxArgLen || 4096)
+      setMaxArgCount(active.policy.maxArgCount || 64)
+      setMaxPathLen(active.policy.maxPathLen || 1024)
+    }
+    setSeeded(true)
+  }, [data, active, seeded])
+
+  const [busy, setBusy] = useState('')
+  const [mutErr, setMutErr] = useState('')
+  const [notice, setNotice] = useState('')
+  const [confirmActivate, setConfirmActivate] = useState('')
+
+  const draftPolicy = (): PrivacyPolicy => ({ dispositions, redactSecrets, maxArgLen, maxArgCount, maxPathLen, version: 'v1' })
+
+  async function admit(thenActivate: boolean) {
+    setBusy(thenActivate ? 'admit-activate' : 'admit')
+    setMutErr('')
+    setNotice('')
+    try {
+      const { assignment, created } = await api.admitPrivacyPolicy(draftPolicy())
+      if (thenActivate) {
+        await api.activatePrivacyPolicy(assignment.digest, newOperationId())
+        setNotice(`Admitted and activated policy ${shortDigest(assignment.digest)}. Agents fetch it on their next poll.`)
+      } else {
+        setNotice(`${created ? 'Admitted' : 'Already admitted'} policy ${shortDigest(assignment.digest)}. Activate it below to roll it out.`)
+      }
+      setRefresh((v) => v + 1)
+    } catch (e) {
+      setMutErr(e instanceof Error ? e.message : 'failed to admit policy')
+    } finally {
+      setBusy('')
+    }
+  }
+
+  async function activate(digest: string) {
+    setBusy(digest)
+    setMutErr('')
+    setNotice('')
+    try {
+      await api.activatePrivacyPolicy(digest, newOperationId())
+      setConfirmActivate('')
+      setNotice(`Activated policy ${shortDigest(digest)}. Agents fetch it on their next poll.`)
+      setRefresh((v) => v + 1)
+    } catch (e) {
+      setMutErr(e instanceof Error ? e.message : 'failed to activate policy')
+    } finally {
+      setBusy('')
+    }
+  }
+
+  const mutating = busy !== ''
+
+  if (loading) return <Spinner label="Loading privacy policy…" />
+  if (error) return <ErrorState message={error} />
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start gap-2 rounded-lg border border-secondary bg-secondary/30 px-4 py-3 text-sm text-tertiary">
+        <ShieldTick className="mt-0.5 size-4 shrink-0 text-quaternary" aria-hidden />
+        <span>
+          Fleet agents apply this policy at the source, redacting each telemetry field before it leaves the
+          host. Admit a policy to register it by content digest, then activate the digest to roll it out.
+        </span>
+      </div>
+
+      {notice && (
+        <div aria-live="polite" className="flex items-center gap-2 rounded-lg border border-success-primary/25 bg-success-primary/5 px-4 py-2.5 text-sm text-success-primary">
+          <CheckCircle className="size-4 shrink-0" aria-hidden />
+          {notice}
+        </div>
+      )}
+      {mutErr && (
+        <div aria-live="polite">
+          <ErrorState message={mutErr} />
+        </div>
+      )}
+
+      <ActivePolicyCard active={active} />
+
+      <Card title="Admit a policy">
+        <fieldset disabled={mutating}>
+          <legend className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-tertiary">Field dispositions</legend>
+          <div className="grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-2">
+            {PRIVACY_CATEGORIES.map((c) => {
+              const changed = active?.policy && dispositions[c.id] !== dispositionOf(active.policy, c.id)
+              return (
+                <div key={c.id} className="flex items-center justify-between gap-3">
+                  <span className="flex items-center gap-2 text-sm text-secondary">
+                    {c.label}
+                    {changed && <span className="size-1.5 rounded-full bg-brand-solid" title="changed from active" aria-label="changed from active" />}
+                  </span>
+                  <Select
+                    ariaLabel={`Disposition for ${c.label}`}
+                    value={dispositions[c.id] ?? 'allow'}
+                    onValueChange={(v) => setDispositions((prev) => ({ ...prev, [c.id]: v as PrivacyDisposition }))}
+                    options={DISPOSITIONS}
+                    size="sm"
+                    className="w-40"
+                  />
+                </div>
+              )
+            })}
+          </div>
+          <div className="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-4">
+            <label className="flex items-center gap-2 text-sm text-secondary">
+              <input
+                type="checkbox"
+                checked={redactSecrets}
+                onChange={(e) => setRedactSecrets(e.target.checked)}
+                className="size-4 rounded border-secondary text-brand-solid focus:ring-brand/40"
+              />
+              Redact secrets
+            </label>
+            <Field label="Max arg length" htmlFor="p-arglen" hint="0 = unlimited">
+              <Input id="p-arglen" type="number" min={0} value={maxArgLen} onChange={(e) => setMaxArgLen(Number(e.target.value) || 0)} />
+            </Field>
+            <Field label="Max arg count" htmlFor="p-argcount" hint="0 = unlimited">
+              <Input id="p-argcount" type="number" min={0} value={maxArgCount} onChange={(e) => setMaxArgCount(Number(e.target.value) || 0)} />
+            </Field>
+            <Field label="Max path length" htmlFor="p-pathlen" hint="0 = unlimited">
+              <Input id="p-pathlen" type="number" min={0} value={maxPathLen} onChange={(e) => setMaxPathLen(Number(e.target.value) || 0)} />
+            </Field>
+          </div>
+        </fieldset>
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <Button variant="primary" onClick={() => admit(true)} loading={busy === 'admit-activate'} disabled={mutating} className="px-3.5 py-2">
+            <Plus className="size-4" aria-hidden />
+            Admit and activate
+          </Button>
+          <Button variant="secondary" onClick={() => admit(false)} loading={busy === 'admit'} disabled={mutating} className="px-3.5 py-2">
+            Admit only
+          </Button>
+        </div>
+      </Card>
+
+      <Card title="Policy history" actions={<Pill>{history.length}</Pill>}>
+        {history.length === 0 ? (
+          <p className="text-sm text-tertiary">No policies admitted yet. Admit one above to build the history.</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-sm">
+              <thead className="bg-secondary/40 text-[10px] uppercase tracking-wider text-tertiary">
+                <tr>
+                  <th className="px-4 py-2 font-bold">Digest</th>
+                  <th className="px-4 py-2 font-bold">Admitted by</th>
+                  <th className="px-4 py-2 font-bold">When</th>
+                  <th className="px-4 py-2 font-bold text-right">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-secondary/50">
+                {history.map((h) => {
+                  const isActive = active?.digest === h.digest
+                  return (
+                    <tr key={h.digest}>
+                      <td className="px-4 py-2.5 font-mono text-xs text-primary" title={h.digest}>{shortDigest(h.digest)}</td>
+                      <td className="px-4 py-2.5 text-xs text-tertiary">{h.createdBy || '—'}</td>
+                      <td className="px-4 py-2.5 text-xs text-tertiary">
+                        <span className="inline-flex items-center gap-1">
+                          <Clock className="size-3" aria-hidden />
+                          {formatWhen(h.createdAt)}
+                        </span>
+                      </td>
+                      <td className="px-4 py-2.5 text-right">
+                        {isActive ? (
+                          <Pill className="text-success-primary">
+                            <CheckCircle className="size-3" aria-hidden />
+                            active
+                          </Pill>
+                        ) : confirmActivate === h.digest ? (
+                          <span className="inline-flex items-center gap-2">
+                            <span className="text-xs text-warning-primary">Roll this policy out to every agent?</span>
+                            <Button variant="secondary" onClick={() => activate(h.digest)} loading={busy === h.digest} disabled={mutating} className="px-2.5 py-1 text-xs">
+                              Confirm
+                            </Button>
+                            <Button variant="ghost" onClick={() => setConfirmActivate('')} disabled={mutating} className="px-2.5 py-1 text-xs">
+                              Cancel
+                            </Button>
+                          </span>
+                        ) : (
+                          <Button variant="secondary" onClick={() => setConfirmActivate(h.digest)} disabled={mutating} className="px-2.5 py-1 text-xs">
+                            <RefreshCcw01 className="size-3.5" aria-hidden />
+                            Activate
+                          </Button>
+                        )}
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## What

Surfaces the fleet source-privacy policy governance routes, which had no UI: `GET /fleet/privacy-policies/active`, `GET/POST /fleet/privacy-policies`, `POST /fleet/privacy-policies/activate`. A new **Settings → Telemetry Privacy** page governs how each fleet agent redacts telemetry fields at the source before they leave the host.

- **Active policy** as a two-column matrix (telemetry field → disposition badge: allow / redact / hash / drop), with the limits (`0 = unlimited`), the content digest (labelled, copyable, full value on hover), and who admitted it and when.
- **Admit a policy** from a `<fieldset>` form: a disposition select per category, a redact-secrets toggle, and the argv/path limits; categories that differ from the active policy get a "changed" marker. Two actions: **Admit and activate** (one step) and **Admit only**.
- **Policy history** as a denser table (digest, admitted by, when, status); activating a historical policy goes through an inline confirm ("Roll this policy out to every agent?"). All controls disable during a mutation.

The hash salt that keys pseudonymization never crosses this human read plane (only the agent plane receives it), matching the backend's security rule, so it is not modelled here.

## Verification

- `web`: `tsc --noEmit` clean; `pnpm test` 519 passing; `pnpm build` clean.
- Rendered in a real browser (MSW dev server) in light and dark. UI/UX independently scored 8.5/10 ("ship") after applying the first-round fixes (scannable matrix, disposition badges instead of colour-only text, labelled/copyable digest, admit-vs-activate split, inline activation confirm, `0 = unlimited` hints, fieldset/legend).

## Notes

No backend change; this surfaces existing wired routes.
