### PR TITLE
feat(fleet): feed runtime detection rates into the behavior baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Runtime detections feed the behavior baseline (#822).** The statistical baseline behind a host's
+  Behavior risk factor only ever saw its process snapshot, so the network, privilege and file features
+  stayed at zero and anomaly scoring never ran over runtime telemetry. The baseline now folds the host's
+  per-class detection rate (network / privilege / file) from the sealed detection ledger over a recent
+  window into the observation, alongside the process features. A new `ClassCountsByAsset` read on the
+  detection store backs it (memory and Postgres, no schema change). The detection source is optional and
+  best-effort: a store error or a deployment without the ledger leaves those features at zero.
+
+
 - **Sequence detection rules (#822).** The detection engine matched single events and, since the rate
   window, bursts; it now also matches an ordered *sequence* of events of one class within a span, grouped
   per host. A new `Sequence` rule type (mutually exclusive with a rate `Window`) carries the ordered step

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -1892,7 +1892,15 @@ func main() {
 			log.Error("behavioral baseline service init failed", "err", blErr)
 			os.Exit(1)
 		}
-		behaviorSvc, bhErr := behaviorbaseline.NewService(baselineSvc, endpointProcessStore)
+		// Fold the host's recent per-class detection rate into the behavior baseline (#822): the detection
+		// ledger already stores each detection with its asset and telemetry class, so the network,
+		// privilege and file features the process snapshot cannot carry are read from it. Optional: a
+		// detection store that does not implement the reader (or none) leaves those features at 0.
+		var detRates behaviorbaseline.DetectionRates
+		if dr, ok := detectionRecordStore.(behaviorbaseline.DetectionRates); ok {
+			detRates = dr
+		}
+		behaviorSvc, bhErr := behaviorbaseline.NewService(baselineSvc, endpointProcessStore, detRates, func() time.Time { return clock.Now().UTC() }, 0)
 		if bhErr != nil {
 			log.Error("behavior-baseline producer init failed", "err", bhErr)
 			os.Exit(1)

--- a/internal/infrastructure/persistence/memory/detection_record_store.go
+++ b/internal/infrastructure/persistence/memory/detection_record_store.go
@@ -82,6 +82,23 @@ func (s *DetectionRecordStore) ListDetections(ctx context.Context, engagementID 
 	return out, nil
 }
 
+// ClassCountsByAsset counts the non-expired detections observed on an asset at or after a cutoff,
+// grouped by telemetry class, under the ctx tenant. It feeds the behavior baseline's runtime-anomaly
+// features (#822): the network / privilege / file per-class rates the process snapshot cannot carry.
+func (s *DetectionRecordStore) ClassCountsByAsset(ctx context.Context, assetID shared.ID, since time.Time) (map[detection.Class]int, error) {
+	tenant := shared.TenantOrDefault(tenantFromCtx(ctx))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	now := s.now()
+	counts := map[detection.Class]int{}
+	for _, r := range s.byTenant[tenant] {
+		if r.AssetID == assetID && !r.Expired(now) && !r.RecordedAt.Before(since) {
+			counts[r.Detection.Class]++
+		}
+	}
+	return counts, nil
+}
+
 // HasDetection reports whether a record with this id already exists in the given engagement under the ctx tenant, so ingest can
 // skip an already-sealed detection on a retry (idempotent resume) rather than sealing it twice.
 func (s *DetectionRecordStore) HasDetection(ctx context.Context, engagementID, id shared.ID) (bool, error) {

--- a/internal/infrastructure/persistence/postgres/detection_record_repo.go
+++ b/internal/infrastructure/persistence/postgres/detection_record_repo.go
@@ -110,6 +110,37 @@ func (r *DetectionRecordRepository) ListDetections(ctx context.Context, engageme
 	return out, err
 }
 
+// ClassCountsByAsset counts the non-expired detections observed on an asset at or after a cutoff,
+// grouped by telemetry class, tenant-scoped by RLS. It feeds the behavior baseline's runtime-anomaly
+// features (#822): the network / privilege / file per-class rates a process snapshot cannot carry.
+func (r *DetectionRecordRepository) ClassCountsByAsset(ctx context.Context, assetID shared.ID, since time.Time) (map[detection.Class]int, error) {
+	counts := map[detection.Class]int{}
+	err := WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `
+			SELECT class, count(*)
+			FROM detections
+			WHERE asset_id = $1 AND recorded_at >= $2 AND (expires_at IS NULL OR expires_at > now())
+			GROUP BY class`, assetID.String(), since.UTC())
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var class string
+			var n int64
+			if err := rows.Scan(&class, &n); err != nil {
+				return err
+			}
+			counts[detection.Class(class)] = int(n)
+		}
+		return rows.Err()
+	})
+	if err != nil {
+		return nil, fmt.Errorf("count detections by class for asset %s: %w", assetID, err)
+	}
+	return counts, nil
+}
+
 // HasDetection reports whether a record with this id already exists in the given engagement (ctx tenant).
 func (r *DetectionRecordRepository) HasDetection(ctx context.Context, engagementID, id shared.ID) (bool, error) {
 	var exists bool

--- a/internal/infrastructure/persistence/postgres/migration_0074_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0074_test.go
@@ -110,6 +110,22 @@ func TestMigration0074Detections(t *testing.T) {
 		t.Fatalf("append critical: %v", err)
 	}
 
+	// #822: the per-class detection rate for an asset, counted over a window, feeds the behavior
+	// baseline's network/privilege/file features. Both records are ClassProcess on asset-x at t=1000.
+	if counts, err := repo.ClassCountsByAsset(tctx, "asset-x", time.Unix(0, 0)); err != nil {
+		t.Fatalf("class counts: %v", err)
+	} else if counts[detection.ClassProcess] != 2 {
+		t.Fatalf("ClassCountsByAsset must count both process detections on the asset, got %+v", counts)
+	}
+	// A cutoff after the records' timestamp excludes them (window respected).
+	if counts, _ := repo.ClassCountsByAsset(tctx, "asset-x", time.Unix(2000, 0)); counts[detection.ClassProcess] != 0 {
+		t.Fatalf("ClassCountsByAsset must respect the since cutoff, got %+v", counts)
+	}
+	// Another asset in the same tenant shares none of these detections.
+	if counts, _ := repo.ClassCountsByAsset(tctx, "asset-other", time.Unix(0, 0)); counts[detection.ClassProcess] != 0 {
+		t.Fatalf("ClassCountsByAsset must be per-asset, got %+v", counts)
+	}
+
 	// RLS under a NOSUPERUSER NOBYPASSRLS role (the pool superuser bypasses RLS).
 	role := "det_runtime"
 	for _, q := range []string{

--- a/internal/usecase/fleet/behaviorbaseline/service.go
+++ b/internal/usecase/fleet/behaviorbaseline/service.go
@@ -1,24 +1,30 @@
-// Package behaviorbaseline turns the B5 per-host running-process projection into the coverage-honest
-// RiskContext.Behavior factor (#594 D). It maps a host's running processes to a baseline.Observation,
-// LEARNS the asset's normal process profile at report time (baselineuc.Observe — which scores-then-folds
-// with anti-poisoning), and SCORES the current profile read-only at risk-assessment time
-// (baselineuc.Score, no fold). Learning and scoring are separated so scoring never poisons the baseline —
-// and, critically, the risk-assessment path (an incident is active) never learns.
-//
-// It observes only the two features a process snapshot honestly carries — process count (spawn-rate proxy)
-// and distinct exec paths — leaving the network/privilege/file features at 0 (unobserved from processes),
-// so the baseline never invents a signal it did not measure.
+// Package behaviorbaseline turns the B5 per-host running-process projection plus the host's sealed
+// runtime detections into the coverage-honest RiskContext.Behavior factor (#594 D). It maps a host's
+// running processes to the process features of a baseline.Observation, and folds the per-class rate of
+// the eBPF detections observed on that host in a recent window into the network / privilege / file
+// features, so the statistical baseline scores anomalies over runtime telemetry rather than over
+// process snapshots alone (#822). It LEARNS the asset's normal profile at report time (baselineuc.Observe,
+// which scores-then-folds with anti-poisoning) and SCORES the current profile read-only at
+// risk-assessment time (baselineuc.Score, no fold). Learning and scoring are separated so scoring never
+// poisons the baseline, and the risk-assessment path (an incident is active) never learns.
 package behaviorbaseline
 
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/baseline"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/baselineuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
+
+// defaultDetectionWindow bounds how far back the per-class detection rate is counted for an observation.
+// A day balances "recent enough to reflect current behavior" against "long enough for a sparse host to
+// register any runtime signal at all".
+const defaultDetectionWindow = 24 * time.Hour
 
 // BaselineEngine is the baselineuc surface this producer needs: Observe (learn+score) and Score (read-only).
 type BaselineEngine interface {
@@ -32,6 +38,14 @@ type ProcessLister interface {
 	ListRunningByAsset(ctx context.Context, assetID shared.ID) ([]ports.ProcessSnapshot, error)
 }
 
+// DetectionRates returns the count of sealed detections observed on an asset since a cutoff, grouped by
+// telemetry class, tenant-scoped by ctx. It is OPTIONAL: a nil DetectionRates leaves the network,
+// privilege and file features unobserved (0), which is the pre-#822 behavior. The memory and Postgres
+// detection-record stores satisfy it.
+type DetectionRates interface {
+	ClassCountsByAsset(ctx context.Context, assetID shared.ID, since time.Time) (map[detection.Class]int, error)
+}
+
 // Factor is the coverage-honest Behavior factor for one asset.
 type Factor struct {
 	Behavior  int
@@ -39,18 +53,28 @@ type Factor struct {
 	Reasons   []string
 }
 
-// Service produces + learns the Behavior factor from process snapshots.
+// Service produces + learns the Behavior factor from process snapshots and runtime detection rates.
 type Service struct {
-	engine    BaselineEngine
-	processes ProcessLister
+	engine     BaselineEngine
+	processes  ProcessLister
+	detections DetectionRates // optional; nil leaves network/privilege/file features at 0
+	now        func() time.Time
+	window     time.Duration
 }
 
-// NewService constructs the producer. Both collaborators are required.
-func NewService(engine BaselineEngine, processes ProcessLister) (*Service, error) {
+// NewService constructs the producer. The engine and process lister are required. detections is optional
+// (nil = process features only); now defaults to time.Now and window to a day when zero.
+func NewService(engine BaselineEngine, processes ProcessLister, detections DetectionRates, now func() time.Time, window time.Duration) (*Service, error) {
 	if engine == nil || processes == nil {
 		return nil, fmt.Errorf("%w: behavior baseline needs a baseline engine and a process lister", shared.ErrValidation)
 	}
-	return &Service{engine: engine, processes: processes}, nil
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+	if window <= 0 {
+		window = defaultDetectionWindow
+	}
+	return &Service{engine: engine, processes: processes, detections: detections, now: now, window: window}, nil
 }
 
 // Learn folds the asset's current running-process profile into its behavior baseline. It is called at
@@ -112,12 +136,21 @@ func (s *Service) observe(ctx context.Context, assetID shared.ID) (baseline.Key,
 	if err != nil {
 		return baseline.Key{}, baseline.Observation{}, fmt.Errorf("list running processes: %w", err)
 	}
-	return baseline.Key{Tenant: tenant, Group: assetID.String()}, observationFrom(procs), nil
+	// Fold the recent per-class detection rate when a detection source is wired. A store hiccup is
+	// best-effort: it must not blind the process-based baseline, so the counts fall back to nil (0).
+	var counts map[detection.Class]int
+	if s.detections != nil {
+		if c, cerr := s.detections.ClassCountsByAsset(ctx, assetID, s.now().Add(-s.window)); cerr == nil {
+			counts = c
+		}
+	}
+	return baseline.Key{Tenant: tenant, Group: assetID.String()}, observationFrom(procs, counts), nil
 }
 
-// observationFrom maps running processes to the two baseline features a process snapshot honestly carries:
-// process count (spawn-rate proxy) and distinct exec paths. Values are clamped to the feature max.
-func observationFrom(procs []ports.ProcessSnapshot) baseline.Observation {
+// observationFrom maps running processes to the process features (count as a spawn-rate proxy, distinct
+// exec paths) and the recent per-class detection rate to the network / privilege / file features. Values
+// are clamped to the feature max. A nil counts map leaves the detection-fed features at 0.
+func observationFrom(procs []ports.ProcessSnapshot, counts map[detection.Class]int) baseline.Observation {
 	paths := make(map[string]struct{}, len(procs))
 	for _, p := range procs {
 		if p.Path != "" {
@@ -127,6 +160,11 @@ func observationFrom(procs []ports.ProcessSnapshot) baseline.Observation {
 	var o baseline.Observation
 	o.Values[baseline.FeatureProcessSpawnRate] = clampFeature(int64(len(procs)))
 	o.Values[baseline.FeatureNewExecPaths] = clampFeature(int64(len(paths)))
+	if counts != nil {
+		o.Values[baseline.FeatureNetworkFanout] = clampFeature(int64(counts[detection.ClassNetwork]))
+		o.Values[baseline.FeaturePrivilegeEvents] = clampFeature(int64(counts[detection.ClassPrivilege]))
+		o.Values[baseline.FeatureFileWriteBreadth] = clampFeature(int64(counts[detection.ClassFile]))
+	}
 	return o
 }
 

--- a/internal/usecase/fleet/behaviorbaseline/service_test.go
+++ b/internal/usecase/fleet/behaviorbaseline/service_test.go
@@ -3,12 +3,25 @@ package behaviorbaseline
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/baseline"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/baselineuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
+
+type fakeRates struct {
+	counts map[detection.Class]int
+	since  time.Time
+	asset  shared.ID
+}
+
+func (f *fakeRates) ClassCountsByAsset(_ context.Context, assetID shared.ID, since time.Time) (map[detection.Class]int, error) {
+	f.asset, f.since = assetID, since
+	return f.counts, nil
+}
 
 type fakeEngine struct {
 	learnedObs  baseline.Observation
@@ -51,7 +64,7 @@ func TestObservationMapsProcessCountAndDistinctPaths(t *testing.T) {
 	procs := fakeProcs{procs: []ports.ProcessSnapshot{
 		{Path: "/usr/sbin/nginx", Running: true}, {Path: "/usr/sbin/nginx", Running: true}, {Path: "/bin/bash", Running: true},
 	}}
-	svc, err := NewService(eng, procs)
+	svc, err := NewService(eng, procs, nil, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,8 +96,40 @@ func TestObservationMapsProcessCountAndDistinctPaths(t *testing.T) {
 	}
 }
 
+func TestObservationFoldsDetectionClassRates(t *testing.T) {
+	eng := &fakeEngine{scoreRet: baselineuc.Assessment{Behavior: 60, Scoreable: true}}
+	procs := fakeProcs{procs: []ports.ProcessSnapshot{{Path: "/bin/bash", Running: true}}}
+	rates := &fakeRates{counts: map[detection.Class]int{detection.ClassNetwork: 5, detection.ClassPrivilege: 2, detection.ClassFile: 3}}
+	now := time.Date(2026, 2, 20, 0, 0, 0, 0, time.UTC)
+	svc, err := NewService(eng, procs, rates, func() time.Time { return now }, time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.Learn(ctxT(), "operator", "asset-1"); err != nil {
+		t.Fatal(err)
+	}
+	// The network / privilege / file features now come from the host's recent per-class detection rate,
+	// not left at 0 (the #822 fix).
+	if eng.learnedObs.Values[baseline.FeatureNetworkFanout] != 5 ||
+		eng.learnedObs.Values[baseline.FeaturePrivilegeEvents] != 2 ||
+		eng.learnedObs.Values[baseline.FeatureFileWriteBreadth] != 3 {
+		t.Fatalf("detection-fed features wrong: %+v", eng.learnedObs.Values)
+	}
+	// Process features are still mapped from the snapshot.
+	if eng.learnedObs.Values[baseline.FeatureProcessSpawnRate] != 1 {
+		t.Fatalf("process feature wrong: %+v", eng.learnedObs.Values)
+	}
+	// The rate is counted over [now-window, now] for exactly this asset.
+	if !rates.since.Equal(now.Add(-time.Hour)) {
+		t.Fatalf("detection cutoff wrong: got %v want %v", rates.since, now.Add(-time.Hour))
+	}
+	if rates.asset != "asset-1" {
+		t.Fatalf("detection asset wrong: %v", rates.asset)
+	}
+}
+
 func TestBehaviorForRequiresTenant(t *testing.T) {
-	svc, _ := NewService(&fakeEngine{}, fakeProcs{})
+	svc, _ := NewService(&fakeEngine{}, fakeProcs{}, nil, nil, 0)
 	if _, err := svc.BehaviorFor(context.Background(), "asset-1"); err == nil {
 		t.Fatal("a missing tenant must be rejected")
 	}
@@ -94,7 +139,7 @@ func TestBehaviorForRequiresTenant(t *testing.T) {
 // tenant + asset id and drives the engine, so an operator can reset a drifted baseline by asset id.
 func TestRebaselineDerivesTheAssetKeyAndDelegates(t *testing.T) {
 	eng := &fakeEngine{}
-	svc, err := NewService(eng, &fakeProcs{})
+	svc, err := NewService(eng, &fakeProcs{}, nil, nil, 0)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## What

Closes the central grievance of #822: runtime statistical anomaly detection never ran, because the behavior baseline only ever saw a host's process snapshot. The `baseline.Observation` set only the process features (spawn-rate proxy, distinct exec paths) and left `FeatureNetworkFanout`, `FeaturePrivilegeEvents` and `FeatureFileWriteBreadth` at zero, so the variance/banding baseline had no runtime telemetry to score.

The behavior baseline now folds the host's **per-class detection rate** from the sealed detection ledger into the observation:

- A new `ClassCountsByAsset(ctx, assetID, since)` read on the detection-record store returns, tenant-scoped, the count of non-expired detections observed on an asset since a cutoff, grouped by telemetry class. Implemented on the in-memory store and the Postgres repository (a `GROUP BY class` over existing `asset_id` / `class` / `recorded_at` columns — **no schema change, no migration**).
- `behaviorbaseline.Service` takes an optional `DetectionRates` reader plus a clock and window (default 24h). On each observation it counts the recent detections for the asset and maps `network → FeatureNetworkFanout`, `privilege → FeaturePrivilegeEvents`, `file → FeatureFileWriteBreadth`, alongside the unchanged process features.
- It is **optional and best-effort**: a store that does not implement the reader (or none), or a transient read error, leaves those features at zero, exactly as before. No behavior regression where there is no detection ledger.

## Verification

- `CGO_ENABLED=0 go build ./...` passes; `go vet` and `gofmt` clean on the touched files.
- New unit test `TestObservationFoldsDetectionClassRates` proves the network/privilege/file features come from the detection rate and that the window cutoff and asset scoping are applied.
- New assertions in `TestMigration0074Detections` exercise `ClassCountsByAsset` against **real Postgres** (`SYNAPSE_TEST_DB_DSN`): per-class count, `since` cutoff, and per-asset isolation.

## Notes

The detection ledger is populated by the fleet agent's sealed detection batches, so this makes anomaly scoring real wherever a fleet reports detections. It does not add a config variable (the window is a sensible in-code default).
