### PR TITLE
feat(emulation): wire governed adversary emulation end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Governed adversary emulation reachable from the control plane.** The emulation catalogue, its
+  offensive-policy admission (#418), and purple coverage (#426) were tested domain and use-case code that
+  no composition root ever built, so the run was unreachable. The API server now wires an emulation runner
+  (`POST /engagements/{id}/emulation/runs`) that authorizes every catalogued technique through the same
+  #418 governance the exploitation chains use, executes each benign observable in the confined sandbox,
+  persists the run, and joins it against the detection ledger for per-asset coverage. It is registered only
+  when a sandbox exists (unregistered in dispatch-only posture) and refuses unless the engagement's
+  offensive rules of engagement are complete and the authorization window is open. Engagements gain an
+  offensive rules-of-engagement surface (`PUT /engagements/{id}/offensive-roe`) for the contacts, risk
+  ceiling, and reviewed exclusions the gate requires; an incomplete set keeps all offensive work refused.
+
 - **Per-engagement vulnerability posture in the dashboard.** The reconciled advisory occurrences and the
   governed action queue for an engagement (`GET /engagements/{id}/vulnerability/occurrences` and
   `.../vulnerability/actions`, with `.../actions/{aid}/acknowledge` and `/resolve`) had no UI. A new

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -306,6 +306,98 @@ paths:
         "403": {$ref: "#/components/responses/Forbidden"}
         "404": {$ref: "#/components/responses/NotFound"}
 
+  /api/v1/engagements/{id}/offensive-roe:
+    parameters:
+    - $ref: "#/components/parameters/EngagementId"
+    put:
+      tags: [engagements]
+      operationId: setOffensiveRoE
+      summary: Set the engagement's offensive-governance rules of engagement
+      description: >
+        Sets the contacts, risk ceiling, and reviewed exclusions the offensive governance gate (#418)
+        requires before any offensive action (live recon, DAST, adversary emulation, exploitation) is
+        authorized. The execution-gate tool-class rules are left untouched. Every field is required before
+        an offensive action is authorized; a partially filled set keeps offensive work refused (fail-closed).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                customer_contact: {type: string, description: Contact reached on an incident during the engagement}
+                emergency_contact: {type: string, description: Out-of-hours emergency contact}
+                risk_ceiling:
+                  type: string
+                  enum: [low, medium, high]
+                  description: Highest risk class the engagement permits; narrows the register, never widens it
+                excluded_assets:
+                  type: array
+                  items: {type: string}
+                  description: Assets explicitly out of offensive scope
+                exclusions_reviewed:
+                  type: boolean
+                  description: The operator has reviewed exclusions (distinguishes "nothing excluded" from "nobody looked")
+      responses:
+        "200":
+          description: Updated engagement with its offensive rules of engagement
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/Engagement"}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/engagements/{id}/emulation/runs:
+    parameters:
+    - $ref: "#/components/parameters/EngagementId"
+    post:
+      tags: [engagements, findings]
+      operationId: runEmulation
+      summary: Run a governed adversary-emulation pass and compute its purple coverage
+      description: >
+        Authorizes every catalogued emulation technique through the same #418 offensive governance the
+        exploitation chains use, executes each benign observable in a confined sandbox, persists the run,
+        and joins it against the detection ledger for per-asset coverage (#426). Refused unless the
+        engagement's offensive rules of engagement are complete and the authorization window is open. A
+        technique that is not authorized, or whose observable does not fire, is recorded as a gap rather
+        than assumed clean.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [target]
+              properties:
+                target:
+                  type: string
+                  minLength: 1
+                  description: Asset id the run is attributed to; coverage is per-asset
+                allow_lab_only:
+                  type: boolean
+                  description: Opt in to lab-only techniques that have no benign proof (still subject to their own approvals)
+      responses:
+        "200":
+          description: Emulation run complete; the coverage summary after the detection join (synchronous)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  run_id: {type: string}
+                  engagement_id: {type: string}
+                  target: {type: string}
+                  techniques: {type: integer, description: Total catalogued techniques evaluated}
+                  executed: {type: integer, description: Techniques authorized and observed}
+                  gaps: {type: integer, description: Executed techniques with no matching detection}
+                  covered: {type: integer, description: Executed techniques a detection confirmed}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
   /api/v1/engagements/{id}/detection-provenance:
     parameters:
     - $ref: "#/components/parameters/EngagementId"
@@ -5716,6 +5808,16 @@ components:
                 properties:
                   from: {type: string, format: date-time}
                   to: {type: string, format: date-time}
+            offensive:
+              type: object
+              description: Offensive-governance rules (#418) the offensive gate requires beyond scope and the window.
+              properties:
+                customer_contact: {type: string}
+                emergency_contact: {type: string}
+                risk_ceiling: {type: string, enum: ["", low, medium, high], description: Empty until set; an empty ceiling keeps offensive work refused}
+                excluded_assets: {type: array, items: {type: string}}
+                exclusions_reviewed: {type: boolean}
+                complete: {type: boolean, description: Whether every field an offensive authorization needs is set}
         authorized_from:
           type: [string, "null"]
           format: date-time

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -46,6 +46,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/ebpf"
 	egressinfra "github.com/KKloudTarus/synapse-ce/internal/infrastructure/egress"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/egressbroker"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/emulationexec"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/fleetca"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/llm/openai"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/logstream"
@@ -111,6 +112,8 @@ import (
 	dastworkflowuc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastworkflow"
 	egresspolicy "github.com/KKloudTarus/synapse-ce/internal/usecase/egress"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/egressgrant"
+	emuc "github.com/KKloudTarus/synapse-ce/internal/usecase/emulation"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/emulationrun"
 	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
 	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/execution"
@@ -357,6 +360,7 @@ func main() {
 	var importedFindingStore ports.ImportedFindingStore // third-party (SARIF) findings under governance
 	var detectionRecordStore ports.DetectionRecordStore // #423 detection ledger projection
 	var purpleCoverageStore ports.PurpleCoverageStore   // #426 emulated technique vs observed detection
+	var emuRunStore emuc.RunStore                       // #421/#823 persisted adversary-emulation runs
 	// Registry of the LLM agent runs executing in this process, so the offensive kill switch can cancel
 	// one mid-decision. Declared here because the kill switch is built before the orchestrator is.
 	agentRunRegistry := orchestrator.NewRunRegistry()
@@ -493,6 +497,7 @@ func main() {
 		importedFindingStore = postgres.NewImportedFindingRepository(pool)
 		detectionRecordStore = postgres.NewDetectionRecordRepository(pool)
 		purpleCoverageStore = postgres.NewPurpleRepository(pool)
+		emuRunStore = postgres.NewEmulationRunRepository(pool)
 		detectionProvenanceStore, err = postgres.NewDetectionProvenanceRepository(pool)
 		if err != nil {
 			log.Error("postgres detection provenance store init failed", "err", err)
@@ -635,6 +640,7 @@ func main() {
 		importedFindingStore = memory.NewImportedFindingStore()
 		detectionRecordStore = memory.NewDetectionRecordStore()
 		purpleCoverageStore = memory.NewPurpleStore()
+		emuRunStore = memory.NewEmulationRunStore()
 		detectionProvenanceStore = memory.NewDetectionProvenanceStore()
 		incidentEventStore = memory.NewIncidentEventStore()
 		memoryFindings, ok := findingRepo.(*memory.FindingRepository)
@@ -1799,6 +1805,37 @@ func main() {
 			os.Exit(1)
 		} else {
 			router.SetPurpleCoverageReader(purpleSvc)
+			// #421/#823 governed adversary emulation: authorize every catalogued technique through the SAME
+			// #418 offensive governance the exploitation chains use, execute each benign observable in the
+			// sandbox, persist the run, then join it against the detection ledger (purpleSvc) for coverage.
+			// Wired only when a sandbox exists (nil in dispatch-only): the executor must confine execution,
+			// so with no sandbox the route stays unregistered rather than running unconfined.
+			if scaSandbox == nil {
+				log.Info("adversary emulation runner DISABLED (no sandbox in this posture); route not registered")
+			} else if emuExecutor, eerr := emulationexec.New(scaSandbox); eerr != nil {
+				log.Error("emulation executor init failed", "err", eerr)
+				os.Exit(1)
+			} else {
+				emuSealer := offensivepolicyuc.NewEvidenceChainSealer(func(ctx context.Context, engagementID shared.ID, kind string, content []byte, createdBy string) (shared.ID, error) {
+					ev, serr := evidenceService.Seal(ctx, engagementID, kind, content, createdBy)
+					if serr != nil {
+						return "", serr
+					}
+					return ev.ID, nil
+				})
+				emuGov, gerr := offensivepolicyuc.NewService(offensiveRegister, emuSealer, auditLog)
+				if gerr != nil {
+					log.Error("emulation governance init failed", "err", gerr)
+					os.Exit(1)
+				}
+				emuRunner, rerr := emulationrun.NewService(engService, emuGov, emuExecutor, emuRunStore, purpleSvc, auditLog, clock, ids, 0)
+				if rerr != nil {
+					log.Error("emulation runner init failed", "err", rerr)
+					os.Exit(1)
+				}
+				router.SetEmulationRunner(emuRunner)
+				log.Info("adversary emulation runner ENABLED (governed, sandbox-confined, coverage-joined)", "route", "POST /api/v1/engagements/{id}/emulation/runs")
+			}
 		}
 		// The ingest writes an append-only audit entry asserting that N external results entered an
 		// engagement. Without Postgres those rows live only in this process, so the banner says so

--- a/internal/adapter/httpapi/emulation_handler.go
+++ b/internal/adapter/httpapi/emulation_handler.go
@@ -1,0 +1,54 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/emulationrun"
+)
+
+// emulationRunner is the narrow HTTP slice for a governed adversary-emulation run: authorize + execute
+// every catalogued technique against a target asset and compute its purple coverage.
+// *emulationrun.Service satisfies it.
+type emulationRunner interface {
+	Run(ctx context.Context, engagementID, target shared.ID, actor string, allowLab bool) (emulationrun.Summary, error)
+}
+
+// SetEmulationRunner wires the governed emulation-run route. Left unset, the route is not registered
+// (the sandbox / offensive governance the run needs is not available in this process posture).
+func (rt *Router) SetEmulationRunner(s emulationRunner) {
+	if s != nil {
+		rt.emulation = s
+	}
+}
+
+type emulationRunRequest struct {
+	// Target is the asset id the run is attributed to; coverage is per-asset, so it is required.
+	Target string `json:"target"`
+	// AllowLabOnly opts in to techniques with no benign proof (they run only in a lab).
+	AllowLabOnly bool `json:"allow_lab_only"`
+}
+
+// runEmulation authorizes and runs the emulation catalogue against the engagement's target asset, then
+// returns the coverage summary. PermOperate + withEngTenant; the offensive gate additionally refuses
+// unless the engagement's offensive rules of engagement are complete and the authorization window is open.
+//
+// The run is SYNCHRONOUS: the response is 200 with the computed coverage, not a 202 that would promise
+// async processing this handler does not do. The catalogue is small (a handful of techniques), so the
+// call is sub-second; if the catalogue grows toward ATT&CK scale, move execution to synapse-worker and
+// return 202 + a run id with a status route, so the request thread is not held for the whole run.
+func (rt *Router) runEmulation(w http.ResponseWriter, r *http.Request) {
+	var req emulationRunRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 8<<10)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
+		return
+	}
+	summary, err := rt.emulation.Run(r.Context(), shared.ID(r.PathValue("id")), shared.ID(req.Target), PrincipalFrom(r.Context()), req.AllowLabOnly)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, summary)
+}

--- a/internal/adapter/httpapi/engagement_handler.go
+++ b/internal/adapter/httpapi/engagement_handler.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
 	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
@@ -424,6 +425,37 @@ func (rt *Router) setRoE(w http.ResponseWriter, r *http.Request) {
 		roe.Blackouts = append(roe.Blackouts, engdom.Blackout{From: from, To: to})
 	}
 	e, err := rt.eng.SetRoE(r.Context(), PrincipalFrom(r.Context()), shared.ID(TenantFrom(r.Context())), shared.ID(r.PathValue("id")), roe)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toEngagementView(e))
+}
+
+type offensiveRoERequest struct {
+	CustomerContact    string   `json:"customer_contact"`
+	EmergencyContact   string   `json:"emergency_contact"`
+	RiskCeiling        string   `json:"risk_ceiling"`
+	ExcludedAssets     []string `json:"excluded_assets"`
+	ExclusionsReviewed bool     `json:"exclusions_reviewed"`
+}
+
+// setOffensiveRoE sets the engagement's offensive-governance rules of engagement (the contacts, risk
+// ceiling, and reviewed exclusions the #418 offensive gate requires before any offensive action runs).
+// It leaves the execution-gate tool-class rules untouched.
+func (rt *Router) setOffensiveRoE(w http.ResponseWriter, r *http.Request) {
+	var req offensiveRoERequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid json body"})
+		return
+	}
+	e, err := rt.eng.SetOffensiveRoE(r.Context(), PrincipalFrom(r.Context()), shared.ID(TenantFrom(r.Context())), shared.ID(r.PathValue("id")), engdom.OffensiveRoE{
+		CustomerContact:    req.CustomerContact,
+		EmergencyContact:   req.EmergencyContact,
+		RiskCeiling:        offensivepolicy.RiskClass(req.RiskCeiling),
+		ExcludedAssets:     req.ExcludedAssets,
+		ExclusionsReviewed: req.ExclusionsReviewed,
+	})
 	if err != nil {
 		writeError(w, rt.log, err)
 		return

--- a/internal/adapter/httpapi/engagement_handler_test.go
+++ b/internal/adapter/httpapi/engagement_handler_test.go
@@ -483,3 +483,32 @@ func TestListEngagementsCarriesFindingCountsAndLastScan(t *testing.T) {
 		t.Fatalf("last_scan_date = %v, want the job's finish time", row["last_scan_date"])
 	}
 }
+
+func TestSetOffensiveRoEHandler(t *testing.T) {
+	rt, repo, audit := newEngRouter(t)
+	rec := engCall(rt.setOffensiveRoE, http.MethodPut, `{"customer_contact":"ciso@client.example","emergency_contact":"+1-555-0100","risk_ceiling":"high","excluded_assets":["10.0.0.9"],"exclusions_reviewed":true}`)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("offensive roe: code=%d body=%s", rec.Code, rec.Body.String())
+	}
+	got, _ := repo.GetByID(context.Background(), shared.ID("eng-1"))
+	if !got.RoE.Offensive.Complete() {
+		t.Errorf("offensive roe not persisted complete: %+v", got.RoE.Offensive)
+	}
+	if got.RoE.Offensive.RiskCeiling != "high" || len(got.RoE.Offensive.ExcludedAssets) != 1 {
+		t.Errorf("offensive roe fields not persisted: %+v", got.RoE.Offensive)
+	}
+	if !auditHas(audit, "engagement.offensive_roe.update") {
+		t.Error("offensive roe update not audited")
+	}
+	// The response view must expose completeness so the UI can show readiness without re-deriving it.
+	if !strings.Contains(rec.Body.String(), `"complete":true`) {
+		t.Errorf("response view missing offensive completeness: %s", rec.Body.String())
+	}
+	// A non-executable risk ceiling is rejected at the domain boundary (400, not persisted as-is).
+	if rec := engCall(rt.setOffensiveRoE, http.MethodPut, `{"customer_contact":"a@b","emergency_contact":"c","risk_ceiling":"prohibited","exclusions_reviewed":true}`); rec.Code != http.StatusBadRequest {
+		t.Errorf("prohibited ceiling: want 400, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	if rec := engCall(rt.setOffensiveRoE, http.MethodPut, `{bad json`); rec.Code != http.StatusBadRequest {
+		t.Errorf("bad json: want 400, got %d", rec.Code)
+	}
+}

--- a/internal/adapter/httpapi/resource_view.go
+++ b/internal/adapter/httpapi/resource_view.go
@@ -28,8 +28,20 @@ type blackoutView struct {
 
 // roeView is the serialized rules of engagement the execution gate enforces.
 type roeView struct {
-	AllowedToolClasses []string       `json:"allowed_tool_classes"`
-	Blackouts          []blackoutView `json:"blackouts"`
+	AllowedToolClasses []string          `json:"allowed_tool_classes"`
+	Blackouts          []blackoutView    `json:"blackouts"`
+	Offensive          offensiveRoEView  `json:"offensive"`
+}
+
+// offensiveRoEView is the serialized offensive-governance rules of engagement. Complete reports whether
+// every field an offensive action needs is set, so the UI can show readiness without re-deriving it.
+type offensiveRoEView struct {
+	CustomerContact    string   `json:"customer_contact"`
+	EmergencyContact   string   `json:"emergency_contact"`
+	RiskCeiling        string   `json:"risk_ceiling"`
+	ExcludedAssets     []string `json:"excluded_assets"`
+	ExclusionsReviewed bool     `json:"exclusions_reviewed"`
+	Complete           bool     `json:"complete"`
 }
 
 // engagementView is the serialized shape of an engagement.
@@ -85,7 +97,23 @@ func toRoEView(roe engdom.RoE) roeView {
 	for _, blackout := range roe.Blackouts {
 		blackouts = append(blackouts, blackoutView{From: blackout.From, To: blackout.To})
 	}
-	return roeView{AllowedToolClasses: classes, Blackouts: blackouts}
+	o := roe.Offensive
+	excluded := append([]string(nil), o.ExcludedAssets...)
+	if excluded == nil {
+		excluded = []string{}
+	}
+	return roeView{
+		AllowedToolClasses: classes,
+		Blackouts:          blackouts,
+		Offensive: offensiveRoEView{
+			CustomerContact:    o.CustomerContact,
+			EmergencyContact:   o.EmergencyContact,
+			RiskCeiling:        string(o.RiskCeiling),
+			ExcludedAssets:     excluded,
+			ExclusionsReviewed: o.ExclusionsReviewed,
+			Complete:           o.Complete(),
+		},
+	}
 }
 
 func toEngagementView(e *engdom.Engagement) engagementView {

--- a/internal/adapter/httpapi/resource_view_contract_test.go
+++ b/internal/adapter/httpapi/resource_view_contract_test.go
@@ -31,7 +31,8 @@ var wireContract = map[string][]string{
 	},
 	"engagementFindingsView": {"total", "critical", "high", "medium", "low", "info"},
 	"scopeView":              {"in_scope", "out_of_scope"},
-	"roeView":                {"allowed_tool_classes", "blackouts"},
+	"roeView":                {"allowed_tool_classes", "blackouts", "offensive"},
+	"offensiveRoEView":       {"customer_contact", "emergency_contact", "risk_ceiling", "excluded_assets", "exclusions_reviewed", "complete"},
 	"blackoutView":           {"from", "to"},
 }
 

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -84,6 +84,7 @@ type Router struct {
 	responseIDs            ports.IDGenerator          // set with responses; mints the server-authoritative action id
 	connectors             connectorService           // optional; nil ⇒ source-control connector routes are not registered
 	cspm                   *cspm.Service              // optional; nil ⇒ CSPM routes are not registered
+	emulation              emulationRunner            // optional; nil ⇒ the governed emulation-run route is not registered
 	businessAssets         businessAssetService       // optional; nil ⇒ business-level Asset routes are not registered
 	attackPaths            attackPathService          // optional; nil ⇒ attack-path routes are not registered
 	coverage               coverageService            // optional; nil ⇒ fleet coverage/agent-view routes are not registered
@@ -587,6 +588,7 @@ func (rt *Router) routes() *http.ServeMux {
 	mux.HandleFunc("PUT /api/v1/engagements/{id}/scope", rt.authz(userdom.PermOperate, rt.updateScope))
 	mux.HandleFunc("PUT /api/v1/engagements/{id}/authorization-window", rt.authz(userdom.PermOperate, rt.setAuthorizationWindow))
 	mux.HandleFunc("PUT /api/v1/engagements/{id}/roe", rt.authz(userdom.PermOperate, rt.setRoE))
+	mux.HandleFunc("PUT /api/v1/engagements/{id}/offensive-roe", rt.authz(userdom.PermOperate, rt.setOffensiveRoE))
 	mux.HandleFunc("PUT /api/v1/engagements/{id}/live-recon", rt.authz(userdom.PermOperate, rt.setLiveRecon))
 	mux.HandleFunc("GET /api/v1/engagements/{id}/findings", rt.authz(userdom.PermView, rt.withEngTenant(rt.listFindings)))
 	mux.HandleFunc("POST /api/v1/engagements/{id}/findings", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.createFinding)))
@@ -755,6 +757,9 @@ func (rt *Router) routes() *http.ServeMux {
 	if rt.cspm != nil {
 		mux.HandleFunc("POST /api/v1/engagements/{id}/cspm/runs", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.runCSPM)))
 		mux.HandleFunc("GET /api/v1/engagements/{id}/cspm/runs/{rid}", rt.authz(userdom.PermView, rt.withEngTenant(rt.getCSPMRun)))
+	}
+	if rt.emulation != nil {
+		mux.HandleFunc("POST /api/v1/engagements/{id}/emulation/runs", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.runEmulation)))
 	}
 	mux.HandleFunc("GET /api/v1/engagements/{id}/recon/runs", rt.authz(userdom.PermView, rt.withEngTenant(rt.listReconRuns)))
 	mux.HandleFunc("GET /api/v1/engagements/{id}/recon/runs/{rid}", rt.authz(userdom.PermView, rt.withEngTenant(rt.getReconRun)))

--- a/internal/domain/engagement/roe.go
+++ b/internal/domain/engagement/roe.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
 
@@ -43,6 +44,46 @@ type RoE struct {
 	AllowedToolClasses []ToolClass `json:"allowed_tool_classes,omitempty"`
 	// Blackouts are time ranges during which no tool may run.
 	Blackouts []Blackout `json:"blackouts,omitempty"`
+	// Offensive holds the #418/#823 offensive-governance rules an offensive action (live recon, DAST,
+	// adversary emulation, exploitation) is authorized against. It persists inside the same JSON RoE
+	// column; an engagement without it refuses every offensive action (fail-closed).
+	Offensive OffensiveRoE `json:"offensive,omitempty"`
+}
+
+// OffensiveRoE is the rules-of-engagement the offensive governance gate (#418) requires beyond scope and
+// the authorization window: the contacts an operator reaches on incident, the highest risk class the
+// engagement permits, and the asset exclusions the operator has reviewed. Every field is required before
+// an offensive action is authorized, so a partially-filled OffensiveRoE keeps offensive work refused.
+type OffensiveRoE struct {
+	CustomerContact    string                    `json:"customer_contact,omitempty"`
+	EmergencyContact   string                    `json:"emergency_contact,omitempty"`
+	RiskCeiling        offensivepolicy.RiskClass `json:"risk_ceiling,omitempty"`
+	ExcludedAssets     []string                  `json:"excluded_assets,omitempty"`
+	ExclusionsReviewed bool                      `json:"exclusions_reviewed,omitempty"`
+}
+
+// Complete reports whether every offensive-RoE FIELD an authorization needs is set: both contacts, a
+// risk ceiling that is an executable class (low/medium/high, never prohibited or unset), and an explicit
+// exclusions review. It is a necessary condition for an authorized run, not the whole gate: the gate
+// additionally requires a non-empty scope, an open authorization window, and the run's specific target to
+// be in scope. So Complete() is never true when a run would be authorized-false, but it can be true while
+// a run is still refused for scope or window; the UI reads it as offensive-RoE readiness, not run-ready.
+func (o OffensiveRoE) Complete() bool {
+	return strings.TrimSpace(o.CustomerContact) != "" &&
+		strings.TrimSpace(o.EmergencyContact) != "" &&
+		offensiveRiskCeilingValid(o.RiskCeiling) &&
+		o.ExclusionsReviewed
+}
+
+// offensiveRiskCeilingValid accepts only the three executable classes as a ceiling. A "prohibited" or
+// unset ceiling is not a permission level and must not read as one.
+func offensiveRiskCeilingValid(c offensivepolicy.RiskClass) bool {
+	switch c {
+	case offensivepolicy.RiskLow, offensivepolicy.RiskMedium, offensivepolicy.RiskHigh:
+		return true
+	default:
+		return false
+	}
 }
 
 // Permits reports whether a tool of the given class may run at time t under these
@@ -69,15 +110,30 @@ func (r RoE) Permits(class ToolClass, t time.Time) (bool, string) {
 	return true, ""
 }
 
-// SetRoE validates and sets the rules of engagement, stamping UpdatedAt. Each
-// blackout must have end >= start.
+// SetRoE validates and sets the execution-gate rules of engagement (tool classes + blackouts), stamping
+// UpdatedAt. Each blackout must have end >= start. It preserves any offensive RoE already set (that is
+// managed separately via SetOffensiveRoE), so replacing the tool-class rules never silently drops the
+// offensive-governance rules.
 func (e *Engagement) SetRoE(roe RoE, now time.Time) error {
 	for _, b := range roe.Blackouts {
 		if b.To.Before(b.From) {
 			return fmt.Errorf("%w: blackout end must not be before its start", shared.ErrValidation)
 		}
 	}
+	roe.Offensive = e.RoE.Offensive
 	e.RoE = roe
+	e.Audit.UpdatedAt = now
+	return nil
+}
+
+// SetOffensiveRoE validates and sets the offensive-governance rules of engagement, stamping UpdatedAt. A
+// set risk ceiling must be an executable class (low/medium/high); an empty ceiling is allowed and simply
+// leaves offensive work refused until it is filled. The tool-class rules are left untouched.
+func (e *Engagement) SetOffensiveRoE(roe OffensiveRoE, now time.Time) error {
+	if roe.RiskCeiling != "" && !offensiveRiskCeilingValid(roe.RiskCeiling) {
+		return fmt.Errorf("%w: offensive risk ceiling %q must be low, medium, or high", shared.ErrValidation, roe.RiskCeiling)
+	}
+	e.RoE.Offensive = roe
 	e.Audit.UpdatedAt = now
 	return nil
 }

--- a/internal/domain/engagement/roe_test.go
+++ b/internal/domain/engagement/roe_test.go
@@ -1,8 +1,12 @@
 package engagement
 
 import (
+	"reflect"
 	"testing"
 	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
 
 func TestToolClassOf(t *testing.T) {
@@ -46,4 +50,86 @@ func TestRoEPermits(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestOffensiveRoEComplete(t *testing.T) {
+	full := OffensiveRoE{
+		CustomerContact:    "soc@client.example",
+		EmergencyContact:   "+1-555-0100",
+		RiskCeiling:        offensivepolicy.RiskMedium,
+		ExclusionsReviewed: true,
+	}
+	cases := []struct {
+		name string
+		roe  OffensiveRoE
+		want bool
+	}{
+		{"complete", full, true},
+		{"low ceiling ok", func() OffensiveRoE { r := full; r.RiskCeiling = offensivepolicy.RiskLow; return r }(), true},
+		{"high ceiling ok", func() OffensiveRoE { r := full; r.RiskCeiling = offensivepolicy.RiskHigh; return r }(), true},
+		{"missing customer contact", func() OffensiveRoE { r := full; r.CustomerContact = "  "; return r }(), false},
+		{"missing emergency contact", func() OffensiveRoE { r := full; r.EmergencyContact = ""; return r }(), false},
+		{"unset ceiling", func() OffensiveRoE { r := full; r.RiskCeiling = ""; return r }(), false},
+		{"prohibited ceiling", func() OffensiveRoE { r := full; r.RiskCeiling = offensivepolicy.RiskProhibited; return r }(), false},
+		{"exclusions not reviewed", func() OffensiveRoE { r := full; r.ExclusionsReviewed = false; return r }(), false},
+		{"empty", OffensiveRoE{}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := c.roe.Complete(); got != c.want {
+				t.Errorf("Complete() = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+func TestSetOffensiveRoE(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	base := time.Unix(1_699_000_000, 0).UTC()
+
+	t.Run("rejects non-executable ceiling", func(t *testing.T) {
+		e := &Engagement{Audit: shared.Audit{UpdatedAt: base}}
+		err := e.SetOffensiveRoE(OffensiveRoE{RiskCeiling: offensivepolicy.RiskProhibited}, now)
+		if err == nil {
+			t.Fatal("expected validation error for prohibited ceiling")
+		}
+		if !e.Audit.UpdatedAt.Equal(base) {
+			t.Errorf("UpdatedAt changed on rejected set: %v", e.Audit.UpdatedAt)
+		}
+	})
+
+	t.Run("accepts empty ceiling and stamps time", func(t *testing.T) {
+		e := &Engagement{Audit: shared.Audit{UpdatedAt: base}}
+		if err := e.SetOffensiveRoE(OffensiveRoE{CustomerContact: "a@b"}, now); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !e.Audit.UpdatedAt.Equal(now) {
+			t.Errorf("UpdatedAt = %v, want %v", e.Audit.UpdatedAt, now)
+		}
+		if e.RoE.Offensive.CustomerContact != "a@b" {
+			t.Errorf("offensive RoE not set: %+v", e.RoE.Offensive)
+		}
+	})
+
+	t.Run("SetRoE preserves offensive rules", func(t *testing.T) {
+		e := &Engagement{Audit: shared.Audit{UpdatedAt: base}}
+		off := OffensiveRoE{
+			CustomerContact:    "soc@client.example",
+			EmergencyContact:   "+1-555-0100",
+			RiskCeiling:        offensivepolicy.RiskHigh,
+			ExclusionsReviewed: true,
+		}
+		if err := e.SetOffensiveRoE(off, now); err != nil {
+			t.Fatalf("SetOffensiveRoE: %v", err)
+		}
+		if err := e.SetRoE(RoE{AllowedToolClasses: []ToolClass{"recon"}}, now); err != nil {
+			t.Fatalf("SetRoE: %v", err)
+		}
+		if !reflect.DeepEqual(e.RoE.Offensive, off) {
+			t.Errorf("SetRoE dropped offensive rules: got %+v, want %+v", e.RoE.Offensive, off)
+		}
+		if len(e.RoE.AllowedToolClasses) != 1 || e.RoE.AllowedToolClasses[0] != "recon" {
+			t.Errorf("tool classes not applied: %+v", e.RoE.AllowedToolClasses)
+		}
+	})
 }

--- a/internal/infrastructure/emulationexec/executor.go
+++ b/internal/infrastructure/emulationexec/executor.go
@@ -1,0 +1,75 @@
+// Package emulationexec is the sandboxed benign step executor an adversary-emulation run uses (#421).
+// Each production-safe technique maps to a benign, read-only observable command (the same signal the
+// technique's expected detection matches on) that the executor runs through the confined tool runner,
+// argv-only, in a network-isolated sandbox. It NEVER performs a real effect: emulation proves the
+// observable, not the attack. A technique with no benign command here is reported not-observed rather
+// than fabricated.
+package emulationexec
+
+import (
+	"context"
+	"fmt"
+
+	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	exploituc "github.com/KKloudTarus/synapse-ce/internal/usecase/exploitation"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const maxProofBytes = 4 << 10
+
+// SandboxExecutor runs an emulation technique's benign observable through a confined tool runner.
+type SandboxExecutor struct {
+	runner   ports.ToolRunner
+	commands map[string][]string
+}
+
+var _ exploituc.StepExecutor = (*SandboxExecutor)(nil)
+
+// New constructs the executor over a sandboxed tool runner (a *sandbox.Runner). The runner must confine
+// execution: the caller passes the same isolated sandbox the SCA/recon paths use, so the benign command
+// runs argv-only with no egress.
+func New(runner ports.ToolRunner) (*SandboxExecutor, error) {
+	if runner == nil {
+		return nil, fmt.Errorf("%w: emulation executor needs a sandboxed tool runner", shared.ErrValidation)
+	}
+	return &SandboxExecutor{runner: runner, commands: benignCommands()}, nil
+}
+
+// benignCommands maps each production-safe emulation technique to the benign, read-only command whose
+// telemetry the technique's expected detection matches on. A lab-only technique (no benign proof) is
+// intentionally absent, so it is refused before it reaches here or reported not-observed.
+func benignCommands() map[string][]string {
+	return map[string][]string{
+		"emu.process_discovery":               {"ps", "-e"},                       // T1057 -> det.process_enumeration (comm=ps)
+		"emu.system_network_config_discovery": {"ip", "addr"},                     // T1016 -> det.network_config_discovery (comm=ip)
+		"emu.dns_beacon_benign":               {"getent", "hosts", "localhost"},   // T1071.004 -> det.suspicious_dns_beacon (a benign resolve)
+		"emu.credential_file_read":            {"head", "-c", "1", "/etc/shadow"}, // T1552.001 -> det.credential_file_access (a benign read of a credential path)
+	}
+}
+
+// Execute runs the technique's benign observable and reports whether the observable was produced. It
+// never returns an error for a technique-level failure: a command that will not run in the sandbox is a
+// not-observed outcome, not a run-ending error, so one un-runnable technique does not blind the rest of
+// the coverage measurement.
+func (x *SandboxExecutor) Execute(ctx context.Context, _ *dexploit.Chain, step dexploit.Step) (exploituc.StepOutcome, error) {
+	argv, ok := x.commands[step.Technique]
+	if !ok {
+		return exploituc.StepOutcome{ObservedRadius: offensivepolicy.RadiusReadOnly, Observation: "no benign observable defined for technique " + step.Technique}, nil
+	}
+	res, err := x.runner.Run(ctx, ports.ToolSpec{Name: argv[0], Args: argv[1:], MaxOutputBytes: maxProofBytes})
+	if err != nil {
+		return exploituc.StepOutcome{ObservedRadius: offensivepolicy.RadiusReadOnly, Observation: fmt.Sprintf("benign observable %v did not run: %v", argv, err)}, nil
+	}
+	proof := res.Stdout
+	if len(proof) > maxProofBytes {
+		proof = proof[:maxProofBytes]
+	}
+	return exploituc.StepOutcome{
+		Succeeded:      res.ExitCode == 0,
+		ObservedRadius: offensivepolicy.RadiusReadOnly,
+		Proof:          proof,
+		Observation:    fmt.Sprintf("ran benign observable %v (exit %d)", argv, res.ExitCode),
+	}, nil
+}

--- a/internal/infrastructure/emulationexec/executor.go
+++ b/internal/infrastructure/emulationexec/executor.go
@@ -8,6 +8,7 @@ package emulationexec
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
@@ -21,8 +22,9 @@ const maxProofBytes = 4 << 10
 
 // SandboxExecutor runs an emulation technique's benign observable through a confined tool runner.
 type SandboxExecutor struct {
-	runner   ports.ToolRunner
-	commands map[string][]string
+	runner    ports.ToolRunner
+	commands  map[string][]string
+	sensitive map[string]bool
 }
 
 var _ exploituc.StepExecutor = (*SandboxExecutor)(nil)
@@ -34,7 +36,7 @@ func New(runner ports.ToolRunner) (*SandboxExecutor, error) {
 	if runner == nil {
 		return nil, fmt.Errorf("%w: emulation executor needs a sandboxed tool runner", shared.ErrValidation)
 	}
-	return &SandboxExecutor{runner: runner, commands: benignCommands()}, nil
+	return &SandboxExecutor{runner: runner, commands: benignCommands(), sensitive: contentSensitive()}, nil
 }
 
 // benignCommands maps each production-safe emulation technique to the benign, read-only command whose
@@ -49,10 +51,19 @@ func benignCommands() map[string][]string {
 	}
 }
 
-// Execute runs the technique's benign observable and reports whether the observable was produced. It
-// never returns an error for a technique-level failure: a command that will not run in the sandbox is a
-// not-observed outcome, not a run-ending error, so one un-runnable technique does not blind the rest of
-// the coverage measurement.
+// contentSensitive names techniques whose observable reads a secret-bearing path. The detection matches
+// on the READ event, not the bytes, so the executor must never capture the command's stdout as proof: a
+// StepExecutor's Proof is sealed as evidence on the exploitation-chain path, and a credential file's
+// content must not enter evidence, logs, or source (safety invariant #3).
+func contentSensitive() map[string]bool {
+	return map[string]bool{"emu.credential_file_read": true}
+}
+
+// Execute runs the technique's benign observable and reports whether the observable was produced. A
+// technique-level failure (a command that will not run in the sandbox) is a not-observed outcome, not a
+// run-ending error, so one un-runnable technique does not blind the rest of the coverage measurement.
+// Context cancellation and deadline are the exception: they are propagated so a cancelled run or a kill
+// switch actually halts instead of recording benign not-observed outcomes and continuing.
 func (x *SandboxExecutor) Execute(ctx context.Context, _ *dexploit.Chain, step dexploit.Step) (exploituc.StepOutcome, error) {
 	argv, ok := x.commands[step.Technique]
 	if !ok {
@@ -60,7 +71,18 @@ func (x *SandboxExecutor) Execute(ctx context.Context, _ *dexploit.Chain, step d
 	}
 	res, err := x.runner.Run(ctx, ports.ToolSpec{Name: argv[0], Args: argv[1:], MaxOutputBytes: maxProofBytes})
 	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return exploituc.StepOutcome{}, err
+		}
 		return exploituc.StepOutcome{ObservedRadius: offensivepolicy.RadiusReadOnly, Observation: fmt.Sprintf("benign observable %v did not run: %v", argv, err)}, nil
+	}
+	// A credential-path read proves the observable by the read itself; its bytes must not become proof.
+	if x.sensitive[step.Technique] {
+		return exploituc.StepOutcome{
+			Succeeded:      res.ExitCode == 0,
+			ObservedRadius: offensivepolicy.RadiusReadOnly,
+			Observation:    fmt.Sprintf("ran benign observable %v (exit %d); output withheld (credential path)", argv, res.ExitCode),
+		}, nil
 	}
 	proof := res.Stdout
 	if len(proof) > maxProofBytes {

--- a/internal/infrastructure/emulationexec/executor_test.go
+++ b/internal/infrastructure/emulationexec/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
@@ -39,11 +40,12 @@ func TestExecuteMapsTechniqueToBenignArgv(t *testing.T) {
 		technique string
 		wantName  string
 		wantArgs  []string
+		redacted  bool // a credential-path read withholds its output, so no proof is captured
 	}{
-		{"emu.process_discovery", "ps", []string{"-e"}},
-		{"emu.system_network_config_discovery", "ip", []string{"addr"}},
-		{"emu.dns_beacon_benign", "getent", []string{"hosts", "localhost"}},
-		{"emu.credential_file_read", "head", []string{"-c", "1", "/etc/shadow"}},
+		{"emu.process_discovery", "ps", []string{"-e"}, false},
+		{"emu.system_network_config_discovery", "ip", []string{"addr"}, false},
+		{"emu.dns_beacon_benign", "getent", []string{"hosts", "localhost"}, false},
+		{"emu.credential_file_read", "head", []string{"-c", "1", "/etc/shadow"}, true},
 	}
 	for _, c := range cases {
 		t.Run(c.technique, func(t *testing.T) {
@@ -73,7 +75,11 @@ func TestExecuteMapsTechniqueToBenignArgv(t *testing.T) {
 			if out.ObservedRadius != offensivepolicy.RadiusReadOnly {
 				t.Errorf("ObservedRadius = %q, want read_only", out.ObservedRadius)
 			}
-			if !bytes.Equal(out.Proof, []byte("ok")) {
+			if c.redacted {
+				if len(out.Proof) != 0 {
+					t.Errorf("Proof = %q, want withheld for a credential-path read", out.Proof)
+				}
+			} else if !bytes.Equal(out.Proof, []byte("ok")) {
 				t.Errorf("Proof = %q, want ok", out.Proof)
 			}
 		})
@@ -129,5 +135,34 @@ func TestExecuteBoundsProof(t *testing.T) {
 	out, _ := x.Execute(context.Background(), nil, dexploit.Step{Technique: "emu.process_discovery"})
 	if len(out.Proof) > maxProofBytes {
 		t.Errorf("Proof len = %d, want <= %d", len(out.Proof), maxProofBytes)
+	}
+}
+
+func TestExecuteRedactsCredentialProof(t *testing.T) {
+	fr := &fakeRunner{result: ports.ToolResult{Stdout: []byte("x"), ExitCode: 0}} // one byte of /etc/shadow
+	x, _ := New(fr)
+	out, err := x.Execute(context.Background(), nil, dexploit.Step{Technique: "emu.credential_file_read"})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !out.Succeeded {
+		t.Error("Succeeded = false on exit 0")
+	}
+	if len(out.Proof) != 0 {
+		t.Errorf("Proof captured credential-file content (%q); it must be withheld", out.Proof)
+	}
+	if !strings.Contains(out.Observation, "withheld") {
+		t.Errorf("Observation should note the output was withheld, got %q", out.Observation)
+	}
+}
+
+func TestExecutePropagatesContextCancellation(t *testing.T) {
+	for _, ce := range []error{context.Canceled, context.DeadlineExceeded} {
+		fr := &fakeRunner{err: ce}
+		x, _ := New(fr)
+		_, err := x.Execute(context.Background(), nil, dexploit.Step{Technique: "emu.process_discovery"})
+		if !errors.Is(err, ce) {
+			t.Errorf("context error %v must propagate, got %v", ce, err)
+		}
 	}
 }

--- a/internal/infrastructure/emulationexec/executor_test.go
+++ b/internal/infrastructure/emulationexec/executor_test.go
@@ -1,0 +1,133 @@
+package emulationexec
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// fakeRunner records the last spec it was asked to run and returns a scripted result.
+type fakeRunner struct {
+	last   ports.ToolSpec
+	result ports.ToolResult
+	err    error
+	calls  int
+}
+
+func (f *fakeRunner) Run(_ context.Context, spec ports.ToolSpec) (ports.ToolResult, error) {
+	f.calls++
+	f.last = spec
+	return f.result, f.err
+}
+
+func TestNewRequiresRunner(t *testing.T) {
+	if _, err := New(nil); err == nil {
+		t.Fatal("expected error when runner is nil")
+	}
+	if _, err := New(&fakeRunner{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestExecuteMapsTechniqueToBenignArgv(t *testing.T) {
+	cases := []struct {
+		technique string
+		wantName  string
+		wantArgs  []string
+	}{
+		{"emu.process_discovery", "ps", []string{"-e"}},
+		{"emu.system_network_config_discovery", "ip", []string{"addr"}},
+		{"emu.dns_beacon_benign", "getent", []string{"hosts", "localhost"}},
+		{"emu.credential_file_read", "head", []string{"-c", "1", "/etc/shadow"}},
+	}
+	for _, c := range cases {
+		t.Run(c.technique, func(t *testing.T) {
+			fr := &fakeRunner{result: ports.ToolResult{Stdout: []byte("ok"), ExitCode: 0}}
+			x, err := New(fr)
+			if err != nil {
+				t.Fatalf("New: %v", err)
+			}
+			out, err := x.Execute(context.Background(), nil, dexploit.Step{Technique: c.technique})
+			if err != nil {
+				t.Fatalf("Execute returned error: %v", err)
+			}
+			if fr.last.Name != c.wantName {
+				t.Errorf("argv name = %q, want %q", fr.last.Name, c.wantName)
+			}
+			if len(fr.last.Args) != len(c.wantArgs) {
+				t.Fatalf("args = %v, want %v", fr.last.Args, c.wantArgs)
+			}
+			for i := range c.wantArgs {
+				if fr.last.Args[i] != c.wantArgs[i] {
+					t.Errorf("arg[%d] = %q, want %q", i, fr.last.Args[i], c.wantArgs[i])
+				}
+			}
+			if !out.Succeeded {
+				t.Errorf("Succeeded = false on exit 0")
+			}
+			if out.ObservedRadius != offensivepolicy.RadiusReadOnly {
+				t.Errorf("ObservedRadius = %q, want read_only", out.ObservedRadius)
+			}
+			if !bytes.Equal(out.Proof, []byte("ok")) {
+				t.Errorf("Proof = %q, want ok", out.Proof)
+			}
+		})
+	}
+}
+
+func TestExecuteNonZeroExitIsNotSucceeded(t *testing.T) {
+	fr := &fakeRunner{result: ports.ToolResult{Stdout: []byte("boom"), ExitCode: 1}}
+	x, _ := New(fr)
+	out, err := x.Execute(context.Background(), nil, dexploit.Step{Technique: "emu.process_discovery"})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if out.Succeeded {
+		t.Error("Succeeded = true on non-zero exit")
+	}
+}
+
+func TestExecuteUnknownTechniqueIsNotObserved(t *testing.T) {
+	fr := &fakeRunner{}
+	x, _ := New(fr)
+	out, err := x.Execute(context.Background(), nil, dexploit.Step{Technique: "emu.service_restart_probe"})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if fr.calls != 0 {
+		t.Errorf("runner invoked for a technique with no benign observable (calls=%d)", fr.calls)
+	}
+	if out.Succeeded {
+		t.Error("Succeeded = true for a technique with no benign observable")
+	}
+	if out.ObservedRadius != offensivepolicy.RadiusReadOnly {
+		t.Errorf("ObservedRadius = %q, want read_only", out.ObservedRadius)
+	}
+}
+
+func TestExecuteRunnerErrorIsNotObservedNotFatal(t *testing.T) {
+	fr := &fakeRunner{err: errors.New("sandbox denied")}
+	x, _ := New(fr)
+	out, err := x.Execute(context.Background(), nil, dexploit.Step{Technique: "emu.dns_beacon_benign"})
+	if err != nil {
+		t.Fatalf("Execute must not surface a technique-level failure as an error: %v", err)
+	}
+	if out.Succeeded {
+		t.Error("Succeeded = true when the sandbox refused to run the command")
+	}
+}
+
+func TestExecuteBoundsProof(t *testing.T) {
+	big := bytes.Repeat([]byte("A"), maxProofBytes+512)
+	fr := &fakeRunner{result: ports.ToolResult{Stdout: big, ExitCode: 0}}
+	x, _ := New(fr)
+	out, _ := x.Execute(context.Background(), nil, dexploit.Step{Technique: "emu.process_discovery"})
+	if len(out.Proof) > maxProofBytes {
+		t.Errorf("Proof len = %d, want <= %d", len(out.Proof), maxProofBytes)
+	}
+}

--- a/internal/usecase/emulationrun/service.go
+++ b/internal/usecase/emulationrun/service.go
@@ -1,0 +1,187 @@
+// Package emulationrun orchestrates a governed adversary-emulation run for one engagement (#421/#823).
+// It resolves the engagement's offensive rules of engagement, admits every technique through the SAME
+// #418 offensive governance the exploitation chains use, executes each benign observable through the
+// sandboxed step executor, persists the run, and computes purple coverage against the detections the
+// host actually produced in the run window (#426). No offensive action runs outside a complete RoE and
+// the authorization window, both derived here from authoritative engagement state.
+package emulationrun
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	demu "github.com/KKloudTarus/synapse-ce/internal/domain/emulation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	pcovdom "github.com/KKloudTarus/synapse-ce/internal/domain/purplecoverage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	emuc "github.com/KKloudTarus/synapse-ce/internal/usecase/emulation"
+	exploituc "github.com/KKloudTarus/synapse-ce/internal/usecase/exploitation"
+	offensivepolicyuc "github.com/KKloudTarus/synapse-ce/internal/usecase/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/purplecoverage"
+)
+
+// defaultCoverageWindow brackets the emulation run when joining detections: it is short because the
+// benign observables and any detection they trigger are near-simultaneous, and a wide window risks
+// counting an unrelated detection as coverage.
+const defaultCoverageWindow = 10 * time.Minute
+
+// EngagementReader loads authoritative engagement state (scope, window, offensive RoE), tenant-scoped.
+type EngagementReader interface {
+	Get(ctx context.Context, tenantID, id shared.ID) (*engagement.Engagement, error)
+}
+
+// Governance authorizes one offensive technique against the offensive policy. *offensivepolicyuc.Service
+// satisfies it; the emulation admitter consults it per technique, exactly like an exploitation step.
+type Governance interface {
+	Authorize(ctx context.Context, req offensivepolicyuc.Request) (offensivepolicyuc.Decision, error)
+}
+
+// Coverage joins an emulation run with the detections observed on its asset and persists the result.
+// *purplecoverage.Service satisfies it.
+type Coverage interface {
+	Compute(ctx context.Context, run demu.Run, window purplecoverage.Window) (purplecoverage.Result, error)
+}
+
+// Service runs a governed emulation and computes its coverage.
+type Service struct {
+	engagements EngagementReader
+	gov         Governance
+	exec        exploituc.StepExecutor
+	runs        emuc.RunStore
+	coverage    Coverage
+	audit       ports.AuditLogger
+	clock       ports.Clock
+	ids         ports.IDGenerator
+	window      time.Duration
+}
+
+// NewService validates its dependencies. window <= 0 uses the default coverage window.
+func NewService(engagements EngagementReader, gov Governance, exec exploituc.StepExecutor, runs emuc.RunStore, coverage Coverage, audit ports.AuditLogger, clock ports.Clock, ids ports.IDGenerator, window time.Duration) (*Service, error) {
+	if engagements == nil || gov == nil || exec == nil || runs == nil || coverage == nil || audit == nil || clock == nil || ids == nil {
+		return nil, fmt.Errorf("%w: emulation run service is missing a dependency", shared.ErrValidation)
+	}
+	if window <= 0 {
+		window = defaultCoverageWindow
+	}
+	return &Service{engagements: engagements, gov: gov, exec: exec, runs: runs, coverage: coverage, audit: audit, clock: clock, ids: ids, window: window}, nil
+}
+
+// Summary is the outcome the caller reports: the run id, how many techniques executed, and the coverage
+// breakdown after the detection join.
+type Summary struct {
+	RunID        string `json:"run_id"`
+	EngagementID string `json:"engagement_id"`
+	Target       string `json:"target"`
+	Techniques   int    `json:"techniques"`
+	Executed     int    `json:"executed"`
+	Gaps         int    `json:"gaps"`
+	Covered      int    `json:"covered"`
+}
+
+// Run authorizes and executes every catalogued emulation technique against target, then computes and
+// persists the purple coverage for the run. target is the asset the run is attributed to (coverage is
+// per-asset). allowLab opts in to lab-only techniques that have no benign proof.
+func (s *Service) Run(ctx context.Context, engagementID, target shared.ID, actor string, allowLab bool) (Summary, error) {
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok || tenant == "" {
+		return Summary{}, fmt.Errorf("%w: emulation run requires a tenant in context", shared.ErrValidation)
+	}
+	if engagementID == "" || target == "" {
+		return Summary{}, fmt.Errorf("%w: emulation run needs an engagement and a target asset", shared.ErrValidation)
+	}
+	e, err := s.engagements.Get(ctx, tenant, engagementID)
+	if err != nil {
+		return Summary{}, fmt.Errorf("load engagement: %w", err)
+	}
+	// Lifecycle gate: the offensive policy checks the authorization window but not the engagement's
+	// status, so a completed or archived engagement (assessment officially over) would still admit a run
+	// until its window lapsed. Refuse it here, matching the execution guard every other tool path uses.
+	if !e.AllowsExecution() {
+		return Summary{}, fmt.Errorf("%w: engagement %s is %s and cannot run offensive actions", shared.ErrForbidden, engagementID, e.Status)
+	}
+	// Scope membership: the offensive policy checks only that a scope EXISTS, not that the target is in
+	// it, so without this a run could be attributed to an out-of-scope (or foreign, same-tenant) asset.
+	// Scope.Allows is the value-based, out-of-scope-wins check every other tool path enforces.
+	if !e.Scope.Allows(target.String()) {
+		return Summary{}, fmt.Errorf("%w: target %s is not within the engagement scope", shared.ErrForbidden, target)
+	}
+	// Enforce the offensive excluded-assets list against the run target. The policy gate records the
+	// list but never tests membership, so without this the exclusion an operator entered would be
+	// advisory only and the run could be attributed to an explicitly excluded asset.
+	for _, ex := range e.RoE.Offensive.ExcludedAssets {
+		if strings.TrimSpace(ex) == target.String() {
+			return Summary{}, fmt.Errorf("%w: target %s is on the engagement's offensive excluded-assets list", shared.ErrForbidden, target)
+		}
+	}
+	roe := rulesOfEngagement(e)
+	admitter := exploituc.NewPolicyStepAdmitter(s.gov, roe, nil, s.clock.Now)
+	emu, err := emuc.NewService(admitter, s.exec, s.runs, s.audit, s.clock, s.ids)
+	if err != nil {
+		return Summary{}, fmt.Errorf("build emulation service: %w", err)
+	}
+	run, err := emu.Emulate(ctx, tenant, engagementID, target, actor, emuc.Options{AllowLabOnly: allowLab})
+	if err != nil {
+		return Summary{}, fmt.Errorf("run emulation: %w", err)
+	}
+	now := s.clock.Now().UTC()
+	result, err := s.coverage.Compute(ctx, run, purplecoverage.Window{From: now.Add(-s.window), To: now})
+	if err != nil {
+		return Summary{}, fmt.Errorf("compute coverage: %w", err)
+	}
+	// The Summary reports the coverage AFTER the detection join, so it is built from the resolved
+	// verdicts, not from run.Coverage (whose actual-detection is empty until the join runs). Reading the
+	// pre-join records would report every executed technique as a gap regardless of what fired.
+	return summarize(run, result), nil
+}
+
+// rulesOfEngagement maps authoritative engagement state to the offensive RoE the governance gate checks:
+// the in-scope targets, the authorization window, and the offensive contacts / risk ceiling / reviewed
+// exclusions. A missing field leaves the gate refusing, which is the fail-closed default.
+func rulesOfEngagement(e *engagement.Engagement) offensivepolicyuc.RulesOfEngagement {
+	scope := make([]string, 0, len(e.Scope.InScope))
+	for _, t := range e.Scope.InScope {
+		scope = append(scope, t.Value)
+	}
+	var start, end time.Time
+	if e.AuthorizedFrom != nil {
+		start = *e.AuthorizedFrom
+	}
+	if e.AuthorizedTo != nil {
+		end = *e.AuthorizedTo
+	}
+	o := e.RoE.Offensive
+	return offensivepolicyuc.RulesOfEngagement{
+		AuthorizedScope:   scope,
+		WindowStart:       start,
+		WindowEnd:         end,
+		CustomerContact:   o.CustomerContact,
+		EmergencyContact:  o.EmergencyContact,
+		RiskCeiling:       o.RiskCeiling,
+		ExcludedAssets:    o.ExcludedAssets,
+		ExclusionsChecked: o.ExclusionsReviewed,
+	}
+}
+
+// summarize builds the response from the resolved coverage verdicts. covered and gap both mean the
+// technique executed; unknown means it was emulatable but did not run this time (refused or not
+// executed). Techniques counts every technique the run evaluated.
+func summarize(run demu.Run, result purplecoverage.Result) Summary {
+	var executed, gaps, covered int
+	for _, c := range result.Coverage {
+		switch c.Verdict {
+		case pcovdom.VerdictCovered:
+			covered++
+			executed++
+		case pcovdom.VerdictGap:
+			gaps++
+			executed++
+		}
+	}
+	return Summary{
+		RunID: run.ID.String(), EngagementID: run.EngagementID.String(), Target: run.Target.String(),
+		Techniques: len(run.Coverage), Executed: executed, Gaps: gaps, Covered: covered,
+	}
+}

--- a/internal/usecase/emulationrun/service.go
+++ b/internal/usecase/emulationrun/service.go
@@ -23,10 +23,11 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/purplecoverage"
 )
 
-// defaultCoverageWindow brackets the emulation run when joining detections: it is short because the
-// benign observables and any detection they trigger are near-simultaneous, and a wide window risks
-// counting an unrelated detection as coverage.
-const defaultCoverageWindow = 10 * time.Minute
+// defaultCoverageGrace pads each side of the run's own execution span when joining detections. The join
+// window is anchored to the run (start .. end), not a floating lookback from "now": a wide lookback would
+// count an unrelated detection that fired before the run as coverage. The grace only absorbs clock skew
+// between the control plane and the reporting host and a little detection-ingest latency.
+const defaultCoverageGrace = 2 * time.Minute
 
 // EngagementReader loads authoritative engagement state (scope, window, offensive RoE), tenant-scoped.
 type EngagementReader interface {
@@ -64,7 +65,7 @@ func NewService(engagements EngagementReader, gov Governance, exec exploituc.Ste
 		return nil, fmt.Errorf("%w: emulation run service is missing a dependency", shared.ErrValidation)
 	}
 	if window <= 0 {
-		window = defaultCoverageWindow
+		window = defaultCoverageGrace
 	}
 	return &Service{engagements: engagements, gov: gov, exec: exec, runs: runs, coverage: coverage, audit: audit, clock: clock, ids: ids, window: window}, nil
 }
@@ -122,12 +123,16 @@ func (s *Service) Run(ctx context.Context, engagementID, target shared.ID, actor
 	if err != nil {
 		return Summary{}, fmt.Errorf("build emulation service: %w", err)
 	}
+	start := s.clock.Now().UTC()
 	run, err := emu.Emulate(ctx, tenant, engagementID, target, actor, emuc.Options{AllowLabOnly: allowLab})
 	if err != nil {
 		return Summary{}, fmt.Errorf("run emulation: %w", err)
 	}
-	now := s.clock.Now().UTC()
-	result, err := s.coverage.Compute(ctx, run, purplecoverage.Window{From: now.Add(-s.window), To: now})
+	// Anchor the detection-join window to the run's own execution span, padded by the grace, rather than
+	// a fixed lookback from now: a lookback would count a detection that fired before the run started as
+	// coverage for this run.
+	end := s.clock.Now().UTC()
+	result, err := s.coverage.Compute(ctx, run, purplecoverage.Window{From: start.Add(-s.window), To: end.Add(s.window)})
 	if err != nil {
 		return Summary{}, fmt.Errorf("compute coverage: %w", err)
 	}

--- a/internal/usecase/emulationrun/service_test.go
+++ b/internal/usecase/emulationrun/service_test.go
@@ -1,0 +1,319 @@
+package emulationrun
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	demu "github.com/KKloudTarus/synapse-ce/internal/domain/emulation"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
+	offdom "github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	pcovdom "github.com/KKloudTarus/synapse-ce/internal/domain/purplecoverage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	exploituc "github.com/KKloudTarus/synapse-ce/internal/usecase/exploitation"
+	offensivepolicyuc "github.com/KKloudTarus/synapse-ce/internal/usecase/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/purplecoverage"
+)
+
+var runNow = time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+
+// --- fakes ---
+
+type fakeEngagements struct {
+	eng *engdom.Engagement
+	err error
+}
+
+func (f fakeEngagements) Get(_ context.Context, _, _ shared.ID) (*engdom.Engagement, error) {
+	return f.eng, f.err
+}
+
+type fakeSealer struct{}
+
+func (fakeSealer) SealOffensiveAuthorization(_ context.Context, _ shared.ID, _ []byte, createdBy string) (shared.ID, error) {
+	return shared.ID("ev-" + createdBy), nil
+}
+
+type fakeAudit struct{}
+
+func (fakeAudit) Record(_ context.Context, _ ports.AuditEntry) error { return nil }
+
+// fakeExec always produces the observable, so admission is the only thing that decides Executed.
+type fakeExec struct{}
+
+func (fakeExec) Execute(_ context.Context, _ *dexploit.Chain, _ dexploit.Step) (exploituc.StepOutcome, error) {
+	return exploituc.StepOutcome{Succeeded: true, ObservedRadius: offdom.RadiusReadOnly}, nil
+}
+
+type fakeRuns struct{ saved []demu.Run }
+
+func (f *fakeRuns) SaveRun(_ context.Context, run demu.Run) error {
+	f.saved = append(f.saved, run)
+	return nil
+}
+
+// fakeCoverage stands in for the detection join. It resolves each executed technique to a gap (no
+// detection) unless its id is in `covered`, mirroring what purplecoverage.Compute produces, so the test
+// exercises the real "Summary is built from the join result" contract.
+type fakeCoverage struct {
+	calls   int
+	lastRun demu.Run
+	lastWin purplecoverage.Window
+	covered map[string]bool
+}
+
+func (f *fakeCoverage) Compute(_ context.Context, run demu.Run, win purplecoverage.Window) (purplecoverage.Result, error) {
+	f.calls++
+	f.lastRun = run
+	f.lastWin = win
+	var cov []pcovdom.Coverage
+	for _, r := range run.Coverage {
+		v := pcovdom.VerdictUnknown
+		if r.Executed {
+			if f.covered[r.TechniqueID] {
+				v = pcovdom.VerdictCovered
+			} else {
+				v = pcovdom.VerdictGap
+			}
+		}
+		cov = append(cov, pcovdom.Coverage{TechniqueID: r.TechniqueID, Verdict: v})
+	}
+	return purplecoverage.Result{Coverage: cov}, nil
+}
+
+type fakeClock struct{}
+
+func (fakeClock) Now() time.Time { return runNow }
+
+type fakeIDs struct{ n int }
+
+func (f *fakeIDs) NewID() shared.ID {
+	f.n++
+	return shared.ID("id-" + time.Duration(f.n).String())
+}
+
+// --- helpers ---
+
+func completeEngagement() *engdom.Engagement {
+	from := runNow.Add(-time.Hour)
+	to := runNow.Add(time.Hour)
+	return &engdom.Engagement{
+		ID:       "eng-1",
+		TenantID: "t1",
+		Scope: engdom.Scope{
+			InScope: []engdom.Target{{Kind: engdom.TargetDomain, Value: "app.example.test"}},
+		},
+		AuthorizedFrom: &from,
+		AuthorizedTo:   &to,
+		RoE: engdom.RoE{Offensive: engdom.OffensiveRoE{
+			CustomerContact:    "ciso@client.example",
+			EmergencyContact:   "+1-555-0100",
+			RiskCeiling:        offdom.RiskHigh,
+			ExclusionsReviewed: true,
+		}},
+	}
+}
+
+func productionSafeCount(t *testing.T) int {
+	t.Helper()
+	cat, err := demu.Catalogue()
+	if err != nil {
+		t.Fatalf("catalogue: %v", err)
+	}
+	n := 0
+	for _, tech := range cat {
+		if tech.ProductionSafe {
+			n++
+		}
+	}
+	return n
+}
+
+func newRunService(t *testing.T, eng *engdom.Engagement, runs *fakeRuns, cov *fakeCoverage) *Service {
+	t.Helper()
+	reg, err := offdom.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	gov, err := offensivepolicyuc.NewService(reg, fakeSealer{}, fakeAudit{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc, err := NewService(fakeEngagements{eng: eng}, gov, fakeExec{}, runs, cov, fakeAudit{}, fakeClock{}, &fakeIDs{}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc
+}
+
+func tenantCtx() context.Context {
+	return shared.WithTenant(context.Background(), "t1")
+}
+
+// --- tests ---
+
+// TestRunAuthorizesProductionSafeTechniquesUnderCompleteRoE is the vertical's core claim: with a complete
+// offensive RoE, an open window and a non-empty scope, every production-safe technique is admitted through
+// the #418 gate and executed, and the run is persisted and joined for coverage. Coverage stays 0 because
+// no detection fired (honest gaps, not assumed-clean).
+func TestRunAuthorizesProductionSafeTechniquesUnderCompleteRoE(t *testing.T) {
+	runs, cov := &fakeRuns{}, &fakeCoverage{}
+	svc := newRunService(t, completeEngagement(), runs, cov)
+
+	sum, err := svc.Run(tenantCtx(), "eng-1", "app.example.test", "alice", false)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	wantExec := productionSafeCount(t)
+	if sum.Executed != wantExec {
+		t.Errorf("Executed = %d, want %d (the production-safe techniques)", sum.Executed, wantExec)
+	}
+	if sum.Covered != 0 {
+		t.Errorf("Covered = %d, want 0 (no detection fired, so every executed technique is a gap)", sum.Covered)
+	}
+	if sum.Techniques <= sum.Executed {
+		t.Errorf("Techniques (%d) should exceed Executed (%d): the lab-only technique is refused", sum.Techniques, sum.Executed)
+	}
+	if len(runs.saved) != 1 {
+		t.Fatalf("run persisted %d times, want 1", len(runs.saved))
+	}
+	if cov.calls != 1 {
+		t.Fatalf("coverage computed %d times, want 1", cov.calls)
+	}
+	if !cov.lastWin.To.Equal(runNow) || !cov.lastWin.From.Equal(runNow.Add(-defaultCoverageWindow)) {
+		t.Errorf("coverage window = [%s,%s], want [%s,%s]", cov.lastWin.From, cov.lastWin.To, runNow.Add(-defaultCoverageWindow), runNow)
+	}
+	if cov.lastRun.ID != runs.saved[0].ID {
+		t.Errorf("coverage joined a different run than was persisted")
+	}
+}
+
+// TestRunRefusesEveryTechniqueUnderIncompleteRoE proves the fail-closed default: an engagement missing a
+// required offensive field authorizes nothing, so Executed is 0 even though the run still records the
+// refusals and computes (empty) coverage.
+func TestRunRefusesEveryTechniqueUnderIncompleteRoE(t *testing.T) {
+	eng := completeEngagement()
+	eng.RoE.Offensive.CustomerContact = "" // one missing field is enough to refuse
+	runs, cov := &fakeRuns{}, &fakeCoverage{}
+	svc := newRunService(t, eng, runs, cov)
+
+	sum, err := svc.Run(tenantCtx(), "eng-1", "app.example.test", "alice", true)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if sum.Executed != 0 {
+		t.Errorf("Executed = %d, want 0 under an incomplete RoE", sum.Executed)
+	}
+	if len(runs.saved) != 1 || cov.calls != 1 {
+		t.Errorf("run should still persist and compute coverage: saved=%d coverage=%d", len(runs.saved), cov.calls)
+	}
+}
+
+func TestRunRequiresTenantInContext(t *testing.T) {
+	runs, cov := &fakeRuns{}, &fakeCoverage{}
+	svc := newRunService(t, completeEngagement(), runs, cov)
+	if _, err := svc.Run(context.Background(), "eng-1", "app.example.test", "alice", false); err == nil {
+		t.Fatal("expected error with no tenant in context")
+	}
+	if len(runs.saved) != 0 {
+		t.Error("nothing should persist without a tenant")
+	}
+}
+
+func TestRunRequiresEngagementAndTarget(t *testing.T) {
+	svc := newRunService(t, completeEngagement(), &fakeRuns{}, &fakeCoverage{})
+	if _, err := svc.Run(tenantCtx(), "", "app.example.test", "alice", false); err == nil {
+		t.Error("expected error with empty engagement id")
+	}
+	if _, err := svc.Run(tenantCtx(), "eng-1", "", "alice", false); err == nil {
+		t.Error("expected error with empty target")
+	}
+}
+
+func TestRunSurfacesEngagementLoadError(t *testing.T) {
+	reg, _ := offdom.Load()
+	gov, _ := offensivepolicyuc.NewService(reg, fakeSealer{}, fakeAudit{})
+	svc, err := NewService(fakeEngagements{err: errors.New("not found")}, gov, fakeExec{}, &fakeRuns{}, &fakeCoverage{}, fakeAudit{}, fakeClock{}, &fakeIDs{}, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Run(tenantCtx(), "eng-1", "app.example.test", "alice", false); err == nil {
+		t.Fatal("expected the engagement load error to surface")
+	}
+}
+
+func TestNewServiceValidatesDependencies(t *testing.T) {
+	if _, err := NewService(nil, nil, nil, nil, nil, nil, nil, nil, 0); err == nil {
+		t.Fatal("expected error when dependencies are missing")
+	}
+}
+
+// TestRunRefusesCompletedEngagement is the lifecycle gate: an engagement whose assessment is over must
+// not admit an offensive run even while its authorization window is still open.
+func TestRunRefusesCompletedEngagement(t *testing.T) {
+	eng := completeEngagement()
+	eng.Status = engdom.StatusCompleted
+	runs, cov := &fakeRuns{}, &fakeCoverage{}
+	svc := newRunService(t, eng, runs, cov)
+	if _, err := svc.Run(tenantCtx(), "eng-1", "app.example.test", "alice", false); err == nil {
+		t.Fatal("expected a completed engagement to refuse the run")
+	}
+	if len(runs.saved) != 0 || cov.calls != 0 {
+		t.Errorf("nothing should persist for a refused-by-lifecycle run: saved=%d coverage=%d", len(runs.saved), cov.calls)
+	}
+}
+
+// TestRunRefusesExcludedTarget enforces the offensive excluded-assets list: a run must not be attributed
+// to an asset the operator explicitly excluded, even under a complete RoE and open window.
+func TestRunRefusesExcludedTarget(t *testing.T) {
+	eng := completeEngagement()
+	eng.RoE.Offensive.ExcludedAssets = []string{"app.example.test"}
+	runs, cov := &fakeRuns{}, &fakeCoverage{}
+	svc := newRunService(t, eng, runs, cov)
+	if _, err := svc.Run(tenantCtx(), "eng-1", "app.example.test", "alice", false); err == nil {
+		t.Fatal("expected an excluded target to refuse the run")
+	}
+	if len(runs.saved) != 0 {
+		t.Error("nothing should persist for an excluded target")
+	}
+}
+
+// TestRunSummaryReflectsDetectionJoin proves the Summary is built from the coverage join, not the
+// pre-join records: when a detection covers one executed technique, the Summary reports covered > 0. This
+// is the regression the QA pass caught (the endpoint previously always reported covered = 0).
+func TestRunSummaryReflectsDetectionJoin(t *testing.T) {
+	runs := &fakeRuns{}
+	cov := &fakeCoverage{covered: map[string]bool{"emu.process_discovery": true}}
+	svc := newRunService(t, completeEngagement(), runs, cov)
+
+	sum, err := svc.Run(tenantCtx(), "eng-1", "app.example.test", "alice", false)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	exec := productionSafeCount(t)
+	if sum.Covered != 1 {
+		t.Errorf("Covered = %d, want 1 (one technique's detection fired)", sum.Covered)
+	}
+	if sum.Executed != exec {
+		t.Errorf("Executed = %d, want %d", sum.Executed, exec)
+	}
+	if sum.Gaps != exec-1 {
+		t.Errorf("Gaps = %d, want %d (executed minus the one covered)", sum.Gaps, exec-1)
+	}
+}
+
+// TestRunRefusesOutOfScopeTarget enforces engagement scope on the run target: a target that is not in
+// scope is refused before any technique runs, matching the execution guard every other tool path uses.
+func TestRunRefusesOutOfScopeTarget(t *testing.T) {
+	runs, cov := &fakeRuns{}, &fakeCoverage{}
+	svc := newRunService(t, completeEngagement(), runs, cov)
+	if _, err := svc.Run(tenantCtx(), "eng-1", "totally-unrelated.attacker.example", "alice", false); err == nil {
+		t.Fatal("expected an out-of-scope target to refuse the run")
+	}
+	if len(runs.saved) != 0 || cov.calls != 0 {
+		t.Errorf("nothing should persist for an out-of-scope target: saved=%d coverage=%d", len(runs.saved), cov.calls)
+	}
+}

--- a/internal/usecase/emulationrun/service_test.go
+++ b/internal/usecase/emulationrun/service_test.go
@@ -183,8 +183,9 @@ func TestRunAuthorizesProductionSafeTechniquesUnderCompleteRoE(t *testing.T) {
 	if cov.calls != 1 {
 		t.Fatalf("coverage computed %d times, want 1", cov.calls)
 	}
-	if !cov.lastWin.To.Equal(runNow) || !cov.lastWin.From.Equal(runNow.Add(-defaultCoverageWindow)) {
-		t.Errorf("coverage window = [%s,%s], want [%s,%s]", cov.lastWin.From, cov.lastWin.To, runNow.Add(-defaultCoverageWindow), runNow)
+	// The window is anchored at the run (start .. end, both runNow here) padded by the grace on each side.
+	if !cov.lastWin.From.Equal(runNow.Add(-defaultCoverageGrace)) || !cov.lastWin.To.Equal(runNow.Add(defaultCoverageGrace)) {
+		t.Errorf("coverage window = [%s,%s], want [%s,%s]", cov.lastWin.From, cov.lastWin.To, runNow.Add(-defaultCoverageGrace), runNow.Add(defaultCoverageGrace))
 	}
 	if cov.lastRun.ID != runs.saved[0].ID {
 		t.Errorf("coverage joined a different run than was persisted")

--- a/internal/usecase/engagement/service.go
+++ b/internal/usecase/engagement/service.go
@@ -263,6 +263,37 @@ func (s *Service) SetRoE(ctx context.Context, actor string, tenantID, id shared.
 	return &cp, nil
 }
 
+// SetOffensiveRoE sets the engagement's offensive-governance rules of engagement (contacts, risk ceiling,
+// reviewed exclusions), which the offensive gate requires before any offensive action runs. It preserves
+// the execution-gate tool-class rules and is audited like any other config change.
+func (s *Service) SetOffensiveRoE(ctx context.Context, actor string, tenantID, id shared.ID, roe domain.OffensiveRoE) (*domain.Engagement, error) {
+	if err := requireActor(actor); err != nil {
+		return nil, err
+	}
+	e, err := s.repo.GetByIDInTenant(ctx, tenantID, id)
+	if err != nil {
+		return nil, err
+	}
+	now := s.clock.Now()
+	cp := *e
+	if err := cp.SetOffensiveRoE(roe, now); err != nil {
+		return nil, err
+	}
+	cp.Audit.UpdatedBy = actor
+	if err := s.repo.Update(ctx, &cp); err != nil {
+		return nil, fmt.Errorf("persist offensive roe: %w", err)
+	}
+	if err := s.auditChange(ctx, actor, "engagement.offensive_roe.update", id, map[string]string{
+		"risk_ceiling":        string(roe.RiskCeiling),
+		"excluded_assets":     strconv.Itoa(len(roe.ExcludedAssets)),
+		"exclusions_reviewed": strconv.FormatBool(roe.ExclusionsReviewed),
+		"complete":            strconv.FormatBool(roe.Complete()),
+	}, now); err != nil {
+		return nil, err
+	}
+	return &cp, nil
+}
+
 // requireActor enforces attributability: never apply an audited
 // change without a principal, even if a caller omits one.
 func requireActor(actor string) error {

--- a/web/src/lib/api.contract.test.ts
+++ b/web/src/lib/api.contract.test.ts
@@ -42,6 +42,14 @@ function engagementWire() {
     roe: {
       allowed_tool_classes: ['scanner'],
       blackouts: [{ from: '2026-09-06T00:00:00Z', to: '2026-09-07T00:00:00Z' }],
+      offensive: {
+        customer_contact: 'ciso@client.example',
+        emergency_contact: '+84-000-000-000',
+        risk_ceiling: 'high',
+        excluded_assets: ['10.0.0.9'],
+        exclusions_reviewed: true,
+        complete: true,
+      },
     },
     authorized_from: '2026-09-05T00:00:00Z',
     authorized_to: '2026-09-12T00:00:00Z',
@@ -99,6 +107,14 @@ describe('engagement wire contract', () => {
       roe: {
         allowedToolClasses: ['scanner'],
         blackouts: [{ from: '2026-09-06T00:00:00Z', to: '2026-09-07T00:00:00Z' }],
+        offensive: {
+          customerContact: 'ciso@client.example',
+          emergencyContact: '+84-000-000-000',
+          riskCeiling: 'high',
+          excludedAssets: ['10.0.0.9'],
+          exclusionsReviewed: true,
+          complete: true,
+        },
       },
       liveReconEnabled: true,
       createdAt: '2026-09-05T02:56:56.617935338Z',

--- a/web/src/lib/api/blueteam.ts
+++ b/web/src/lib/api/blueteam.ts
@@ -88,6 +88,31 @@ export interface PurpleWorkItem {
   missingDetection: string
 }
 
+// The outcome of a governed adversary-emulation run (POST /engagements/{id}/emulation/runs), after the
+// detection join. `executed` counts techniques that were authorized and observed; `gaps` are executed
+// techniques with no matching detection; `covered` are executed techniques a detection confirmed.
+export interface EmulationRunSummary {
+  runId: string
+  engagementId: string
+  target: string
+  techniques: number
+  executed: number
+  gaps: number
+  covered: number
+}
+
+function mapEmulationSummary(r: any): EmulationRunSummary {
+  return {
+    runId: r?.run_id ?? '',
+    engagementId: r?.engagement_id ?? '',
+    target: r?.target ?? '',
+    techniques: r?.techniques ?? 0,
+    executed: r?.executed ?? 0,
+    gaps: r?.gaps ?? 0,
+    covered: r?.covered ?? 0,
+  }
+}
+
 // The coverage records carry no JSON tags server-side, so the wire keys are PascalCase; tolerate a
 // snake_case shape too in case tags are added later.
 function mapPurpleRow(r: any): PurpleCoverageRow {
@@ -146,6 +171,21 @@ export const blueteamApi = {
     )
     return Array.isArray(r?.work_items) ? r.work_items.map(mapPurpleWorkItem) : []
   },
+  // Run a governed adversary-emulation pass against a target asset. The server authorizes every
+  // catalogued technique through the offensive governance gate, executes each benign observable in the
+  // sandbox, and joins the run against the detection ledger. Refused (403) unless the engagement's
+  // offensive rules of engagement are complete and the authorization window is open.
+  runEmulation: async (
+    engagementId: string,
+    target: string,
+    allowLabOnly = false,
+  ): Promise<EmulationRunSummary> =>
+    mapEmulationSummary(
+      await req(`/engagements/${encodeURIComponent(engagementId)}/emulation/runs`, {
+        method: 'POST',
+        body: JSON.stringify({ target, allow_lab_only: allowLabOnly }),
+      }),
+    ),
   /** Halt every offensive path fleet-wide (kill switch). PermAdminister. */
   haltOffensive: async (reason: string): Promise<HaltResult> => {
     const r = await req('/redteam/halt', { method: 'POST', body: JSON.stringify({ reason }) })

--- a/web/src/lib/api/engagements.ts
+++ b/web/src/lib/api/engagements.ts
@@ -37,6 +37,14 @@ function mapEngagement(r: EngagementWire): Engagement {
     roe: {
       allowedToolClasses: r.roe?.allowed_tool_classes ?? [],
       blackouts: (r.roe?.blackouts ?? []).map((b) => ({ from: b?.from ?? '', to: b?.to ?? '' })),
+      offensive: {
+        customerContact: r.roe?.offensive?.customer_contact ?? '',
+        emergencyContact: r.roe?.offensive?.emergency_contact ?? '',
+        riskCeiling: r.roe?.offensive?.risk_ceiling ?? '',
+        excludedAssets: r.roe?.offensive?.excluded_assets ?? [],
+        exclusionsReviewed: r.roe?.offensive?.exclusions_reviewed ?? false,
+        complete: r.roe?.offensive?.complete ?? false,
+      },
     },
     liveReconEnabled: r.live_recon_enabled ?? false,
     createdAt: r.created_at ?? null,
@@ -136,6 +144,29 @@ export const engagementsApi = {
       await req(`/engagements/${encodeURIComponent(id)}/roe`, {
         method: 'PUT',
         body: JSON.stringify({ allowed_tool_classes: allowedToolClasses, blackouts }),
+      }),
+    ),
+
+  setOffensiveRoE: async (
+    id: string,
+    roe: {
+      customerContact: string
+      emergencyContact: string
+      riskCeiling: string
+      excludedAssets: string[]
+      exclusionsReviewed: boolean
+    },
+  ): Promise<Engagement> =>
+    mapEngagement(
+      await req(`/engagements/${encodeURIComponent(id)}/offensive-roe`, {
+        method: 'PUT',
+        body: JSON.stringify({
+          customer_contact: roe.customerContact,
+          emergency_contact: roe.emergencyContact,
+          risk_ceiling: roe.riskCeiling,
+          excluded_assets: roe.excludedAssets,
+          exclusions_reviewed: roe.exclusionsReviewed,
+        }),
       }),
     ),
 

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -6,7 +6,7 @@ export { type ReportType, type ReportBuildOptions } from './evidence'
 export { type ReconLogEvent, streamReconLogs } from './recon'
 export { type AgentStreamEvent, streamAgentSession } from './agent'
 export { type Connector, type ConnectorCreate, type ConnectorProvider } from './connectors'
-export { type ResponseRecord, type ResponsePlan, type ResponseKind, type ResponseState, type HaltResult, type PurpleVerdict, type PurpleCoverageRow, type PurpleWorkItem } from './blueteam'
+export { type ResponseRecord, type ResponsePlan, type ResponseKind, type ResponseState, type HaltResult, type PurpleVerdict, type PurpleCoverageRow, type PurpleWorkItem, type EmulationRunSummary } from './blueteam'
 export { type RiskStory, type RiskFinding, type RiskExposure, type RiskPath, type RiskDetection, type RiskAssetFacts } from './riskstory'
 export { type ReconcileRun, type ReconcileCounts, type ReconcileState, type ReconcileDiff, type ReconcileDiffClass, type ReconcileDiffCursor, type ReconcileDiffPage } from './vulnerability'
 

--- a/web/src/lib/api/wire.ts
+++ b/web/src/lib/api/wire.ts
@@ -22,9 +22,19 @@ export interface BlackoutWire {
   to: string
 }
 
+export interface OffensiveRoEWire {
+  customer_contact?: string
+  emergency_contact?: string
+  risk_ceiling?: string
+  excluded_assets?: string[]
+  exclusions_reviewed?: boolean
+  complete?: boolean
+}
+
 export interface RoEWire {
   allowed_tool_classes: string[]
   blackouts: BlackoutWire[]
+  offensive?: OffensiveRoEWire
 }
 
 export interface ScopeWire {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -20,11 +20,25 @@ export interface Blackout {
   to: string // RFC3339
 }
 
+// OffensiveRoE – the offensive-governance rules (#418) the offensive gate requires beyond scope and
+// the authorization window, before any offensive action (live recon, DAST, adversary emulation,
+// exploitation) is authorized. `complete` is server-derived: every field an authorization needs is set.
+export interface OffensiveRoE {
+  customerContact: string
+  emergencyContact: string
+  // '' | 'low' | 'medium' | 'high'. Empty keeps offensive work refused.
+  riskCeiling: string
+  excludedAssets: string[]
+  exclusionsReviewed: boolean
+  complete: boolean
+}
+
 // RoE – rules of engagement the execution gate enforces. Empty
 // allowedToolClasses means no tool-class restriction (all allowed).
 export interface RoE {
   allowedToolClasses: string[]
   blackouts: Blackout[]
+  offensive?: OffensiveRoE
 }
 
 /**

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -149,7 +149,7 @@ const CAPABILITIES = [
 export const ENGAGEMENTS = [
   { id: 'eng-001', tenant_id: 'tenant-dev', project_id: '', business_asset_id: 'ba-001', name: 'synapse-ce-audit', client: 'Internal', status: 'active', findings_count: { total: 45, critical: 4, high: 12, medium: 19, low: 10, info: 0 }, last_scan_date: HOUR_AGO, last_scan_status: 'succeeded', scope: { in_scope: [{ kind: 'repo', value: 'https://github.com/KKloudTarus/synapse-ce.git' }], out_of_scope: [] }, roe: { allowed_tool_classes: [], blackouts: [] }, authorized_from: MONTH_AGO, authorized_to: null, timezone: 'UTC', live_recon_enabled: false, created_at: MONTH_AGO, updated_at: MONTH_AGO },
   { id: 'eng-002', tenant_id: 'tenant-dev', project_id: '', business_asset_id: '', name: 'gin-framework-scan', client: 'OSS Review', status: 'completed', findings_count: { total: 3, critical: 0, high: 1, medium: 2, low: 0, info: 0 }, last_scan_date: WEEK_AGO, last_scan_status: 'succeeded', scope: { in_scope: [{ kind: 'repo', value: 'https://github.com/gin-gonic/gin.git' }], out_of_scope: [] }, roe: { allowed_tool_classes: [], blackouts: [] }, authorized_from: WEEK_AGO, authorized_to: null, timezone: 'UTC', live_recon_enabled: false, created_at: WEEK_AGO, updated_at: WEEK_AGO },
-  { id: 'eng-003', tenant_id: 'tenant-dev', project_id: '', business_asset_id: 'ba-002', name: 'api-pentest-q3', client: 'Acme Corp', status: 'active', findings_count: { total: 8, critical: 0, high: 2, medium: 4, low: 2, info: 0 }, last_scan_date: DAY_AGO, last_scan_status: 'failed', scope: { in_scope: [{ kind: 'domain', value: 'api.acme.io' }, { kind: 'url', value: 'https://api.acme.io/v2' }], out_of_scope: [{ kind: 'host', value: '10.0.0.0/8' }] }, roe: { allowed_tool_classes: ['scanner', 'fuzzer'], blackouts: [] }, authorized_from: WEEK_AGO, authorized_to: new Date(Date.now() + 30 * 86400_000).toISOString(), timezone: 'UTC', live_recon_enabled: true, created_at: WEEK_AGO, updated_at: WEEK_AGO },
+  { id: 'eng-003', tenant_id: 'tenant-dev', project_id: '', business_asset_id: 'ba-002', name: 'api-pentest-q3', client: 'Acme Corp', status: 'active', findings_count: { total: 8, critical: 0, high: 2, medium: 4, low: 2, info: 0 }, last_scan_date: DAY_AGO, last_scan_status: 'failed', scope: { in_scope: [{ kind: 'domain', value: 'api.acme.io' }, { kind: 'url', value: 'https://api.acme.io/v2' }], out_of_scope: [{ kind: 'host', value: '10.0.0.0/8' }] }, roe: { allowed_tool_classes: ['scanner', 'fuzzer'], blackouts: [], offensive: { customer_contact: 'ciso@acme.io', emergency_contact: '+1-555-0100', risk_ceiling: 'medium', excluded_assets: ['10.0.0.9'], exclusions_reviewed: true, complete: true } }, authorized_from: WEEK_AGO, authorized_to: new Date(Date.now() + 30 * 86400_000).toISOString(), timezone: 'UTC', live_recon_enabled: true, created_at: WEEK_AGO, updated_at: WEEK_AGO },
   { id: 'eng-004', tenant_id: 'tenant-dev', project_id: '', business_asset_id: 'ba-004', name: 'payment-gateway-review', client: 'Payments', status: 'active', findings_count: { total: 0, critical: 0, high: 0, medium: 0, low: 0, info: 0 }, last_scan_date: HOUR_AGO, last_scan_status: 'running', scope: { in_scope: [{ kind: 'repo', value: 'https://github.com/internal/payment-service.git' }], out_of_scope: [] }, roe: { allowed_tool_classes: [], blackouts: [] }, authorized_from: DAY_AGO, authorized_to: null, timezone: 'UTC', live_recon_enabled: false, created_at: DAY_AGO, updated_at: DAY_AGO },
   { id: 'eng-005', tenant_id: 'tenant-dev', project_id: '', business_asset_id: 'ba-005', name: 'auth-hardening', client: '', status: 'draft', scope: { in_scope: [{ kind: 'repo', value: 'https://github.com/internal/auth-service.git' }], out_of_scope: [] }, roe: { allowed_tool_classes: [], blackouts: [] }, authorized_from: null, authorized_to: null, timezone: 'UTC', live_recon_enabled: false, created_at: DAY_AGO, updated_at: DAY_AGO },
   { id: 'eng-006', tenant_id: 'tenant-dev', project_id: '', business_asset_id: '', name: 'mobile-app-scan', client: '', status: 'draft', scope: { in_scope: [{ kind: 'repo', value: 'https://github.com/internal/mobile-app.git' }], out_of_scope: [] }, roe: { allowed_tool_classes: [], blackouts: [] }, authorized_from: null, authorized_to: null, timezone: 'UTC', live_recon_enabled: false, created_at: NOW, updated_at: NOW },
@@ -551,6 +551,28 @@ export const handlers = [
     const url = new URL(request.url)
     if (url.searchParams.get('run')) return HttpResponse.json({ work_items: PURPLE_WORK_ITEMS })
     return HttpResponse.json({ coverage: PURPLE_COVERAGE })
+  }),
+  // #421/#823 offensive rules of engagement: echo the request back onto the engagement so the Settings
+  // surface reflects the save, and report completeness the way the server derives it.
+  http.put('/api/v1/engagements/:id/offensive-roe', async ({ params, request }) => {
+    const body = (await request.json()) as Record<string, unknown>
+    const eng = ENGAGEMENTS.find(e => e.id === params.id) ?? ENGAGEMENTS[0]
+    const complete = Boolean(body.customer_contact) && Boolean(body.emergency_contact) &&
+      ['low', 'medium', 'high'].includes(String(body.risk_ceiling)) && body.exclusions_reviewed === true
+    return HttpResponse.json({ ...eng, roe: { ...eng.roe, offensive: { ...body, complete } } })
+  }),
+  // Governed adversary-emulation run: a synchronous coverage summary after the detection join.
+  http.post('/api/v1/engagements/:id/emulation/runs', async ({ params, request }) => {
+    const body = (await request.json()) as { target?: string }
+    return HttpResponse.json({
+      run_id: 'emu-' + Math.random().toString(36).slice(2, 8),
+      engagement_id: params.id,
+      target: body.target ?? '',
+      techniques: 5,
+      executed: 4,
+      gaps: 3,
+      covered: 1,
+    })
   }),
   http.get('/api/v1/engagements/:id/risk-stories', () => HttpResponse.json({ stories: RISK_STORIES })),
   http.get('/api/v1/vulnerability/reconcile-runs/:id', () => HttpResponse.json(RECONCILE_RUN)),

--- a/web/src/pages/EngagementDetail/PurpleCoverageTab.test.tsx
+++ b/web/src/pages/EngagementDetail/PurpleCoverageTab.test.tsx
@@ -1,18 +1,50 @@
 import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { api } from '../../lib/api'
 import type { PurpleCoverageRow } from '../../lib/api'
+import type { Engagement } from '../../lib/types'
 import { PurpleCoverageTab } from './PurpleCoverageTab'
 
 vi.mock('../../lib/api', () => ({
   api: {
     purpleCoverage: vi.fn(),
     purpleWorkItems: vi.fn(),
+    runEmulation: vi.fn(),
   },
 }))
 
 function row(runId: string, technique: string, verdict: PurpleCoverageRow['verdict'], at: string): PurpleCoverageRow {
   return { runId, assetId: 'a1', techniqueId: technique, taxonomyRef: `attack:${technique}`, expected: 'det', actual: [], verdict, computedAt: at }
+}
+
+function engagement(overrides: Partial<Engagement> = {}): Engagement {
+  return {
+    id: 'eng-001',
+    name: 'Acme',
+    client: 'Acme',
+    status: 'active',
+    inScope: [{ kind: 'domain', value: 'app.example.test' }],
+    outOfScope: [],
+    authorizedFrom: null,
+    authorizedTo: null,
+    roe: {
+      allowedToolClasses: [],
+      blackouts: [],
+      offensive: {
+        customerContact: 'ciso@acme.example',
+        emergencyContact: '+1-555-0100',
+        riskCeiling: 'high',
+        excludedAssets: [],
+        exclusionsReviewed: true,
+        complete: true,
+      },
+    },
+    liveReconEnabled: false,
+    createdAt: null,
+    businessAssetId: 'asset-9',
+    ...overrides,
+  }
 }
 
 describe('PurpleCoverageTab', () => {
@@ -44,5 +76,37 @@ describe('PurpleCoverageTab', () => {
     render(<PurpleCoverageTab engagementId="eng-001" />)
     expect(await screen.findByText('No purple-team coverage yet')).toBeInTheDocument()
     expect(api.purpleWorkItems).not.toHaveBeenCalled()
+  })
+
+  it('runs an emulation and reloads coverage when the offensive RoE is complete', async () => {
+    vi.mocked(api.purpleCoverage).mockResolvedValue([])
+    vi.mocked(api.runEmulation).mockResolvedValue({
+      runId: 'emu-new',
+      engagementId: 'eng-001',
+      target: 'app.example.test',
+      techniques: 5,
+      executed: 4,
+      gaps: 4,
+      covered: 0,
+    })
+    render(<PurpleCoverageTab engagementId="eng-001" eng={engagement()} />)
+
+    const run = await screen.findByRole('button', { name: /run emulation/i })
+    expect(run).toBeEnabled()
+    await userEvent.click(run)
+
+    await waitFor(() => expect(api.runEmulation).toHaveBeenCalledWith('eng-001', 'app.example.test'))
+    // onRan triggers a coverage refetch (initial load + reload = 2 calls).
+    await waitFor(() => expect(api.purpleCoverage).toHaveBeenCalledTimes(2))
+  })
+
+  it('gates the run when the offensive RoE is incomplete', async () => {
+    vi.mocked(api.purpleCoverage).mockResolvedValue([])
+    const eng = engagement()
+    eng.roe.offensive!.complete = false
+    render(<PurpleCoverageTab engagementId="eng-001" eng={eng} />)
+
+    expect(await screen.findByText(/offensive roe incomplete/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /run emulation/i })).toBeDisabled()
   })
 })

--- a/web/src/pages/EngagementDetail/PurpleCoverageTab.tsx
+++ b/web/src/pages/EngagementDetail/PurpleCoverageTab.tsx
@@ -3,14 +3,17 @@ import {
   AlertTriangle,
   CheckCircle,
   HelpCircle,
+  Play,
   ShieldTick,
   SlashCircle01,
   Target04,
 } from '@untitledui/icons'
-import { Card, EmptyState, ErrorState, Pill, Spinner, cn } from '../../components/ui'
+import { Button, Card, EmptyState, ErrorState, Field, Input, Pill, Spinner, cn } from '../../components/ui'
+import { useToast } from '../../components/synapse/Toast'
 import { useParallelFetch } from '../../hooks'
 import { api } from '../../lib/api'
-import type { PurpleCoverageRow, PurpleWorkItem } from '../../lib/api'
+import type { EmulationRunSummary, PurpleCoverageRow, PurpleWorkItem } from '../../lib/api'
+import type { Engagement } from '../../lib/types'
 
 interface RunSummary {
   runId: string
@@ -204,8 +207,121 @@ function GapList({ items, loading, error }: { items: PurpleWorkItem[]; loading: 
   )
 }
 
-export function PurpleCoverageTab({ engagementId }: { engagementId: string }) {
-  const { data, loading, error } = useParallelFetch<[PurpleCoverageRow[]]>(
+// windowOpen reports whether now sits inside the engagement's authorization window. An unset bound is
+// open on that side. It mirrors the server gate so the run action can explain a closed window before the
+// request 403s.
+function windowOpen(eng: Engagement | undefined): boolean {
+  if (!eng) return true
+  const now = Date.now()
+  if (eng.authorizedFrom) {
+    const f = new Date(eng.authorizedFrom).getTime()
+    if (!Number.isNaN(f) && now < f) return false
+  }
+  if (eng.authorizedTo) {
+    const t = new Date(eng.authorizedTo).getTime()
+    if (!Number.isNaN(t) && now > t) return false
+  }
+  return true
+}
+
+function RunEmulationPanel({
+  engagementId,
+  eng,
+  onRan,
+}: {
+  engagementId: string
+  eng: Engagement | undefined
+  onRan: (runId: string) => void
+}) {
+  // Default to the first in-scope target: the run target must be within engagement scope (the server
+  // refuses an out-of-scope target), and coverage joins against detections keyed by that asset value.
+  const [target, setTarget] = useState(eng?.inScope[0]?.value ?? '')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+  const [last, setLast] = useState<EmulationRunSummary | null>(null)
+  const { notify } = useToast()
+
+  const roeComplete = eng?.roe.offensive?.complete ?? false
+  const inWindow = windowOpen(eng)
+  const gated = !roeComplete || !inWindow
+  const canRun = target.trim() !== '' && !busy && !gated
+
+  async function run() {
+    setBusy(true)
+    setErr('')
+    try {
+      const summary = await api.runEmulation(engagementId, target.trim())
+      setLast(summary)
+      notify(
+        `Emulation run complete: ${summary.executed}/${summary.techniques} executed, ${summary.gaps} gap${summary.gaps === 1 ? '' : 's'}.`,
+        'success',
+      )
+      onRan(summary.runId)
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Failed to run emulation'
+      setErr(message)
+      notify(message, 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Card title="Run adversary emulation" titleClassName="flex items-center gap-2">
+      <p className="text-xs text-tertiary">
+        Runs each catalogued technique through the offensive governance gate and joins it against the
+        detections on the target asset. An authorized-but-undetected technique is a coverage gap.
+      </p>
+      <div className="mt-3 flex flex-wrap items-end gap-3">
+        <div className="min-w-64 flex-1">
+          <Field label="Target asset" hint="Coverage is per-asset">
+            <Input
+              value={target}
+              onChange={(e) => setTarget(e.target.value)}
+              placeholder="in-scope asset"
+              className="font-mono"
+              aria-label="Emulation target asset id"
+            />
+          </Field>
+        </div>
+        <div className="flex flex-col items-end gap-1">
+          <Button loading={busy} disabled={!canRun} onClick={run} variant="primary" className="px-3 py-2">
+            <Play className="size-4" /> Run emulation
+          </Button>
+          {gated && (
+            <span className="inline-flex items-center gap-1 text-[11px] text-medium">
+              <AlertTriangle className="size-3 shrink-0" aria-hidden />
+              {!roeComplete ? 'Offensive RoE incomplete' : 'Outside authorization window'}
+            </span>
+          )}
+        </div>
+      </div>
+      {gated && (
+        <p className="mt-2 text-[11px] text-tertiary">
+          {!roeComplete
+            ? 'Complete the offensive rules of engagement under Settings before a run can be authorized.'
+            : 'A run is refused until the engagement is inside its authorization window.'}
+        </p>
+      )}
+      {last && !err && (
+        <p className="mt-3 text-xs text-tertiary">
+          Latest run <span className="font-mono text-secondary">{shortId(last.runId)}</span>:{' '}
+          <span className="font-semibold text-primary">{last.executed}</span> executed,{' '}
+          <span className="font-semibold text-error-primary">{last.gaps}</span> gap{last.gaps === 1 ? '' : 's'},{' '}
+          <span className="font-semibold text-success-primary">{last.covered}</span> covered.
+        </p>
+      )}
+      {err && (
+        <div className="mt-3">
+          <ErrorState message={err} />
+        </div>
+      )}
+    </Card>
+  )
+}
+
+export function PurpleCoverageTab({ engagementId, eng }: { engagementId: string; eng?: Engagement }) {
+  const { data, loading, error, refetch } = useParallelFetch<[PurpleCoverageRow[]]>(
     () => Promise.all([api.purpleCoverage(engagementId)]),
     { deps: [engagementId] },
   )
@@ -240,19 +356,29 @@ export function PurpleCoverageTab({ engagementId }: { engagementId: string }) {
     }
   }, [engagementId, activeRun])
 
+  // After a run, reload coverage and point at the new run once it lands in the reloaded list.
+  const onRan = (runId: string) => {
+    setSelectedRun(runId)
+    refetch()
+  }
+
   if (loading) return <Spinner label="Loading purple coverage…" />
   if (error) return <ErrorState message={error} />
   if (runs.length === 0)
     return (
-      <EmptyState
-        icon={ShieldTick}
-        title="No purple-team coverage yet"
-        hint="Run an adversary emulation on an enrolled asset; coverage joins each executed technique with the detections that fired."
-      />
+      <div className="space-y-6">
+        <RunEmulationPanel engagementId={engagementId} eng={eng} onRan={onRan} />
+        <EmptyState
+          icon={ShieldTick}
+          title="No purple-team coverage yet"
+          hint="Run an adversary emulation on the target asset above; coverage joins each executed technique with the detections that fired."
+        />
+      </div>
     )
 
   return (
     <div className="space-y-6">
+      <RunEmulationPanel engagementId={engagementId} eng={eng} onRan={onRan} />
       <SummaryCard latest={runs[0]} />
       {runs.length > 1 && (
         <Card title="Coverage by emulation run">

--- a/web/src/pages/EngagementDetail/SettingsTab.test.tsx
+++ b/web/src/pages/EngagementDetail/SettingsTab.test.tsx
@@ -4,10 +4,10 @@ import { MemoryRouter } from 'react-router-dom'
 import { api } from '../../lib/api'
 import { ToastProvider } from '../../components/synapse/Toast'
 import type { Engagement } from '../../lib/types'
-import { LifecycleCard, isTerminalStatus } from './SettingsTab'
+import { LifecycleCard, OffensiveRoeEditorCard, isTerminalStatus } from './SettingsTab'
 
 vi.mock('../../lib/api', () => ({
-  api: { transitionEngagement: vi.fn() },
+  api: { transitionEngagement: vi.fn(), setOffensiveRoE: vi.fn() },
   ApiError: class ApiError extends Error {
     constructor(
       public status: number,
@@ -110,5 +110,82 @@ describe('LifecycleCard', () => {
 
     expect(await screen.findAllByText('archive refused')).not.toHaveLength(0)
     expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+})
+
+describe('OffensiveRoeEditorCard', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  // Seed the risk ceiling (a Radix Select that jsdom cannot drive); the test exercises the Input and
+  // toggle controls, which is where the readiness rule and the save payload are assembled.
+  function engOffensive(over: Partial<{ customer: string; emergency: string; ceiling: string; reviewed: boolean }> = {}): Engagement {
+    return {
+      id: 'eng-1',
+      name: 'Acme',
+      client: 'Acme',
+      status: 'active',
+      inScope: [],
+      outOfScope: [],
+      authorizedFrom: null,
+      authorizedTo: null,
+      roe: {
+        allowedToolClasses: [],
+        blackouts: [],
+        offensive: {
+          customerContact: over.customer ?? '',
+          emergencyContact: over.emergency ?? '',
+          riskCeiling: over.ceiling ?? '',
+          excludedAssets: [],
+          exclusionsReviewed: over.reviewed ?? false,
+          complete: false,
+        },
+      },
+      liveReconEnabled: false,
+      createdAt: null,
+      businessAssetId: '',
+    }
+  }
+
+  function renderOffensive(eng: Engagement) {
+    const onUpdated = vi.fn()
+    render(
+      <MemoryRouter>
+        <ToastProvider>
+          <OffensiveRoeEditorCard eng={eng} onUpdated={onUpdated} />
+        </ToastProvider>
+      </MemoryRouter>,
+    )
+    return { onUpdated }
+  }
+
+  it('shows Incomplete until every required field is set, then Ready', async () => {
+    // Contacts and ceiling are set; only the exclusions review is missing.
+    renderOffensive(engOffensive({ customer: 'ciso@acme.example', emergency: '+1-555-0100', ceiling: 'high' }))
+    expect(screen.getByText(/to go/)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /exclusions reviewed/i }))
+
+    await waitFor(() => expect(screen.getByText('Ready')).toBeInTheDocument())
+  })
+
+  it('saves the offensive rules of engagement with the entered values', async () => {
+    vi.mocked(api.setOffensiveRoE).mockResolvedValue(engOffensive({ customer: 'x', emergency: 'y', ceiling: 'medium', reviewed: true }))
+    renderOffensive(engOffensive({ ceiling: 'medium' }))
+
+    fireEvent.change(screen.getByLabelText('Offensive RoE customer contact'), { target: { value: 'ciso@acme.example' } })
+    fireEvent.change(screen.getByLabelText('Offensive RoE emergency contact'), { target: { value: '+1-555-0100' } })
+    fireEvent.change(screen.getByLabelText('Offensive RoE excluded assets'), { target: { value: '10.0.0.9, db-prod' } })
+    fireEvent.click(screen.getByRole('button', { name: /exclusions reviewed/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    await waitFor(() =>
+      expect(api.setOffensiveRoE).toHaveBeenCalledWith('eng-1', {
+        customerContact: 'ciso@acme.example',
+        emergencyContact: '+1-555-0100',
+        riskCeiling: 'medium',
+        excludedAssets: ['10.0.0.9', 'db-prod'],
+        exclusionsReviewed: true,
+      }),
+    )
   })
 })

--- a/web/src/pages/EngagementDetail/SettingsTab.tsx
+++ b/web/src/pages/EngagementDetail/SettingsTab.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { AlertTriangle, Plus, Save01, Trash01 } from '@untitledui/icons'
+import { AlertTriangle, CheckCircle, Plus, Save01, ShieldTick, Trash01 } from '@untitledui/icons'
 import { Button, Card, ErrorState, Field, Input, Pill, Select, cn } from '../../components/ui'
 import { ConfirmDialog } from '../../components/synapse/ConfirmDialog'
 import { useToast } from '../../components/synapse/Toast'
@@ -18,6 +18,7 @@ export function SettingsTab({ eng, onUpdated }: { eng: Engagement; onUpdated: (e
       <ScopeEditorCard eng={eng} onUpdated={onUpdated} />
       <WindowEditorCard eng={eng} onUpdated={onUpdated} />
       <RoeEditorCard eng={eng} onUpdated={onUpdated} />
+      <OffensiveRoeEditorCard eng={eng} onUpdated={onUpdated} />
       <LiveReconCard eng={eng} onUpdated={onUpdated} />
     </div>
   )
@@ -568,6 +569,178 @@ export function RoeEditorCard({ eng, onUpdated }: { eng: Engagement; onUpdated: 
         </div>
       )}
       {saved && !err && <p className="mt-3 text-xs text-accent">Rules of engagement saved.</p>}
+    </Card>
+  )
+}
+
+export const RISK_CEILINGS: { value: string; label: string }[] = [
+  { value: '', label: 'Not set — offensive work refused' },
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+]
+
+// OffensiveRoeEditorCard sets the offensive-governance rules (#418) the offensive gate requires before
+// any offensive action (adversary emulation, DAST, exploitation) runs. Every field must be set and the
+// exclusions reviewed; until then the gate refuses, which the readiness pill makes visible.
+export function OffensiveRoeEditorCard({ eng, onUpdated }: { eng: Engagement; onUpdated: (e: Engagement) => void }) {
+  const off = eng.roe.offensive
+  const [customer, setCustomer] = useState(off?.customerContact ?? '')
+  const [emergency, setEmergency] = useState(off?.emergencyContact ?? '')
+  const [ceiling, setCeiling] = useState(off?.riskCeiling ?? '')
+  const [excluded, setExcluded] = useState((off?.excludedAssets ?? []).join(', '))
+  const [reviewed, setReviewed] = useState(off?.exclusionsReviewed ?? false)
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+
+  useEffect(() => {
+    const o = eng.roe.offensive
+    setCustomer(o?.customerContact ?? '')
+    setEmergency(o?.emergencyContact ?? '')
+    setCeiling(o?.riskCeiling ?? '')
+    setExcluded((o?.excludedAssets ?? []).join(', '))
+    setReviewed(o?.exclusionsReviewed ?? false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eng.id])
+
+  // Live readiness mirrors the server's completeness rule so the operator sees the effect before saving.
+  const missing = [
+    customer.trim() === '' && 'customer contact',
+    emergency.trim() === '' && 'emergency contact',
+    !(ceiling === 'low' || ceiling === 'medium' || ceiling === 'high') && 'risk ceiling',
+    !reviewed && 'exclusions review',
+  ].filter(Boolean) as string[]
+  const ready = missing.length === 0
+
+  async function save() {
+    setBusy(true)
+    setErr(null)
+    setSaved(false)
+    try {
+      const excludedAssets = excluded
+        .split(/[\n,]/)
+        .map((s) => s.trim())
+        .filter((s) => s !== '')
+      onUpdated(
+        await api.setOffensiveRoE(eng.id, {
+          customerContact: customer.trim(),
+          emergencyContact: emergency.trim(),
+          riskCeiling: ceiling,
+          excludedAssets,
+          exclusionsReviewed: reviewed,
+        }),
+      )
+      setSaved(true)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to save offensive rules of engagement')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Card
+      title="Offensive rules of engagement"
+      titleClassName="flex items-center gap-2"
+      actions={
+        <div className="flex items-center gap-3">
+          {ready ? (
+            <Pill className="bg-accent/10 text-accent ring-1 ring-inset ring-accent/25">
+              <CheckCircle className="mr-1 inline size-3.5" /> Ready
+            </Pill>
+          ) : (
+            <Pill className="bg-medium/10 text-medium ring-1 ring-inset ring-medium/30">
+              {missing.length} to go
+            </Pill>
+          )}
+          <Button loading={busy} onClick={save} variant="secondary-color" className="px-3 py-1.5">
+            <Save01 className="size-4" /> Save
+          </Button>
+        </div>
+      }
+    >
+      <div className="flex items-start gap-2 rounded-lg border border-secondary bg-secondary/20 p-3 text-xs text-tertiary">
+        <ShieldTick className="mt-0.5 size-4 shrink-0 text-brand-secondary" aria-hidden />
+        <span>
+          Offensive actions (adversary emulation, DAST, exploitation) are refused until every field here is
+          set and the authorization window is open. The risk ceiling narrows what the register permits; it
+          never widens it.
+        </span>
+      </div>
+      {!ready && (
+        <p className="mt-2 text-xs text-medium">
+          Still needed: {missing.join(', ')}.
+        </p>
+      )}
+      <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Field label="Customer contact" hint="Reached on an incident during the engagement">
+          <Input
+            value={customer}
+            onChange={(e) => setCustomer(e.target.value)}
+            placeholder="Name and email or phone"
+            aria-label="Offensive RoE customer contact"
+          />
+        </Field>
+        <Field label="Emergency contact" hint="Out-of-hours escalation">
+          <Input
+            value={emergency}
+            onChange={(e) => setEmergency(e.target.value)}
+            placeholder="24/7 phone or email"
+            aria-label="Offensive RoE emergency contact"
+          />
+        </Field>
+        <Field label="Risk ceiling" hint="Highest risk class this engagement permits">
+          <Select
+            value={ceiling}
+            onValueChange={setCeiling}
+            ariaLabel="Offensive RoE risk ceiling"
+            options={RISK_CEILINGS}
+          />
+        </Field>
+        <Field label="Excluded assets" hint="Comma or newline separated; may be empty">
+          <Input
+            value={excluded}
+            onChange={(e) => setExcluded(e.target.value)}
+            placeholder="10.0.0.9, db-prod"
+            className="font-mono"
+            aria-label="Offensive RoE excluded assets"
+          />
+        </Field>
+      </div>
+      <button
+        type="button"
+        aria-pressed={reviewed}
+        onClick={() => setReviewed((v) => !v)}
+        className={cn(
+          'mt-4 flex w-full items-start gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/40',
+          reviewed ? 'border-brand/40 bg-brand-primary/5' : 'border-secondary bg-primary hover:bg-secondary/40',
+        )}
+      >
+        <span
+          className={cn(
+            'mt-0.5 flex size-4 shrink-0 items-center justify-center rounded border',
+            reviewed ? 'border-brand bg-brand-primary text-brand-secondary' : 'border-tertiary',
+          )}
+          aria-hidden
+        >
+          {reviewed && <CheckCircle className="size-3" />}
+        </span>
+        <span className="text-sm text-primary">
+          Exclusions reviewed
+          <span className="mt-0.5 block text-xs text-tertiary">
+            The operator has considered what is out of offensive scope. This distinguishes "nothing excluded"
+            from "nobody looked" and is required even when the list is empty.
+          </span>
+        </span>
+      </button>
+      {err && (
+        <div className="mt-3">
+          <ErrorState message={err} />
+        </div>
+      )}
+      {saved && !err && <p className="mt-3 text-xs text-accent">Offensive rules of engagement saved.</p>}
     </Card>
   )
 }

--- a/web/src/pages/EngagementDetail/index.tsx
+++ b/web/src/pages/EngagementDetail/index.tsx
@@ -521,7 +521,7 @@ export function EngagementDetail() {
         {tab === 'threats' && <ThreatModelTab engagementId={id} />}
         {tab === 'quality' && <CodeQualityTab engagementId={id} />}
         {tab === 'recon' && <ReconTab eng={eng} onGoTab={setTab} />}
-        {tab === 'purple' && <PurpleCoverageTab key={id} engagementId={id} />}
+        {tab === 'purple' && <PurpleCoverageTab key={id} engagementId={id} eng={eng} />}
         {tab === 'agent' && <AgentTab engagementId={id} />}
         {tab === 'detections' && <DetectionsTab key={id} engagementId={id} />}
         {tab === 'imported' && <ImportedFindingsTab key={id} engagementId={id} />}


### PR DESCRIPTION
## What

Wires the governed adversary-emulation vertical (#421/#823) end to end. The emulation
catalogue, its offensive-policy admission (#418), and purple coverage (#426) were
tested domain and use-case code that no composition root ever built, so the run was
unreachable from a running server. This makes it reachable, governed, and visible in
the dashboard.

## Backend

- `internal/usecase/emulationrun`: an orchestrator that loads the engagement, maps its
  offensive rules of engagement, admits every catalogued technique through the same
  #418 governance the exploitation chains use, executes each benign observable, persists
  the run, and joins it against the detection ledger for per-asset coverage.
- `internal/infrastructure/emulationexec`: a sandbox-confined step executor that maps
  each production-safe technique to a benign, read-only, argv-only observable. The
  target is never interpolated into a command.
- `cmd/synapse-api`: composition wiring that registers the runner only when a sandbox
  exists (unregistered in dispatch-only posture, so unconfined execution is impossible).
- Routes: `POST /engagements/{id}/emulation/runs` (synchronous 200 with the coverage
  summary) and `PUT /engagements/{id}/offensive-roe`, both `PermOperate` + tenant-scoped.
- Governance enforced server-side before execution: complete offensive RoE, open
  authorization window, engagement lifecycle, engagement scope membership, and the
  offensive excluded-assets list. Fail-closed on every missing precondition.

## Frontend

- An offensive rules-of-engagement editor in Settings (contacts, risk ceiling, excluded
  assets, an exclusions-reviewed attestation) with a readiness pill and a "still needed"
  hint.
- A "Run adversary emulation" panel on the Purple Coverage tab, target defaulted to the
  first in-scope asset, gated on RoE readiness and the authorization window, refreshing
  coverage on completion.
- Verified in light and dark themes against real rendered UI.

## Safety

- Argv-only execution, no shell, target never on a command line.
- Authorization sealed as evidence before a technique runs.
- Tenant taken from the authenticated context, never the request body; cross-tenant run
  returns 404. Postgres rows are RLS-scoped (`migration_0073`).

## Tests

- Domain: offensive RoE completeness, validation, and preservation across `SetRoE`.
- Use case: full-governance integration (authorizes under a complete RoE, refuses under
  an incomplete one, out-of-scope, excluded, completed engagement, missing tenant), and
  the Summary reflecting the detection join.
- Executor: technique-to-argv mapping, non-observed and error outcomes, proof bounding.
- HTTP: offensive-RoE handler round-trip and validation; wire-contract and OpenAPI drift
  guards updated.
- Web: api mapping/contract, the Settings editor, and the run panel (happy path + gating).
- `make build vet test typecheck` and `cd web && pnpm build` green; Postgres
  `migration_0073` suite run against a real database.

## Review

Internal QA, security, and performance audits ran on the diff; findings addressed:
summary built from the join result, scope/lifecycle/excluded enforcement added, and the
synchronous run returns 200 rather than a misleading 202. UI reviewed with an external
design pass and refined (attestation styling, readiness explanation, copy).

Refs: #421, #823
