### PR TITLE
feat(detection): add ordered sequence detection rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Sequence detection rules (#822).** The detection engine matched single events and, since the rate
+  window, bursts; it now also matches an ordered *sequence* of events of one class within a span, grouped
+  per host. A new `Sequence` rule type (mutually exclusive with a rate `Window`) carries the ordered step
+  matchers; the per-class evaluator tracks each group's partial match under the same `MaxWindowGroups`
+  memory bound, allocates a group only on a first-step match, re-anchors on a repeated first step so a
+  restaged tool is not missed, and fires once with the ordered evidence. The shipped catalogue gains
+  `det.tool_staging_sequence`: a downloader (curl/wget/tftp/ftp) followed by a remote-shell tool
+  (nc/ncat/socat) on one host within two minutes, which neither process alone reveals.
+
+
 - **Attack paths, SLA policy, offensive policy, and alerting reach the dashboard.** Four capabilities
   were wired non-nil in `cmd/synapse-api` but had no UI, so operators could not reach them. A new
   **Attack paths** tab under Vulnerability Intelligence renders the exposure-to-finding graph
@@ -67,6 +77,7 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
   and an interrupted run terminalizes `interrupted` instead. A worker that has no live scoped-egress
   broker still claims the job and fails the run `egress_unavailable` rather than leave it orphaned at
   `queued`, so an enqueued run is always visible to the poller.
+
 
 - **Per-engagement vulnerability posture in the dashboard.** The reconciled advisory occurrences and the
   governed action queue for an engagement (`GET /engagements/{id}/vulnerability/occurrences` and

--- a/internal/domain/detection/catalog.go
+++ b/internal/domain/detection/catalog.go
@@ -70,6 +70,25 @@ var catalogue = []Rule{
 			{Field: FieldPrivKind, Op: OpIn, Values: []string{"setuid", "capset"}},
 		}},
 	},
+	{
+		// A sequence, not a single event: a downloader (ingress tooling, T1105) followed by a
+		// remote-shell tool on the same host within two minutes is staging then use. Neither process on
+		// its own is a detection — curl is ordinary, and nc is ordinary — but the ordered pair is the
+		// behaviour a single-event or rate rule cannot express. Grouped by host (the default).
+		ID: "det.tool_staging_sequence", Version: 1, Class: ClassProcess,
+		Title: "Tool staging then remote shell (T1105 -> T1059)", Severity: shared.SeverityHigh,
+		Sequence: &Sequence{
+			Within: 2 * time.Minute,
+			Steps: []Matcher{
+				{Class: ClassProcess, All: []Predicate{
+					{Field: FieldProcComm, Op: OpIn, Values: []string{"curl", "wget", "tftp", "ftp"}},
+				}},
+				{Class: ClassProcess, All: []Predicate{
+					{Field: FieldProcComm, Op: OpIn, Values: []string{"nc", "ncat", "socat"}},
+				}},
+			},
+		},
+	},
 }
 
 // Catalogue returns a validated copy of the built-in rule set, deterministically ordered by id so a

--- a/internal/domain/detection/matcher.go
+++ b/internal/domain/detection/matcher.go
@@ -141,6 +141,24 @@ func (m Matcher) validate() error {
 	return nil
 }
 
