### PR TITLE
feat(web): dashboard surfaces for wired-but-UI-less routes (6 surfaces)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,6 +29,7 @@ const QualityProfiles = lazy(() => import('./pages/CodeQuality/QualityProfiles')
 const FleetCoverage = lazy(() => import('./pages/Fleet/FleetCoverage').then(m => ({ default: m.FleetCoverage })))
 const Incidents = lazy(() => import('./pages/Fleet/Incidents').then(m => ({ default: m.Incidents })))
 const Hosts = lazy(() => import('./pages/Fleet/Hosts').then(m => ({ default: m.Hosts })))
+const CoverageWindows = lazy(() => import('./pages/Fleet/CoverageWindows').then(m => ({ default: m.CoverageWindows })))
 const HostDetail = lazy(() => import('./pages/Fleet/HostDetail').then(m => ({ default: m.HostDetail })))
 const IncidentDetail = lazy(() => import('./pages/Fleet/IncidentDetail').then(m => ({ default: m.IncidentDetail })))
 const Rules = lazy(() => import('./pages/Rules/index'))
@@ -36,6 +37,7 @@ const RuleDetail = lazy(() => import('./pages/Rules/RuleDetail'))
 const Audit = lazy(() => import('./pages/Settings/Audit').then(m => ({ default: m.Audit })))
 const Settings = lazy(() => import('./pages/Settings/Settings').then(m => ({ default: m.Settings })))
 const SettingsConfig = lazy(() => import('./pages/Settings/SettingsConfig').then(m => ({ default: m.SettingsConfig })))
+const SLAPolicy = lazy(() => import('./pages/Settings/SLAPolicy').then(m => ({ default: m.SLAPolicy })))
 const Connectors = lazy(() => import('./pages/Settings/Connectors').then(m => ({ default: m.Connectors })))
 const ResponseOps = lazy(() => import('./pages/BlueTeam/ResponseOps').then(m => ({ default: m.ResponseOps })))
 const AITriageReviews = lazy(() => import('./pages/AITriage/AITriageReviews').then(m => ({ default: m.AITriageReviews })))
@@ -99,6 +101,7 @@ function Gate() {
         <Route path="fleet" element={<FleetCoverage />} />
         <Route path="fleet/agents" element={<Navigate to="/fleet" replace />} />
         <Route path="fleet/hosts" element={<Hosts />} />
+        <Route path="fleet/coverage-windows" element={<CoverageWindows />} />
         <Route path="fleet/hosts/:id" element={<HostDetail />} />
         <Route path="fleet/incidents" element={<Incidents />} />
         <Route path="blueteam/response" element={<ResponseOps />} />
@@ -110,6 +113,7 @@ function Gate() {
           <Route path="team" element={<Team />} />
           <Route path="connectors" element={<Connectors />} />
           <Route path="config" element={<SettingsConfig />} />
+          <Route path="sla" element={<SLAPolicy />} />
         </Route>
         <Route path="audit" element={<Navigate to="/settings" replace />} />
         <Route path="team" element={<Navigate to="/settings/team" replace />} />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,6 +29,7 @@ const QualityProfiles = lazy(() => import('./pages/CodeQuality/QualityProfiles')
 const FleetCoverage = lazy(() => import('./pages/Fleet/FleetCoverage').then(m => ({ default: m.FleetCoverage })))
 const Incidents = lazy(() => import('./pages/Fleet/Incidents').then(m => ({ default: m.Incidents })))
 const Hosts = lazy(() => import('./pages/Fleet/Hosts').then(m => ({ default: m.Hosts })))
+const AttackPaths = lazy(() => import('./pages/VulnerabilityIntelligence/AttackPaths').then(m => ({ default: m.AttackPaths })))
 const CoverageWindows = lazy(() => import('./pages/Fleet/CoverageWindows').then(m => ({ default: m.CoverageWindows })))
 const HostDetail = lazy(() => import('./pages/Fleet/HostDetail').then(m => ({ default: m.HostDetail })))
 const IncidentDetail = lazy(() => import('./pages/Fleet/IncidentDetail').then(m => ({ default: m.IncidentDetail })))
@@ -77,6 +78,7 @@ function Gate() {
         <Route path="engagements/:id" element={<EngagementDetail />} />
         <Route path="engagements/:id/:tabSlug" element={<EngagementDetail />} />
         <Route path="assets" element={<Assets />} />
+        <Route path="attack-paths" element={<AttackPaths />} />
         <Route path="assets/:key" element={<AssetDetail />}>
           <Route index element={<AssetOverview />} />
           <Route path="components" element={<AssetComponents />} />

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Plus,
   Monitor01,
   Server01,
+  Share07,
   Signal01,
   Settings01,
   ShieldTick,
@@ -65,6 +66,7 @@ const NAV_GROUPS: Array<{
       items: [
         { icon: Cube01, label: 'Assets', to: '/assets' },
         { icon: ShieldZap, label: 'Vulnerability Intelligence', to: '/vulnerability-intelligence' },
+        { icon: Share07, label: 'Attack Paths', to: '/attack-paths' },
       ],
     },
     {

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Plus,
   Monitor01,
   Server01,
+  Signal01,
   Settings01,
   ShieldTick,
   SlashCircle01,
@@ -86,6 +87,7 @@ const NAV_GROUPS: Array<{
       items: [
         { icon: Server01, label: 'Fleet', to: '/fleet', capability: 'fleet' },
         { icon: Monitor01, label: 'Hosts', to: '/fleet/hosts', capability: 'fleet' },
+        { icon: Signal01, label: 'Coverage Windows', to: '/fleet/coverage-windows', capability: 'fleet' },
         { icon: AlertTriangle, label: 'Incidents', to: '/fleet/incidents' },
         { icon: ShieldTick, label: 'Response', to: '/blueteam/response', capability: 'fleet' },
         { icon: Activity, label: 'Automation Observability', to: '/ai-triage/observability', capability: 'ai_triage' },

--- a/web/src/lib/api/attackpath.ts
+++ b/web/src/lib/api/attackpath.ts
@@ -1,0 +1,92 @@
+import { req } from './client'
+
+// Attack paths (#... attackpath): root-to-finding traversals over the asset/finding graph. Each path is
+// an ordered chain of nodes (assets and a terminal finding) connected by evidence-carrying steps. A path
+// is "confident" only when every step is observed; otherwise it carries uncertainties (an inferred edge,
+// missing/unknown/unconfirmed reachability). The traversal is bounded, so a result can be truncated.
+//
+// The wire nests a PascalCase asset.Asset inside a camelCase-tagged node, so the mapper tolerates both.
+
+export interface AttackPathNode {
+  id: string
+  label: string
+  kind: 'asset' | 'finding'
+  detail: string
+}
+
+export interface AttackPathStep {
+  kind: string
+  observed: boolean
+  toFinding: boolean
+}
+
+export interface AttackPath {
+  id: string
+  nodes: AttackPathNode[]
+  steps: AttackPathStep[]
+  uncertainties: string[]
+  confident: boolean
+}
+
+export interface AttackPathResult {
+  paths: AttackPath[]
+  truncated: boolean
+}
+
+export interface AttackPathFilters {
+  target?: string
+  entrypoint?: string
+  finding?: string
+}
+
+function findingLabel(input: any): { label: string; detail: string } {
+  const f = input?.finding ?? {}
+  const label = f.Title ?? f.title ?? f.RuleID ?? f.rule_id ?? input?.target?.id ?? input?.target?.ID ?? 'finding'
+  const sev = f.Severity ?? f.severity ?? ''
+  const reach = input?.reachability ?? ''
+  const detail = [sev, reach && `reachability ${reach}`].filter(Boolean).join(' · ')
+  return { label: String(label), detail }
+}
+
+function mapNode(n: any): AttackPathNode {
+  if (n?.asset) {
+    const a = n.asset.asset ?? n.asset.Asset ?? {}
+    return {
+      id: a.ID ?? a.id ?? '',
+      label: a.Name ?? a.name ?? a.Key ?? a.key ?? 'asset',
+      kind: 'asset',
+      detail: String(a.Kind ?? a.kind ?? ''),
+    }
+  }
+  const input = n?.finding?.input ?? n?.finding?.Input ?? {}
+  const { label, detail } = findingLabel(input)
+  return { id: input?.target?.id ?? input?.target?.ID ?? '', label, kind: 'finding', detail }
+}
+
+function mapPath(p: any): AttackPath {
+  return {
+    id: p?.id ?? '',
+    nodes: Array.isArray(p?.nodes) ? p.nodes.map(mapNode) : [],
+    steps: Array.isArray(p?.steps)
+      ? p.steps.map((s: any): AttackPathStep => ({ kind: s?.kind ?? '', observed: s?.observed ?? false, toFinding: s?.toFinding ?? s?.to_finding ?? false }))
+      : [],
+    uncertainties: Array.isArray(p?.uncertainties) ? p.uncertainties : [],
+    confident: p?.confident ?? false,
+  }
+}
+
+export const attackPathApi = {
+  // Returns [] when the attack-path feature is disabled (the route answers empty rather than 404).
+  listAttackPaths: async (filters: AttackPathFilters = {}): Promise<AttackPathResult> => {
+    const qs = new URLSearchParams()
+    if (filters.target) qs.set('target', filters.target)
+    if (filters.entrypoint) qs.set('entrypoint', filters.entrypoint)
+    if (filters.finding) qs.set('finding', filters.finding)
+    const q = qs.toString()
+    const r = await req(`/attack-paths${q ? `?${q}` : ''}`)
+    return {
+      paths: Array.isArray(r?.paths) ? r.paths.map(mapPath) : [],
+      truncated: r?.bounds?.truncated ?? false,
+    }
+  },
+}

--- a/web/src/lib/api/cspm.ts
+++ b/web/src/lib/api/cspm.ts
@@ -1,0 +1,68 @@
+import { req } from './client'
+
+// Cloud posture (CSPM) runs (#... cspm). A bounded, read-only live scan of a cloud account's posture.
+// Targets carry a provider, a root (account/subscription/project), and a vault credential reference
+// (never credential material). The run is durable and executed in an isolated worker; the surface polls
+// its status.
+
+export type CloudProvider = 'aws' | 'azure' | 'gcp'
+
+export type CSPMStatus = 'queued' | 'running' | 'succeeded' | 'partial' | 'failed' | 'cancelled'
+
+export interface CloudTarget {
+  provider: CloudProvider
+  root: string
+  credentialRef: string
+}
+
+export interface CSPMEvidenceRef {
+  scopeKey: string
+  id: string
+  hash: string
+}
+
+export interface CSPMRun {
+  id: string
+  engagementId: string
+  actor: string
+  status: CSPMStatus
+  complete: boolean
+  assets: number
+  findings: number
+  coverageIssues: unknown[]
+  errorCode: string
+  evidenceRefs: CSPMEvidenceRef[]
+  startedAt: string
+  finishedAt: string | null
+}
+
+function mapRun(r: any): CSPMRun {
+  return {
+    id: r?.id ?? '',
+    engagementId: r?.engagement_id ?? '',
+    actor: r?.actor ?? '',
+    status: (r?.status ?? 'queued') as CSPMStatus,
+    complete: r?.complete ?? false,
+    assets: r?.assets ?? 0,
+    findings: r?.findings ?? 0,
+    coverageIssues: Array.isArray(r?.coverage_issues) ? r.coverage_issues : [],
+    errorCode: r?.error_code ?? '',
+    evidenceRefs: Array.isArray(r?.evidence_refs)
+      ? r.evidence_refs.map((e: any): CSPMEvidenceRef => ({ scopeKey: e?.scope_key ?? '', id: e?.id ?? '', hash: e?.hash ?? '' }))
+      : [],
+    startedAt: r?.started_at ?? '',
+    finishedAt: r?.finished_at ?? null,
+  }
+}
+
+export const cspmApi = {
+  runCSPM: async (engagementId: string, targets: CloudTarget[]): Promise<CSPMRun> =>
+    mapRun(
+      await req(`/engagements/${encodeURIComponent(engagementId)}/cspm/runs`, {
+        method: 'POST',
+        body: JSON.stringify({ targets: targets.map((t) => ({ provider: t.provider, root: t.root, credential_ref: t.credentialRef })) }),
+      }),
+    ),
+  getCSPMRun: async (engagementId: string, runId: string): Promise<CSPMRun> =>
+    mapRun(await req(`/engagements/${encodeURIComponent(engagementId)}/cspm/runs/${encodeURIComponent(runId)}`)),
+}

--- a/web/src/lib/api/fleet.ts
+++ b/web/src/lib/api/fleet.ts
@@ -163,6 +163,21 @@ export const fleetApi = {
     return (Array.isArray(res?.coverage_windows) ? res.coverage_windows : []).map(mapCoverageWindow)
   },
 
+  // Re-hunt the endpoint state timeline in [around-before, around+after] on a host asset (#594 B7).
+  retroHunt: async (assetId: string, input: RetroHuntRequest): Promise<RetroHuntResult> =>
+    mapRetroHuntResult(
+      await req(`/fleet/assets/${encodeURIComponent(assetId)}/retro-hunt`, {
+        method: 'POST',
+        body: JSON.stringify({
+          around: input.around,
+          before_seconds: input.beforeSeconds,
+          after_seconds: input.afterSeconds,
+          entity_id: input.entityId ?? '',
+          limit: input.limit ?? 0,
+        }),
+      }),
+    ),
+
   // The route only exists when the desired-capabilities service is wired, so callers degrade gracefully.
   fleetDesiredGaps: async (): Promise<FleetDesiredGap[]> => {
     const res = await req('/fleet/desired-capabilities/gaps')
@@ -261,5 +276,53 @@ function mapCoverageWindow(r: any): CoverageWindow {
       privilege: r?.coverage?.privilege ?? 0,
       reasons: Array.isArray(r?.coverage?.reasons) ? r.coverage.reasons : [],
     },
+  }
+}
+
+// --- Retro-hunt (#594 B7): re-hunt the endpoint state timeline in a window around a pivot ---
+
+export interface RetroHuntRequest {
+  around: string // RFC3339 pivot time
+  beforeSeconds: number
+  afterSeconds: number
+  entityId?: string
+  limit?: number
+}
+
+export interface TimelineEntry {
+  occurredAt: string
+  entityKind: string
+  entityId: string
+  kind: string
+  eventId: string
+  summary: string
+}
+
+export interface RetroHuntResult {
+  assetId: string
+  from: string
+  to: string
+  entries: TimelineEntry[]
+  truncated: boolean
+}
+
+function mapTimelineEntry(r: any): TimelineEntry {
+  return {
+    occurredAt: r?.OccurredAt ?? r?.occurred_at ?? '',
+    entityKind: r?.EntityKind ?? r?.entity_kind ?? '',
+    entityId: r?.EntityID ?? r?.entity_id ?? '',
+    kind: r?.Kind ?? r?.kind ?? '',
+    eventId: r?.EventID ?? r?.event_id ?? '',
+    summary: r?.Summary ?? r?.summary ?? '',
+  }
+}
+
+export function mapRetroHuntResult(r: any): RetroHuntResult {
+  return {
+    assetId: r?.AssetID ?? r?.asset_id ?? '',
+    from: r?.From ?? r?.from ?? '',
+    to: r?.To ?? r?.to ?? '',
+    entries: Array.isArray(r?.Entries) ? r.Entries.map(mapTimelineEntry) : Array.isArray(r?.entries) ? r.entries.map(mapTimelineEntry) : [],
+    truncated: r?.Truncated ?? r?.truncated ?? false,
   }
 }

--- a/web/src/lib/api/fleet.ts
+++ b/web/src/lib/api/fleet.ts
@@ -147,6 +147,22 @@ export const fleetApi = {
   },
 
   // Desired-vs-observed capability reconciliation (#633). Rows are snake_case-tagged (ReconciliationRow).
+  // Immutable telemetry coverage-window revisions (#611): one sealed record per asset/agent/host window,
+  // carrying the per-class sensor state and the sample/drop/gap counts the revision was computed from.
+  // Filters are optional; the tenant comes from the authenticated session.
+  listCoverageWindows: async (filters: CoverageWindowFilters = {}): Promise<CoverageWindow[]> => {
+    const qs = new URLSearchParams()
+    if (filters.agentId) qs.set('agent_id', filters.agentId)
+    if (filters.assetId) qs.set('asset_id', filters.assetId)
+    if (filters.hostId) qs.set('host_id', filters.hostId)
+    if (filters.since) qs.set('since', filters.since)
+    if (filters.until) qs.set('until', filters.until)
+    if (filters.limit) qs.set('limit', String(filters.limit))
+    const q = qs.toString()
+    const res = await req(`/fleet/coverage-windows${q ? `?${q}` : ''}`)
+    return (Array.isArray(res?.coverage_windows) ? res.coverage_windows : []).map(mapCoverageWindow)
+  },
+
   // The route only exists when the desired-capabilities service is wired, so callers degrade gracefully.
   fleetDesiredGaps: async (): Promise<FleetDesiredGap[]> => {
     const res = await req('/fleet/desired-capabilities/gaps')
@@ -163,4 +179,87 @@ export const fleetApi = {
       }),
     )
   },
+}
+
+// --- Coverage windows (#611 immutable telemetry coverage revisions) ---
+
+export interface CoverageWindowFilters {
+  agentId?: string
+  assetId?: string
+  hostId?: string
+  since?: string
+  until?: string
+  limit?: number
+}
+
+export type CoverageClass = 'process' | 'network' | 'file' | 'privilege'
+
+export interface CoverageClassState {
+  class: string
+  hostId: string
+  agentId: string
+  state: string
+  reason: string
+  since: string
+}
+
+export interface CoverageVector {
+  process: number
+  network: number
+  file: number
+  privilege: number
+  reasons: string[]
+}
+
+export interface CoverageWindow {
+  assetId: string
+  agentId: string
+  hostId: string
+  since: string
+  until: string
+  inputDigest: string
+  revision: string
+  createdAt: string
+  states: CoverageClassState[]
+  sampledCount: number
+  truncatedCount: number
+  droppedCount: number
+  gapCount: number
+  batchCount: number
+  coverage: CoverageVector
+}
+
+function mapCoverageWindow(r: any): CoverageWindow {
+  return {
+    assetId: r?.asset_id ?? '',
+    agentId: r?.agent_id ?? '',
+    hostId: r?.host_id ?? '',
+    since: r?.since ?? '',
+    until: r?.until ?? '',
+    inputDigest: r?.input_digest ?? '',
+    revision: r?.revision ?? '',
+    createdAt: r?.created_at ?? '',
+    states: Array.isArray(r?.states)
+      ? r.states.map((s: any): CoverageClassState => ({
+          class: s?.class ?? '',
+          hostId: s?.host_id ?? '',
+          agentId: s?.agent_id ?? '',
+          state: s?.state ?? '',
+          reason: s?.reason ?? '',
+          since: s?.since ?? '',
+        }))
+      : [],
+    sampledCount: r?.sampled_count ?? 0,
+    truncatedCount: r?.truncated_count ?? 0,
+    droppedCount: r?.dropped_count ?? 0,
+    gapCount: r?.gap_count ?? 0,
+    batchCount: r?.batch_count ?? 0,
+    coverage: {
+      process: r?.coverage?.process ?? 0,
+      network: r?.coverage?.network ?? 0,
+      file: r?.coverage?.file ?? 0,
+      privilege: r?.coverage?.privilege ?? 0,
+      reasons: Array.isArray(r?.coverage?.reasons) ? r.coverage.reasons : [],
+    },
+  }
 }

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -32,6 +32,7 @@ import { connectorsApi } from './connectors'
 import { blueteamApi } from './blueteam'
 import { riskStoryApi } from './riskstory'
 import { slaApi } from './sla'
+import { writeupApi } from './writeup'
 
 // projectMeasures was a standalone export in the old api.ts
 export const projectMeasures = codeQualityApi.projectMeasures
@@ -67,6 +68,7 @@ export const api = {
   ...blueteamApi,
   ...riskStoryApi,
   ...slaApi,
+  ...writeupApi,
 }
 export {
   type SlaConfig,
@@ -85,3 +87,4 @@ export {
   type CoverageClassState,
   type CoverageVector,
 } from './fleet'
+export { type WriteupDraft, type WriteupDraftState } from './writeup'

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -33,6 +33,7 @@ import { blueteamApi } from './blueteam'
 import { riskStoryApi } from './riskstory'
 import { slaApi } from './sla'
 import { writeupApi } from './writeup'
+import { cspmApi } from './cspm'
 
 // projectMeasures was a standalone export in the old api.ts
 export const projectMeasures = codeQualityApi.projectMeasures
@@ -69,6 +70,7 @@ export const api = {
   ...riskStoryApi,
   ...slaApi,
   ...writeupApi,
+  ...cspmApi,
 }
 export {
   type SlaConfig,
@@ -93,3 +95,10 @@ export {
   type RetroHuntResult,
   type TimelineEntry,
 } from './fleet'
+export {
+  type CSPMRun,
+  type CSPMStatus,
+  type CloudProvider,
+  type CloudTarget,
+  type CSPMEvidenceRef,
+} from './cspm'

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -34,6 +34,7 @@ import { riskStoryApi } from './riskstory'
 import { slaApi } from './sla'
 import { writeupApi } from './writeup'
 import { cspmApi } from './cspm'
+import { attackPathApi } from './attackpath'
 
 // projectMeasures was a standalone export in the old api.ts
 export const projectMeasures = codeQualityApi.projectMeasures
@@ -71,6 +72,7 @@ export const api = {
   ...slaApi,
   ...writeupApi,
   ...cspmApi,
+  ...attackPathApi,
 }
 export {
   type SlaConfig,
@@ -102,3 +104,10 @@ export {
   type CloudTarget,
   type CSPMEvidenceRef,
 } from './cspm'
+export {
+  type AttackPath,
+  type AttackPathNode,
+  type AttackPathStep,
+  type AttackPathResult,
+  type AttackPathFilters,
+} from './attackpath'

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -31,6 +31,7 @@ import { capabilitiesApi } from './capabilities'
 import { connectorsApi } from './connectors'
 import { blueteamApi } from './blueteam'
 import { riskStoryApi } from './riskstory'
+import { slaApi } from './sla'
 
 // projectMeasures was a standalone export in the old api.ts
 export const projectMeasures = codeQualityApi.projectMeasures
@@ -65,4 +66,22 @@ export const api = {
   ...connectorsApi,
   ...blueteamApi,
   ...riskStoryApi,
+  ...slaApi,
 }
+export {
+  type SlaConfig,
+  type SlaPolicy,
+  type SlaWeights,
+  type SlaThresholds,
+  type SlaDueRange,
+  type SlaDueRanges,
+  type SlaTier,
+  SLA_TIERS,
+} from './sla'
+export {
+  type CoverageWindow,
+  type CoverageWindowFilters,
+  type CoverageClass,
+  type CoverageClassState,
+  type CoverageVector,
+} from './fleet'

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -88,3 +88,8 @@ export {
   type CoverageVector,
 } from './fleet'
 export { type WriteupDraft, type WriteupDraftState } from './writeup'
+export {
+  type RetroHuntRequest,
+  type RetroHuntResult,
+  type TimelineEntry,
+} from './fleet'

--- a/web/src/lib/api/sla.ts
+++ b/web/src/lib/api/sla.ts
@@ -1,0 +1,139 @@
+import { req } from './client'
+
+// Risk-based-remediation SLA policy (#... slauc). The server stores an append-only history of policy
+// versions per tenant and marks one active. A policy scores a finding 0-100 from weighted factors, maps
+// the score to a tier via thresholds, and assigns a per-tier mitigate/remediate due range.
+//
+// The wire carries due ranges as Go time.Duration (nanoseconds). This module converts them to whole days
+// at the boundary so the UI only ever deals in days.
+
+const NS_PER_DAY = 86_400_000_000_000
+
+export interface SlaWeights {
+  severity: number
+  exploitability: number
+  threatIntel: number
+  exposure: number
+  criticality: number
+  feasibilityRelief: number
+}
+
+export interface SlaThresholds {
+  emergency: number
+  critical: number
+  high: number
+  medium: number
+}
+
+// Due range in whole days (converted from the wire's nanoseconds).
+export interface SlaDueRange {
+  mitigateDays: number
+  remediateDays: number
+}
+
+export type SlaTier = 'emergency' | 'critical' | 'high' | 'medium' | 'low' | 'exception'
+
+export type SlaDueRanges = Record<SlaTier, SlaDueRange>
+
+export interface SlaConfig {
+  weights: SlaWeights
+  thresholds: SlaThresholds
+  dueRanges: SlaDueRanges
+  version: string
+}
+
+export interface SlaPolicy {
+  config: SlaConfig
+  sha256: string
+  createdBy: string
+  createdAt: string | null
+}
+
+export const SLA_TIERS: SlaTier[] = ['emergency', 'critical', 'high', 'medium', 'low', 'exception']
+
+function nsToDays(ns: unknown): number {
+  const n = typeof ns === 'number' ? ns : 0
+  return Math.round((n / NS_PER_DAY) * 10) / 10
+}
+
+function daysToNs(days: number): number {
+  return Math.round(days * NS_PER_DAY)
+}
+
+function mapDueRange(r: any): SlaDueRange {
+  return { mitigateDays: nsToDays(r?.mitigate_within), remediateDays: nsToDays(r?.remediate_within) }
+}
+
+function mapConfig(r: any): SlaConfig {
+  const dr = r?.due_ranges ?? {}
+  const ranges = {} as SlaDueRanges
+  for (const tier of SLA_TIERS) ranges[tier] = mapDueRange(dr[tier])
+  return {
+    version: r?.version ?? '',
+    weights: {
+      severity: r?.weights?.severity ?? 0,
+      exploitability: r?.weights?.exploitability ?? 0,
+      threatIntel: r?.weights?.threat_intel ?? 0,
+      exposure: r?.weights?.exposure ?? 0,
+      criticality: r?.weights?.criticality ?? 0,
+      feasibilityRelief: r?.weights?.feasibility_relief ?? 0,
+    },
+    thresholds: {
+      emergency: r?.thresholds?.emergency ?? 0,
+      critical: r?.thresholds?.critical ?? 0,
+      high: r?.thresholds?.high ?? 0,
+      medium: r?.thresholds?.medium ?? 0,
+    },
+    dueRanges: ranges,
+  }
+}
+
+function mapPolicy(r: any): SlaPolicy | null {
+  if (!r || !r.config) return null
+  return {
+    config: mapConfig(r.config),
+    sha256: r?.sha256 ?? '',
+    createdBy: r?.created_by ?? '',
+    createdAt: r?.created_at ?? null,
+  }
+}
+
+function configToWire(c: SlaConfig) {
+  const dr: Record<string, { mitigate_within: number; remediate_within: number }> = {}
+  for (const tier of SLA_TIERS) {
+    dr[tier] = {
+      mitigate_within: daysToNs(c.dueRanges[tier].mitigateDays),
+      remediate_within: daysToNs(c.dueRanges[tier].remediateDays),
+    }
+  }
+  return {
+    version: c.version,
+    weights: {
+      severity: c.weights.severity,
+      exploitability: c.weights.exploitability,
+      threat_intel: c.weights.threatIntel,
+      exposure: c.weights.exposure,
+      criticality: c.weights.criticality,
+      feasibility_relief: c.weights.feasibilityRelief,
+    },
+    thresholds: c.thresholds,
+    due_ranges: dr,
+  }
+}
+
+export const slaApi = {
+  // Active policy plus the append-only version history for the tenant.
+  slaPolicies: async (): Promise<{ active: SlaPolicy | null; policies: SlaPolicy[] }> => {
+    const r = await req('/sla/policies')
+    return {
+      active: mapPolicy(r?.active),
+      policies: Array.isArray(r?.policies) ? r.policies.map(mapPolicy).filter(Boolean) : [],
+    }
+  },
+  // Append and activate a new policy version. PermAdminister. `created` is false when the config is
+  // byte-identical to the already-active version (the server re-activates rather than duplicating).
+  activateSLAPolicy: async (config: SlaConfig): Promise<{ policy: SlaPolicy | null; created: boolean }> => {
+    const r = await req('/sla/policies', { method: 'POST', body: JSON.stringify({ config: configToWire(config) }) })
+    return { policy: mapPolicy(r?.policy), created: r?.created === true }
+  },
+}

--- a/web/src/lib/api/writeup.ts
+++ b/web/src/lib/api/writeup.ts
@@ -1,0 +1,69 @@
+import { req } from './client'
+
+// AI-proposed finding write-up drafts (#... writeupdraft). An agent proposes description/remediation
+// prose for a finding; a human with review authority edits, then accepts or rejects it. Separation of
+// duties is enforced server-side: the acceptor must not be the proposer. Nothing here renders into a
+// report on its own — an accepted draft becomes eligible to be applied to its finding.
+//
+// The domain Draft carries no JSON tags, so the wire keys are Go PascalCase; this maps them and tolerates
+// a snake_case shape in case tags are added later.
+
+export type WriteupDraftState = 'proposed' | 'accepted' | 'rejected'
+
+export interface WriteupDraft {
+  id: string
+  engagementId: string
+  findingId: string
+  description: string
+  remediation: string
+  state: WriteupDraftState
+  proposedBy: string
+  decidedBy: string
+  createdAt: string
+  updatedAt: string
+}
+
+function mapDraft(r: any): WriteupDraft {
+  return {
+    id: r?.ID ?? r?.id ?? '',
+    engagementId: r?.EngagementID ?? r?.engagement_id ?? '',
+    findingId: r?.FindingID ?? r?.finding_id ?? '',
+    description: r?.Description ?? r?.description ?? '',
+    remediation: r?.Remediation ?? r?.remediation ?? '',
+    state: (r?.State ?? r?.state ?? 'proposed') as WriteupDraftState,
+    proposedBy: r?.ProposedBy ?? r?.proposed_by ?? '',
+    decidedBy: r?.DecidedBy ?? r?.decided_by ?? '',
+    createdAt: r?.CreatedAt ?? r?.created_at ?? '',
+    updatedAt: r?.UpdatedAt ?? r?.updated_at ?? '',
+  }
+}
+
+export const writeupApi = {
+  listWriteupDrafts: async (engagementId: string): Promise<WriteupDraft[]> => {
+    const r = await req(`/engagements/${encodeURIComponent(engagementId)}/writeup-drafts`)
+    return Array.isArray(r?.writeup_drafts) ? r.writeup_drafts.map(mapDraft) : []
+  },
+  editWriteupDraft: async (
+    engagementId: string,
+    draftId: string,
+    body: { description: string; remediation: string },
+  ): Promise<WriteupDraft> =>
+    mapDraft(
+      await req(`/engagements/${encodeURIComponent(engagementId)}/writeup-drafts/${encodeURIComponent(draftId)}/edit`, {
+        method: 'POST',
+        body: JSON.stringify(body),
+      }),
+    ),
+  acceptWriteupDraft: async (engagementId: string, draftId: string): Promise<WriteupDraft> =>
+    mapDraft(
+      await req(`/engagements/${encodeURIComponent(engagementId)}/writeup-drafts/${encodeURIComponent(draftId)}/accept`, {
+        method: 'POST',
+      }),
+    ),
+  rejectWriteupDraft: async (engagementId: string, draftId: string): Promise<WriteupDraft> =>
+    mapDraft(
+      await req(`/engagements/${encodeURIComponent(engagementId)}/writeup-drafts/${encodeURIComponent(draftId)}/reject`, {
+        method: 'POST',
+      }),
+    ),
+}

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -852,6 +852,14 @@ export const handlers = [
     const a = BUSINESS_ASSETS.find(x => x.ID === params.id) ?? BUSINESS_ASSETS[0]
     return HttpResponse.json({ ...a, type: 'host', tags: ['production'], finding_count: 12, last_scanned: HOUR_AGO, engagements: ENGAGEMENTS.slice(0, 2) })
   }),
+  http.get('/api/v1/assets/:id/vulnerabilities', ({ params }) => HttpResponse.json({
+    asset: { ID: params.id, Kind: 'host', Key: 'hostname/web-01', Name: 'web-01', Attributes: { reporting_agent_id: 'agent-001', coverage_gaps: '1', degraded: 'false', os: 'ubuntu 22.04' } },
+    engagement_id: 'eng-001', packages: 842, recorded_at: HOUR_AGO,
+    last_scan: { job_id: 'hs-1', status: 'succeeded', stage: '', error: '', started_at: HOUR_AGO, finished_at: HOUR_AGO },
+    summary: { total: 0, critical: 0, high: 0, medium: 0, low: 0, info: 0, fixable: 0, kev: 0 },
+    findings: [],
+  })),
+  http.get('/api/v1/assets/:id/packages', ({ params }) => HttpResponse.json({ asset_id: params.id, engagement_id: 'eng-001', recorded_at: HOUR_AGO, packages: [{ name: 'openssl', version: '3.0.2', purl: 'pkg:deb/ubuntu/openssl@3.0.2' }] })),
   http.get('/api/v1/appsec/assets', ({ request }) => {
     const url = new URL(request.url)
     const limit = Number(url.searchParams.get('limit')) || 5
@@ -1140,6 +1148,23 @@ export const handlers = [
   }),
   http.get('/api/v1/fleet/coverage', () => HttpResponse.json(FLEET_COVERAGE)),
   http.get('/api/v1/fleet/coverage-windows', () => HttpResponse.json({ coverage_windows: COVERAGE_WINDOWS })),
+  http.post('/api/v1/fleet/assets/:id/retro-hunt', async ({ params, request }) => {
+    const body = (await request.json()) as { around?: string; before_seconds?: number; after_seconds?: number }
+    const around = body.around ? new Date(body.around) : new Date()
+    const from = new Date(around.getTime() - (body.before_seconds ?? 900) * 1000).toISOString()
+    const to = new Date(around.getTime() + (body.after_seconds ?? 900) * 1000).toISOString()
+    return HttpResponse.json({
+      AssetID: params.id,
+      From: from,
+      To: to,
+      Truncated: false,
+      Entries: [
+        { OccurredAt: from, EntityKind: 'process', EntityID: 'pid-4821', Kind: 'process_exec', EventID: 'ev-1', Summary: 'curl spawned by bash (parent sshd)' },
+        { OccurredAt: around.toISOString(), EntityKind: 'network', EntityID: 'conn-77', Kind: 'egress_connect', EventID: 'ev-2', Summary: 'outbound 443 to 203.0.113.9 (unclassified)' },
+        { OccurredAt: to, EntityKind: 'file', EntityID: '/etc/cron.d/x', Kind: 'file_write', EventID: 'ev-3', Summary: 'new file written under /etc/cron.d' },
+      ],
+    })
+  }),
   http.get('/api/v1/fleet/incidents', ({ request }) => {
     const state = new URL(request.url).searchParams.get('state')
     const incidents = FLEET_INCIDENTS.filter((i) => !state || i.State === state)

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -324,6 +324,25 @@ const OBSERVABILITY = {
 }
 
 // --- Remediation SLA ---
+const DAY_NS = 86_400_000_000_000
+const SLA_POLICY = {
+  config: {
+    version: 'sla-v1',
+    weights: { severity: 35, exploitability: 25, threat_intel: 10, exposure: 15, criticality: 15, feasibility_relief: 15 },
+    thresholds: { emergency: 85, critical: 70, high: 50, medium: 30 },
+    due_ranges: {
+      emergency: { mitigate_within: 1 * DAY_NS, remediate_within: 7 * DAY_NS },
+      critical: { mitigate_within: 3 * DAY_NS, remediate_within: 15 * DAY_NS },
+      high: { mitigate_within: 7 * DAY_NS, remediate_within: 30 * DAY_NS },
+      medium: { mitigate_within: 30 * DAY_NS, remediate_within: 90 * DAY_NS },
+      low: { mitigate_within: 90 * DAY_NS, remediate_within: 180 * DAY_NS },
+      exception: { mitigate_within: 30 * DAY_NS, remediate_within: 180 * DAY_NS },
+    },
+  },
+  sha256: 'a1b2c3d4e5f6a1b2c3d4e5f6',
+  created_by: 'system',
+  created_at: MONTH_AGO,
+}
 const SLA_ITEMS = [
   { assessment: { tenant_id: 't1', id: 'sla-001', engagement_id: 'eng-001', finding_id: 'finding-001', source_risk_assessment_id: 'ra-1', inputs: { severity: 'critical', cvss_score: 9.8, kev: true, epss: 0.92, public_poc: true, active_exploitation: true, criticality: 'high', exposure: 'external', feasibility: 'patch_available' }, result: { tier: 'emergency', score: 98, breakdown: { severity: 30, exploitability: 25, threat_intel: 20, exposure: 10, criticality: 8, feasibility: 5, overrides: ['kev_active'] }, mitigate_by: new Date(Date.now() + 86400_000).toISOString(), remediate_by: new Date(Date.now() + 3 * 86400_000).toISOString(), reason: 'Active exploitation + KEV + external', computed_at: HOUR_AGO, config_version: '2026.08' }, input_hash: 'abc', config_hash: 'cfg', previous_assessment_id: '', deadline_anchor_at: DAY_AGO, assessed_at: HOUR_AGO, created_at: DAY_AGO }, lifecycle: { tenant_id: 't1', engagement_id: 'eng-001', finding_id: 'finding-001', assessment_id: 'sla-001', status: 'open', version: 1, reason: '', compensating_control: '', accepted_by: '', accepted_at: null, acceptance_expires_at: null, updated_by: 'system', updated_at: HOUR_AGO }, effective_state: 'open', overdue: false, acceptance_expired: false },
   { assessment: { tenant_id: 't1', id: 'sla-002', engagement_id: 'eng-001', finding_id: 'finding-003', source_risk_assessment_id: 'ra-2', inputs: { severity: 'high', cvss_score: 7.5, kev: false, epss: 0.45, public_poc: true, active_exploitation: false, criticality: 'medium', exposure: 'external', feasibility: 'patch_available' }, result: { tier: 'critical', score: 72, breakdown: { severity: 25, exploitability: 18, threat_intel: 12, exposure: 8, criticality: 5, feasibility: 4, overrides: [] }, mitigate_by: new Date(Date.now() + 7 * 86400_000).toISOString(), remediate_by: new Date(Date.now() + 14 * 86400_000).toISOString(), reason: 'High + public PoC + external', computed_at: HOUR_AGO, config_version: '2026.08' }, input_hash: 'def', config_hash: 'cfg', previous_assessment_id: '', deadline_anchor_at: WEEK_AGO, assessed_at: HOUR_AGO, created_at: WEEK_AGO }, lifecycle: { tenant_id: 't1', engagement_id: 'eng-001', finding_id: 'finding-003', assessment_id: 'sla-002', status: 'mitigating', version: 2, reason: 'WAF rule deployed', compensating_control: 'WAF block rule #4521', accepted_by: '', accepted_at: null, acceptance_expires_at: null, updated_by: 'alice', updated_at: DAY_AGO }, effective_state: 'mitigating', overdue: false, acceptance_expired: false },
@@ -339,6 +358,32 @@ const FLEET_AGENTS = [
   { id: 'agent-005', name: 'k8s-node-scanner', platform: 'linux/amd64', agent_version: '0.9.4', state: 'healthy', last_seen: NOW, capabilities: ['scan.host', 'scan.container', 'detect.runtime', 'scan.k8s'], current_work: 3 },
 ]
 
+const COVERAGE_WINDOWS = [
+  {
+    asset_id: 'ba-001', agent_id: 'agent-001', host_id: 'host-web-01',
+    since: DAY_AGO, until: NOW, input_digest: 'sha256:9f1c0a44e7b2', revision: 'rev-0042', created_at: NOW,
+    states: [
+      { class: 'process', host_id: 'host-web-01', agent_id: 'agent-001', state: 'covered', reason: '', since: DAY_AGO },
+      { class: 'network', host_id: 'host-web-01', agent_id: 'agent-001', state: 'covered', reason: '', since: DAY_AGO },
+      { class: 'file', host_id: 'host-web-01', agent_id: 'agent-001', state: 'degraded', reason: 'sampling above target', since: HOUR_AGO },
+      { class: 'privilege', host_id: 'host-web-01', agent_id: 'agent-001', state: 'covered', reason: '', since: DAY_AGO },
+    ],
+    sampled_count: 18420, truncated_count: 12, dropped_count: 3, gap_count: 1, batch_count: 96,
+    coverage: { process: 1, network: 1, file: 1, privilege: 1, reasons: ['file sensor above sampling target for 42m'] },
+  },
+  {
+    asset_id: 'ba-002', agent_id: 'agent-002', host_id: 'host-db-02',
+    since: WEEK_AGO, until: DAY_AGO, input_digest: 'sha256:1abed3390f77', revision: 'rev-0031', created_at: DAY_AGO,
+    states: [
+      { class: 'process', host_id: 'host-db-02', agent_id: 'agent-002', state: 'covered', reason: '', since: WEEK_AGO },
+      { class: 'network', host_id: 'host-db-02', agent_id: 'agent-002', state: 'blind', reason: 'ebpf program failed to load', since: DAY_AGO },
+      { class: 'file', host_id: 'host-db-02', agent_id: 'agent-002', state: 'covered', reason: '', since: WEEK_AGO },
+      { class: 'privilege', host_id: 'host-db-02', agent_id: 'agent-002', state: 'covered', reason: '', since: WEEK_AGO },
+    ],
+    sampled_count: 9280, truncated_count: 0, dropped_count: 141, gap_count: 2, batch_count: 44,
+    coverage: { process: 1, network: 0, file: 1, privilege: 1, reasons: ['network class blind: ebpf load failure', 'kernel 5.4 lacks BTF'] },
+  },
+]
 const FLEET_COVERAGE = [
   { asset_id: 'ba-001', capability: 'scan.host', verdict: 'covered', detail: 'Last scan 2h ago', last_run: HOUR_AGO, agent_id: 'agent-001' },
   { asset_id: 'ba-001', capability: 'detect.runtime', verdict: 'covered', detail: 'Active monitoring', last_run: NOW, agent_id: 'agent-001' },
@@ -591,6 +636,13 @@ export const handlers = [
   ),
   http.get('/api/v1/engagements/:id/scan', () => HttpResponse.json(SCAN_RESULT)),
   http.post('/api/v1/sca/scans', () => HttpResponse.json({ id: 'job-mock', engagement_id: 'eng-001', target: 'https://github.com/KKloudTarus/synapse-ce.git', kind: 'git', status: 'complete', stage: 'done', progress: 100, error: '', started_at: new Date(Date.now() - 300000).toISOString(), finished_at: NOW, debug_events: SCAN_RESULT.debug_events })),
+
+  // --- SLA policy admin (GET/POST /sla/policies). Durations are Go time.Duration (nanoseconds). ---
+  http.get('/api/v1/sla/policies', () => HttpResponse.json({ active: SLA_POLICY, policies: [SLA_POLICY] })),
+  http.post('/api/v1/sla/policies', async ({ request }) => {
+    const body = (await request.json()) as { config?: Record<string, unknown> }
+    return HttpResponse.json({ policy: { ...SLA_POLICY, config: body.config ?? SLA_POLICY.config, sha256: 'newdigest0000' }, created: true }, { status: 201 })
+  }),
 
   // --- Engagement SLA (returns { slas: [...] }) ---
   http.get('/api/v1/engagements/:id/slas', () => HttpResponse.json({ slas: SLA_ITEMS })),
@@ -1055,6 +1107,7 @@ export const handlers = [
     return HttpResponse.json({ agent, recent_work: [{ id: 'wo-1', capability: 'scan.host', asset_id: 'ba-001', state: 'succeeded', updated_at: HOUR_AGO }, { id: 'wo-2', capability: 'detect.runtime', asset_id: 'ba-001', state: 'running', updated_at: NOW }] })
   }),
   http.get('/api/v1/fleet/coverage', () => HttpResponse.json(FLEET_COVERAGE)),
+  http.get('/api/v1/fleet/coverage-windows', () => HttpResponse.json({ coverage_windows: COVERAGE_WINDOWS })),
   http.get('/api/v1/fleet/incidents', ({ request }) => {
     const state = new URL(request.url).searchParams.get('state')
     const incidents = FLEET_INCIDENTS.filter((i) => !state || i.State === state)

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -622,6 +622,20 @@ export const handlers = [
       ['low', 'medium', 'high'].includes(String(body.risk_ceiling)) && body.exclusions_reviewed === true
     return HttpResponse.json({ ...eng, roe: { ...eng.roe, offensive: { ...body, complete } } })
   }),
+  // Cloud posture (CSPM) run: POST accepts and returns a running run; GET completes it (poll).
+  http.post('/api/v1/engagements/:id/cspm/runs', ({ params }) => HttpResponse.json({
+    id: 'cspm-run-1', engagement_id: params.id, actor: 'you', status: 'running', complete: false,
+    assets: 0, findings: 0, coverage_issues: [], error_code: '', evidence_refs: [], started_at: NOW, finished_at: null,
+  }, { status: 202 })),
+  http.get('/api/v1/engagements/:id/cspm/runs/:rid', ({ params }) => HttpResponse.json({
+    id: params.rid, engagement_id: params.id, actor: 'you', status: 'succeeded', complete: true,
+    assets: 214, findings: 9,
+    coverage_issues: [{ scope: 'aws:123456789012', reason: 'CloudTrail not multi-region' }],
+    error_code: '',
+    evidence_refs: [{ scope_key: 'aws:123456789012', id: 'ev-cspm-1', hash: 'sha256:abcd' }],
+    started_at: NOW, finished_at: NOW,
+  })),
+
   // Governed adversary-emulation run: a synchronous coverage summary after the detection join.
   http.post('/api/v1/engagements/:id/emulation/runs', async ({ params, request }) => {
     const body = (await request.json()) as { target?: string }

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -323,6 +323,22 @@ const OBSERVABILITY = {
   alerts: [{ project_id: 'proj-synapse', project_name: 'synapse-ce', alert: { metric: 'disagreement_rate', observed_basis_points: 707, baseline_basis_points: 400, deviation_basis_points: 307, sample_size: 99, message: 'Disagreement rate elevated above baseline for synapse-ce' } }],
 }
 
+// --- AI-proposed write-up drafts (raw domain, PascalCase) ---
+const WRITEUP_DRAFTS = [
+  {
+    ID: 'draft-001', EngagementID: 'eng-001', FindingID: 'finding-001',
+    Description: 'The application deserializes untrusted session data with a permissive type resolver, allowing an attacker who controls a cookie to instantiate arbitrary gadget chains.',
+    Remediation: 'Pin the deserializer to an allow-list of expected types and sign session payloads. Reject any type outside the allow-list before construction.',
+    State: 'proposed', ProposedBy: 'agent:writer-01', DecidedBy: '', CreatedAt: HOUR_AGO, UpdatedAt: HOUR_AGO,
+  },
+  {
+    ID: 'draft-002', EngagementID: 'eng-001', FindingID: 'finding-003',
+    Description: 'Reflected XSS in the search parameter; the value is echoed into an HTML attribute without encoding.',
+    Remediation: 'Context-encode the parameter for the HTML-attribute sink and add a strict Content-Security-Policy.',
+    State: 'accepted', ProposedBy: 'agent:writer-01', DecidedBy: 'alice', CreatedAt: DAY_AGO, UpdatedAt: HOUR_AGO,
+  },
+]
+
 // --- Remediation SLA ---
 const DAY_NS = 86_400_000_000_000
 const SLA_POLICY = {
@@ -636,6 +652,22 @@ export const handlers = [
   ),
   http.get('/api/v1/engagements/:id/scan', () => HttpResponse.json(SCAN_RESULT)),
   http.post('/api/v1/sca/scans', () => HttpResponse.json({ id: 'job-mock', engagement_id: 'eng-001', target: 'https://github.com/KKloudTarus/synapse-ce.git', kind: 'git', status: 'complete', stage: 'done', progress: 100, error: '', started_at: new Date(Date.now() - 300000).toISOString(), finished_at: NOW, debug_events: SCAN_RESULT.debug_events })),
+
+  // --- AI-proposed write-up drafts (PascalCase wire; the domain Draft has no JSON tags) ---
+  http.get('/api/v1/engagements/:id/writeup-drafts', () => HttpResponse.json({ writeup_drafts: WRITEUP_DRAFTS })),
+  http.post('/api/v1/engagements/:id/writeup-drafts/:did/edit', async ({ params, request }) => {
+    const body = (await request.json()) as { description?: string; remediation?: string }
+    const d = WRITEUP_DRAFTS.find((x) => x.ID === params.did) ?? WRITEUP_DRAFTS[0]
+    return HttpResponse.json({ ...d, Description: body.description ?? d.Description, Remediation: body.remediation ?? d.Remediation })
+  }),
+  http.post('/api/v1/engagements/:id/writeup-drafts/:did/accept', ({ params }) => {
+    const d = WRITEUP_DRAFTS.find((x) => x.ID === params.did) ?? WRITEUP_DRAFTS[0]
+    return HttpResponse.json({ ...d, State: 'accepted', DecidedBy: 'you' })
+  }),
+  http.post('/api/v1/engagements/:id/writeup-drafts/:did/reject', ({ params }) => {
+    const d = WRITEUP_DRAFTS.find((x) => x.ID === params.did) ?? WRITEUP_DRAFTS[0]
+    return HttpResponse.json({ ...d, State: 'rejected', DecidedBy: 'you' })
+  }),
 
   // --- SLA policy admin (GET/POST /sla/policies). Durations are Go time.Duration (nanoseconds). ---
   http.get('/api/v1/sla/policies', () => HttpResponse.json({ active: SLA_POLICY, policies: [SLA_POLICY] })),

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -862,6 +862,32 @@ export const handlers = [
 
   // --- Assets ---
   http.get('/api/v1/assets', () => HttpResponse.json(BUSINESS_ASSETS.map(a => ({ ...a, type: 'host', tags: ['production'], finding_count: 12, last_scanned: HOUR_AGO })))),
+  // Attack paths (#... attackpath): nested nodes (asset.Asset is PascalCase inside the camelCase node).
+  http.get('/api/v1/attack-paths', () => HttpResponse.json({
+    bounds: { truncated: false, maxLength: 8, maxPaths: 50 },
+    paths: [
+      {
+        id: 'path-001', confident: true, uncertainties: [],
+        nodes: [
+          { asset: { asset: { ID: 'asset-edge', Kind: 'host', Key: 'hostname/edge-gw', Name: 'edge-gw' } } },
+          { asset: { asset: { ID: 'asset-app', Kind: 'service', Key: 'svc/checkout', Name: 'checkout-svc' } } },
+          { finding: { input: { target: { id: 'finding-001', kind: 'canonical' }, finding: { Title: 'Deserialization of untrusted data', Severity: 'critical' }, reachability: 'reachable' } } },
+        ],
+        steps: [
+          { kind: 'network', observed: true, toFinding: false },
+          { kind: 'reachability', observed: true, toFinding: true },
+        ],
+      },
+      {
+        id: 'path-002', confident: false, uncertainties: ['inferred_edge', 'unconfirmed_reachability'],
+        nodes: [
+          { asset: { asset: { ID: 'asset-app', Kind: 'service', Key: 'svc/checkout', Name: 'checkout-svc' } } },
+          { finding: { input: { target: { id: 'finding-003', kind: 'canonical' }, finding: { Title: 'Reflected XSS in search', Severity: 'high' }, reachability: 'unknown' } } },
+        ],
+        steps: [{ kind: 'inferred', observed: false, toFinding: true }],
+      },
+    ],
+  })),
   http.get('/api/v1/assets/:id', ({ params }) => {
     const a = BUSINESS_ASSETS.find(x => x.ID === params.id) ?? BUSINESS_ASSETS[0]
     return HttpResponse.json({ ...a, type: 'host', tags: ['production'], finding_count: 12, last_scanned: HOUR_AGO, engagements: ENGAGEMENTS.slice(0, 2) })

--- a/web/src/pages/EngagementDetail/CloudPostureTab.test.tsx
+++ b/web/src/pages/EngagementDetail/CloudPostureTab.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ToastProvider } from '../../components/synapse/Toast'
+import { api } from '../../lib/api'
+import type { CSPMRun } from '../../lib/api'
+import { CloudPostureTab } from './CloudPostureTab'
+
+vi.mock('../../lib/api', () => ({
+  api: { runCSPM: vi.fn(), getCSPMRun: vi.fn() },
+}))
+
+function succeededRun(): CSPMRun {
+  return {
+    id: 'cspm-run-1',
+    engagementId: 'eng-001',
+    actor: 'you',
+    status: 'succeeded',
+    complete: true,
+    assets: 214,
+    findings: 9,
+    coverageIssues: [{ scope: 'aws:1', reason: 'x' }],
+    errorCode: '',
+    evidenceRefs: [{ scopeKey: 'aws:1', id: 'ev-1', hash: 'sha256:abcd' }],
+    startedAt: '2026-09-01T00:00:00Z',
+    finishedAt: '2026-09-01T00:05:00Z',
+  }
+}
+
+function renderTab() {
+  render(
+    <MemoryRouter>
+      <ToastProvider>
+        <CloudPostureTab engagementId="eng-001" />
+      </ToastProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('CloudPostureTab', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('requires a root and credential reference before running', async () => {
+    renderTab()
+    expect(screen.getByRole('button', { name: /run posture scan/i })).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Target 1 root'), { target: { value: '123456789012' } })
+    fireEvent.change(screen.getByLabelText('Target 1 credential reference'), { target: { value: 'vault://aws-ro' } })
+    await waitFor(() => expect(screen.getByRole('button', { name: /run posture scan/i })).toBeEnabled())
+  })
+
+  it('starts a run and renders its status', async () => {
+    vi.mocked(api.runCSPM).mockResolvedValue(succeededRun())
+    renderTab()
+
+    fireEvent.change(screen.getByLabelText('Target 1 root'), { target: { value: '123456789012' } })
+    fireEvent.change(screen.getByLabelText('Target 1 credential reference'), { target: { value: 'vault://aws-ro' } })
+    fireEvent.click(screen.getByRole('button', { name: /run posture scan/i }))
+
+    await waitFor(() =>
+      expect(api.runCSPM).toHaveBeenCalledWith('eng-001', [
+        { provider: 'aws', root: '123456789012', credentialRef: 'vault://aws-ro' },
+      ]),
+    )
+    expect(await screen.findByText('succeeded')).toBeInTheDocument()
+    expect(screen.getByText('214')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/EngagementDetail/CloudPostureTab.tsx
+++ b/web/src/pages/EngagementDetail/CloudPostureTab.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useRef, useState } from 'react'
+import { AlertTriangle, Cloud01, Play, Plus, Trash01 } from '@untitledui/icons'
+import { Button, Card, ErrorState, Field, Input, Select, cn } from '../../components/ui'
+import { useToast } from '../../components/synapse/Toast'
+import { api } from '../../lib/api'
+import type { CSPMRun, CloudProvider, CloudTarget } from '../../lib/api'
+
+const PROVIDERS: { value: CloudProvider; label: string }[] = [
+  { value: 'aws', label: 'AWS' },
+  { value: 'azure', label: 'Azure' },
+  { value: 'gcp', label: 'GCP' },
+]
+
+const ROOT_HINT: Record<CloudProvider, string> = {
+  aws: 'account id, e.g. 123456789012',
+  azure: 'subscription id',
+  gcp: 'project id',
+}
+
+const ROOT_LABEL: Record<CloudProvider, string> = {
+  aws: 'AWS account',
+  azure: 'Azure subscription',
+  gcp: 'GCP project',
+}
+
+function statusTone(status: CSPMRun['status']): string {
+  switch (status) {
+    case 'succeeded':
+      return 'bg-success-primary/10 text-success-primary ring-1 ring-inset ring-success-primary/25'
+    case 'partial':
+      return 'bg-warning-primary/10 text-warning-primary ring-1 ring-inset ring-warning-primary/25'
+    case 'failed':
+    case 'cancelled':
+      return 'bg-error-primary/10 text-error-primary ring-1 ring-inset ring-error-primary/25'
+    default:
+      return 'bg-brand-primary/10 text-brand-secondary ring-1 ring-inset ring-brand/25'
+  }
+}
+
+function formatWhen(iso: string | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-lg font-semibold tabular-nums text-primary">{value.toLocaleString()}</span>
+      <span className="text-[11px] uppercase tracking-wide text-quaternary">{label}</span>
+    </div>
+  )
+}
+
+function RunStatus({ run, targets }: { run: CSPMRun; targets: CloudTarget[] }) {
+  return (
+    <Card title="Latest run" titleClassName="flex items-center gap-2">
+      {targets.length > 0 && (
+        <div className="mb-3 flex flex-wrap gap-1.5">
+          {targets.map((t, i) => (
+            <span key={i} className="inline-flex items-center gap-1 rounded-md bg-secondary px-2 py-0.5 font-mono text-[11px] text-secondary ring-1 ring-inset ring-secondary">
+              <span className="uppercase text-brand-secondary">{t.provider}</span> {t.root}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+        <span className={cn('inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium capitalize', statusTone(run.status))}>
+          {run.status}
+          {!run.complete && run.status !== 'failed' && <span className="ml-1.5 size-1.5 animate-pulse rounded-full bg-current" aria-hidden />}
+        </span>
+        <Stat label="Assets" value={run.assets} />
+        <Stat label="Findings" value={run.findings} />
+        <Stat label="Coverage issues" value={run.coverageIssues.length} />
+        <Stat label="Evidence" value={run.evidenceRefs.length} />
+        <div className="ml-auto text-right text-xs text-tertiary">
+          <div>started {formatWhen(run.startedAt)}</div>
+          <div>{run.finishedAt ? `finished ${formatWhen(run.finishedAt)}` : 'in progress'}</div>
+        </div>
+      </div>
+      {run.errorCode && (
+        <p className="mt-3 flex items-center gap-1.5 text-xs text-error-primary">
+          <AlertTriangle className="size-3.5 shrink-0" aria-hidden /> {run.errorCode}
+        </p>
+      )}
+      <p className="mt-3 font-mono text-[11px] text-quaternary">run {run.id}</p>
+    </Card>
+  )
+}
+
+export function CloudPostureTab({ engagementId }: { engagementId: string }) {
+  const [targets, setTargets] = useState<CloudTarget[]>([{ provider: 'aws', root: '', credentialRef: '' }])
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+  const [run, setRun] = useState<CSPMRun | null>(null)
+  const [submitted, setSubmitted] = useState<CloudTarget[]>([])
+  const { notify } = useToast()
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // Poll the run until it completes, so the durable worker's progress reaches the surface.
+  useEffect(() => {
+    if (!run || run.complete) {
+      if (pollRef.current) clearInterval(pollRef.current)
+      return
+    }
+    pollRef.current = setInterval(async () => {
+      try {
+        const next = await api.getCSPMRun(engagementId, run.id)
+        setRun(next)
+      } catch {
+        // A transient read error keeps the last known state; the next tick retries.
+      }
+    }, 2500)
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current)
+    }
+  }, [engagementId, run])
+
+  const valid = targets.filter((t) => t.root.trim() !== '' && t.credentialRef.trim() !== '')
+
+  function patch(i: number, p: Partial<CloudTarget>) {
+    setTargets((cur) => cur.map((t, j) => (j === i ? { ...t, ...p } : t)))
+  }
+
+  async function runScan() {
+    setBusy(true)
+    setErr('')
+    try {
+      const cleaned = valid.map((t) => ({ ...t, root: t.root.trim(), credentialRef: t.credentialRef.trim() }))
+      const started = await api.runCSPM(engagementId, cleaned)
+      setSubmitted(cleaned)
+      setRun(started)
+      notify('Cloud posture run accepted.', 'success')
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Failed to start CSPM run'
+      setErr(message)
+      notify(message, 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card title="Run cloud posture scan" titleClassName="flex items-center gap-2">
+        <p className="text-xs text-tertiary">
+          A bounded, read-only live scan of a cloud account's posture. Each target names a provider, its
+          root (account, subscription, or project), and a vault credential reference. The reference points
+          at a stored credential; it is never the credential material.
+        </p>
+        <div className="mt-4 space-y-2">
+          {targets.map((t, i) => (
+            <div key={i} className="grid grid-cols-1 items-end gap-2 sm:grid-cols-[8rem_1fr_1fr_auto]">
+              <Field label={i === 0 ? 'Provider' : ''}>
+                <Select value={t.provider} onValueChange={(v) => patch(i, { provider: v as CloudProvider })} options={PROVIDERS} ariaLabel={`Target ${i + 1} provider`} />
+              </Field>
+              <Field label={i === 0 ? ROOT_LABEL[t.provider] : ''}>
+                <Input value={t.root} onChange={(e) => patch(i, { root: e.target.value })} placeholder={ROOT_HINT[t.provider]} className="font-mono" aria-label={`Target ${i + 1} root`} />
+              </Field>
+              <Field label={i === 0 ? 'Credential reference' : ''}>
+                <Input value={t.credentialRef} onChange={(e) => patch(i, { credentialRef: e.target.value })} placeholder="vault reference" className="font-mono" aria-label={`Target ${i + 1} credential reference`} />
+              </Field>
+              <button
+                type="button"
+                onClick={() => setTargets((cur) => (cur.length === 1 ? cur : cur.filter((_, j) => j !== i)))}
+                aria-label={`Remove target ${i + 1}`}
+                disabled={targets.length === 1}
+                className="justify-self-start rounded-md p-2.5 text-quaternary transition-colors hover:bg-secondary hover:text-critical disabled:opacity-40 sm:justify-self-auto"
+              >
+                <Trash01 className="size-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={() => setTargets((cur) => [...cur, { provider: 'aws', root: '', credentialRef: '' }])}
+            className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-brand-secondary transition-colors hover:bg-secondary"
+          >
+            <Plus className="size-3.5" /> Add target
+          </button>
+          <Button variant="primary" className="ml-auto px-3 py-2" loading={busy} disabled={busy || valid.length === 0} onClick={runScan}>
+            <Play className="size-4" /> Run posture scan
+          </Button>
+        </div>
+        {valid.length === 0 && (
+          <p className="mt-2 text-[11px] text-quaternary">Each target needs a root and a credential reference.</p>
+        )}
+        {err && (
+          <div className="mt-3">
+            <ErrorState message={err} />
+          </div>
+        )}
+      </Card>
+
+      {run ? (
+        <RunStatus run={run} targets={submitted} />
+      ) : (
+        <Card>
+          <div className="flex items-center gap-2 text-sm text-tertiary">
+            <Cloud01 className="size-4 text-quaternary" aria-hidden />
+            No run yet. Add a target above and start a scan; its status and findings appear here.
+          </div>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+export default CloudPostureTab

--- a/web/src/pages/EngagementDetail/WriteupDraftsTab.test.tsx
+++ b/web/src/pages/EngagementDetail/WriteupDraftsTab.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ToastProvider } from '../../components/synapse/Toast'
+import { api } from '../../lib/api'
+import type { WriteupDraft } from '../../lib/api'
+import { WriteupDraftsTab } from './WriteupDraftsTab'
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    listWriteupDrafts: vi.fn(),
+    editWriteupDraft: vi.fn(),
+    acceptWriteupDraft: vi.fn(),
+    rejectWriteupDraft: vi.fn(),
+  },
+}))
+
+function draft(over: Partial<WriteupDraft> = {}): WriteupDraft {
+  return {
+    id: 'draft-001',
+    engagementId: 'eng-001',
+    findingId: 'finding-001',
+    description: 'Deserialization of untrusted data',
+    remediation: 'Pin the type allow-list',
+    state: 'proposed',
+    proposedBy: 'agent:writer-01',
+    decidedBy: '',
+    createdAt: '2026-09-01T00:00:00Z',
+    updatedAt: '2026-09-01T00:00:00Z',
+    ...over,
+  }
+}
+
+function renderTab() {
+  render(
+    <MemoryRouter>
+      <ToastProvider>
+        <WriteupDraftsTab engagementId="eng-001" />
+      </ToastProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('WriteupDraftsTab', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('lists drafts and shows the awaiting-sign-off count', async () => {
+    vi.mocked(api.listWriteupDrafts).mockResolvedValue([
+      draft(),
+      draft({ id: 'draft-002', state: 'accepted', decidedBy: 'alice', description: 'Reflected XSS in search' }),
+    ])
+    renderTab()
+
+    expect(await screen.findByText(/1 awaiting sign-off/)).toBeInTheDocument()
+    expect(screen.getByText('Deserialization of untrusted data')).toBeInTheDocument()
+    expect(screen.getByText('Reflected XSS in search')).toBeInTheDocument()
+    expect(screen.getByText('accepted')).toBeInTheDocument()
+  })
+
+  it('accepts a proposed draft', async () => {
+    vi.mocked(api.listWriteupDrafts).mockResolvedValue([draft()])
+    vi.mocked(api.acceptWriteupDraft).mockResolvedValue(draft({ state: 'accepted', decidedBy: 'you' }))
+    renderTab()
+
+    fireEvent.click(await screen.findByRole('button', { name: /accept/i }))
+    await waitFor(() => expect(api.acceptWriteupDraft).toHaveBeenCalledWith('eng-001', 'draft-001'))
+  })
+
+  it('only offers accept/edit/reject on a proposed draft', async () => {
+    vi.mocked(api.listWriteupDrafts).mockResolvedValue([draft({ state: 'accepted', decidedBy: 'alice' })])
+    renderTab()
+
+    await screen.findByText('accepted')
+    expect(screen.queryByRole('button', { name: /accept/i })).not.toBeInTheDocument()
+  })
+})

--- a/web/src/pages/EngagementDetail/WriteupDraftsTab.tsx
+++ b/web/src/pages/EngagementDetail/WriteupDraftsTab.tsx
@@ -1,0 +1,192 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Check, CpuChip01, Edit03, FileX02, ShieldTick, X } from '@untitledui/icons'
+import { Button, Card, EmptyState, ErrorState, Pill, Spinner, cn } from '../../components/ui'
+import { useToast } from '../../components/synapse/Toast'
+import { useFetch } from '../../hooks'
+import { api } from '../../lib/api'
+import type { WriteupDraft } from '../../lib/api'
+
+function formatWhen(iso: string): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? '' : d.toLocaleString()
+}
+
+function stateTone(state: WriteupDraft['state']): string {
+  switch (state) {
+    case 'accepted':
+      return 'bg-success-primary/10 text-success-primary ring-1 ring-inset ring-success-primary/25'
+    case 'rejected':
+      return 'bg-error-primary/10 text-error-primary ring-1 ring-inset ring-error-primary/25'
+    default:
+      return 'bg-brand-primary/10 text-brand-secondary ring-1 ring-inset ring-brand/25'
+  }
+}
+
+function shortId(id: string): string {
+  return id.length > 10 ? `${id.slice(0, 8)}…` : id
+}
+
+function DraftCard({
+  draft,
+  onChanged,
+}: {
+  draft: WriteupDraft
+  onChanged: (d: WriteupDraft) => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const [description, setDescription] = useState(draft.description)
+  const [remediation, setRemediation] = useState(draft.remediation)
+  const [busy, setBusy] = useState<'save' | 'accept' | 'reject' | null>(null)
+  const { notify } = useToast()
+  const proposed = draft.state === 'proposed'
+
+  async function run(kind: 'save' | 'accept' | 'reject') {
+    setBusy(kind)
+    try {
+      let updated: WriteupDraft
+      if (kind === 'save') updated = await api.editWriteupDraft(draft.engagementId, draft.id, { description, remediation })
+      else if (kind === 'accept') updated = await api.acceptWriteupDraft(draft.engagementId, draft.id)
+      else updated = await api.rejectWriteupDraft(draft.engagementId, draft.id)
+      onChanged(updated)
+      if (kind === 'save') setEditing(false)
+      notify(kind === 'save' ? 'Draft revised.' : kind === 'accept' ? 'Draft accepted.' : 'Draft rejected.', 'success')
+    } catch (e) {
+      notify(e instanceof Error ? e.message : `Failed to ${kind} draft`, 'error')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  return (
+    <Card>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className={cn('inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium capitalize', stateTone(draft.state))}>
+          {draft.state}
+        </span>
+        <span className="inline-flex items-center gap-1 text-xs text-tertiary">
+          <CpuChip01 className="size-3.5 text-quaternary" aria-hidden /> proposed by <span className="font-mono text-secondary">{draft.proposedBy || 'agent'}</span>
+        </span>
+        <Link
+          to={`/engagements/${encodeURIComponent(draft.engagementId)}/findings#finding-${encodeURIComponent(draft.findingId)}`}
+          className="font-mono text-xs text-brand-secondary underline-offset-2 hover:underline"
+          title="Open the finding this draft is about"
+        >
+          {shortId(draft.findingId)}
+        </Link>
+        {draft.decidedBy && (
+          <span className="ml-auto text-xs text-tertiary">
+            {draft.state} by <span className="text-secondary">{draft.decidedBy}</span>
+            {formatWhen(draft.updatedAt) && <span className="text-quaternary"> · {formatWhen(draft.updatedAt)}</span>}
+          </span>
+        )}
+      </div>
+
+      {editing ? (
+        <div className="mt-3 space-y-3">
+          <label className="block">
+            <span className="mb-1 block text-[11px] font-semibold uppercase tracking-wider text-tertiary">Description</span>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={4}
+              aria-label="Draft description"
+              className="input-inset w-full rounded-lg border border-secondary bg-secondary px-3 py-2 text-sm text-primary outline-none focus:border-brand focus:ring-2 focus:ring-brand/40"
+            />
+          </label>
+          <label className="block">
+            <span className="mb-1 block text-[11px] font-semibold uppercase tracking-wider text-tertiary">Remediation</span>
+            <textarea
+              value={remediation}
+              onChange={(e) => setRemediation(e.target.value)}
+              rows={4}
+              aria-label="Draft remediation"
+              className="input-inset w-full rounded-lg border border-secondary bg-secondary px-3 py-2 text-sm text-primary outline-none focus:border-brand focus:ring-2 focus:ring-brand/40"
+            />
+          </label>
+          <div className="flex gap-2">
+            <Button loading={busy === 'save'} onClick={() => run('save')} variant="secondary-color" className="px-3 py-1.5">
+              <Check className="size-4" /> Save revision
+            </Button>
+            <Button
+              variant="secondary"
+              className="px-3 py-1.5"
+              disabled={busy !== null}
+              onClick={() => {
+                setDescription(draft.description)
+                setRemediation(draft.remediation)
+                setEditing(false)
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-3 space-y-3">
+          <div>
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-tertiary">Description</span>
+            <p className="mt-1 whitespace-pre-wrap text-sm text-secondary">{draft.description || <span className="text-quaternary">—</span>}</p>
+          </div>
+          <div>
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-tertiary">Remediation</span>
+            <p className="mt-1 whitespace-pre-wrap text-sm text-secondary">{draft.remediation || <span className="text-quaternary">—</span>}</p>
+          </div>
+        </div>
+      )}
+
+      {proposed && !editing && (
+        <div className="mt-4 flex flex-wrap gap-2 border-t border-secondary pt-3">
+          <Button variant="secondary-color" className="px-3 py-1.5" loading={busy === 'accept'} disabled={busy !== null} onClick={() => run('accept')}>
+            <Check className="size-4" /> Accept
+          </Button>
+          <Button variant="secondary" className="px-3 py-1.5" disabled={busy !== null} onClick={() => setEditing(true)}>
+            <Edit03 className="size-4" /> Edit
+          </Button>
+          <Button variant="secondary" className="px-3 py-1.5 text-error-primary" loading={busy === 'reject'} disabled={busy !== null} onClick={() => run('reject')}>
+            <X className="size-4" /> Reject
+          </Button>
+        </div>
+      )}
+    </Card>
+  )
+}
+
+export function WriteupDraftsTab({ engagementId }: { engagementId: string }) {
+  const { data, loading, error, refetch } = useFetch(() => api.listWriteupDrafts(engagementId), { deps: [engagementId] })
+  const drafts = data ?? []
+  const proposed = drafts.filter((d) => d.state === 'proposed').length
+
+  if (loading) return <Spinner label="Loading write-up drafts…" />
+  if (error) return <ErrorState message={error} />
+  if (drafts.length === 0)
+    return (
+      <EmptyState
+        icon={FileX02}
+        title="No write-up drafts"
+        hint="When an agent proposes finding description or remediation prose, it appears here for a reviewer to edit, accept, or reject."
+      />
+    )
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <h2 className="text-sm font-semibold text-primary">AI-proposed write-up drafts</h2>
+        {proposed > 0 && <Pill className="bg-brand-primary/10 text-brand-secondary ring-1 ring-inset ring-brand/25">{proposed} awaiting sign-off</Pill>}
+      </div>
+      <p className="flex items-start gap-2 rounded-lg border border-secondary bg-secondary/20 p-3 text-xs text-tertiary">
+        <ShieldTick className="mt-0.5 size-4 shrink-0 text-brand-secondary" aria-hidden />
+        Separation of duties: the reviewer who accepts a draft must be someone other than the proposing
+        agent. Accepting makes the draft eligible to be applied to its finding; it renders nothing on its own.
+      </p>
+      <div className="space-y-3">
+        {drafts.map((d) => (
+          <DraftCard key={d.id} draft={d} onChanged={() => refetch()} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default WriteupDraftsTab

--- a/web/src/pages/EngagementDetail/index.tsx
+++ b/web/src/pages/EngagementDetail/index.tsx
@@ -43,6 +43,7 @@ import { DetectionsTab } from './DetectionsTab'
 import { ImportedFindingsTab } from './ImportedFindingsTab'
 import { DataGovernanceTab } from './DataGovernanceTab'
 import { WriteupDraftsTab } from './WriteupDraftsTab'
+import { CloudPostureTab } from './CloudPostureTab'
 import { EvidenceTab } from './EvidenceTab'
 import { SettingsTab } from './SettingsTab'
 import { JudgmentReviewTab } from './ReviewsTab'
@@ -68,6 +69,7 @@ export type Tab =
   | 'recon'
   | 'purple'
   | 'agent'
+  | 'cspm'
   | 'detections'
   | 'reviews'
   | 'evidence'
@@ -127,6 +129,7 @@ export const TAB_GROUPS: TabGroupDefinition[] = [
       { id: 'threats', label: 'Threat Model' },
       { id: 'purple', label: 'Purple Coverage' },
       { id: 'agent', label: 'Agent' },
+      { id: 'cspm', label: 'Cloud Posture' },
     ],
   },
   {
@@ -530,6 +533,7 @@ export function EngagementDetail() {
         {tab === 'imported' && <ImportedFindingsTab key={id} engagementId={id} />}
         {tab === 'data-governance' && <DataGovernanceTab key={id} engagementId={id} />}
         {tab === 'writeup-drafts' && <WriteupDraftsTab key={id} engagementId={id} />}
+        {tab === 'cspm' && <CloudPostureTab key={id} engagementId={id} />}
         {tab === 'reviews' && <JudgmentReviewTab key={id} engagementId={id} />}
         {tab === 'evidence' && <EvidenceTab key={id} engagementId={id} />}
         {tab === 'settings' && <SettingsTab eng={eng} onUpdated={setEng} />}

--- a/web/src/pages/EngagementDetail/index.tsx
+++ b/web/src/pages/EngagementDetail/index.tsx
@@ -42,6 +42,7 @@ import { VulnPostureTab } from './VulnPostureTab'
 import { DetectionsTab } from './DetectionsTab'
 import { ImportedFindingsTab } from './ImportedFindingsTab'
 import { DataGovernanceTab } from './DataGovernanceTab'
+import { WriteupDraftsTab } from './WriteupDraftsTab'
 import { EvidenceTab } from './EvidenceTab'
 import { SettingsTab } from './SettingsTab'
 import { JudgmentReviewTab } from './ReviewsTab'
@@ -71,6 +72,7 @@ export type Tab =
   | 'reviews'
   | 'evidence'
   | 'data-governance'
+  | 'writeup-drafts'
   | 'settings'
 
 export interface SubTabDefinition {
@@ -142,6 +144,7 @@ export const TAB_GROUPS: TabGroupDefinition[] = [
       { id: 'reviews', label: 'Awaiting Review' },
       { id: 'quality', label: 'Code Quality' },
       { id: 'data-governance', label: 'Data governance' },
+      { id: 'writeup-drafts', label: 'Write-up Drafts' },
     ],
   },
   {
@@ -526,6 +529,7 @@ export function EngagementDetail() {
         {tab === 'detections' && <DetectionsTab key={id} engagementId={id} />}
         {tab === 'imported' && <ImportedFindingsTab key={id} engagementId={id} />}
         {tab === 'data-governance' && <DataGovernanceTab key={id} engagementId={id} />}
+        {tab === 'writeup-drafts' && <WriteupDraftsTab key={id} engagementId={id} />}
         {tab === 'reviews' && <JudgmentReviewTab key={id} engagementId={id} />}
         {tab === 'evidence' && <EvidenceTab key={id} engagementId={id} />}
         {tab === 'settings' && <SettingsTab eng={eng} onUpdated={setEng} />}

--- a/web/src/pages/Fleet/CoverageWindows.test.tsx
+++ b/web/src/pages/Fleet/CoverageWindows.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import type { CoverageWindow } from '../../lib/api'
+import { CoverageWindows } from './CoverageWindows'
+
+vi.mock('../../lib/api', () => ({
+  api: { listCoverageWindows: vi.fn() },
+}))
+
+function windowFixture(over: Partial<CoverageWindow> = {}): CoverageWindow {
+  return {
+    assetId: 'ba-001',
+    agentId: 'agent-001',
+    hostId: 'host-web-01',
+    since: '2026-09-01T00:00:00Z',
+    until: '2026-09-02T00:00:00Z',
+    inputDigest: 'sha256:9f1c0a44e7b2',
+    revision: 'rev-0042',
+    createdAt: '2026-09-02T00:00:00Z',
+    states: [
+      { class: 'network', hostId: 'host-web-01', agentId: 'agent-001', state: 'blind', reason: 'ebpf load failed', since: '2026-09-01T12:00:00Z' },
+    ],
+    sampledCount: 18420,
+    truncatedCount: 12,
+    droppedCount: 3,
+    gapCount: 2,
+    batchCount: 96,
+    coverage: { process: 1, network: 0, file: 1, privilege: 1, reasons: ['network class blind'] },
+    ...over,
+  }
+}
+
+describe('CoverageWindows', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('renders sealed windows with their gap count and a blind class state', async () => {
+    vi.mocked(api.listCoverageWindows).mockResolvedValue([windowFixture()])
+    render(<CoverageWindows />)
+
+    expect(await screen.findByText(/2 gaps/)).toBeInTheDocument()
+    expect(screen.getByText('rev-0042')).toBeInTheDocument()
+    expect(screen.getByText('blind')).toBeInTheDocument()
+    expect(screen.getByText(/network class blind/)).toBeInTheDocument()
+  })
+
+  it('shows an empty state when no windows match', async () => {
+    vi.mocked(api.listCoverageWindows).mockResolvedValue([])
+    render(<CoverageWindows />)
+    expect(await screen.findByText('No coverage windows')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/Fleet/CoverageWindows.tsx
+++ b/web/src/pages/Fleet/CoverageWindows.tsx
@@ -1,0 +1,181 @@
+import { useState } from 'react'
+import { AlertTriangle, SearchLg, Signal01 } from '@untitledui/icons'
+import { Button, Card, EmptyState, ErrorState, Field, Input, Pill, Spinner, cn } from '../../components/ui'
+import { useFetch } from '../../hooks'
+import { api } from '../../lib/api'
+import type { CoverageVector, CoverageWindow } from '../../lib/api'
+
+const CLASSES: { key: keyof Pick<CoverageVector, 'process' | 'network' | 'file' | 'privilege'>; label: string }[] = [
+  { key: 'process', label: 'Process' },
+  { key: 'network', label: 'Network' },
+  { key: 'file', label: 'File' },
+  { key: 'privilege', label: 'Privilege' },
+]
+
+function shortId(id: string): string {
+  if (!id) return '—'
+  return id.length > 12 ? `${id.slice(0, 10)}…` : id
+}
+
+function formatWhen(iso: string): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+
+function stateTone(state: string): string {
+  const s = state.toLowerCase()
+  if (s.includes('covered') || s.includes('healthy') || s.includes('active')) return 'text-success-primary bg-success-primary/10 ring-success-primary/25'
+  if (s.includes('degrad') || s.includes('partial') || s.includes('stale')) return 'text-warning-primary bg-warning-primary/10 ring-warning-primary/25'
+  if (s.includes('blind') || s.includes('gap') || s.includes('lost') || s.includes('none')) return 'text-error-primary bg-error-primary/10 ring-error-primary/25'
+  return 'text-tertiary bg-secondary ring-secondary'
+}
+
+function CoverageDot({ label, value }: { label: string; value: number }) {
+  const covered = value > 0
+  return (
+    <div className="flex items-center gap-1.5" title={`${label}: ${covered ? 'covered' : 'no coverage'}`}>
+      <span className={cn('size-2.5 rounded-full', covered ? 'bg-success-primary' : 'bg-error-primary/70')} aria-hidden />
+      <span className={cn('text-xs', covered ? 'font-medium text-secondary' : 'text-quaternary')}>{label}</span>
+    </div>
+  )
+}
+
+function Stat({ label, value, warn }: { label: string; value: number; warn?: boolean }) {
+  return (
+    <div className="flex flex-col">
+      <span className={cn('text-sm font-semibold tabular-nums', warn && value > 0 ? 'text-error-primary' : 'text-primary')}>{value}</span>
+      <span className="text-[11px] uppercase tracking-wide text-quaternary">{label}</span>
+    </div>
+  )
+}
+
+function WindowCard({ w }: { w: CoverageWindow }) {
+  return (
+    <Card>
+      <div className="flex flex-wrap items-start justify-between gap-x-6 gap-y-3">
+        <div className="min-w-0 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono text-sm font-semibold text-primary">{shortId(w.assetId)}</span>
+            {w.revision && <Pill className="font-mono">{shortId(w.revision)}</Pill>}
+            {w.gapCount > 0 && (
+              <Pill className="bg-error-primary/10 text-error-primary ring-1 ring-inset ring-error-primary/25">
+                <AlertTriangle className="mr-1 inline size-3" /> {w.gapCount} gap{w.gapCount === 1 ? '' : 's'}
+              </Pill>
+            )}
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-tertiary">
+            <span>agent <span className="font-mono text-secondary">{shortId(w.agentId)}</span></span>
+            <span>host <span className="font-mono text-secondary">{shortId(w.hostId)}</span></span>
+          </div>
+          <div className="text-xs text-quaternary">
+            {formatWhen(w.since)} → {formatWhen(w.until)} · sealed {formatWhen(w.createdAt)}
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+          {CLASSES.map((c) => (
+            <CoverageDot key={c.key} label={c.label} value={w.coverage[c.key]} />
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-x-8 gap-y-3 border-t border-secondary pt-3">
+        <Stat label="Sampled" value={w.sampledCount} />
+        <Stat label="Batches" value={w.batchCount} />
+        <Stat label="Truncated" value={w.truncatedCount} warn />
+        <Stat label="Dropped" value={w.droppedCount} warn />
+        <Stat label="Gaps" value={w.gapCount} warn />
+      </div>
+
+      {w.states.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {w.states.map((s, i) => (
+            <span
+              key={`${s.class}-${i}`}
+              className={cn('inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs ring-1 ring-inset', stateTone(s.state))}
+              title={s.reason || undefined}
+            >
+              <span className="font-medium capitalize">{s.class}</span>
+              <span className="opacity-80">{s.state}</span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {w.coverage.reasons.length > 0 && (
+        <p className="mt-2 text-xs text-tertiary">{w.coverage.reasons.join(' · ')}</p>
+      )}
+      {w.inputDigest && (
+        <p className="mt-2 font-mono text-[11px] text-quaternary">input {shortId(w.inputDigest)}</p>
+      )}
+    </Card>
+  )
+}
+
+export function CoverageWindows() {
+  const [asset, setAsset] = useState('')
+  const [agent, setAgent] = useState('')
+  const [applied, setApplied] = useState<{ assetId?: string; agentId?: string }>({})
+
+  const { data, loading, error } = useFetch(() => api.listCoverageWindows({ ...applied, limit: 100 }), {
+    deps: [applied.assetId, applied.agentId],
+  })
+
+  const windows = data ?? []
+
+  return (
+    <div className="mx-auto max-w-[1600px] animate-fade-in space-y-6 pb-12">
+      <header>
+        <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight text-primary sm:text-display-xs">
+          <Signal01 className="size-6 text-brand-secondary" aria-hidden /> Coverage windows
+        </h1>
+        <p className="mt-1 text-sm text-secondary">
+          Immutable telemetry-coverage revisions per asset. Each window seals the per-class sensor state and
+          the sample, drop, and gap counts it was computed from, so coverage over time is auditable.
+        </p>
+      </header>
+
+      <Card title="Filters">
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="min-w-56 flex-1">
+            <Field label="Asset id">
+              <Input value={asset} onChange={(e) => setAsset(e.target.value)} placeholder="asset id" className="font-mono" aria-label="Filter by asset id" />
+            </Field>
+          </div>
+          <div className="min-w-56 flex-1">
+            <Field label="Agent id">
+              <Input value={agent} onChange={(e) => setAgent(e.target.value)} placeholder="agent id" className="font-mono" aria-label="Filter by agent id" />
+            </Field>
+          </div>
+          <Button
+            variant="secondary-color"
+            className="px-3 py-2"
+            onClick={() => setApplied({ assetId: asset.trim() || undefined, agentId: agent.trim() || undefined })}
+          >
+            <SearchLg className="size-4" /> Apply
+          </Button>
+        </div>
+      </Card>
+
+      {loading ? (
+        <Spinner label="Loading coverage windows…" />
+      ) : error ? (
+        <ErrorState message={error} />
+      ) : windows.length === 0 ? (
+        <EmptyState
+          icon={Signal01}
+          title="No coverage windows"
+          hint="A window is sealed when the fleet reconciles an agent's telemetry into a coverage revision. None match this filter yet."
+        />
+      ) : (
+        <div className="space-y-3">
+          {windows.map((w) => (
+            <WindowCard key={`${w.assetId}-${w.revision}-${w.createdAt}`} w={w} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default CoverageWindows

--- a/web/src/pages/Fleet/HostDetail.tsx
+++ b/web/src/pages/Fleet/HostDetail.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { ArrowLeft, Copy01, SearchSm } from '@untitledui/icons'
 import { api } from '../../lib/api'
+import type { RetroHuntResult } from '../../lib/api'
 import type { HostFinding, HostPackages, HostVulnerabilities, Severity } from '../../lib/types'
 import { Button, Card, Input, Pill, SevBadge, cn } from '../../components/ui'
 import { FeatureDisabledState, isFeatureDisabledMessage } from '../../components/synapse/FeatureDisabledState'
@@ -12,7 +13,7 @@ import { useFetch } from '../../hooks'
 import { formatFleetTime } from './fleetShared'
 import { HostScanBadge, hostDegraded, hostFindingAdvisory, hostFindingPackage, hostOS, hostScanState, hostShortName, reportedPackages } from './hostShared'
 
-type Tab = 'vulnerabilities' | 'packages' | 'coverage'
+type Tab = 'vulnerabilities' | 'packages' | 'coverage' | 'retrohunt'
 type SeverityFilter = 'all' | Severity | 'unrated'
 const RATED: Severity[] = ['critical', 'high', 'medium', 'low']
 type FixFilter = 'all' | 'fixable' | 'unfixed'
@@ -314,6 +315,116 @@ function PackagesBody({ assetId }: { assetId: string }) {
   )
 }
 
+function toLocalInput(d: Date): string {
+  return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16)
+}
+
+export function RetroHuntBody({ assetId }: { assetId: string }) {
+  const localZone = (() => {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || 'local'
+    } catch {
+      return 'local'
+    }
+  })()
+  const [around, setAround] = useState(() => toLocalInput(new Date()))
+  const [beforeMin, setBeforeMin] = useState(15)
+  const [afterMin, setAfterMin] = useState(15)
+  const [entityId, setEntityId] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+  const [result, setResult] = useState<RetroHuntResult | null>(null)
+
+  async function run() {
+    setBusy(true)
+    setErr('')
+    try {
+      const iso = around ? new Date(around).toISOString() : ''
+      const res = await api.retroHunt(assetId, {
+        around: iso,
+        beforeSeconds: Math.max(0, Math.round(beforeMin * 60)),
+        afterSeconds: Math.max(0, Math.round(afterMin * 60)),
+        entityId: entityId.trim() || undefined,
+        limit: 500,
+      })
+      setResult(res)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Retro-hunt failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      <p className="text-xs text-tertiary">
+        Re-hunt this host's endpoint state timeline in a window around a pivot time, optionally scoped to
+        one entity. The window is anchored to the pivot; a capped window is reported as truncated.
+      </p>
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-tertiary">
+            Pivot time <span className="font-normal normal-case text-quaternary">({localZone})</span>
+          </span>
+          <Input type="datetime-local" value={around} onChange={(e) => setAround(e.target.value)} aria-label="Retro-hunt pivot time" />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-tertiary">Look back (min)</span>
+          <Input type="number" min={0} value={beforeMin} onChange={(e) => setBeforeMin(Number(e.target.value) || 0)} className="w-28" aria-label="Retro-hunt look-back minutes" />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-tertiary">Look forward (min)</span>
+          <Input type="number" min={0} value={afterMin} onChange={(e) => setAfterMin(Number(e.target.value) || 0)} className="w-28" aria-label="Retro-hunt look-forward minutes" />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-tertiary">Entity (optional)</span>
+          <Input value={entityId} onChange={(e) => setEntityId(e.target.value)} placeholder="entity id" className="w-48 font-mono" aria-label="Retro-hunt entity id" />
+        </label>
+        <Button variant="primary" className="px-3 py-2" loading={busy} disabled={busy || (beforeMin === 0 && afterMin === 0)} onClick={run}>
+          <SearchSm className="size-4" /> Hunt
+        </Button>
+      </div>
+      {beforeMin === 0 && afterMin === 0 && (
+        <p className="text-xs text-warning-primary">Set a non-zero look-back or look-forward; a zero-width window is rejected.</p>
+      )}
+      {err && <OperationalState tone="error" title="Retro-hunt failed" detail={err} />}
+      {result && !err && (
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-tertiary">
+            <span>{formatFleetTime(result.from)} → {formatFleetTime(result.to)}</span>
+            <Pill>{result.entries.length} transition{result.entries.length === 1 ? '' : 's'}</Pill>
+            {result.truncated ? (
+              <Pill className="bg-warning-primary/10 text-warning-primary ring-1 ring-inset ring-warning-primary/25">
+                truncated — window capped
+              </Pill>
+            ) : (
+              <Pill className="bg-success-primary/10 text-success-primary ring-1 ring-inset ring-success-primary/25">complete window</Pill>
+            )}
+          </div>
+          {result.entries.length === 0 ? (
+            <p className="text-sm text-tertiary">No endpoint transitions in this window.</p>
+          ) : (
+            <ol className="relative space-y-2 border-l border-secondary pl-4">
+              {result.entries.map((en) => (
+                <li key={en.eventId || `${en.occurredAt}-${en.entityId}`} className="relative">
+                  <span className="absolute -left-[21px] top-1.5 size-2 rounded-full bg-brand-solid" aria-hidden />
+                  <div className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5">
+                    <span className="inline-block w-40 shrink-0 font-mono text-xs tabular-nums text-secondary">{formatFleetTime(en.occurredAt)}</span>
+                    <span className="text-sm font-medium text-primary">{en.kind}</span>
+                    {en.entityKind && <Pill className="capitalize">{en.entityKind}</Pill>}
+                    {en.entityId && <span className="font-mono text-xs text-quaternary">{en.entityId}</span>}
+                  </div>
+                  {en.summary && <p className="mt-0.5 text-sm text-tertiary">{en.summary}</p>}
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 export function HostDetail() {
   const { id = '' } = useParams()
   const [tab, setTab] = useState<Tab>('vulnerabilities')
@@ -375,7 +486,7 @@ export function HostDetail() {
 
       <Card bodyClass="p-0">
         <div className="flex items-center gap-1 border-b border-secondary px-2" role="tablist" aria-label="Host views">
-          {([['vulnerabilities', `Vulnerabilities`, host.findings.length], ['packages', 'Packages', host.packages || reported], ['coverage', 'Coverage gaps', Number(a.coverage_gaps ?? '0') || 0]] as [Tab, string, number][]).map(([value, label, count]) => (
+          {([['vulnerabilities', `Vulnerabilities`, host.findings.length], ['packages', 'Packages', host.packages || reported], ['coverage', 'Coverage gaps', Number(a.coverage_gaps ?? '0') || 0], ['retrohunt', 'Timeline', null]] as [Tab, string, number | null][]).map(([value, label, count]) => (
             <button
               key={value}
               type="button"
@@ -384,11 +495,20 @@ export function HostDetail() {
               onClick={() => setTab(value)}
               className={cn('-mb-px border-b-2 px-3 py-2.5 text-sm font-semibold transition-colors', tab === value ? 'border-brand-solid text-primary' : 'border-transparent text-tertiary hover:text-primary')}
             >
-              {label} <span className="ml-1 font-mono text-xs tabular-nums text-quaternary">{count.toLocaleString()}</span>
+              {label}{' '}
+              {count !== null && <span className="font-mono text-xs tabular-nums text-quaternary">{count.toLocaleString()}</span>}
             </button>
           ))}
         </div>
-        {tab === 'vulnerabilities' ? <VulnerabilitiesBody host={host} /> : tab === 'packages' ? <PackagesBody assetId={host.asset.id} /> : <CoverageBody host={host} />}
+        {tab === 'vulnerabilities' ? (
+          <VulnerabilitiesBody host={host} />
+        ) : tab === 'packages' ? (
+          <PackagesBody assetId={host.asset.id} />
+        ) : tab === 'retrohunt' ? (
+          <RetroHuntBody assetId={host.asset.id} />
+        ) : (
+          <CoverageBody host={host} />
+        )}
       </Card>
     </div>
   )

--- a/web/src/pages/Fleet/RetroHuntBody.test.tsx
+++ b/web/src/pages/Fleet/RetroHuntBody.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import type { RetroHuntResult } from '../../lib/api'
+import { RetroHuntBody } from './HostDetail'
+
+vi.mock('../../lib/api', () => ({
+  api: { retroHunt: vi.fn() },
+}))
+
+function result(): RetroHuntResult {
+  return {
+    assetId: 'ba-001',
+    from: '2026-09-01T11:45:00Z',
+    to: '2026-09-01T12:15:00Z',
+    truncated: true,
+    entries: [
+      { occurredAt: '2026-09-01T11:50:00Z', entityKind: 'process', entityId: 'pid-4821', kind: 'process_exec', eventId: 'ev-1', summary: 'curl spawned by bash' },
+      { occurredAt: '2026-09-01T12:00:00Z', entityKind: 'network', entityId: 'conn-77', kind: 'egress_connect', eventId: 'ev-2', summary: 'outbound 443' },
+    ],
+  }
+}
+
+describe('RetroHuntBody', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('hunts the timeline window and renders the transitions and truncation', async () => {
+    vi.mocked(api.retroHunt).mockResolvedValue(result())
+    render(<RetroHuntBody assetId="ba-001" />)
+
+    fireEvent.click(screen.getByRole('button', { name: /hunt/i }))
+
+    await waitFor(() => expect(api.retroHunt).toHaveBeenCalled())
+    const [assetId, req] = vi.mocked(api.retroHunt).mock.calls[0]
+    expect(assetId).toBe('ba-001')
+    // 15 minutes look-back/forward defaults => 900 seconds.
+    expect(req.beforeSeconds).toBe(900)
+    expect(req.afterSeconds).toBe(900)
+
+    expect(await screen.findByText('process_exec')).toBeInTheDocument()
+    expect(screen.getByText('egress_connect')).toBeInTheDocument()
+    expect(screen.getByText(/window capped/)).toBeInTheDocument()
+    expect(screen.getByText(/2 transitions/)).toBeInTheDocument()
+  })
+
+  it('blocks a zero-width window', () => {
+    render(<RetroHuntBody assetId="ba-001" />)
+    fireEvent.change(screen.getByLabelText('Retro-hunt look-back minutes'), { target: { value: '0' } })
+    fireEvent.change(screen.getByLabelText('Retro-hunt look-forward minutes'), { target: { value: '0' } })
+    expect(screen.getByText(/zero-width window is rejected/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /hunt/i })).toBeDisabled()
+  })
+})

--- a/web/src/pages/Settings/SLAPolicy.test.tsx
+++ b/web/src/pages/Settings/SLAPolicy.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ToastProvider } from '../../components/synapse/Toast'
+import { api } from '../../lib/api'
+import type { SlaConfig, SlaPolicy } from '../../lib/api'
+import { SLAPolicy } from './SLAPolicy'
+
+vi.mock('../../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/api')>('../../lib/api')
+  return { ...actual, api: { slaPolicies: vi.fn(), activateSLAPolicy: vi.fn() } }
+})
+
+function config(): SlaConfig {
+  const dr = { mitigateDays: 1, remediateDays: 7 }
+  return {
+    version: 'sla-v1',
+    weights: { severity: 35, exploitability: 25, threatIntel: 10, exposure: 15, criticality: 15, feasibilityRelief: 15 },
+    thresholds: { emergency: 85, critical: 70, high: 50, medium: 30 },
+    dueRanges: { emergency: dr, critical: dr, high: dr, medium: dr, low: dr, exception: dr },
+  }
+}
+
+function policy(): SlaPolicy {
+  return { config: config(), sha256: 'a1b2c3d4e5f6', createdBy: 'system', createdAt: '2026-08-01T00:00:00Z' }
+}
+
+function renderPage() {
+  render(
+    <ToastProvider>
+      <SLAPolicy />
+    </ToastProvider>,
+  )
+}
+
+describe('SLAPolicy', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('shows the active policy, its digest, and a balanced weight sum', async () => {
+    vi.mocked(api.slaPolicies).mockResolvedValue({ active: policy(), policies: [policy()] })
+    renderPage()
+
+    // 'sla-v1' and the digest appear in both the active card and the history, so match all.
+    expect((await screen.findAllByText('sla-v1')).length).toBeGreaterThan(0)
+    expect(screen.getByText('Active policy')).toBeInTheDocument()
+    expect(screen.getAllByText(/a1b2c3d4e5f6/).length).toBeGreaterThan(0)
+    // severity+exploitability+threatIntel+exposure+criticality = 100
+    expect(screen.getByText(/sums to 100/)).toBeInTheDocument()
+  })
+
+  it('blocks activation when the weights no longer sum to 100', async () => {
+    vi.mocked(api.slaPolicies).mockResolvedValue({ active: policy(), policies: [policy()] })
+    renderPage()
+
+    fireEvent.change(await screen.findByLabelText('Weight Severity'), { target: { value: '50' } })
+
+    expect(await screen.findByText(/cannot activate/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /activate new version/i })).toBeDisabled()
+  })
+
+  it('activates a new version after an edit', async () => {
+    vi.mocked(api.slaPolicies).mockResolvedValue({ active: policy(), policies: [policy()] })
+    vi.mocked(api.activateSLAPolicy).mockResolvedValue({ policy: policy(), created: true })
+    renderPage()
+
+    // Keep the five factors summing to 100 (severity +5, exploitability -5) so the config stays valid.
+    fireEvent.change(await screen.findByLabelText('Weight Severity'), { target: { value: '40' } })
+    fireEvent.change(screen.getByLabelText('Weight Exploitability'), { target: { value: '20' } })
+
+    const activate = screen.getByRole('button', { name: /activate new version/i })
+    await waitFor(() => expect(activate).toBeEnabled())
+    fireEvent.click(activate)
+
+    await waitFor(() => expect(api.activateSLAPolicy).toHaveBeenCalled())
+    const sent = vi.mocked(api.activateSLAPolicy).mock.calls[0][0]
+    expect(sent.weights.severity).toBe(40)
+    expect(sent.weights.exploitability).toBe(20)
+  })
+})

--- a/web/src/pages/Settings/SLAPolicy.tsx
+++ b/web/src/pages/Settings/SLAPolicy.tsx
@@ -1,0 +1,333 @@
+import { useEffect, useMemo, useState } from 'react'
+import { AlertTriangle, CheckCircle, Save01, Shield01 } from '@untitledui/icons'
+import { Button, Card, ErrorState, Pill, Spinner, cn } from '../../components/ui'
+import { useToast } from '../../components/synapse/Toast'
+import { useFetch } from '../../hooks'
+import { api, SLA_TIERS } from '../../lib/api'
+import type { SlaConfig, SlaPolicy, SlaTier } from '../../lib/api'
+
+const WEIGHT_FIELDS: { key: keyof SlaConfig['weights']; label: string }[] = [
+  { key: 'severity', label: 'Severity' },
+  { key: 'exploitability', label: 'Exploitability' },
+  { key: 'threatIntel', label: 'Threat intel' },
+  { key: 'exposure', label: 'Exposure' },
+  { key: 'criticality', label: 'Asset criticality' },
+]
+
+const THRESHOLD_FIELDS: { key: keyof SlaConfig['thresholds']; label: string }[] = [
+  { key: 'emergency', label: 'Emergency' },
+  { key: 'critical', label: 'Critical' },
+  { key: 'high', label: 'High' },
+  { key: 'medium', label: 'Medium' },
+]
+
+const TIER_LABEL: Record<SlaTier, string> = {
+  emergency: 'Emergency',
+  critical: 'Critical',
+  high: 'High',
+  medium: 'Medium',
+  low: 'Low',
+  exception: 'Exception',
+}
+
+function shortDigest(sha: string): string {
+  return sha ? sha.slice(0, 12) : '—'
+}
+
+function formatWhen(iso: string | null): string {
+  if (!iso) return 'unknown'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+
+function NumberInput({
+  value,
+  onChange,
+  ariaLabel,
+  min = 0,
+  step = 1,
+  suffix,
+}: {
+  value: number
+  onChange: (n: number) => void
+  ariaLabel: string
+  min?: number
+  step?: number
+  suffix?: string
+}) {
+  return (
+    <div className="flex items-center gap-1.5">
+      <input
+        type="number"
+        inputMode="decimal"
+        value={Number.isFinite(value) ? value : 0}
+        min={min}
+        step={step}
+        aria-label={ariaLabel}
+        onChange={(e) => onChange(e.target.value === '' ? 0 : Number(e.target.value))}
+        className="input-inset w-20 rounded-lg border border-secondary bg-secondary px-2.5 py-1.5 text-right text-sm tabular-nums text-primary outline-none transition-colors focus:border-brand focus:ring-2 focus:ring-brand/40"
+      />
+      {suffix && <span className="text-xs text-tertiary">{suffix}</span>}
+    </div>
+  )
+}
+
+function WeightsEditor({ cfg, set }: { cfg: SlaConfig; set: (c: SlaConfig) => void }) {
+  const sum = WEIGHT_FIELDS.reduce((acc, f) => acc + (cfg.weights[f.key] || 0), 0)
+  const balanced = Math.round(sum) === 100
+  return (
+    <Card
+      title="Scoring weights"
+      titleClassName="flex items-center gap-2"
+      actions={
+        <Pill
+          className={cn(
+            'tabular-nums',
+            balanced ? 'bg-success-primary/10 text-success-primary ring-1 ring-inset ring-success-primary/25' : 'bg-warning-primary/10 text-warning-primary ring-1 ring-inset ring-warning-primary/25',
+          )}
+        >
+          {balanced ? <CheckCircle className="mr-1 inline size-3.5" /> : <AlertTriangle className="mr-1 inline size-3.5" />}
+          sums to {Math.round(sum)}
+        </Pill>
+      }
+    >
+      <p className="text-xs text-tertiary">
+        Each factor's maximum point contribution. The five scoring factors sum to 100, so a maxed finding
+        scores 100 before feasibility relief.
+      </p>
+      <div className="mt-4 space-y-2.5">
+        {WEIGHT_FIELDS.map((f) => {
+          const v = cfg.weights[f.key] || 0
+          return (
+            <div key={f.key} className="flex items-center gap-3">
+              <span className="w-36 shrink-0 text-sm text-secondary">{f.label}</span>
+              <div className="h-2 flex-1 overflow-hidden rounded-full bg-secondary">
+                <div className="h-full rounded-full bg-brand-solid" style={{ width: `${Math.min(100, v)}%` }} />
+              </div>
+              <NumberInput
+                value={v}
+                ariaLabel={`Weight ${f.label}`}
+                onChange={(n) => set({ ...cfg, weights: { ...cfg.weights, [f.key]: n } })}
+              />
+            </div>
+          )
+        })}
+        <div className="flex items-center gap-3 border-t border-secondary pt-2.5">
+          <span className="w-36 shrink-0 text-sm text-tertiary">Feasibility relief</span>
+          <span className="flex-1 text-xs text-quaternary">Maximum urgency reduction for a hard-to-fix finding</span>
+          <NumberInput
+            value={cfg.weights.feasibilityRelief || 0}
+            ariaLabel="Weight feasibility relief"
+            onChange={(n) => set({ ...cfg, weights: { ...cfg.weights, feasibilityRelief: n } })}
+          />
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+function ThresholdsEditor({ cfg, set }: { cfg: SlaConfig; set: (c: SlaConfig) => void }) {
+  const t = cfg.thresholds
+  const descending = t.emergency >= t.critical && t.critical >= t.high && t.high >= t.medium
+  return (
+    <Card
+      title="Tier thresholds"
+      titleClassName="flex items-center gap-2"
+      actions={
+        !descending ? (
+          <Pill className="bg-error-primary/10 text-error-primary ring-1 ring-inset ring-error-primary/25">
+            <AlertTriangle className="mr-1 inline size-3.5" /> must descend
+          </Pill>
+        ) : undefined
+      }
+    >
+      <p className="text-xs text-tertiary">
+        Inclusive lower score bound for each tier, strictly descending. A score below Medium is Low.
+      </p>
+      <div className="mt-4 space-y-2">
+        {THRESHOLD_FIELDS.map((f) => (
+          <div key={f.key} className="flex items-center gap-3">
+            <span className="w-28 shrink-0 text-sm text-secondary">{f.label}</span>
+            <span className="flex-1 text-xs text-quaternary">score &ge;</span>
+            <NumberInput
+              value={t[f.key] || 0}
+              ariaLabel={`Threshold ${f.label}`}
+              onChange={(n) => set({ ...cfg, thresholds: { ...t, [f.key]: n } })}
+            />
+          </div>
+        ))}
+      </div>
+    </Card>
+  )
+}
+
+function DueRangesEditor({ cfg, set }: { cfg: SlaConfig; set: (c: SlaConfig) => void }) {
+  return (
+    <Card title="Due ranges">
+      <p className="text-xs text-tertiary">
+        How long each tier has to mitigate (a compensating step) and to fully remediate, in days.
+      </p>
+      <div className="mt-4 overflow-x-auto">
+        <table className="w-full min-w-[420px] text-sm">
+          <thead>
+            <tr className="text-left text-[11px] uppercase tracking-wider text-tertiary">
+              <th className="pb-2 font-semibold">Tier</th>
+              <th className="pb-2 text-right font-semibold">Mitigate (days)</th>
+              <th className="pb-2 text-right font-semibold">Remediate (days)</th>
+            </tr>
+          </thead>
+          <tbody>
+            {SLA_TIERS.map((tier) => {
+              const dr = cfg.dueRanges[tier]
+              const bad = dr.mitigateDays > dr.remediateDays
+              return (
+                <tr key={tier} className="border-t border-secondary">
+                  <td className="py-2 text-secondary">{TIER_LABEL[tier]}</td>
+                  <td className="py-2">
+                    <div className="flex justify-end">
+                      <NumberInput
+                        value={dr.mitigateDays}
+                        step={0.5}
+                        ariaLabel={`${TIER_LABEL[tier]} mitigate days`}
+                        onChange={(n) => set({ ...cfg, dueRanges: { ...cfg.dueRanges, [tier]: { ...dr, mitigateDays: n } } })}
+                      />
+                    </div>
+                  </td>
+                  <td className="py-2">
+                    <div className="flex items-center justify-end gap-2">
+                      {bad && <AlertTriangle className="size-3.5 text-error-primary" aria-label="mitigate exceeds remediate" />}
+                      <NumberInput
+                        value={dr.remediateDays}
+                        step={0.5}
+                        ariaLabel={`${TIER_LABEL[tier]} remediate days`}
+                        onChange={(n) => set({ ...cfg, dueRanges: { ...cfg.dueRanges, [tier]: { ...dr, remediateDays: n } } })}
+                      />
+                    </div>
+                  </td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </table>
+      </div>
+    </Card>
+  )
+}
+
+function PolicyHistory({ policies, activeSha }: { policies: SlaPolicy[]; activeSha: string }) {
+  if (policies.length === 0) return null
+  return (
+    <Card title="Version history">
+      <ul className="divide-y divide-secondary">
+        {policies.map((p) => (
+          <li key={p.sha256} className="flex flex-wrap items-center gap-x-3 gap-y-1 py-2.5">
+            <span className="font-mono text-xs text-secondary">{shortDigest(p.sha256)}</span>
+            {p.sha256 === activeSha && (
+              <Pill className="bg-brand-primary/10 text-brand-secondary ring-1 ring-inset ring-brand/25">active</Pill>
+            )}
+            <span className="text-xs text-tertiary">{p.config.version}</span>
+            <span className="ml-auto text-xs text-quaternary">
+              {p.createdBy} · {formatWhen(p.createdAt)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  )
+}
+
+export function SLAPolicy() {
+  const { data, loading, error, refetch } = useFetch(() => api.slaPolicies(), { deps: [] })
+  const active = data?.active ?? null
+  const [draft, setDraft] = useState<SlaConfig | null>(null)
+  const [busy, setBusy] = useState(false)
+  const { notify } = useToast()
+
+  // Seed the editable draft from the active policy the first time it loads (and when it changes).
+  useEffect(() => {
+    if (active) setDraft(structuredClone(active.config))
+  }, [active])
+
+  const dirty = useMemo(
+    () => (active && draft ? JSON.stringify(draft) !== JSON.stringify(active.config) : false),
+    [active, draft],
+  )
+
+  // Mirror the server's validity rules so an invalid config is refused here with a clear reason rather
+  // than a 400. The block is empty only when the draft would be accepted.
+  const invalidReason = useMemo(() => {
+    if (!draft) return ''
+    const w = draft.weights
+    const sum = w.severity + w.exploitability + w.threatIntel + w.exposure + w.criticality
+    if (Math.round(sum) !== 100) return 'the five scoring factors must sum to 100'
+    const t = draft.thresholds
+    if (!(t.emergency >= t.critical && t.critical >= t.high && t.high >= t.medium)) return 'tier thresholds must descend'
+    for (const tier of SLA_TIERS) {
+      const dr = draft.dueRanges[tier]
+      if (dr.mitigateDays > dr.remediateDays) return `${tier} mitigate must not exceed remediate`
+    }
+    return ''
+  }, [draft])
+
+  async function activate() {
+    if (!draft) return
+    setBusy(true)
+    try {
+      const { created } = await api.activateSLAPolicy(draft)
+      notify(created ? 'New SLA policy version activated.' : 'Policy re-activated (identical to the active version).', 'success')
+      refetch()
+    } catch (e) {
+      notify(e instanceof Error ? e.message : 'Failed to activate policy', 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (loading) return <Spinner label="Loading SLA policy…" />
+  if (error) return <ErrorState message={error} />
+  if (!active || !draft)
+    return <ErrorState message="No SLA policy is available. The remediation-governance feature may be disabled." />
+
+  return (
+    <div className="space-y-4">
+      <Card title="Active policy" titleClassName="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+          <div className="flex items-center gap-2">
+            <Shield01 className="size-4 text-brand-secondary" aria-hidden />
+            <span className="text-sm font-semibold text-primary">{active.config.version}</span>
+          </div>
+          <div className="text-xs text-tertiary">
+            digest <span className="font-mono text-secondary">{shortDigest(active.sha256)}</span>
+          </div>
+          <div className="text-xs text-tertiary">
+            activated by <span className="text-secondary">{active.createdBy || 'system'}</span> · {formatWhen(active.createdAt)}
+          </div>
+          <div className="ml-auto flex items-center gap-3">
+            {dirty && !invalidReason && <span className="text-xs text-warning-primary">Unsaved edits</span>}
+            <Button loading={busy} disabled={!dirty || invalidReason !== ''} onClick={activate} variant="primary" className="px-3 py-1.5">
+              <Save01 className="size-4" /> Activate new version
+            </Button>
+          </div>
+        </div>
+        {dirty && invalidReason ? (
+          <p className="mt-3 flex items-center gap-1.5 text-xs text-error-primary">
+            <AlertTriangle className="size-3.5 shrink-0" aria-hidden /> Cannot activate: {invalidReason}.
+          </p>
+        ) : (
+          <p className="mt-3 text-xs text-quaternary">
+            {dirty
+              ? 'Editing appends a new immutable version and makes it active; previous versions stay in the history below. Activation requires administrator permission.'
+              : 'Edit the weights, thresholds, or due ranges below to stage a new version. Activation requires administrator permission.'}
+          </p>
+        )}
+      </Card>
+
+      <WeightsEditor cfg={draft} set={setDraft} />
+      <ThresholdsEditor cfg={draft} set={setDraft} />
+      <DueRangesEditor cfg={draft} set={setDraft} />
+      <PolicyHistory policies={data?.policies ?? []} activeSha={active.sha256} />
+    </div>
+  )
+}
+
+export default SLAPolicy

--- a/web/src/pages/Settings/Settings.tsx
+++ b/web/src/pages/Settings/Settings.tsx
@@ -6,6 +6,7 @@ const TABS = [
   { label: 'Team', to: '/settings/team' },
   { label: 'Connectors', to: '/settings/connectors' },
   { label: 'Config', to: '/settings/config' },
+  { label: 'SLA policy', to: '/settings/sla' },
 ]
 
 export function Settings() {

--- a/web/src/pages/VulnerabilityIntelligence/AttackPaths.test.tsx
+++ b/web/src/pages/VulnerabilityIntelligence/AttackPaths.test.tsx
@@ -1,0 +1,59 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import type { AttackPathResult } from '../../lib/api'
+import { AttackPaths } from './AttackPaths'
+
+vi.mock('../../lib/api', () => ({
+  api: { listAttackPaths: vi.fn() },
+}))
+
+function result(): AttackPathResult {
+  return {
+    truncated: false,
+    paths: [
+      {
+        id: 'path-001',
+        confident: true,
+        uncertainties: [],
+        nodes: [
+          { id: 'asset-edge', label: 'edge-gw', kind: 'asset', detail: 'host' },
+          { id: 'finding-001', label: 'Deserialization of untrusted data', kind: 'finding', detail: 'critical · reachability reachable' },
+        ],
+        steps: [{ kind: 'reachability', observed: true, toFinding: true }],
+      },
+      {
+        id: 'path-002',
+        confident: false,
+        uncertainties: ['inferred_edge', 'unconfirmed_reachability'],
+        nodes: [
+          { id: 'asset-app', label: 'checkout-svc', kind: 'asset', detail: 'service' },
+          { id: 'finding-003', label: 'Reflected XSS in search', kind: 'finding', detail: 'high · reachability unknown' },
+        ],
+        steps: [{ kind: 'inferred', observed: false, toFinding: true }],
+      },
+    ],
+  }
+}
+
+describe('AttackPaths', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('renders each path with its confidence and terminal finding', async () => {
+    vi.mocked(api.listAttackPaths).mockResolvedValue(result())
+    render(<AttackPaths />)
+
+    expect(await screen.findByText('edge-gw')).toBeInTheDocument()
+    expect(screen.getByText('Deserialization of untrusted data')).toBeInTheDocument()
+    expect(screen.getByText('confident')).toBeInTheDocument()
+    expect(screen.getByText('uncertain')).toBeInTheDocument()
+    // uncertainties are humanised (underscores stripped)
+    expect(screen.getByText('inferred edge')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when no paths', async () => {
+    vi.mocked(api.listAttackPaths).mockResolvedValue({ paths: [], truncated: false })
+    render(<AttackPaths />)
+    expect(await screen.findByText('No attack paths')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/VulnerabilityIntelligence/AttackPaths.tsx
+++ b/web/src/pages/VulnerabilityIntelligence/AttackPaths.tsx
@@ -1,0 +1,149 @@
+import { Fragment, useState } from 'react'
+import { AlertTriangle, ArrowRight, CheckCircle, HelpCircle, Cube01, Share07, Target04 } from '@untitledui/icons'
+import { Button, Card, EmptyState, ErrorState, Field, Input, Pill, Spinner, cn } from '../../components/ui'
+import { useFetch } from '../../hooks'
+import { api } from '../../lib/api'
+import type { AttackPath, AttackPathNode } from '../../lib/api'
+
+function uncertaintyLabel(u: string): string {
+  return u.replace(/_/g, ' ')
+}
+
+function NodeChip({ node }: { node: AttackPathNode }) {
+  const isFinding = node.kind === 'finding'
+  const Icon = isFinding ? Target04 : Cube01
+  return (
+    <span
+      className={cn(
+        'inline-flex max-w-[16rem] items-center gap-1.5 rounded-md px-2 py-1 text-xs ring-1 ring-inset',
+        isFinding ? 'bg-error-primary/10 text-error-primary ring-error-primary/25' : 'bg-secondary text-secondary ring-secondary',
+      )}
+      title={node.detail ? `${node.label} — ${node.detail}` : node.label}
+    >
+      <Icon className="size-3.5 shrink-0" aria-hidden />
+      <span className="truncate font-medium">{node.label}</span>
+    </span>
+  )
+}
+
+function PathCard({ path }: { path: AttackPath }) {
+  return (
+    <Card>
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          {path.confident ? (
+            <Pill className="bg-success-primary/10 text-success-primary ring-1 ring-inset ring-success-primary/25">
+              <CheckCircle className="mr-1 inline size-3.5" /> confident
+            </Pill>
+          ) : (
+            <Pill className="bg-warning-primary/10 text-warning-primary ring-1 ring-inset ring-warning-primary/25">
+              <HelpCircle className="mr-1 inline size-3.5" /> uncertain
+            </Pill>
+          )}
+          <span className="text-xs text-quaternary">{path.nodes.length} hops</span>
+        </div>
+        <span className="font-mono text-[11px] text-quaternary">{path.id}</span>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-x-1 gap-y-2">
+        {path.nodes.map((node, i) => (
+          <Fragment key={`${node.id}-${i}`}>
+            <NodeChip node={node} />
+            {i < path.nodes.length - 1 && (() => {
+              const observed = path.steps[i]?.observed
+              return (
+                <span
+                  className={cn('inline-flex items-center gap-1 px-1', observed ? 'text-tertiary' : 'text-warning-primary')}
+                  title={observed ? 'observed edge' : 'inferred edge (not observed)'}
+                >
+                  <ArrowRight className={cn('size-3.5', observed ? 'text-success-primary' : 'text-warning-primary')} aria-hidden />
+                  {path.steps[i]?.kind && <span className="text-[10px] uppercase tracking-wide">{path.steps[i].kind}</span>}
+                  {!observed && <span className="text-[10px]">(inferred)</span>}
+                </span>
+              )
+            })()}
+          </Fragment>
+        ))}
+      </div>
+
+      {path.uncertainties.length > 0 && (
+        <div className="mt-3 flex flex-wrap items-center gap-1.5">
+          <AlertTriangle className="size-3.5 text-warning-primary" aria-hidden />
+          {path.uncertainties.map((u) => (
+            <span key={u} className="rounded bg-warning-primary/10 px-1.5 py-0.5 text-[11px] text-warning-primary ring-1 ring-inset ring-warning-primary/25">
+              {uncertaintyLabel(u)}
+            </span>
+          ))}
+        </div>
+      )}
+    </Card>
+  )
+}
+
+export function AttackPaths() {
+  const [target, setTarget] = useState('')
+  const [finding, setFinding] = useState('')
+  const [applied, setApplied] = useState<{ target?: string; finding?: string }>({})
+
+  const { data, loading, error } = useFetch(() => api.listAttackPaths(applied), { deps: [applied.target, applied.finding] })
+  const paths = data?.paths ?? []
+
+  return (
+    <div className="mx-auto max-w-[1600px] animate-fade-in space-y-6 pb-12">
+      <header>
+        <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight text-primary sm:text-display-xs">
+          <Share07 className="size-6 text-brand-secondary" aria-hidden /> Attack paths
+        </h1>
+        <p className="mt-1 text-sm text-secondary">
+          Root-to-finding traversals over the asset graph. A path is confident only when every edge is
+          observed; otherwise it carries the uncertainties that weaken it.
+        </p>
+      </header>
+
+      <Card title="Filters">
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="min-w-56 flex-1">
+            <Field label="Target asset">
+              <Input value={target} onChange={(e) => setTarget(e.target.value)} placeholder="asset id" className="font-mono" aria-label="Filter by target asset" />
+            </Field>
+          </div>
+          <div className="min-w-56 flex-1">
+            <Field label="Finding">
+              <Input value={finding} onChange={(e) => setFinding(e.target.value)} placeholder="finding id" className="font-mono" aria-label="Filter by finding" />
+            </Field>
+          </div>
+          <Button variant="secondary-color" className="px-3 py-2" onClick={() => setApplied({ target: target.trim() || undefined, finding: finding.trim() || undefined })}>
+            Apply
+          </Button>
+        </div>
+      </Card>
+
+      {data?.truncated && (
+        <div className="flex items-start gap-2 rounded-lg border border-warning-primary/40 bg-warning-primary/10 p-3 text-xs text-warning-primary">
+          <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden />
+          The traversal hit its bounds; some paths are not shown. Narrow the filter to see a specific target's paths.
+        </div>
+      )}
+
+      {loading ? (
+        <Spinner label="Loading attack paths…" />
+      ) : error ? (
+        <ErrorState message={error} />
+      ) : paths.length === 0 ? (
+        <EmptyState
+          icon={Share07}
+          title="No attack paths"
+          hint="A path appears when the graph connects an exposed entrypoint to a finding. None match this filter yet."
+        />
+      ) : (
+        <div className="space-y-3">
+          {paths.map((p) => (
+            <PathCard key={p.id} path={p} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default AttackPaths


### PR DESCRIPTION
## What

Adds dashboard surfaces for backend routes that were wired non-nil but had no UI, so a running server
exposed the capability with no way to reach it. Six surfaces, each with an api adapter, a component, a
test, MSW mocks, and a design pass (built against the running app in light and dark, scored by an
external design review, and refined).

Stacked on #831 (shares `web/src/lib/api/index.ts` and `web/src/mocks/handlers.ts`). Retarget to main
once #831 merges.

## Surfaces

1. **SLA policy admin** (Settings): view the active risk-based remediation policy (scoring weights with a
   sum-to-100 check, tier thresholds, per-tier due ranges) and its version history; activate a new
   immutable version, refused client-side with a reason when invalid.
2. **Fleet coverage windows** (Fleet): the immutable telemetry-coverage revisions per asset — per-class
   sensor state (process/network/file/privilege), the sample/drop/gap counts, and the input digest.
3. **Write-up drafts** (Governance, per engagement): an agent proposes a finding's description and
   remediation; a reviewer edits, accepts, or rejects it, with separation of duties.
4. **Retro-hunt** (Fleet host detail): re-hunt a host's endpoint state timeline in a window around a
   pivot, rendered as an event-ordered transition timeline; truncation stated explicitly.
5. **Cloud posture (CSPM)** (Offensive, per engagement): define cloud targets (provider, root, vault
   credential reference) and run a bounded read-only posture scan, polling the durable run to completion.
6. **Attack paths** (Exposure Management): root-to-finding traversals as node chains with per-edge kind;
   a path is confident only when every edge is observed, and inferred edges and uncertainties are marked.

## Tests

`pnpm test` (535), `pnpm run typecheck`, and `pnpm build` are green. Each surface adds api-mapping and
component tests; MSW mocks are added for every new route (the attack-path and write-up mocks reproduce the
PascalCase domain wire shape so the mappers are exercised).
