### PR TITLE
feat(dast): run governed verification probes as durable worker jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Governed DAST verification runs execute on the worker (#823).** An approved DAST probe used to run on
+  the API request thread. With the Postgres job queue it now runs as a durable, lease-executed job: the
+  run route (`POST /engagements/{id}/judgments/{jid}/runtime-verification/proposals/{aid}/run`) enqueues
+  it and answers `202` with a queued run, `synapse-worker` executes the SAME approval-gated, sandboxed,
+  evidence-sealing probe (so the single-use consume and the evidence seal still happen exactly once), and
+  `GET /engagements/{id}/dast/runs/{rid}` polls the run to a terminal state. The run record is secret-free
+  (verdict class, observed HTTP status, sealed-evidence id). Without the queue (in-memory dev) the probe
+  stays synchronous. Backed by a new `dast_runs` table with tenant RLS. A redelivered job never re-runs a
+  probe that may already have consumed its single-use approval: the outcome is written with a
+  compare-and-set that only fires from `running`, so a late delivery cannot overwrite a recorded success,
+  and an interrupted run terminalizes `interrupted` instead. A worker that has no live scoped-egress
+  broker still claims the job and fails the run `egress_unavailable` rather than leave it orphaned at
+  `queued`, so an enqueued run is always visible to the poller.
+
 - **Per-engagement vulnerability posture in the dashboard.** The reconciled advisory occurrences and the
   governed action queue for an engagement (`GET /engagements/{id}/vulnerability/occurrences` and
   `.../vulnerability/actions`, with `.../actions/{aid}/acknowledge` and `/resolve`) had no UI. A new

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -306,6 +306,32 @@ paths:
         "403": {$ref: "#/components/responses/Forbidden"}
         "404": {$ref: "#/components/responses/NotFound"}
 
+  /api/v1/engagements/{id}/dast/runs/{rid}:
+    parameters:
+    - $ref: "#/components/parameters/EngagementId"
+    - name: rid
+      in: path
+      required: true
+      schema: {type: string}
+    get:
+      tags: [engagements, findings]
+      operationId: getDASTRun
+      summary: Get a durable DAST verification run
+      description: >
+        Returns the status of a governed DAST verification probe executed as a worker job (#823). The run
+        route enqueues the probe and answers 202 with a queued run; this route polls it to completion. The
+        record is secret-free: it carries the verdict class, the observed HTTP status, and the
+        sealed-evidence id, never the probe body or any request or response content.
+      responses:
+        "200":
+          description: DAST verification run status
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/DASTRun"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
   /api/v1/engagements/{id}/detection-provenance:
     parameters:
     - $ref: "#/components/parameters/EngagementId"
@@ -4884,6 +4910,22 @@ components:
       properties:
         items: {type: array, items: {$ref: '#/components/schemas/VulnerabilityReconcileDiff'}}
         next: {$ref: '#/components/schemas/VulnerabilityReconcileDiffCursor'}
+
+    DASTRun:
+      type: object
+      required: [id, engagement_id, action_id, actor, status, started_at]
+      properties:
+        id: {type: string}
+        engagement_id: {type: string}
+        action_id: {type: string, description: The consumed DAST approval the probe bound to}
+        actor: {type: string}
+        status: {type: string, enum: [queued, running, succeeded, failed]}
+        verdict: {type: string, description: The verification's proof class; empty until terminal}
+        http_status: {type: integer, minimum: 0, description: The probe's observed HTTP status; zero until observed}
+        evidence_id: {type: string, description: The sealed evidence the run produced}
+        error_code: {type: string}
+        started_at: {type: string, format: date-time}
+        finished_at: {type: [string, "null"], format: date-time}
 
     CSPMRun:
       type: object

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -105,6 +105,7 @@ import (
 	credentialsuc "github.com/KKloudTarus/synapse-ce/internal/usecase/credentials"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/crosscheckjudge"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/cspm"
+	dastrunuc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastrun"
 	dastrunneruc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastrunner"
 	dastsessionuc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastsession"
 	dastverifieruc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastverifier"
@@ -371,6 +372,7 @@ func main() {
 	var qualityGateMutator ports.QualityGateMutator
 	var reconRunStore ports.ReconRunStore
 	var cloudRunStore ports.CloudRunStore
+	var dastRunStore ports.DASTRunStore
 	var cloudObservationStore ports.CloudObservationStore
 	var evidenceStore ports.EvidenceStore
 	var advisoryStore ports.AdvisoryStore         // owned normalized-advisory store (global reference data, not tenant-scoped)
@@ -511,6 +513,7 @@ func main() {
 		qualityProfileStore = postgres.NewQualityProfileStore(pool)
 		reconRunStore = postgres.NewReconRunStore(pool)
 		cloudRunStore = postgres.NewCloudRunStore(pool)
+		dastRunStore = postgres.NewDASTRunStore(pool)
 		cloudObservationStore = postgres.NewCloudObservationStore(pool)
 		evidenceStore = postgres.NewEvidenceStore(pool)
 		advisoryStore = postgres.NewAdvisoryRepository(pool)
@@ -660,6 +663,7 @@ func main() {
 		qualityProfileStore = memory.NewQualityProfileStore()
 		reconRunStore = memory.NewReconRunRepository()
 		cloudRunStore = memory.NewCloudRunStore()
+		dastRunStore = memory.NewDASTRunStore()
 		cloudObservationStore = memory.NewCloudObservationStore()
 		evidenceStore = memory.NewEvidenceStore()
 		advisoryStore = memory.NewAdvisoryStore()
@@ -1566,6 +1570,20 @@ func main() {
 					os.Exit(1)
 				}
 				router.SetDASTWorkflow(dastWorkflowSvc)
+				// #823 durable DAST verification: with the Postgres job queue, the run route enqueues a
+				// worker job (executed by synapse-worker's dast_run handler) instead of running the probe
+				// on the request thread, and a status route polls it. Without the queue (in-memory dev)
+				// the run stays synchronous. The submit-side service carries no prober; only the worker
+				// executes.
+				if reconQueue != nil {
+					dastRunSvc, drerr := dastrunuc.NewService(dastRunStore, nil, auditLog, clock, ids)
+					if drerr != nil {
+						log.Error("DAST durable run service init failed", "err", drerr)
+						os.Exit(1)
+					}
+					router.SetDASTRunner(dastRunSvc)
+					log.Info("DAST verification runs execute on the worker (durable)", "route", "POST .../runtime-verification/proposals/{aid}/run")
+				}
 				engine, eerr := dastengine.New(reconRunner, cfg.DASTHelperBin, cfg.DASTMaxWallClock, cfg.ReconMaxOutput)
 				if eerr != nil {
 					log.Error("authenticated DAST engine init failed", "err", eerr)

--- a/cmd/synapse-worker/main.go
+++ b/cmd/synapse-worker/main.go
@@ -56,6 +56,10 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
 	attackpathuc "github.com/KKloudTarus/synapse-ce/internal/usecase/attackpath"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/cspm"
+	dastrunuc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastrun"
+	dastrunneruc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastrunner"
+	dastverifieruc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastverifier"
+	dastworkflowuc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastworkflow"
 	egresspolicy "github.com/KKloudTarus/synapse-ce/internal/usecase/egress"
 	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/execution"
@@ -428,6 +432,61 @@ func main() {
 	vulnerabilityMonitor.SetReconciler(vulnerabilityRuntime)
 	handlers[vulnerabilitymonitor.JobKind] = vulnerabilitySyncJobHandler{svc: vulnerabilityMonitor}
 	handlers[vulnerabilityreconcile.JobKind] = vulnerabilityReconcileJobHandler{svc: vulnerabilityReconciliation}
+
+	// #823 durable DAST verification. A governed, approved probe used to execute on the API request
+	// thread; it now runs here as a lease job. The stack is the SAME the API's in-process path uses
+	// (runtime verifier + sandboxed runner + safety gate + approval consume + evidence seal), so the
+	// single-use consume and the evidence seal happen exactly once, on the worker. DAST actively probes a
+	// URL, so it can only execute when the sandbox kernel-enforces egress (egressLive). The handler is
+	// registered UNCONDITIONALLY, though: the API enqueues a run whenever the durable queue exists, so a
+	// worker without a live egress broker must still claim the job and fail it egress_unavailable rather
+	// than leave the run orphaned at 'queued' forever (invisible to the operator polling GET .../runs).
+	{
+		var dastProber dastrunuc.Prober
+		if egressLive {
+			dastJudgmentSvc, jerr := analysisuc.NewService(postgres.NewJudgmentRepository(pool), evidenceService, auditLog, clock, ids)
+			if jerr != nil {
+				log.Error("DAST judgment service init failed", "err", jerr)
+				os.Exit(1)
+			}
+			runtimeVerifierSvc, rverr := dastverifieruc.NewService(dastJudgmentSvc)
+			if rverr != nil {
+				log.Error("DAST runtime verifier init failed", "err", rverr)
+				os.Exit(1)
+			}
+			dastRunnerSvc, drerr := dastrunneruc.NewService(sb, evidenceService, runtimeVerifierSvc, "curl", 10*time.Second, cfg.ReconMaxOutput)
+			if drerr != nil {
+				log.Error("DAST runner init failed", "err", drerr)
+				os.Exit(1)
+			}
+			dastApprovalStore := postgres.NewApprovalStore(pool)
+			dastApprovalSvc, aerr := approval.NewService(dastApprovalStore, auditLog, clock, agent.ApprovalMode(cfg.AgentApprovalMode), cfg.AgentApprovalTimeout)
+			if aerr != nil {
+				log.Error("DAST approval service init failed", "err", aerr)
+				os.Exit(1)
+			}
+			dastGate, gerr := safety.NewGate(guard, dastApprovalSvc, evidenceService)
+			if gerr != nil {
+				log.Error("DAST safety gate init failed", "err", gerr)
+				os.Exit(1)
+			}
+			dastWorkflowSvc, werr := dastworkflowuc.NewService(dastGate, dastApprovalSvc, dastApprovalStore, dastRunnerSvc, evidenceService, clock, ids)
+			if werr != nil {
+				log.Error("DAST workflow init failed", "err", werr)
+				os.Exit(1)
+			}
+			dastProber = dastWorkflowSvc
+			log.Info("DAST verification runs execute on this worker (dast_run handler)")
+		} else {
+			log.Warn("worker has no scoped-egress broker – DAST runs will fail egress_unavailable")
+		}
+		dastRunSvc, rserr := dastrunuc.NewService(postgres.NewDASTRunStore(pool), dastProber, auditLog, clock, ids)
+		if rserr != nil {
+			log.Error("DAST durable run service init failed", "err", rserr)
+			os.Exit(1)
+		}
+		handlers[dastrunuc.JobKind] = dastRunJobHandler{svc: dastRunSvc}
+	}
 	if cfg.CSPMEnabled {
 		connectors := make(map[cloudposture.Provider]ports.CloudConnector, len(cfg.CSPMProviders))
 		for _, name := range cfg.CSPMProviders {
@@ -812,6 +871,17 @@ func (h reconJobHandler) OnDeadLetter(ctx context.Context, job ports.QueuedJob, 
 // agentJobHandler binds the orchestrator to the worker's Handler + DeadLetterer interfaces:
 // running an agent job is RunJob; dead-lettering one finalizes the backing session, so the
 // reconciler stops re-driving it (closes the dead-letter → re-drive livelock).
+// dastRunJobHandler binds durable DAST verification execution and dead-letter finalization.
+type dastRunJobHandler struct{ svc *dastrunuc.Service }
+
+func (h dastRunJobHandler) Handle(ctx context.Context, job ports.QueuedJob) error {
+	return h.svc.RunJob(ctx, job.Payload)
+}
+
+func (h dastRunJobHandler) OnDeadLetter(ctx context.Context, job ports.QueuedJob, cause error) error {
+	return h.svc.FailStrandedJob(ctx, job.Payload, cause)
+}
+
 // cspmJobHandler binds durable CSPM execution and dead-letter finalization.
 type cspmJobHandler struct{ svc *cspm.Service }
 

--- a/internal/adapter/httpapi/dast_workflow_handler.go
+++ b/internal/adapter/httpapi/dast_workflow_handler.go
@@ -2,6 +2,7 @@ package httpapi
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -66,16 +67,45 @@ func (rt *Router) decideRuntimeVerification(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, http.StatusOK, out)
 }
 
+// runRuntimeVerification runs an approved DAST verification probe. When durable execution is wired the
+// probe runs as a lease-executed worker job: the route enqueues it and returns 202 with the queued run,
+// whose status the status route below polls. Without durable execution it falls back to running the probe
+// synchronously in the request (dev / in-memory), returning 200 with the result.
 func (rt *Router) runRuntimeVerification(w http.ResponseWriter, r *http.Request) {
 	var body runtimeVerificationBody
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 32<<10)).Decode(&body); err != nil {
 		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid request body"})
 		return
 	}
-	out, err := rt.dastWorkflow.Run(r.Context(), PrincipalFrom(r.Context()), shared.ID(r.PathValue("id")), shared.ID(r.PathValue("aid")), body.probe(r.PathValue("jid")))
+	engagementID, actionID := shared.ID(r.PathValue("id")), shared.ID(r.PathValue("aid"))
+	probe := body.probe(r.PathValue("jid"))
+	if rt.dastRun != nil {
+		run, err := rt.dastRun.Submit(r.Context(), engagementID, actionID, PrincipalFrom(r.Context()), probe)
+		if err != nil {
+			writeError(w, rt.log, err)
+			return
+		}
+		writeJSON(w, http.StatusAccepted, run)
+		return
+	}
+	out, err := rt.dastWorkflow.Run(r.Context(), PrincipalFrom(r.Context()), engagementID, actionID, probe)
 	if err != nil {
 		writeError(w, rt.log, err)
 		return
 	}
 	writeJSON(w, http.StatusOK, out)
+}
+
+// getDASTRun returns the status of a durable DAST verification run. PermView + withEngTenant.
+func (rt *Router) getDASTRun(w http.ResponseWriter, r *http.Request) {
+	run, err := rt.dastRun.GetRun(r.Context(), shared.ID(TenantFrom(r.Context())), shared.ID(r.PathValue("rid")))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	if run.EngagementID != shared.ID(r.PathValue("id")) {
+		writeError(w, rt.log, fmt.Errorf("%w: DAST run", shared.ErrNotFound))
+		return
+	}
+	writeJSON(w, http.StatusOK, run)
 }

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -2,6 +2,7 @@ package httpapi
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -12,6 +13,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
 	ap "github.com/KKloudTarus/synapse-ce/internal/domain/attackpath"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastrun"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
 	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
@@ -225,6 +227,21 @@ func (fakeDASTWorkflow) Run(context.Context, string, shared.ID, shared.ID, dastr
 	return dastrunner.Result{}, nil
 }
 
+// fakeDASTRunner backs the durable DAST run status route. It holds one run owned by tenantA/engA and is
+// tenant-scoped like the real store, so the harness can prove the read route rejects a cross-tenant caller
+// (through withEngTenant) and a machine role (through the view gate).
+type fakeDASTRunner struct{}
+
+func (fakeDASTRunner) Submit(context.Context, shared.ID, shared.ID, string, dastrunner.Probe) (dastrun.Run, error) {
+	return dastrun.Run{}, nil
+}
+func (fakeDASTRunner) GetRun(_ context.Context, tenantID, runID shared.ID) (dastrun.Run, error) {
+	if tenantID == "tenantA" && runID == "dast-run-a" {
+		return dastrun.Run{ID: "dast-run-a", TenantID: "tenantA", EngagementID: "engA", ActionID: "act-a", Actor: "operator", Status: dastrun.RunSucceeded, Verdict: "confirmed", HTTPStatus: 200, EvidenceID: "ev-a", StartedAt: time.Unix(1_700_000_000, 0).UTC()}, nil
+	}
+	return dastrun.Run{}, fmt.Errorf("%w: DAST run", shared.ErrNotFound)
+}
+
 type fakeThreatModel struct{}
 
 func (fakeThreatModel) Ingest(context.Context, string, shared.ID, shared.ID, threatmodel.Model) (threatmodel.ModelDelta, error) {
@@ -398,6 +415,7 @@ func TestHostileHarness(t *testing.T) {
 	rt.SetJudgments(promotionAnalysis) // real judgment/promotion lifecycle for hostile verification coverage
 	rt.SetRuntimeVerifier(&fakeRuntimeVerifier{})
 	rt.SetDASTWorkflow(&fakeDASTWorkflow{})
+	rt.SetDASTRunner(fakeDASTRunner{})        // register the #823 durable DAST run status route so the harness guards its view + tenant gates
 	rt.SetThreatModel(&fakeThreatModel{})     // register the threat-model ingest/read routes so the harness guards their gates
 	rt.SetWriteupDrafts(&fakeWriteupDrafts{}) // register the writeup-draft sign-off routes so the harness guards their SoD gates
 	rt.SetAITriageReviews(&aiReviewFake{})    // register AI-triage queue read/claim/decision routes
@@ -550,6 +568,10 @@ func TestHostileHarness(t *testing.T) {
 		// The scan-job read carries its engagement in the RESPONSE, not the path, so withEngTenant
 		// cannot wrap it; the handler re-checks the tenant itself. A machine role is denied outright.
 		{"machine may not read scan job (view)", "agent", "tenantA", true, http.MethodGet, "/api/v1/sca/scans/job-1", http.StatusForbidden},
+		// #823 durable DAST run status route: view-gated and tenant-scoped through withEngTenant.
+		{"readonly may read own-tenant dast run", "readonly", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA/dast/runs/dast-run-a", http.StatusOK},
+		{"machine may not read dast run (view)", "agent", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA/dast/runs/dast-run-a", http.StatusForbidden},
+		{"tenantB cannot read tenantA dast run", "admin", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA/dast/runs/dast-run-a", http.StatusNotFound},
 		{"readonly may not read audit (review)", "readonly", "tenantA", true, http.MethodGet, "/api/v1/audit", http.StatusForbidden},
 		{"readonly may not manage users (administer)", "readonly", "tenantA", true, http.MethodGet, "/api/v1/users", http.StatusForbidden},
 		// Consultant: operate yes (covered elsewhere), but NOT review or administer.

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/aitriagereview"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastrun"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
@@ -66,6 +67,7 @@ type Router struct {
 	credentials            *credentialsuc.Service
 	dastVerifier           runtimeVerifierService
 	dastWorkflow           dastWorkflowService
+	dastRun                dastRunService             // optional; nil ⇒ DAST verification runs execute synchronously in-process
 	agent                  *agentDeps                 // optional; nil ⇒ agent routes are not registered
 	exploitation           findingVerifier            // optional; nil ⇒ the verify route is not registered
 	judgments              judgmentService            // optional; nil ⇒ judgment routes are not registered
@@ -191,6 +193,17 @@ type dastWorkflowService interface {
 
 // SetDASTWorkflow wires the governed safe-DAST proposal/approval/run endpoints.
 func (rt *Router) SetDASTWorkflow(s dastWorkflowService) { rt.dastWorkflow = s }
+
+// dastRunService is the durable-execution slice: submit a governed DAST verification as a worker job and
+// read its status. *dastrun.Service satisfies it. Left unset, a verification run executes synchronously.
+type dastRunService interface {
+	Submit(ctx context.Context, engagementID, actionID shared.ID, actor string, probe dastrunner.Probe) (dastrun.Run, error)
+	GetRun(ctx context.Context, tenantID, runID shared.ID) (dastrun.Run, error)
+}
+
+// SetDASTRunner wires durable DAST verification execution: the run route enqueues a job and a status
+// route reads it. nil ⇒ the run route executes the probe synchronously (dev / in-memory).
+func (rt *Router) SetDASTRunner(s dastRunService) { rt.dastRun = s }
 
 type dastScanService interface {
 	ProposeScan(context.Context, string, shared.ID, dastworkflowuc.ScanConfig) (dastworkflowuc.Proposal, error)
@@ -643,6 +656,9 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("POST /api/v1/engagements/{id}/judgments/{jid}/runtime-verification/proposals", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.proposeRuntimeVerification)))
 		mux.HandleFunc("POST /api/v1/engagements/{id}/dast/approvals/{aid}/decide", rt.authz(userdom.PermReview, rt.withEngTenant(rt.decideRuntimeVerification)))
 		mux.HandleFunc("POST /api/v1/engagements/{id}/judgments/{jid}/runtime-verification/proposals/{aid}/run", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.runRuntimeVerification)))
+		if rt.dastRun != nil {
+			mux.HandleFunc("GET /api/v1/engagements/{id}/dast/runs/{rid}", rt.authz(userdom.PermView, rt.withEngTenant(rt.getDASTRun)))
+		}
 	}
 	if rt.dastScan != nil {
 		mux.HandleFunc("POST /api/v1/engagements/{id}/dast/proposals", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.proposeDASTScan)))

--- a/internal/domain/dastrun/run.go
+++ b/internal/domain/dastrun/run.go
@@ -1,0 +1,106 @@
+// Package dastrun is the durable record of a governed DAST verification run. A DAST probe used to execute
+// synchronously in the API request goroutine; this makes the run a durable, lease-executed job so the
+// request returns immediately, the run survives a control-plane restart, and its outcome is pollable. The
+// record is secret-free: it carries the verdict class and the sealed-evidence id, never the probe body or
+// any response content.
+package dastrun
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// RunStatus is the durable DAST run lifecycle. A probe is a single verification, so there is no partial
+// state: it is queued, running, then succeeded (the probe ran and produced a verdict) or failed.
+type RunStatus string
+
+const (
+	RunQueued    RunStatus = "queued"
+	RunRunning   RunStatus = "running"
+	RunSucceeded RunStatus = "succeeded"
+	RunFailed    RunStatus = "failed"
+)
+
+func (s RunStatus) Valid() bool {
+	switch s {
+	case RunQueued, RunRunning, RunSucceeded, RunFailed:
+		return true
+	}
+	return false
+}
+
+func (s RunStatus) Terminal() bool { return s == RunSucceeded || s == RunFailed }
+
+// Run is the durable, secret-free record the DAST run API returns.
+type Run struct {
+	ID           shared.ID `json:"id"`
+	TenantID     shared.ID `json:"-"`
+	EngagementID shared.ID `json:"engagement_id"`
+	ActionID     shared.ID `json:"action_id"`
+	Actor        string    `json:"actor"`
+	Status       RunStatus `json:"status"`
+	// Verdict is the verification's proof class (e.g. confirmed / refuted / inconclusive); empty until the
+	// run reaches a terminal state.
+	Verdict string `json:"verdict,omitempty"`
+	// HTTPStatus is the probe's observed response status; zero until observed.
+	HTTPStatus int `json:"http_status,omitempty"`
+	// EvidenceID is the sealed evidence the run produced; zero when the run failed before sealing.
+	EvidenceID shared.ID  `json:"evidence_id,omitempty"`
+	ErrorCode  string     `json:"error_code,omitempty"`
+	StartedAt  time.Time  `json:"started_at"`
+	FinishedAt *time.Time `json:"finished_at,omitempty"`
+}
+
+// NewRun builds a queued run. The action is the consumed DAST approval the probe binds to.
+func NewRun(id, tenantID, engagementID, actionID shared.ID, actor string, now time.Time) (Run, error) {
+	if id.IsZero() || tenantID.IsZero() || engagementID.IsZero() || actionID.IsZero() || actor == "" || now.IsZero() {
+		return Run{}, fmt.Errorf("%w: DAST run needs id, tenant, engagement, action, actor, and time", shared.ErrValidation)
+	}
+	return Run{ID: id, TenantID: tenantID, EngagementID: engagementID, ActionID: actionID, Actor: actor, Status: RunQueued, StartedAt: now.UTC()}, nil
+}
+
+// Start moves a queued run to running.
+func (r *Run) Start() error {
+	if r.Status != RunQueued {
+		return fmt.Errorf("%w: DAST run %s is %s, not queued", shared.ErrConflict, r.ID, r.Status)
+	}
+	r.Status = RunRunning
+	return nil
+}
+
+// Succeed records the verdict of a completed probe. A successful run always carries a sealed verdict and
+// its evidence: a governed probe that produced no sealed evidence is not a success, so an empty verdict or
+// evidence id is refused rather than recorded as a hollow success.
+func (r *Run) Succeed(verdict string, httpStatus int, evidenceID shared.ID, now time.Time) error {
+	if r.Status != RunRunning {
+		return fmt.Errorf("%w: DAST run %s is %s, not running", shared.ErrConflict, r.ID, r.Status)
+	}
+	if verdict == "" || evidenceID.IsZero() {
+		return fmt.Errorf("%w: DAST run %s cannot succeed without a verdict and sealed evidence", shared.ErrValidation, r.ID)
+	}
+	t := now.UTC()
+	r.Status, r.Verdict, r.HTTPStatus, r.EvidenceID, r.FinishedAt = RunSucceeded, verdict, httpStatus, evidenceID, &t
+	return nil
+}
+
+// Fail records a terminal failure with a machine reason.
+func (r *Run) Fail(code string, now time.Time) {
+	t := now.UTC()
+	r.Status, r.ErrorCode, r.FinishedAt = RunFailed, code, &t
+}
+
+// Validate enforces the record invariants.
+func (r Run) Validate() error {
+	if r.ID.IsZero() || r.TenantID.IsZero() || r.EngagementID.IsZero() || r.ActionID.IsZero() || r.Actor == "" || !r.Status.Valid() || r.StartedAt.IsZero() {
+		return fmt.Errorf("%w: invalid DAST run", shared.ErrValidation)
+	}
+	if r.Status.Terminal() != (r.FinishedAt != nil) {
+		return fmt.Errorf("%w: DAST run terminal timestamp does not match status %s", shared.ErrValidation, r.Status)
+	}
+	if r.Status == RunSucceeded && (r.Verdict == "" || r.EvidenceID.IsZero()) {
+		return fmt.Errorf("%w: a succeeded DAST run must carry a verdict and sealed evidence", shared.ErrValidation)
+	}
+	return nil
+}

--- a/internal/domain/dastrun/run_test.go
+++ b/internal/domain/dastrun/run_test.go
@@ -1,0 +1,62 @@
+package dastrun
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+var now = time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+
+func TestNewRunValidation(t *testing.T) {
+	if _, err := NewRun("", "t", "e", "a", "actor", now); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("empty id accepted")
+	}
+	if _, err := NewRun("id", "t", "e", "a", "", now); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("empty actor accepted")
+	}
+	r, err := NewRun("id", "t", "e", "a", "actor", now)
+	if err != nil || r.Status != RunQueued {
+		t.Fatalf("valid run: %v status=%s", err, r.Status)
+	}
+}
+
+func TestRunLifecycle(t *testing.T) {
+	r, _ := NewRun("id", "t", "e", "a", "actor", now)
+	if err := r.Validate(); err != nil {
+		t.Fatalf("queued run invalid: %v", err)
+	}
+	// Cannot succeed before starting.
+	if err := r.Succeed("confirmed", 200, "ev", now); !errors.Is(err, shared.ErrConflict) {
+		t.Errorf("succeed-before-start allowed")
+	}
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.Start(); !errors.Is(err, shared.ErrConflict) {
+		t.Errorf("double start allowed")
+	}
+	if err := r.Succeed("confirmed", 200, "ev", now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if r.Status != RunSucceeded || r.FinishedAt == nil || r.Verdict != "confirmed" {
+		t.Fatalf("succeeded state wrong: %+v", r)
+	}
+	if err := r.Validate(); err != nil {
+		t.Fatalf("succeeded run invalid: %v", err)
+	}
+}
+
+func TestRunFailIsTerminal(t *testing.T) {
+	r, _ := NewRun("id", "t", "e", "a", "actor", now)
+	_ = r.Start()
+	r.Fail("forbidden", now.Add(time.Second))
+	if r.Status != RunFailed || r.ErrorCode != "forbidden" || r.FinishedAt == nil {
+		t.Fatalf("failed state wrong: %+v", r)
+	}
+	if err := r.Validate(); err != nil {
+		t.Fatalf("failed run invalid: %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/memory/dast_run_store.go
+++ b/internal/infrastructure/persistence/memory/dast_run_store.go
@@ -1,0 +1,115 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// DASTRunStore is the in-memory DAST run lifecycle store used in local development and tests.
+type DASTRunStore struct {
+	mu    sync.RWMutex
+	runs  map[string]dastrun.Run
+	queue ports.JobQueue
+}
+
+var _ ports.DASTRunStore = (*DASTRunStore)(nil)
+var _ ports.DASTRunEnqueuer = (*DASTRunStore)(nil)
+
+func NewDASTRunStore() *DASTRunStore { return &DASTRunStore{runs: map[string]dastrun.Run{}} }
+
+// runKey mirrors the Postgres primary key (tenant_id, id): a run id is only unique within its tenant, so
+// keying by id alone would let one tenant's run overwrite another's. Keeping the composite key here keeps
+// the memory store's tenant isolation at parity with the RLS-backed Postgres store.
+func runKey(tenantID, id shared.ID) string { return tenantID.String() + "\x00" + id.String() }
+
+// SaveDASTRun upserts the run but never moves a terminal row backward, matching the Postgres store: once a
+// run is 'succeeded' or 'failed' its record is frozen, so a stale write cannot un-terminalize it.
+func (s *DASTRunStore) SaveDASTRun(_ context.Context, run dastrun.Run) error {
+	if err := run.Validate(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := runKey(run.TenantID, run.ID)
+	if cur, ok := s.runs[k]; ok && cur.Status.Terminal() {
+		return nil // terminal runs are immutable
+	}
+	s.runs[k] = run
+	return nil
+}
+
+func (s *DASTRunStore) GetDASTRun(_ context.Context, tenantID, id shared.ID) (dastrun.Run, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	run, ok := s.runs[runKey(tenantID, id)]
+	if !ok {
+		return dastrun.Run{}, fmt.Errorf("%w: DAST run", shared.ErrNotFound)
+	}
+	return run, nil
+}
+
+// StartRun moves a run queued -> running only if the stored run is still queued (compare-and-set),
+// reporting whether it won. A worker that finds the run already running or terminal loses and must not probe.
+func (s *DASTRunStore) StartRun(_ context.Context, tenantID shared.ID, run dastrun.Run) (bool, error) {
+	if run.Status != dastrun.RunRunning {
+		return false, fmt.Errorf("%w: StartRun needs a running run, got %s", shared.ErrValidation, run.Status)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := runKey(tenantID, run.ID)
+	cur, ok := s.runs[k]
+	if !ok {
+		return false, fmt.Errorf("%w: DAST run", shared.ErrNotFound)
+	}
+	if cur.Status != dastrun.RunQueued {
+		return false, nil // lost the start race: another delivery already started or finished it
+	}
+	s.runs[k] = run
+	return true, nil
+}
+
+// FinishRun writes the terminal run only if the stored run is still running (compare-and-set).
+func (s *DASTRunStore) FinishRun(_ context.Context, tenantID shared.ID, run dastrun.Run) (bool, error) {
+	if err := run.Validate(); err != nil {
+		return false, err
+	}
+	if !run.Status.Terminal() {
+		return false, fmt.Errorf("%w: FinishRun needs a terminal run, got %s", shared.ErrValidation, run.Status)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	k := runKey(tenantID, run.ID)
+	cur, ok := s.runs[k]
+	if !ok {
+		return false, fmt.Errorf("%w: DAST run", shared.ErrNotFound)
+	}
+	if cur.Status != dastrun.RunRunning {
+		return false, nil // another delivery already terminalized it
+	}
+	s.runs[k] = run
+	return true, nil
+}
+
+// SetQueue binds the in-memory queue so EnqueueDASTRun can persist the run and enqueue its job together.
+func (s *DASTRunStore) SetQueue(queue ports.JobQueue) { s.queue = queue }
+
+func (s *DASTRunStore) EnqueueDASTRun(ctx context.Context, run dastrun.Run, kind string, payload []byte) error {
+	if s.queue == nil {
+		return fmt.Errorf("%w: in-memory DAST queue is not bound", shared.ErrValidation)
+	}
+	if err := s.SaveDASTRun(ctx, run); err != nil {
+		return err
+	}
+	if _, err := s.queue.Enqueue(ctx, kind, payload); err != nil {
+		s.mu.Lock()
+		delete(s.runs, runKey(run.TenantID, run.ID))
+		s.mu.Unlock()
+		return err
+	}
+	return nil
+}

--- a/internal/infrastructure/persistence/memory/dast_run_store_test.go
+++ b/internal/infrastructure/persistence/memory/dast_run_store_test.go
@@ -1,0 +1,128 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func mkRun(t *testing.T, tenant, id shared.ID) dastrun.Run {
+	t.Helper()
+	run, err := dastrun.NewRun(id, tenant, "eng-1", "act-1", "operator", time.Unix(1_700_000_000, 0).UTC())
+	if err != nil {
+		t.Fatalf("NewRun: %v", err)
+	}
+	return run
+}
+
+func TestDASTRunStoreTenantIsolationByCompositeKey(t *testing.T) {
+	// A run id is only unique within a tenant. Two tenants using the same id must not collide: reading
+	// tenant B's id must not return tenant A's run, and saving B must not overwrite A. This matches the
+	// Postgres (tenant_id, id) primary key.
+	s := NewDASTRunStore()
+	ctx := context.Background()
+	shared0 := shared.ID("dup-id")
+	if err := s.SaveDASTRun(ctx, mkRun(t, "tenant-a", shared0)); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.SaveDASTRun(ctx, mkRun(t, "tenant-b", shared0)); err != nil {
+		t.Fatal(err)
+	}
+	a, err := s.GetDASTRun(ctx, "tenant-a", shared0)
+	if err != nil || a.TenantID != "tenant-a" {
+		t.Fatalf("tenant-a run = %+v, err=%v", a, err)
+	}
+	b, err := s.GetDASTRun(ctx, "tenant-b", shared0)
+	if err != nil || b.TenantID != "tenant-b" {
+		t.Fatalf("tenant-b run = %+v, err=%v", b, err)
+	}
+	// A tenant cannot read another tenant's run under the same id.
+	if _, err := s.GetDASTRun(ctx, "tenant-c", shared0); err == nil {
+		t.Fatal("tenant-c read a run it does not own")
+	}
+}
+
+func TestDASTRunStoreTerminalRunIsImmutable(t *testing.T) {
+	// Once a run is terminal, SaveDASTRun must not move it backward. This is the defense-in-depth that
+	// stops a stale worker (whose lease was reclaimed) from un-terminalizing a recorded outcome.
+	s := NewDASTRunStore()
+	ctx := context.Background()
+	run := mkRun(t, "t1", "run-1")
+	_ = run.Start()
+	if err := s.SaveDASTRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	succeeded := run
+	if err := succeeded.Succeed("confirmed", 200, "ev-1", time.Unix(1_700_000_001, 0).UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.FinishRun(ctx, "t1", succeeded); err != nil {
+		t.Fatal(err)
+	}
+	// A stale worker tries to write the run back to running, then to a failure.
+	stale := run // still 'running'
+	if err := s.SaveDASTRun(ctx, stale); err != nil {
+		t.Fatal(err)
+	}
+	failed := run
+	failed.Fail("interrupted", time.Unix(1_700_000_002, 0).UTC())
+	if err := s.SaveDASTRun(ctx, failed); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.GetDASTRun(ctx, "t1", "run-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != dastrun.RunSucceeded || got.Verdict != "confirmed" || got.ErrorCode != "" {
+		t.Fatalf("terminal run was mutated by a stale write: %+v", got)
+	}
+}
+
+func TestDASTRunStoreFinishRunCompareAndSet(t *testing.T) {
+	// FinishRun only terminalizes from 'running', and a second conflicting FinishRun does not clobber.
+	s := NewDASTRunStore()
+	ctx := context.Background()
+	run := mkRun(t, "t1", "run-2")
+	_ = run.Start()
+	if err := s.SaveDASTRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	winner := run
+	if err := winner.Succeed("confirmed", 200, "ev-2", time.Unix(1_700_000_001, 0).UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if won, err := s.FinishRun(ctx, "t1", winner); err != nil || !won {
+		t.Fatalf("first FinishRun won=%v err=%v", won, err)
+	}
+	loser := run // stale 'running' copy
+	loser.Fail("interrupted", time.Unix(1_700_000_002, 0).UTC())
+	if won, err := s.FinishRun(ctx, "t1", loser); err != nil || won {
+		t.Fatalf("second FinishRun won=%v err=%v, want won=false", won, err)
+	}
+	got, _ := s.GetDASTRun(ctx, "t1", "run-2")
+	if got.Status != dastrun.RunSucceeded {
+		t.Fatalf("CAS clobbered success: %+v", got)
+	}
+}
+
+func TestDASTRunStoreStartRunCompareAndSet(t *testing.T) {
+	// StartRun moves queued -> running only once; a second delivery that finds the run already running
+	// loses the compare-and-set (won=false) and must not go on to probe.
+	s := NewDASTRunStore()
+	ctx := context.Background()
+	run := mkRun(t, "t1", "run-s")
+	if err := s.SaveDASTRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	running := run
+	_ = running.Start()
+	if won, err := s.StartRun(ctx, "t1", running); err != nil || !won {
+		t.Fatalf("first StartRun won=%v err=%v, want won=true", won, err)
+	}
+	if won, err := s.StartRun(ctx, "t1", running); err != nil || won {
+		t.Fatalf("second StartRun won=%v err=%v, want won=false", won, err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/dast_run_store.go
+++ b/internal/infrastructure/persistence/postgres/dast_run_store.go
@@ -1,0 +1,134 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// DASTRunStore persists the tenant-scoped DAST run lifecycle under RLS.
+type DASTRunStore struct{ pool *pgxpool.Pool }
+
+var _ ports.DASTRunStore = (*DASTRunStore)(nil)
+var _ ports.DASTRunEnqueuer = (*DASTRunStore)(nil)
+
+func NewDASTRunStore(pool *pgxpool.Pool) *DASTRunStore { return &DASTRunStore{pool: pool} }
+
+// SaveDASTRun upserts the run, but NEVER moves a terminal row backward: the ON CONFLICT update is guarded
+// so a stored 'succeeded' or 'failed' row is frozen. This is defense-in-depth against a stale worker whose
+// lease was reclaimed (its claim context is cancelled, so its writes should already fail, but a write that
+// slips through the cancellation window must not un-terminalize a recorded outcome). FinishRun is the CAS
+// that records terminal outcomes; SaveDASTRun only advances a run toward one.
+func (s *DASTRunStore) SaveDASTRun(ctx context.Context, run dastrun.Run) error {
+	if err := run.Validate(); err != nil {
+		return err
+	}
+	return WithTenant(ctx, s.pool, run.TenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO dast_runs
+			(tenant_id,id,engagement_id,action_id,actor,status,verdict,http_status,evidence_id,error_code,started_at,finished_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+			ON CONFLICT (tenant_id,id) DO UPDATE SET status=EXCLUDED.status, verdict=EXCLUDED.verdict,
+			http_status=EXCLUDED.http_status, evidence_id=EXCLUDED.evidence_id, error_code=EXCLUDED.error_code,
+			finished_at=EXCLUDED.finished_at
+			WHERE dast_runs.status NOT IN ('succeeded','failed')`,
+			run.TenantID.String(), run.ID.String(), run.EngagementID.String(), run.ActionID.String(), run.Actor,
+			string(run.Status), run.Verdict, run.HTTPStatus, run.EvidenceID.String(), run.ErrorCode, run.StartedAt, run.FinishedAt)
+		return err
+	})
+}
+
+func (s *DASTRunStore) EnqueueDASTRun(ctx context.Context, run dastrun.Run, kind string, payload []byte) error {
+	if err := run.Validate(); err != nil {
+		return err
+	}
+	jobID := run.ID.String() + "-job"
+	return WithTenant(ctx, s.pool, run.TenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO dast_runs
+			(tenant_id,id,engagement_id,action_id,actor,status,verdict,http_status,evidence_id,error_code,started_at,finished_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+			run.TenantID.String(), run.ID.String(), run.EngagementID.String(), run.ActionID.String(), run.Actor,
+			string(run.Status), run.Verdict, run.HTTPStatus, run.EvidenceID.String(), run.ErrorCode, run.StartedAt, run.FinishedAt); err != nil {
+			return err
+		}
+		_, err := tx.Exec(ctx, `INSERT INTO jobs (id,tenant_id,kind,payload,status,available_at) VALUES ($1,$2,$3,$4,'queued',now())`,
+			jobID, run.TenantID.String(), kind, payload)
+		return err
+	})
+}
+
+// StartRun moves a run 'queued' -> 'running' only if the stored row is still 'queued' (compare-and-set),
+// reporting whether it won. A redelivered or lease-overlapping worker that finds the run already running or
+// terminal loses (won=false) and must not execute the probe.
+func (s *DASTRunStore) StartRun(ctx context.Context, tenantID shared.ID, run dastrun.Run) (won bool, err error) {
+	if run.Status != dastrun.RunRunning {
+		return false, fmt.Errorf("%w: StartRun needs a running run, got %s", shared.ErrValidation, run.Status)
+	}
+	err = WithTenant(ctx, s.pool, tenantID.String(), func(tx pgx.Tx) error {
+		tag, e := tx.Exec(ctx, `UPDATE dast_runs SET status='running' WHERE tenant_id=$1 AND id=$2 AND status='queued'`,
+			tenantID.String(), run.ID.String())
+		if e != nil {
+			return e
+		}
+		won = tag.RowsAffected() == 1
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("start DAST run: %w", err)
+	}
+	return won, nil
+}
+
+// FinishRun writes the terminal run only if the stored row is still 'running' (compare-and-set), and
+// reports whether the row was updated. A redelivered or lease-overlapping worker that lost the race
+// changes nothing.
+func (s *DASTRunStore) FinishRun(ctx context.Context, tenantID shared.ID, run dastrun.Run) (won bool, err error) {
+	if err := run.Validate(); err != nil {
+		return false, err
+	}
+	if !run.Status.Terminal() {
+		return false, fmt.Errorf("%w: FinishRun needs a terminal run, got %s", shared.ErrValidation, run.Status)
+	}
+	err = WithTenant(ctx, s.pool, tenantID.String(), func(tx pgx.Tx) error {
+		tag, e := tx.Exec(ctx, `UPDATE dast_runs SET status=$3, verdict=$4, http_status=$5, evidence_id=$6, error_code=$7, finished_at=$8
+			WHERE tenant_id=$1 AND id=$2 AND status='running'`,
+			tenantID.String(), run.ID.String(), string(run.Status), run.Verdict, run.HTTPStatus, run.EvidenceID.String(), run.ErrorCode, run.FinishedAt)
+		if e != nil {
+			return e
+		}
+		won = tag.RowsAffected() == 1
+		return nil
+	})
+	if err != nil {
+		return false, fmt.Errorf("finish DAST run: %w", err)
+	}
+	return won, nil
+}
+
+func (s *DASTRunStore) GetDASTRun(ctx context.Context, tenantID, id shared.ID) (out dastrun.Run, err error) {
+	err = WithTenant(ctx, s.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var status, evidenceID string
+		e := tx.QueryRow(ctx, `SELECT id,tenant_id,engagement_id,action_id,actor,status,verdict,http_status,evidence_id,error_code,started_at,finished_at
+			FROM dast_runs WHERE tenant_id=$1 AND id=$2`, tenantID.String(), id.String()).Scan(
+			&out.ID, &out.TenantID, &out.EngagementID, &out.ActionID, &out.Actor, &status, &out.Verdict,
+			&out.HTTPStatus, &evidenceID, &out.ErrorCode, &out.StartedAt, &out.FinishedAt)
+		if e != nil {
+			if e == pgx.ErrNoRows {
+				return fmt.Errorf("%w: DAST run", shared.ErrNotFound)
+			}
+			return e
+		}
+		out.Status = dastrun.RunStatus(status)
+		out.EvidenceID = shared.ID(evidenceID)
+		return nil
+	})
+	if err != nil {
+		return dastrun.Run{}, fmt.Errorf("get DAST run: %w", err)
+	}
+	return out, nil
+}

--- a/internal/infrastructure/persistence/postgres/migration_0134_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0134_test.go
@@ -1,0 +1,156 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestMigration0134DASTRuns(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN to run the postgres integration test")
+	}
+	ctx := context.Background()
+	if err := MigrateLocked(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	id := randHex(t)
+	tenantA, tenantB := shared.ID("dr-a-"+id), shared.ID("dr-b-"+id)
+	engA := "dr-eng-" + id
+	for _, stmt := range []struct {
+		q    string
+		args []any
+	}{
+		{`INSERT INTO tenants(id,name) VALUES($1,$1),($2,$2)`, []any{tenantA.String(), tenantB.String()}},
+		{`INSERT INTO engagements(id,tenant_id,name) VALUES($1,$2,'dast-eng')`, []any{engA, tenantA.String()}},
+	} {
+		if _, err := pool.Exec(ctx, stmt.q, stmt.args...); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		bg := context.Background()
+		for _, q := range []string{
+			`DELETE FROM dast_runs WHERE tenant_id IN ($1,$2)`,
+			`DELETE FROM engagements WHERE tenant_id IN ($1,$2)`,
+			`DELETE FROM tenants WHERE id IN ($1,$2)`,
+		} {
+			if _, err := pool.Exec(bg, q, tenantA.String(), tenantB.String()); err != nil {
+				t.Errorf("cleanup %q: %v (next run will fail)", q, err)
+			}
+		}
+	})
+
+	repo := NewDASTRunStore(pool)
+	tctx := shared.WithTenant(ctx, tenantA)
+	now := time.Now().UTC()
+	run, err := dastrun.NewRun(shared.ID("run-"+id), tenantA, shared.ID(engA), shared.ID("act-"+id), "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.SaveDASTRun(tctx, run); err != nil {
+		t.Fatalf("save queued: %v", err)
+	}
+	// Advance it to a terminal state and persist the outcome.
+	_ = run.Start()
+	if err := run.Succeed("confirmed", 200, shared.ID("ev-"+id), now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.SaveDASTRun(tctx, run); err != nil {
+		t.Fatalf("save succeeded: %v", err)
+	}
+
+	got, err := repo.GetDASTRun(tctx, tenantA, run.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.Status != dastrun.RunSucceeded || got.Verdict != "confirmed" || got.HTTPStatus != 200 || got.EvidenceID != shared.ID("ev-"+id) || got.FinishedAt == nil {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+
+	// Cross-tenant read is rejected: tenant B cannot see tenant A's run.
+	if _, err := repo.GetDASTRun(shared.WithTenant(ctx, tenantB), tenantB, run.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant read = %v, want ErrNotFound", err)
+	}
+
+	// FinishRun is the compare-and-set that terminalizes a run only from 'running'. A second, conflicting
+	// FinishRun (a redelivered or lease-overlapping worker that lost the race) must not clobber the first
+	// outcome. This is the postgres side of the HIGH-severity clobber fix.
+	run2, err := dastrun.NewRun(shared.ID("run2-"+id), tenantA, shared.ID(engA), shared.ID("act2-"+id), "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = run2.Start()
+	if err := repo.SaveDASTRun(tctx, run2); err != nil {
+		t.Fatalf("save running: %v", err)
+	}
+	winner := run2
+	if err := winner.Succeed("confirmed", 200, shared.ID("ev2-"+id), now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if won, err := repo.FinishRun(tctx, tenantA, winner); err != nil || !won {
+		t.Fatalf("first FinishRun won=%v err=%v, want won=true", won, err)
+	}
+	loser := run2 // a stale copy still 'running'
+	loser.Fail("interrupted", now.Add(2*time.Second))
+	if won, err := repo.FinishRun(tctx, tenantA, loser); err != nil {
+		t.Fatalf("second FinishRun: %v", err)
+	} else if won {
+		t.Fatal("second FinishRun won the CAS; it must not clobber a terminal run")
+	}
+	got2, err := repo.GetDASTRun(tctx, tenantA, run2.ID)
+	if err != nil {
+		t.Fatalf("get run2: %v", err)
+	}
+	if got2.Status != dastrun.RunSucceeded || got2.Verdict != "confirmed" || got2.ErrorCode != "" {
+		t.Fatalf("CAS clobbered the recorded success: %+v", got2)
+	}
+	if got2.EngagementID != shared.ID(engA) || got2.ActionID != shared.ID("act2-"+id) || got2.Actor != "operator" || got2.StartedAt.IsZero() {
+		t.Fatalf("identity fields did not round-trip: %+v", got2)
+	}
+
+	// SaveDASTRun must not move a terminal row backward (the ON CONFLICT guard). A stale worker writing a
+	// failure over a recorded success is a no-op.
+	stale := run2
+	stale.Fail("interrupted", now.Add(3*time.Second))
+	if err := repo.SaveDASTRun(tctx, stale); err != nil {
+		t.Fatalf("stale SaveDASTRun errored: %v", err)
+	}
+	frozen, err := repo.GetDASTRun(tctx, tenantA, run2.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if frozen.Status != dastrun.RunSucceeded || frozen.Verdict != "confirmed" {
+		t.Fatalf("terminal row was moved backward by a stale save: %+v", frozen)
+	}
+
+	// StartRun is the queued -> running compare-and-set: it wins once from queued and loses thereafter, so
+	// only one worker executes the probe.
+	run3, err := dastrun.NewRun(shared.ID("run3-"+id), tenantA, shared.ID(engA), shared.ID("act3-"+id), "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.SaveDASTRun(tctx, run3); err != nil {
+		t.Fatalf("save queued run3: %v", err)
+	}
+	started := run3
+	_ = started.Start()
+	if won, err := repo.StartRun(tctx, tenantA, started); err != nil || !won {
+		t.Fatalf("first StartRun won=%v err=%v, want won=true", won, err)
+	}
+	if won, err := repo.StartRun(tctx, tenantA, started); err != nil || won {
+		t.Fatalf("second StartRun won=%v err=%v, want won=false", won, err)
+	}
+}

--- a/internal/usecase/dastrun/service.go
+++ b/internal/usecase/dastrun/service.go
@@ -1,0 +1,254 @@
+// Package dastrun turns a governed DAST verification probe from a synchronous request-thread execution
+// into a durable, lease-executed job. The API Submits a run (persist + enqueue atomically) and returns
+// immediately; a worker claims the job and runs the SAME approval-gated, evidence-sealing probe the
+// in-process path ran, then records the verdict on the durable run. The approval's single-use consume and
+// its evidence seal are unchanged: they still happen exactly once, inside the probe, now on the worker.
+package dastrun
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	ddast "github.com/KKloudTarus/synapse-ce/internal/domain/dastrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/dastrunner"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// JobKind is the durable job kind for a DAST verification run.
+const JobKind = "dast_run"
+
+// Prober runs one governed DAST probe against a consumed approval. *dastworkflow.Service satisfies it.
+type Prober interface {
+	Run(ctx context.Context, actor string, engagementID, actionID shared.ID, probe dastrunner.Probe) (dastrunner.Result, error)
+}
+
+// jobPayload travels with the durable job. It carries the tenant (cross-checked against the ctx tenant),
+// the run id, and the probe to execute. The probe binds to the consumed approval by digest, so carrying
+// it on the internal queue is safe; it is never persisted on the secret-free run record.
+type jobPayload struct {
+	TenantID shared.ID        `json:"tenant_id"`
+	RunID    shared.ID        `json:"run_id"`
+	Probe    dastrunner.Probe `json:"probe"`
+}
+
+// Service submits and reads DAST runs (API) and executes them (worker).
+type Service struct {
+	runs     ports.DASTRunStore
+	enqueuer ports.DASTRunEnqueuer
+	prober   Prober // nil on the API side (submit/read only); required on the worker
+	audit    ports.AuditLogger
+	clock    ports.Clock
+	ids      ports.IDGenerator
+}
+
+// NewService validates dependencies. prober may be nil for a submit/read-only (API) service; it is
+// required to execute jobs on the worker.
+func NewService(runs ports.DASTRunStore, prober Prober, audit ports.AuditLogger, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
+	if runs == nil || audit == nil || clock == nil || ids == nil {
+		return nil, fmt.Errorf("%w: DAST run service is missing a dependency", shared.ErrValidation)
+	}
+	enqueuer, ok := runs.(ports.DASTRunEnqueuer)
+	if !ok {
+		return nil, fmt.Errorf("%w: DAST run store must support atomic enqueue", shared.ErrValidation)
+	}
+	return &Service{runs: runs, enqueuer: enqueuer, prober: prober, audit: audit, clock: clock, ids: ids}, nil
+}
+
+// Submit persists a queued run and its durable job atomically, then returns the run. The probe is not
+// executed here; the worker does, and the worker is where the approval is enforced: prober.Run admits
+// through the safety gate, requires the approval decision to be approved, binds the probe to it by digest,
+// and consumes it once before probing. Submit does not re-check the approval, so a run for a missing or
+// unapproved action enqueues and then fails on the worker rather than at the edge.
+func (s *Service) Submit(ctx context.Context, engagementID, actionID shared.ID, actor string, probe dastrunner.Probe) (ddast.Run, error) {
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok || tenant == "" {
+		return ddast.Run{}, fmt.Errorf("%w: DAST run submit requires a tenant in context", shared.ErrValidation)
+	}
+	// Reject a malformed or credential-bearing target at the edge, before the probe is persisted on the
+	// durable job, so an invalid URL fails in-request and never sits at rest in the jobs payload.
+	if err := dastrunner.ValidateURL(probe.URL); err != nil {
+		return ddast.Run{}, err
+	}
+	run, err := ddast.NewRun(s.ids.NewID(), tenant, engagementID, actionID, actor, s.clock.Now())
+	if err != nil {
+		return ddast.Run{}, err
+	}
+	payload, err := json.Marshal(jobPayload{TenantID: tenant, RunID: run.ID, Probe: probe})
+	if err != nil {
+		return ddast.Run{}, fmt.Errorf("marshal DAST job: %w", err)
+	}
+	if err := s.enqueuer.EnqueueDASTRun(ctx, run, JobKind, payload); err != nil {
+		_ = s.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: "dast.run_submit_failed", Target: engagementID.String(), At: s.clock.Now().UTC(), Metadata: map[string]string{"run": run.ID.String()}})
+		return ddast.Run{}, fmt.Errorf("enqueue DAST run: %w", err)
+	}
+	_ = s.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: "dast.run_submitted", Target: engagementID.String(), At: s.clock.Now().UTC(), Metadata: map[string]string{"run": run.ID.String(), "action": actionID.String()}})
+	return run, nil
+}
+
+// GetRun reads a run's status, tenant-scoped.
+func (s *Service) GetRun(ctx context.Context, tenantID, runID shared.ID) (ddast.Run, error) {
+	return s.runs.GetDASTRun(shared.WithTenant(ctx, tenantID), tenantID, runID)
+}
+
+// RunJob is the worker handler. It loads the run and drives it to a terminal state exactly once, then
+// completes the job. The run's own status is the redelivery marker:
+//
+//   - terminal: a prior delivery already finished it. No-op.
+//   - running: a prior delivery started the probe and died before recording the outcome. The probe may
+//     have already consumed the single-use approval and moved the judgment score, so it is NEVER
+//     re-executed (re-running would double-probe, and re-admitting a consumed approval returns forbidden
+//     and would overwrite a real success with a false failure). The run is terminalized "interrupted"
+//     via the FinishRun compare-and-set; the operator re-submits, and the approval, if it was never
+//     consumed, is still valid.
+//   - queued: this delivery owns execution. With no prober (this worker has no live scoped egress) the
+//     run is failed "egress_unavailable" so it is operator-visible instead of orphaned in the queue.
+//     With a prober, the run is marked running (the redelivery marker above) and the probe executes.
+//
+// A probe-level error terminalizes the run rather than returning it for retry: the run is running, so the
+// queue cannot safely retry it, and a transient pre-consume error is indistinguishable from a
+// post-consume one without re-admitting a possibly-consumed approval. The operator re-submits. Only a
+// store or tenant error is returned to the queue.
+func (s *Service) RunJob(ctx context.Context, payload []byte) error {
+	var p jobPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return fmt.Errorf("%w: malformed DAST job", shared.ErrValidation)
+	}
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok || tenant != p.TenantID {
+		return fmt.Errorf("%w: DAST job tenant mismatch", shared.ErrValidation)
+	}
+	run, err := s.runs.GetDASTRun(ctx, tenant, p.RunID)
+	if err != nil {
+		return err
+	}
+	if run.Status.Terminal() {
+		return nil // already finished on an earlier delivery
+	}
+	if run.Status == ddast.RunRunning {
+		// A started-but-unrecorded prior attempt. Do not re-run; terminalize deterministically.
+		run.Fail("interrupted", s.clock.Now())
+		won, ferr := s.runs.FinishRun(ctx, tenant, run)
+		if ferr != nil {
+			return ferr
+		}
+		if won {
+			_ = s.audit.Record(ctx, ports.AuditEntry{Actor: run.Actor, Action: "dast.run_interrupted", Target: run.EngagementID.String(), At: s.clock.Now().UTC(), Metadata: map[string]string{"run": run.ID.String()}})
+		}
+		return nil
+	}
+	// run.Status == RunQueued: claim execution with a compare-and-set BEFORE doing anything else. Whoever
+	// wins queued -> running owns the run; a redelivered or lease-overlapping worker that loses returns
+	// without touching it. This is why both the probe and the no-egress branches sit AFTER the claim: a
+	// blind SaveDASTRun here would overwrite a running row a capable peer is already probing (terminal
+	// immutability only freezes succeeded/failed), letting a stale worker clobber a live run or hit the
+	// target for a run that is already owned.
+	if err := run.Start(); err != nil {
+		return err
+	}
+	won, err := s.runs.StartRun(ctx, tenant, run)
+	if err != nil {
+		return err
+	}
+	if !won {
+		return nil // another delivery owns this run
+	}
+	if s.prober == nil {
+		// This worker has no live scoped egress, so it cannot probe. Having won the claim, it fails the run
+		// visibly through the FinishRun CAS instead of orphaning it at queued; the approval, if unconsumed,
+		// stays valid for a re-submit. This assumes a homogeneous worker fleet (the norm): a probe cannot
+		// run without egress, so a deployment offering DAST runs no egress-less workers. In a heterogeneous
+		// fleet an egress-less worker can win the claim for a run a capable peer could have executed; the
+		// run fails egress_unavailable and the operator re-submits, which is recoverable, not a lost or
+		// clobbered outcome.
+		run.Fail("egress_unavailable", s.clock.Now())
+		if _, err := s.runs.FinishRun(ctx, tenant, run); err != nil {
+			return err
+		}
+		_ = s.audit.Record(ctx, ports.AuditEntry{Actor: run.Actor, Action: "dast.run_failed", Target: run.EngagementID.String(), At: s.clock.Now().UTC(), Metadata: map[string]string{"run": run.ID.String(), "reason": "egress_unavailable"}})
+		return nil
+	}
+	result, runErr := s.prober.Run(ctx, run.Actor, run.EngagementID, run.ActionID, p.Probe)
+	if runErr != nil {
+		// A transport-level probe error can still carry sealed evidence (the runner seals before returning
+		// the error). Preserve the sealed-evidence id and observed status on the failed run so the operator
+		// can reach the hash-chained custody record.
+		if !result.Evidence.IsZero() {
+			run.EvidenceID, run.HTTPStatus = result.Evidence, result.Status
+		}
+		run.Fail(errorCode(runErr), s.clock.Now())
+		won, err := s.runs.FinishRun(ctx, tenant, run)
+		if err != nil {
+			return err // could not record the failure: let the queue retry the record
+		}
+		if won {
+			_ = s.audit.Record(ctx, ports.AuditEntry{Actor: run.Actor, Action: "dast.run_failed", Target: run.EngagementID.String(), At: s.clock.Now().UTC(), Metadata: map[string]string{"run": run.ID.String(), "reason": errorCode(runErr)}})
+		}
+		return nil // terminal: the approval is consumed, so a retry cannot help
+	}
+	if err := run.Succeed(string(result.Proof), result.Status, result.Evidence, s.clock.Now()); err != nil {
+		// A nil-error result missing its proof class or sealed evidence is not a valid success. The
+		// approval is already consumed, so this cannot be retried: terminalize it as a failure rather than
+		// returning the error to the queue (which the running-redelivery guard would only turn into
+		// "interrupted" anyway).
+		run.Fail("invalid_result", s.clock.Now())
+		if _, ferr := s.runs.FinishRun(ctx, tenant, run); ferr != nil {
+			return ferr
+		}
+		_ = s.audit.Record(ctx, ports.AuditEntry{Actor: run.Actor, Action: "dast.run_failed", Target: run.EngagementID.String(), At: s.clock.Now().UTC(), Metadata: map[string]string{"run": run.ID.String(), "reason": "invalid_result"}})
+		return nil
+	}
+	won, err = s.runs.FinishRun(ctx, tenant, run)
+	if err != nil {
+		return err
+	}
+	if won {
+		_ = s.audit.Record(ctx, ports.AuditEntry{Actor: run.Actor, Action: "dast.run_completed", Target: run.EngagementID.String(), At: s.clock.Now().UTC(), Metadata: map[string]string{"run": run.ID.String(), "verdict": string(result.Proof)}})
+	}
+	return nil
+}
+
+// FailStrandedJob records a run as failed when its job is dead-lettered, so a stranded run does not sit in
+// a non-terminal state forever. It writes through SaveDASTRun rather than the FinishRun CAS on purpose: a
+// dead-lettered run may be either queued (never started) or running (started by this same worker), and
+// FinishRun can only terminalize from running, so it would orphan a queued stranded run. The blind write
+// is safe because the worker calls OnDeadLetter only AFTER its fenced queue.Deadletter succeeds, which
+// proves this worker still holds the claim at the current fence; no other worker owns the job, so no live
+// run of another worker can be clobbered. SaveDASTRun's terminal-immutability still guards the case where a
+// terminal outcome was recorded between the Terminal() check and the write.
+func (s *Service) FailStrandedJob(ctx context.Context, payload []byte, cause error) error {
+	var p jobPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return fmt.Errorf("%w: malformed DAST job", shared.ErrValidation)
+	}
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok || tenant != p.TenantID {
+		return fmt.Errorf("%w: DAST job tenant mismatch", shared.ErrValidation)
+	}
+	run, err := s.runs.GetDASTRun(ctx, tenant, p.RunID)
+	if err != nil {
+		return err
+	}
+	if run.Status.Terminal() {
+		return nil
+	}
+	run.Fail("dead_lettered", s.clock.Now())
+	return s.runs.SaveDASTRun(ctx, run)
+}
+
+func errorCode(err error) string {
+	switch {
+	case errors.Is(err, shared.ErrForbidden):
+		return "forbidden"
+	case errors.Is(err, shared.ErrValidation):
+		return "invalid"
+	case errors.Is(err, shared.ErrNotFound):
+		return "not_found"
+	case errors.Is(err, shared.ErrConflict):
+		return "conflict"
+	default:
+		return "run_failed"
+	}
+}

--- a/internal/usecase/dastrun/service_test.go
+++ b/internal/usecase/dastrun/service_test.go
@@ -1,0 +1,294 @@
+package dastrun
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	ddast "github.com/KKloudTarus/synapse-ce/internal/domain/dastrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/dastrunner"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var t0 = time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+
+type fakeProber struct {
+	result dastrunner.Result
+	err    error
+	calls  int
+}
+
+func (f *fakeProber) Run(_ context.Context, _ string, _, _ shared.ID, _ dastrunner.Probe) (dastrunner.Result, error) {
+	f.calls++
+	return f.result, f.err
+}
+
+type fakeAudit struct{ entries []ports.AuditEntry }
+
+func (f *fakeAudit) Record(_ context.Context, e ports.AuditEntry) error {
+	f.entries = append(f.entries, e)
+	return nil
+}
+
+type fixedClock struct{}
+
+func (fixedClock) Now() time.Time { return t0 }
+
+type fixedIDs struct{ n int }
+
+func (g *fixedIDs) NewID() shared.ID { g.n++; return shared.ID("run-" + time.Duration(g.n).String()) }
+
+func newHarness(t *testing.T, prober Prober) (*Service, *memory.DASTRunStore, ports.JobQueue) {
+	t.Helper()
+	runs := memory.NewDASTRunStore()
+	queue := memory.NewJobQueue(&fixedIDs{}, func() time.Time { return t0 })
+	runs.SetQueue(queue)
+	svc, err := NewService(runs, prober, &fakeAudit{}, fixedClock{}, &fixedIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return svc, runs, queue
+}
+
+func tenantCtx() context.Context { return shared.WithTenant(context.Background(), "t1") }
+
+func TestSubmitPersistsAndEnqueues(t *testing.T) {
+	svc, runs, queue := newHarness(t, &fakeProber{})
+	run, err := svc.Submit(tenantCtx(), "eng-1", "act-1", "alice", dastrunner.Probe{URL: "https://app.example.test"})
+	if err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+	if run.Status != ddast.RunQueued {
+		t.Errorf("submitted run status = %s, want queued", run.Status)
+	}
+	got, err := runs.GetDASTRun(tenantCtx(), "t1", run.ID)
+	if err != nil {
+		t.Fatalf("run not persisted: %v", err)
+	}
+	if got.EngagementID != "eng-1" || got.ActionID != "act-1" || got.Actor != "alice" {
+		t.Errorf("persisted run fields wrong: %+v", got)
+	}
+	job, err := queue.Claim(context.Background(), time.Minute, JobKind)
+	if err != nil || job == nil {
+		t.Fatalf("no job enqueued: %v", err)
+	}
+}
+
+func TestRunJobExecutesAndRecordsVerdict(t *testing.T) {
+	prober := &fakeProber{result: dastrunner.Result{Proof: "confirmed", Status: 200, Evidence: "ev-1"}}
+	svc, runs, queue := newHarness(t, prober)
+	run, _ := svc.Submit(tenantCtx(), "eng-1", "act-1", "alice", dastrunner.Probe{URL: "https://app.example.test"})
+	job, _ := queue.Claim(context.Background(), time.Minute, JobKind)
+
+	if err := svc.RunJob(tenantCtx(), job.Payload); err != nil {
+		t.Fatalf("RunJob: %v", err)
+	}
+	if prober.calls != 1 {
+		t.Errorf("prober called %d times, want 1", prober.calls)
+	}
+	got, _ := runs.GetDASTRun(tenantCtx(), "t1", run.ID)
+	if got.Status != ddast.RunSucceeded || got.Verdict != "confirmed" || got.HTTPStatus != 200 || got.EvidenceID != "ev-1" {
+		t.Fatalf("run not recorded as succeeded with verdict: %+v", got)
+	}
+}
+
+func TestRunJobRecordsFailureAndDoesNotRetry(t *testing.T) {
+	prober := &fakeProber{err: errors.New("probe refused")}
+	svc, runs, queue := newHarness(t, prober)
+	run, _ := svc.Submit(tenantCtx(), "eng-1", "act-1", "alice", dastrunner.Probe{URL: "https://app.example.test"})
+	job, _ := queue.Claim(context.Background(), time.Minute, JobKind)
+
+	// A probe failure is terminal (the approval is consumed): RunJob records it and returns nil, so the
+	// queue does not retry a run that cannot succeed.
+	if err := svc.RunJob(tenantCtx(), job.Payload); err != nil {
+		t.Fatalf("RunJob should not surface a probe failure for retry: %v", err)
+	}
+	got, _ := runs.GetDASTRun(tenantCtx(), "t1", run.ID)
+	if got.Status != ddast.RunFailed || got.ErrorCode == "" {
+		t.Fatalf("run not recorded as failed: %+v", got)
+	}
+}
+
+func TestRunJobIsIdempotentOnTerminalRun(t *testing.T) {
+	prober := &fakeProber{result: dastrunner.Result{Proof: "confirmed", Status: 200, Evidence: "ev-1"}}
+	svc, _, queue := newHarness(t, prober)
+	_, _ = svc.Submit(tenantCtx(), "eng-1", "act-1", "alice", dastrunner.Probe{URL: "https://app.example.test"})
+	job, _ := queue.Claim(context.Background(), time.Minute, JobKind)
+	if err := svc.RunJob(tenantCtx(), job.Payload); err != nil {
+		t.Fatal(err)
+	}
+	// A redelivery of the same job must not execute the probe again.
+	if err := svc.RunJob(tenantCtx(), job.Payload); err != nil {
+		t.Fatalf("redelivered RunJob: %v", err)
+	}
+	if prober.calls != 1 {
+		t.Errorf("prober called %d times across a redelivery, want 1", prober.calls)
+	}
+}
+
+func TestRunJobRejectsTenantMismatch(t *testing.T) {
+	svc, _, queue := newHarness(t, &fakeProber{})
+	_, _ = svc.Submit(tenantCtx(), "eng-1", "act-1", "alice", dastrunner.Probe{URL: "https://app.example.test"})
+	job, _ := queue.Claim(context.Background(), time.Minute, JobKind)
+	// A worker running the job under a different tenant context must refuse it.
+	if err := svc.RunJob(shared.WithTenant(context.Background(), "t2"), job.Payload); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("tenant-mismatch RunJob = %v, want ErrValidation", err)
+	}
+}
+
+func TestRunJobDoesNotReExecuteAnInterruptedRun(t *testing.T) {
+	// A prior delivery started the probe (run is 'running') and died before recording the outcome. A
+	// redelivery must NOT re-run the probe (it may already have consumed the single-use approval); it
+	// terminalizes the run 'interrupted' instead of re-admitting a consumed approval and clobbering a
+	// real success with a false forbidden.
+	prober := &fakeProber{err: shared.ErrForbidden}
+	svc, runs, queue := newHarness(t, prober)
+	run, _ := svc.Submit(tenantCtx(), "eng-1", "act-1", "alice", dastrunner.Probe{URL: "https://app.example.test"})
+	job, _ := queue.Claim(context.Background(), time.Minute, JobKind)
+	// Simulate the crash: mark the run running and persist it, as the first delivery would have.
+	started := run
+	if err := started.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := runs.SaveDASTRun(tenantCtx(), started); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.RunJob(tenantCtx(), job.Payload); err != nil {
+		t.Fatalf("RunJob on a running run: %v", err)
+	}
+	if prober.calls != 0 {
+		t.Errorf("prober called %d times on an interrupted run, want 0", prober.calls)
+	}
+	got, _ := runs.GetDASTRun(tenantCtx(), "t1", run.ID)
+	if got.Status != ddast.RunFailed || got.ErrorCode != "interrupted" {
+		t.Fatalf("interrupted run = %+v, want failed/interrupted", got)
+	}
+}
+
+func TestRunJobWithoutProberFailsEgressUnavailable(t *testing.T) {
+	// A worker with no live scoped egress (nil prober) must still terminalize an enqueued run so it is
+	// operator-visible, not orphaned at 'queued' forever.
+	svc, runs, queue := newHarness(t, nil)
+	run, _ := svc.Submit(tenantCtx(), "eng-1", "act-1", "alice", dastrunner.Probe{URL: "https://app.example.test"})
+	job, _ := queue.Claim(context.Background(), time.Minute, JobKind)
+	if err := svc.RunJob(tenantCtx(), job.Payload); err != nil {
+		t.Fatalf("RunJob without prober: %v", err)
+	}
+	got, _ := runs.GetDASTRun(tenantCtx(), "t1", run.ID)
+	if got.Status != ddast.RunFailed || got.ErrorCode != "egress_unavailable" {
+		t.Fatalf("run without prober = %+v, want failed/egress_unavailable", got)
+	}
+}
+
+// staleStartStore returns a queued run from Get but always loses the StartRun compare-and-set, simulating
+// a redelivery where another worker started or finished the run between our Get and our StartRun.
+type staleStartStore struct {
+	run          ddast.Run
+	finishCalls  int
+	terminWrites int
+}
+
+func (s *staleStartStore) SaveDASTRun(context.Context, ddast.Run) error { s.terminWrites++; return nil }
+func (s *staleStartStore) GetDASTRun(context.Context, shared.ID, shared.ID) (ddast.Run, error) {
+	return s.run, nil
+}
+func (s *staleStartStore) StartRun(context.Context, shared.ID, ddast.Run) (bool, error) {
+	return false, nil
+}
+func (s *staleStartStore) FinishRun(context.Context, shared.ID, ddast.Run) (bool, error) {
+	s.finishCalls++
+	return false, nil
+}
+func (s *staleStartStore) EnqueueDASTRun(context.Context, ddast.Run, string, []byte) error {
+	return nil
+}
+
+func TestRunJobDoesNotProbeWhenStartRunLost(t *testing.T) {
+	run, err := ddast.NewRun("run-x", "t1", "eng-1", "act-1", "alice", t0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prober := &fakeProber{result: dastrunner.Result{Proof: "confirmed", Status: 200, Evidence: "ev"}}
+	svc, err := NewService(&staleStartStore{run: run}, prober, &fakeAudit{}, fixedClock{}, &fixedIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, _ := json.Marshal(jobPayload{TenantID: "t1", RunID: "run-x", Probe: dastrunner.Probe{URL: "https://app.example.test"}})
+	if err := svc.RunJob(tenantCtx(), payload); err != nil {
+		t.Fatalf("RunJob: %v", err)
+	}
+	if prober.calls != 0 {
+		t.Errorf("prober called %d times after losing the start CAS, want 0", prober.calls)
+	}
+}
+
+func TestSubmitRejectsCredentialBearingURL(t *testing.T) {
+	// A malformed or credential-bearing target must be rejected at the edge, before the probe is persisted
+	// on the durable job (parity with the old synchronous path).
+	svc, runs, queue := newHarness(t, &fakeProber{})
+	_, err := svc.Submit(tenantCtx(), "eng-1", "act-1", "alice", dastrunner.Probe{URL: "https://app.example.test/?token=secret"})
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("Submit with credential URL = %v, want ErrValidation", err)
+	}
+	// Nothing was enqueued or persisted.
+	if job, _ := queue.Claim(context.Background(), time.Minute, JobKind); job != nil {
+		t.Fatal("an invalid submit enqueued a job")
+	}
+	_ = runs
+}
+
+func TestRunJobPreservesSealedEvidenceOnFailure(t *testing.T) {
+	// A transport-level probe error can still carry sealed evidence; the failed run must surface it.
+	prober := &fakeProber{result: dastrunner.Result{Status: 502, Evidence: "ev-seal"}, err: errors.New("probe transport error")}
+	svc, runs, queue := newHarness(t, prober)
+	run, _ := svc.Submit(tenantCtx(), "eng-1", "act-1", "alice", dastrunner.Probe{URL: "https://app.example.test"})
+	job, _ := queue.Claim(context.Background(), time.Minute, JobKind)
+	if err := svc.RunJob(tenantCtx(), job.Payload); err != nil {
+		t.Fatalf("RunJob: %v", err)
+	}
+	got, _ := runs.GetDASTRun(tenantCtx(), "t1", run.ID)
+	if got.Status != ddast.RunFailed || got.EvidenceID != "ev-seal" || got.HTTPStatus != 502 {
+		t.Fatalf("failed run did not preserve sealed evidence: %+v", got)
+	}
+}
+
+func TestRunJobTerminalizesInvalidSuccessResult(t *testing.T) {
+	// A nil-error result missing its proof/evidence is not a valid success. It must terminalize (approval
+	// already consumed), not be returned to the queue for retry.
+	prober := &fakeProber{result: dastrunner.Result{Status: 200}} // no Proof, no Evidence, nil error
+	svc, runs, queue := newHarness(t, prober)
+	run, _ := svc.Submit(tenantCtx(), "eng-1", "act-1", "alice", dastrunner.Probe{URL: "https://app.example.test"})
+	job, _ := queue.Claim(context.Background(), time.Minute, JobKind)
+	if err := svc.RunJob(tenantCtx(), job.Payload); err != nil {
+		t.Fatalf("RunJob returned an invalid-result error to the queue: %v", err)
+	}
+	got, _ := runs.GetDASTRun(tenantCtx(), "t1", run.ID)
+	if got.Status != ddast.RunFailed || got.ErrorCode != "invalid_result" {
+		t.Fatalf("invalid success result not terminalized: %+v", got)
+	}
+}
+
+func TestRunJobWithoutProberDoesNotClobberWhenStartLost(t *testing.T) {
+	// An egress-less worker that loses the StartRun claim (a capable peer already owns the run) must return
+	// without any terminal write, so it cannot clobber the peer's live run with egress_unavailable.
+	run, err := ddast.NewRun("run-y", "t1", "eng-1", "act-1", "alice", t0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := &staleStartStore{run: run}
+	svc, err := NewService(store, nil, &fakeAudit{}, fixedClock{}, &fixedIDs{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload, _ := json.Marshal(jobPayload{TenantID: "t1", RunID: "run-y", Probe: dastrunner.Probe{URL: "https://app.example.test"}})
+	if err := svc.RunJob(tenantCtx(), payload); err != nil {
+		t.Fatalf("RunJob: %v", err)
+	}
+	if store.finishCalls != 0 || store.terminWrites != 0 {
+		t.Fatalf("worker that lost the claim wrote the run: finishCalls=%d terminWrites=%d", store.finishCalls, store.terminWrites)
+	}
+}

--- a/internal/usecase/dastrunner/service.go
+++ b/internal/usecase/dastrunner/service.go
@@ -348,3 +348,30 @@ func redactProbeExcerpt(body []byte) string {
 	}
 	return text
 }
+
+// ValidateURL rejects a malformed or credential-bearing DAST target URL. It is the single source of truth
+// for probe-target validation, enforced at both edges: when a run is submitted (before the probe is
+// persisted on the durable job) and again inside the governed workflow before execution. Rejecting at
+// submit keeps a credential-like URL (e.g. ?token=...) out of the durable jobs payload at rest.
+func ValidateURL(raw string) error {
+	u, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || u == nil || u.User != nil || u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("%w: invalid DAST target URL", shared.ErrValidation)
+	}
+	for key := range u.Query() {
+		if sensitiveURLQueryKey(key) {
+			return fmt.Errorf("%w: DAST target URL cannot contain credential-like query keys", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+func sensitiveURLQueryKey(key string) bool {
+	key = strings.ToLower(key)
+	for _, sensitive := range []string{"token", "session", "api_key", "key", "secret", "password", "auth", "signature", "sig"} {
+		if strings.Contains(key, sensitive) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/usecase/dastworkflow/service.go
+++ b/internal/usecase/dastworkflow/service.go
@@ -13,7 +13,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"net/url"
 	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
@@ -158,25 +157,8 @@ func probeDigest(probe dastrunner.Probe, method string) string {
 	return hex.EncodeToString(digest[:])
 }
 
+// validateDASTURL delegates to dastrunner.ValidateURL, the single source of truth for probe-target
+// validation, so the durable submit edge and the execution edge reject exactly the same URLs.
 func validateDASTURL(raw string) error {
-	u, err := url.Parse(strings.TrimSpace(raw))
-	if err != nil || u == nil || u.User != nil || u.Scheme == "" || u.Host == "" {
-		return fmt.Errorf("%w: invalid DAST target URL", shared.ErrValidation)
-	}
-	for key := range u.Query() {
-		if sensitiveDASTQueryKey(key) {
-			return fmt.Errorf("%w: DAST target URL cannot contain credential-like query keys", shared.ErrValidation)
-		}
-	}
-	return nil
-}
-
-func sensitiveDASTQueryKey(key string) bool {
-	key = strings.ToLower(key)
-	for _, sensitive := range []string{"token", "session", "api_key", "key", "secret", "password", "auth", "signature", "sig"} {
-		if strings.Contains(key, sensitive) {
-			return true
-		}
-	}
-	return false
+	return dastrunner.ValidateURL(raw)
 }

--- a/internal/usecase/ports/dastrun.go
+++ b/internal/usecase/ports/dastrun.go
@@ -1,0 +1,32 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/dastrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// DASTRunStore persists the durable DAST verification run and reads it back, tenant-scoped.
+type DASTRunStore interface {
+	SaveDASTRun(context.Context, dastrun.Run) error
+	GetDASTRun(ctx context.Context, tenantID, runID shared.ID) (dastrun.Run, error)
+	// StartRun transitions a run 'queued' -> 'running' with a compare-and-set, reporting whether it won.
+	// Only the worker that wins the transition executes the probe; a redelivered or lease-overlapping
+	// worker that finds the run already running or terminal loses and must not probe. This is the entry
+	// half of the run's CAS pair (StartRun claims execution, FinishRun records the outcome), so the probe
+	// runs exactly once even though SaveDASTRun's terminal-immutability makes a losing start a silent
+	// no-op that could otherwise be mistaken for a successful claim.
+	StartRun(ctx context.Context, tenantID shared.ID, run dastrun.Run) (bool, error)
+	// FinishRun writes a terminal run only if the stored run is still 'running', and reports whether it
+	// won that transition. This is the compare-and-set that stops a redelivered or lease-overlapping
+	// worker from overwriting a run another delivery already terminalized (e.g. clobbering a recorded
+	// success with a late failure). The run must be terminal.
+	FinishRun(ctx context.Context, tenantID shared.ID, run dastrun.Run) (bool, error)
+}
+
+// DASTRunEnqueuer atomically persists one queued run and its durable job, so a run is never enqueued
+// without a record and never recorded without being enqueued.
+type DASTRunEnqueuer interface {
+	EnqueueDASTRun(ctx context.Context, run dastrun.Run, jobKind string, payload []byte) error
+}

--- a/migrations/0134_dast_runs.sql
+++ b/migrations/0134_dast_runs.sql
@@ -1,0 +1,29 @@
+-- +goose Up
+-- Durable, tenant-scoped DAST verification-run lifecycle. A probe used to execute synchronously in the
+-- API request; it now runs as a lease-executed job, so this table tracks its status and secret-free
+-- outcome (the verdict class, the observed HTTP status, and the sealed-evidence id). It never stores the
+-- probe body, any request/response content, or a credential.
+CREATE TABLE dast_runs (
+    tenant_id     TEXT NOT NULL REFERENCES tenants(id),
+    id            TEXT NOT NULL,
+    engagement_id TEXT NOT NULL,
+    action_id     TEXT NOT NULL,
+    actor         TEXT NOT NULL,
+    status        TEXT NOT NULL CHECK (status IN ('queued','running','succeeded','failed')),
+    verdict       TEXT NOT NULL DEFAULT '',
+    http_status   INTEGER NOT NULL DEFAULT 0 CHECK (http_status >= 0),
+    evidence_id   TEXT NOT NULL DEFAULT '',
+    error_code    TEXT NOT NULL DEFAULT '',
+    started_at    TIMESTAMPTZ NOT NULL,
+    finished_at   TIMESTAMPTZ,
+    PRIMARY KEY (tenant_id, id),
+    FOREIGN KEY (tenant_id, engagement_id) REFERENCES engagements(tenant_id, id) ON DELETE CASCADE,
+    -- The terminal states carry a finish time; the in-flight states do not.
+    CHECK ((status IN ('succeeded','failed')) = (finished_at IS NOT NULL))
+);
+
+CREATE INDEX idx_dast_runs_engagement ON dast_runs(tenant_id, engagement_id, started_at DESC);
+CALL synapse_enable_tenant_rls('dast_runs');
+
+-- +goose Down
+DROP TABLE dast_runs;


### PR DESCRIPTION
## What

A governed DAST verification probe used to execute on the API request thread. With the Postgres job queue it now runs as a durable, lease-executed worker job.

- The run route (`POST /engagements/{id}/judgments/{jid}/runtime-verification/proposals/{aid}/run`) enqueues the probe and answers `202` with a queued run.
- `synapse-worker` executes the same approval-gated, sandboxed, evidence-sealing probe, so the single-use approval consume and the evidence seal still happen exactly once.
- `GET /engagements/{id}/dast/runs/{rid}` polls the run to a terminal state.
- Without the queue (in-memory dev) the probe stays synchronous.

The run record is secret-free: verdict class, observed HTTP status, and the sealed-evidence id, never the probe body or any response content. Backed by a new `dast_runs` table with tenant RLS (`migrations/0134_dast_runs.sql`).

## Concurrency model

The job queue is an at-least-once, fenced lease queue, so two workers can hold the same run across a lease boundary. Correctness rests on a compare-and-set pair over the run row plus a monotonic terminal state, all tenant-scoped under RLS:

- `StartRun` claims execution `queued -> running` only from `queued`. A redelivered or lease-overlapping worker that loses the claim returns without probing, so it never re-consumes the single-use approval or re-hits the target.
- `FinishRun` records the terminal outcome only from `running`, and `SaveDASTRun` refuses to move a `succeeded`/`failed` row backward. A late delivery can never overwrite a recorded success.
- A run found `running` on redelivery is terminalized `interrupted` rather than re-run.
- A worker with no live scoped-egress broker still claims the job and fails the run `egress_unavailable`, so an enqueued run is always visible to the poller instead of orphaned at `queued`. `FailStrandedJob` terminalizes a dead-lettered run and is safe because the worker calls it only after a fenced `Deadletter` succeeds.

The probe target is validated at the submit edge through the single `dastrunner.ValidateURL`, so a malformed or credential-bearing URL is rejected in-request and never persisted in the jobs payload.

Complexity: each store operation is O(1) on the `(tenant_id, id)` primary key; the status route reads one row.

## Tests

- Domain lifecycle, service (submit, execute, redelivery, interrupted, no-egress, tenant mismatch, lost-claim, invalid-result, evidence-on-failure), and both store CAS suites.
- Postgres integration (`TestMigration0134DASTRuns`): round-trip, cross-tenant read rejected, `StartRun`/`FinishRun` CAS, terminal-immutability, all against a live database.
- The hostile tenant-isolation harness now drives the run status route: own-tenant read `200`, machine role `403`, cross-tenant `404`.

## Verification

Independent QA and security review both pass (tenant isolation, RLS, approval exactly-once, secret-free record, egress gating, and the CAS guards, verified under `-race`), plus an external Codex review that found no remaining defects. `make build vet test` is green; the only repo-wide failures are the sandbox namespace tests, which require kernel privileges this CI sandbox lacks.

Closes #823.