+// clone returns a deep copy of the matcher: the predicate slice and each predicate's Values slice are
+// copied, not aliased, so a returned rule cannot be reached through to mutate the package-level catalogue.
+func (m Matcher) clone() Matcher {
+	c := m
+	if m.All != nil {
+		preds := make([]Predicate, len(m.All))
+		for i, p := range m.All {
+			pc := p
+			if p.Values != nil {
+				pc.Values = append([]string(nil), p.Values...)
+			}
+			preds[i] = pc
+		}
+		c.All = preds
+	}
+	return c
+}
+
 // Match reports whether the event satisfies every predicate. A cross-class event, or one missing the
 // field a predicate names, does not match — a rule never matches something it cannot see.
 func (m Matcher) Match(e Event) bool {

--- a/internal/domain/detection/rule.go
+++ b/internal/domain/detection/rule.go
@@ -24,6 +24,10 @@ type Rule struct {
 	// Window, when set, makes the rule fire on a rate of matching events rather than on each one. Nil is
 	// the plain per-event rule.
 	Window *Window
+	// Sequence, when set, makes the rule fire on an ordered series of matching events rather than on one.
+	// It is mutually exclusive with Window, and it replaces the top-level Matcher (each step carries its
+	// own), so a sequence rule leaves Matcher empty.
+	Sequence *Sequence
 }
 
 // Validate enforces the invariants a catalogued rule must hold. A rule that fails these cannot produce a
@@ -45,6 +49,20 @@ func (r Rule) Validate() error {
 	if !r.Severity.Valid() || r.Severity == shared.SeverityUnknown {
 		return fmt.Errorf("%w: rule %s has an invalid severity %q", shared.ErrValidation, r.ID, r.Severity)
 	}
+	if r.Sequence != nil {
+		// A sequence rule is defined entirely by its steps: it must not also be windowed, and its
+		// top-level matcher must be empty so there is one place a step's predicates live.
+		if r.Window != nil {
+			return fmt.Errorf("%w: rule %s cannot be both windowed and a sequence", shared.ErrValidation, r.ID)
+		}
+		if len(r.Matcher.All) != 0 {
+			return fmt.Errorf("%w: rule %s is a sequence; its top-level matcher must be empty (each step carries its own)", shared.ErrValidation, r.ID)
+		}
+		if err := r.Sequence.validate(r.Class); err != nil {
+			return fmt.Errorf("rule %s: %w", r.ID, err)
+		}
+		return nil
+	}
 	if r.Matcher.Class != r.Class {
 		return fmt.Errorf("%w: rule %s class %s does not match its matcher's class %s",
 			shared.ErrValidation, r.ID, r.Class, r.Matcher.Class)
@@ -59,6 +77,9 @@ func (r Rule) Validate() error {
 	}
 	return nil
 }
+
+// Sequenced reports whether the rule fires on an ordered series of events rather than one.
+func (r Rule) Sequenced() bool { return r.Sequence != nil }
 
 // Match reports whether an event satisfies this rule's predicates. It observes and matches only — it
 // never executes anything (golden rule 1); the Matcher is typed data, not a shell expression. For a
@@ -89,5 +110,6 @@ func (r Rule) clone() Rule {
 		c.Matcher.All = preds
 	}
 	c.Window = r.Window.clone()
+	c.Sequence = r.Sequence.clone()
 	return c
 }

--- a/internal/domain/detection/sequence.go
+++ b/internal/domain/detection/sequence.go
@@ -1,0 +1,77 @@
+package detection
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// MaxSequenceSteps bounds a sequence rule's length. Per-group state holds at most this many events, so a
+// rule cannot make the evaluator allocate an unbounded partial match.
+const MaxSequenceSteps = 8
+
+// Sequence turns a rule from "one matching event is a detection" into "these matchers, satisfied by
+// events of the rule's class IN THIS ORDER, for the same group, all within this span, is a detection".
+// It expresses an ordered behaviour that no single event and no rate shows: stage a tool, then use it;
+// probe identity, then attempt escalation. The steps match over the rule's own class; a cross-class
+// sequence is out of scope for the per-class engine, which sees one class at a time.
+type Sequence struct {
+	// Steps are the ordered matchers. An event advances the sequence only when it matches the next
+	// unsatisfied step. At least two steps: a one-step sequence is a plain rule.
+	Steps []Matcher
+	// Within is the span from the FIRST matched step's event to the last, exclusive. A partial match that
+	// lapses is reset, so a slow, unrelated recurrence is never stitched into a sequence.
+	Within time.Duration
+	// GroupBy partitions progress by these fields so two hosts' (or two entities') unrelated events do
+	// not interleave into one sequence. Empty groups by host only. Fields must belong to the rule's class.
+	GroupBy []Field
+}
+
+func (s Sequence) validate(class Class) error {
+	if len(s.Steps) < 2 {
+		return fmt.Errorf("%w: sequence needs at least 2 steps (a one-step sequence is a plain rule)", shared.ErrValidation)
+	}
+	if len(s.Steps) > MaxSequenceSteps {
+		return fmt.Errorf("%w: sequence has %d steps, over the %d cap", shared.ErrValidation, len(s.Steps), MaxSequenceSteps)
+	}
+	if s.Within <= 0 {
+		return fmt.Errorf("%w: sequence span must be positive", shared.ErrValidation)
+	}
+	for i, step := range s.Steps {
+		if step.Class != class {
+			return fmt.Errorf("%w: sequence step %d matches class %s, not the rule's class %s", shared.ErrValidation, i, step.Class, class)
+		}
+		if err := step.validate(); err != nil {
+			return fmt.Errorf("sequence step %d: %w", i, err)
+		}
+	}
+	for _, f := range s.GroupBy {
+		fc, ok := fieldClass(f)
+		if !ok {
+			return fmt.Errorf("%w: sequence groups by unknown field %q", shared.ErrValidation, f)
+		}
+		if fc != class {
+			return fmt.Errorf("%w: sequence field %q belongs to class %s, not %s", shared.ErrValidation, f, fc, class)
+		}
+	}
+	return nil
+}
+
+func (s *Sequence) clone() *Sequence {
+	if s == nil {
+		return nil
+	}
+	c := *s
+	if s.Steps != nil {
+		steps := make([]Matcher, len(s.Steps))
+		for i, m := range s.Steps {
+			steps[i] = m.clone()
+		}
+		c.Steps = steps
+	}
+	if s.GroupBy != nil {
+		c.GroupBy = append([]Field(nil), s.GroupBy...)
+	}
+	return &c
+}

--- a/internal/domain/detection/sequence_test.go
+++ b/internal/domain/detection/sequence_test.go
@@ -1,0 +1,240 @@
+package detection
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func seqEvent(at time.Time, host shared.ID, comm string) Event {
+	return Event{Class: ClassProcess, At: at, Host: host, Process: &ProcessEvent{PID: 7, Comm: comm, Path: "/usr/bin/" + comm}}
+}
+
+func stepMatcher(values ...string) Matcher {
+	return Matcher{Class: ClassProcess, All: []Predicate{{Field: FieldProcComm, Op: OpIn, Values: values}}}
+}
+
+func sequenceRule(within time.Duration) Rule {
+	return Rule{
+		ID: "det.test_sequence", Version: 1, Class: ClassProcess, Title: "seq", Severity: shared.SeverityHigh,
+		Sequence: &Sequence{Within: within, Steps: []Matcher{stepMatcher("curl", "wget"), stepMatcher("nc", "ncat")}},
+	}
+}
+
+func TestSequenceValidation(t *testing.T) {
+	if err := sequenceRule(time.Minute).Validate(); err != nil {
+		t.Fatalf("valid sequence rule rejected: %v", err)
+	}
+	base := func() Rule { return sequenceRule(time.Minute) }
+	cases := map[string]func(r *Rule){
+		"one step": func(r *Rule) { r.Sequence.Steps = r.Sequence.Steps[:1] },
+		"no span":  func(r *Rule) { r.Sequence.Within = 0 },
+		"cross-class step": func(r *Rule) {
+			r.Sequence.Steps[1] = Matcher{Class: ClassNetwork, All: []Predicate{{Field: FieldNetRemotePort, Op: OpEquals, Value: "53"}}}
+		},
+		"empty step matcher":  func(r *Rule) { r.Sequence.Steps[0] = Matcher{Class: ClassProcess} },
+		"bad groupby field":   func(r *Rule) { r.Sequence.GroupBy = []Field{"nope"} },
+		"cross-class groupby": func(r *Rule) { r.Sequence.GroupBy = []Field{FieldNetRemoteAddr} },
+		"also windowed":       func(r *Rule) { r.Window = &Window{Count: 2, Within: time.Minute} },
+		"non-empty top match": func(r *Rule) {
+			r.Matcher = Matcher{Class: ClassProcess, All: []Predicate{{Field: FieldProcComm, Op: OpEquals, Value: "x"}}}
+		},
+	}
+	for name, mut := range cases {
+		r := base()
+		mut(&r)
+		if err := r.Validate(); !errors.Is(err, shared.ErrValidation) {
+			t.Errorf("%s: err = %v, want ErrValidation", name, err)
+		}
+	}
+	// Over the step cap.
+	over := base()
+	steps := make([]Matcher, MaxSequenceSteps+1)
+	for i := range steps {
+		steps[i] = stepMatcher("curl")
+	}
+	over.Sequence.Steps = steps
+	if err := over.Validate(); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("over step cap: err = %v, want ErrValidation", err)
+	}
+}
+
+func TestEvaluatorSequenceFiresInOrderWithinSpan(t *testing.T) {
+	ev, err := NewEvaluator([]Rule{sequenceRule(2 * time.Minute)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t0 := time.Unix(1_000, 0)
+
+	// Step 1 alone does not fire.
+	if fired := ev.Evaluate(seqEvent(t0, "h", "curl")); len(fired) != 0 {
+		t.Fatalf("fired on the first step alone: %+v", fired)
+	}
+	// An unrelated event in between does not break the sequence.
+	if fired := ev.Evaluate(seqEvent(t0.Add(time.Second), "h", "ps")); len(fired) != 0 {
+		t.Fatalf("unrelated event fired: %+v", fired)
+	}
+	// The second step completes the sequence.
+	fired := ev.Evaluate(seqEvent(t0.Add(30*time.Second), "h", "nc"))
+	if len(fired) != 1 {
+		t.Fatalf("second step should complete the sequence, got %d", len(fired))
+	}
+	if len(fired[0].Evidence) != 2 || fired[0].Evidence[0].Process.Comm != "curl" || fired[0].Evidence[1].Process.Comm != "nc" {
+		t.Fatalf("evidence is not the ordered pair: %+v", fired[0].Evidence)
+	}
+}
+
+func TestEvaluatorSequenceIgnoresWrongOrder(t *testing.T) {
+	ev, _ := NewEvaluator([]Rule{sequenceRule(2 * time.Minute)})
+	t0 := time.Unix(2_000, 0)
+	// Second step first, then first step: no completed sequence.
+	if fired := ev.Evaluate(seqEvent(t0, "h", "nc")); len(fired) != 0 {
+		t.Fatalf("second step alone fired: %+v", fired)
+	}
+	if fired := ev.Evaluate(seqEvent(t0.Add(time.Second), "h", "curl")); len(fired) != 0 {
+		t.Fatalf("out-of-order events fired: %+v", fired)
+	}
+}
+
+func TestEvaluatorSequenceResetsWhenLapsed(t *testing.T) {
+	ev, _ := NewEvaluator([]Rule{sequenceRule(time.Minute)})
+	t0 := time.Unix(3_000, 0)
+	ev.Evaluate(seqEvent(t0, "h", "curl"))
+	// The second step arrives after the span: the partial match has lapsed, so nothing fires.
+	if fired := ev.Evaluate(seqEvent(t0.Add(90*time.Second), "h", "nc")); len(fired) != 0 {
+		t.Fatalf("a lapsed sequence fired: %+v", fired)
+	}
+}
+
+func TestEvaluatorSequenceGroupsByHost(t *testing.T) {
+	ev, _ := NewEvaluator([]Rule{sequenceRule(2 * time.Minute)})
+	t0 := time.Unix(4_000, 0)
+	// host a stages, host b uses: two different hosts must not stitch into one sequence.
+	ev.Evaluate(seqEvent(t0, "host-a", "curl"))
+	if fired := ev.Evaluate(seqEvent(t0.Add(time.Second), "host-b", "nc")); len(fired) != 0 {
+		t.Fatalf("events on different hosts completed a sequence: %+v", fired)
+	}
+	// host a completing its own sequence still fires.
+	if fired := ev.Evaluate(seqEvent(t0.Add(2*time.Second), "host-a", "nc")); len(fired) != 1 {
+		t.Fatalf("same-host sequence should fire, got %d", len(fired))
+	}
+}
+
+// TestCataloguedSequenceFires proves the shipped tool-staging sequence rule reconciles through a fresh
+// evaluator built from the catalogue: a downloader then a remote-shell tool on one host completes it.
+func TestCataloguedSequenceFires(t *testing.T) {
+	rules, err := CatalogueByClass(ClassProcess)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ev, err := NewEvaluator(rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t0 := time.Unix(5_000, 0)
+	ev.Evaluate(seqEvent(t0, "h", "wget"))
+	fired := ev.Evaluate(seqEvent(t0.Add(10*time.Second), "h", "ncat"))
+	var got bool
+	for _, f := range fired {
+		if f.Rule.ID == "det.tool_staging_sequence" {
+			got = true
+		}
+	}
+	if !got {
+		t.Fatalf("the catalogued tool-staging sequence did not fire; got %+v", fired)
+	}
+}
+
+// TestEvaluatorSequenceRestartsOnRepeatedFirstStep proves a repeated staging is not missed: A, A, B where
+// the second A and the B are within the span must fire, even though the first A's window would lapse.
+func TestEvaluatorSequenceRestartsOnRepeatedFirstStep(t *testing.T) {
+	ev, _ := NewEvaluator([]Rule{sequenceRule(2 * time.Minute)})
+	t0 := time.Unix(6_000, 0)
+	if fired := ev.Evaluate(seqEvent(t0, "h", "curl")); len(fired) != 0 {
+		t.Fatalf("first staging fired alone: %+v", fired)
+	}
+	// A second staging 119s later supersedes the first (which is about to lapse).
+	if fired := ev.Evaluate(seqEvent(t0.Add(119*time.Second), "h", "curl")); len(fired) != 0 {
+		t.Fatalf("second staging fired alone: %+v", fired)
+	}
+	// The remote shell 61s after the second staging is inside its span, so the sequence fires.
+	fired := ev.Evaluate(seqEvent(t0.Add(180*time.Second), "h", "nc"))
+	if len(fired) != 1 {
+		t.Fatalf("the restarted sequence should fire, got %d", len(fired))
+	}
+	if fired[0].Evidence[0].Process.Comm != "curl" || !fired[0].Evidence[0].At.Equal(t0.Add(119*time.Second)) {
+		t.Fatalf("evidence should start from the SECOND staging, got %+v", fired[0].Evidence[0])
+	}
+}
+
+// TestEvaluatorSequenceFiresAgainAfterCompletion proves a completed sequence frees its group, so an
+// identical later sequence on the same host fires again rather than being swallowed.
+func TestEvaluatorSequenceFiresAgainAfterCompletion(t *testing.T) {
+	ev, _ := NewEvaluator([]Rule{sequenceRule(2 * time.Minute)})
+	t0 := time.Unix(7_000, 0)
+	ev.Evaluate(seqEvent(t0, "h", "curl"))
+	if fired := ev.Evaluate(seqEvent(t0.Add(time.Second), "h", "nc")); len(fired) != 1 {
+		t.Fatalf("first sequence should fire, got %d", len(fired))
+	}
+	ev.Evaluate(seqEvent(t0.Add(10*time.Second), "h", "curl"))
+	if fired := ev.Evaluate(seqEvent(t0.Add(11*time.Second), "h", "nc")); len(fired) != 1 {
+		t.Fatalf("a second identical sequence should fire again, got %d", len(fired))
+	}
+}
+
+// TestSequenceRuleReturnsAreImmutable proves a returned sequence rule cannot be reached through to mutate
+// the package catalogue: the deep copy must cover the step matchers' Values, which the plain-rule
+// immutability test never touches (a sequence rule's top-level Matcher.All is nil).
+func TestSequenceRuleReturnsAreImmutable(t *testing.T) {
+	r, ok := Lookup("det.tool_staging_sequence")
+	if !ok || r.Sequence == nil || len(r.Sequence.Steps) == 0 || len(r.Sequence.Steps[0].All) == 0 {
+		t.Fatal("expected the catalogued tool-staging sequence with step predicates")
+	}
+	r.Sequence.Steps[0].All[0].Values[0] = "TAMPERED"
+	r.Sequence.Steps[0].All[0].Value = "TAMPERED"
+
+	fresh, ok := Lookup("det.tool_staging_sequence")
+	if !ok {
+		t.Fatal("re-lookup failed")
+	}
+	for _, v := range fresh.Sequence.Steps[0].All[0].Values {
+		if v == "TAMPERED" {
+			t.Fatal("mutating a returned sequence rule's step Values leaked into the catalogue")
+		}
+	}
+	if fresh.Sequence.Steps[0].All[0].Value == "TAMPERED" {
+		t.Fatal("mutating a returned sequence rule's step Value leaked into the catalogue")
+	}
+}
+
+// TestEvaluatorSequenceGroupsAreBounded proves an attacker cannot grow the evaluator without bound by
+// varying the grouped field: a sequence rule grouped by a high-cardinality field, fed a unique first-step
+// value per event, never holds more than MaxWindowGroups partial matches, and only step-0 events allocate
+// a group at all (an unrelated event allocates nothing).
+func TestEvaluatorSequenceGroupsAreBounded(t *testing.T) {
+	r := Rule{
+		ID: "det.test_seq_grouped", Version: 1, Class: ClassProcess, Title: "seq", Severity: shared.SeverityHigh,
+		Sequence: &Sequence{Within: time.Hour, GroupBy: []Field{FieldProcPath}, Steps: []Matcher{stepMatcher("curl"), stepMatcher("nc")}},
+	}
+	ev, err := NewEvaluator([]Rule{r})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t0 := time.Unix(8_000, 0)
+	// Unrelated events allocate no group.
+	for i := 0; i < 100; i++ {
+		ev.Evaluate(Event{Class: ClassProcess, At: t0, Host: "h", Process: &ProcessEvent{Comm: "bash", Path: "/bin/bash" + string(rune(i))}})
+	}
+	if n := len(ev.seqs[r.ID]); n != 0 {
+		t.Fatalf("unrelated events allocated %d groups, want 0", n)
+	}
+	// A step-0 event per unique path, well past the cap.
+	for i := 0; i < MaxWindowGroups+500; i++ {
+		ev.Evaluate(Event{Class: ClassProcess, At: t0.Add(time.Duration(i) * time.Millisecond), Host: "h", Process: &ProcessEvent{Comm: "curl", Path: "/p/" + string(rune(i))}})
+	}
+	if n := len(ev.seqs[r.ID]); n > MaxWindowGroups {
+		t.Fatalf("group count %d exceeds the %d cap", n, MaxWindowGroups)
+	}
+}

--- a/internal/domain/detection/window.go
+++ b/internal/domain/detection/window.go
@@ -85,7 +85,8 @@ type Fired struct {
 // events, which a sensor stream already does.
 type Evaluator struct {
 	rules   []Rule
-	buckets map[string]map[string]*bucket // rule id -> group key -> burst
+	buckets map[string]map[string]*bucket      // rule id -> group key -> burst
+	seqs    map[string]map[string]*seqProgress // rule id -> group key -> ordered partial match
 }
 
 type bucket struct {
@@ -94,9 +95,17 @@ type bucket struct {
 	newest time.Time
 }
 
-// NewEvaluator validates the rules and prepares state for the windowed ones.
+// seqProgress is one group's partial match of a sequence rule: how many steps are satisfied, the events
+// that satisfied them, and the instant the whole sequence must finish by (first-match time + Within).
+type seqProgress struct {
+	step     int
+	events   []Event
+	deadline time.Time
+}
+
+// NewEvaluator validates the rules and prepares state for the windowed and sequence ones.
 func NewEvaluator(rules []Rule) (*Evaluator, error) {
-	out := &Evaluator{rules: make([]Rule, 0, len(rules)), buckets: map[string]map[string]*bucket{}}
+	out := &Evaluator{rules: make([]Rule, 0, len(rules)), buckets: map[string]map[string]*bucket{}, seqs: map[string]map[string]*seqProgress{}}
 	for _, r := range rules {
 		if err := r.Validate(); err != nil {
 			return nil, err
@@ -110,6 +119,12 @@ func NewEvaluator(rules []Rule) (*Evaluator, error) {
 func (ev *Evaluator) Evaluate(e Event) []Fired {
 	var fired []Fired
 	for _, r := range ev.rules {
+		if r.Sequence != nil {
+			if burst, ok := ev.observeSequence(r, e); ok {
+				fired = append(fired, Fired{Rule: r, Evidence: burst, Observed: len(burst)})
+			}
+			continue
+		}
 		if !r.Match(e) {
 			continue
 		}
@@ -122,6 +137,86 @@ func (ev *Evaluator) Evaluate(e Event) []Fired {
 		}
 	}
 	return fired
+}
+
+// observeSequence advances a sequence rule's partial match for the event's group and reports the ordered
+// evidence once the last step is satisfied within the span. A group holds a partial match only while one
+// is live: a lapsed or completed match is deleted, and an event that neither advances a live match nor
+// starts one leaves no group. So an unrelated event never occupies a slot, and it cannot evict another
+// group's live partial match. An event that matches the first step while a later step was pending
+// restarts the sequence from that event, so a repeated staging is not missed.
+func (ev *Evaluator) observeSequence(r Rule, e Event) ([]Event, bool) {
+	if e.Class != r.Class {
+		return nil, false // an event of another class cannot advance a same-class sequence
+	}
+	groups := ev.seqs[r.ID]
+	if groups == nil {
+		groups = map[string]*seqProgress{}
+		ev.seqs[r.ID] = groups
+	}
+	key := groupKey(e, r.Sequence.GroupBy)
+	if p := groups[key]; p != nil {
+		// The next step advances the match, but only inside the anchor's span and not before the last
+		// matched event: a skewed timestamp (kernel vs wall-clock) must neither extend the span nor
+		// reorder the evidence. A late or out-of-order event simply does not advance.
+		last := p.events[len(p.events)-1].At
+		if e.At.Before(p.deadline) && !e.At.Before(last) && r.Sequence.Steps[p.step].Match(e) {
+			p.events = append(p.events, e.clone())
+			p.step++
+			if p.step < len(r.Sequence.Steps) {
+				return nil, false
+			}
+			burst := make([]Event, len(p.events))
+			copy(burst, p.events)
+			if len(burst) > MaxEvidence {
+				burst = burst[len(burst)-MaxEvidence:]
+			}
+			delete(groups, key) // completed: free the group so an identical later sequence fires again
+			return burst, true
+		}
+		// A fresh first step re-anchors the (possibly stalled) match to this newer staging, so a repeated
+		// downloader whose use lands after the first anchor's span is not missed.
+		if r.Sequence.Steps[0].Match(e) {
+			p.step, p.events, p.deadline = 1, []Event{e.clone()}, e.At.Add(r.Sequence.Within)
+		}
+		// Otherwise the live match is left untouched: an unrelated event, even one with a skewed forward
+		// timestamp, never drops it. An expired match is reclaimed lazily by evictSeqIfFull, which frees
+		// expired groups first, so memory stays bounded without trusting a stray timestamp.
+		return nil, false
+	}
+
+	// No live match for this group: only a first-step event starts one, so unrelated events never
+	// allocate a slot. A sequence has at least two steps, so a first-step match never completes here.
+	if !r.Sequence.Steps[0].Match(e) {
+		return nil, false
+	}
+	evictSeqIfFull(groups)
+	groups[key] = &seqProgress{step: 1, events: []Event{e.clone()}, deadline: e.At.Add(r.Sequence.Within)}
+	return nil, false
+}
+
+// evictSeqIfFull makes room for a new group when a sequence rule is at its group cap, which is only
+// reached by that many concurrent LIVE partial matches (unrelated events hold no group). It drops exactly
+// the earliest-deadline (stalest) match, with the lowest group key breaking a tie so eviction is
+// deterministic and never depends on map iteration order. It does NOT compare deadlines to any incoming
+// event's timestamp: a skewed step-0 timestamp must not be able to reclassify other groups as expired and
+// evict live partial matches en masse. The earliest-deadline group is the stalest whether it has expired
+// or not, so a single deterministic drop is both correct and skew-proof.
+func evictSeqIfFull(groups map[string]*seqProgress) {
+	if len(groups) < MaxWindowGroups {
+		return
+	}
+	var victim string
+	var earliest time.Time
+	found := false
+	for k, p := range groups {
+		if !found || p.deadline.Before(earliest) || (p.deadline.Equal(earliest) && k < victim) {
+			victim, earliest, found = k, p.deadline, true
+		}
+	}
+	if found {
+		delete(groups, victim)
+	}
 }
 
 // observe records a matching event in its group's bucket and reports the burst once the count is reached

--- a/internal/usecase/fleet/detect/engine_test.go
+++ b/internal/usecase/fleet/detect/engine_test.go
@@ -367,3 +367,30 @@ func TestEngineWindowedRuleFiresOnBurstOnly(t *testing.T) {
 		t.Fatalf("second destination did not fire independently: %d", len(got))
 	}
 }
+
+// TestEngineEmitsSequenceDetection: a downloader then a remote-shell tool on one host becomes a single
+// det.tool_staging_sequence detection carrying the ordered pair as evidence, proving the engine routes a
+// sequence match through the burst-detection path.
+func TestEngineEmitsSequenceDetection(t *testing.T) {
+	sensor, sink := newFakeSensor(), &fakeSink{}
+	e := newEngine(t, sensor, sink, Options{Classes: []detection.Class{detection.ClassProcess}})
+
+	e.process(context.Background(), procEvent("curl")) // staging: no detection yet
+	if got := sink.detections(); len(got) != 0 {
+		t.Fatalf("the staging step alone must not detect, got %d", len(got))
+	}
+	e.process(context.Background(), procEvent("ncat")) // use: completes the sequence
+
+	var seq *detection.Detection
+	for i, d := range sink.detections() {
+		if d.RuleID == "det.tool_staging_sequence" {
+			seq = &sink.detections()[i]
+		}
+	}
+	if seq == nil {
+		t.Fatalf("the tool-staging sequence was not detected: %+v", sink.detections())
+	}
+	if len(seq.Evidence) != 2 || seq.Evidence[0].Process.Comm != "curl" || seq.Evidence[1].Process.Comm != "ncat" {
+		t.Fatalf("sequence evidence is not the ordered pair: %+v", seq.Evidence)
+	}
+}


### PR DESCRIPTION
## What

Adds ordered **sequence** detection rules to the agent-side detection engine (#822). The engine matched
single events and, since the rate `Window`, bursts; it now also fires on an ordered series of events of
one class, for the same group, within a span — a behaviour no single event and no rate shows.

## Design

- `internal/domain/detection/sequence.go`: the `Sequence` type (`Steps []Matcher`, `Within`, `GroupBy`),
  validated (2..8 steps, each step a matcher of the rule's class, positive span, class-owned group fields).
- `rule.go`: `Rule.Sequence`, mutually exclusive with `Window`; a sequence rule leaves the top-level
  matcher empty (each step carries its own). `matcher.go`: a shared `Matcher.clone()` so a returned
  sequence rule cannot be reached through to mutate the catalogue.
- `window.go` (the per-class `Evaluator`): per-group partial-match state, evaluated per event. It
  - allocates a group **only on a first-step match**, so an unrelated event never occupies or evicts a slot;
  - **re-anchors on a repeated first step**, so a restaged tool whose use lands after the first anchor's
    span is not missed;
  - guards an advance by the span and by event order, so a skewed sensor timestamp neither extends the
    span nor reorders the evidence, and never drops a live match;
  - evicts the stalest partial match **deterministically** (found-flag + key tie-break) and **without
    trusting an incoming timestamp**, staying inside the existing `MaxWindowGroups` bound.
- `catalog.go`: `det.tool_staging_sequence` — a downloader (curl/wget/tftp/ftp) then a remote-shell tool
  (nc/ncat/socat) on one host within two minutes.

## Safety and bounds

Observe-only (never executes). Memory is bounded at `MaxWindowGroups` (1024) live partial matches per
rule, each holding at most `MaxSequenceSteps` (8) events; only first-step events allocate, so an
adversarial novel-key flood no longer creates groups or runs eviction on the no-match path.

## Tests

Domain: sequence validation, in-order firing within the span, wrong-order and lapsed no-fire, re-anchor
on a repeated first step (with evidence from the real pair), re-fire after completion, per-host grouping,
returned-rule immutability, and a bounded-groups test that a high-cardinality group field never exceeds
the cap. Engine: a curl→nc pair emits one `det.tool_staging_sequence` detection carrying the ordered
evidence. `go build ./...`, the detection and engine suites, and the docs drift guard are green.

## Review

Verified by internal QA and performance auditors and an external code review; every finding was fixed and
covered by a test (first-step-gated allocation, re-anchor on repeated staging, skew-proof advance and
eviction, deterministic eviction).

Refs: #822
