### PR TITLE
feat(engagement): carry offensive rules of engagement on the engagement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Engagements carry their offensive rules of engagement.** The offensive governance policy refuses
+  adversary emulation and exploitation chains until an engagement declares its customer and emergency
+  contacts, a risk ceiling (`low`/`medium`/`high`/`prohibited`), and that the out-of-scope list was
+  reviewed. The `Engagement` aggregate now holds these fields, `PUT /api/v1/engagements/{id}/offensive-roe`
+  sets them (operate-gated, tenant-scoped, audited), and every engagement response returns them under
+  `offensive_roe`. Migration `0135` adds the columns backward-compatibly (defaults leave the offensive
+  pillar refused until an operator fills them in) with a `risk_ceiling` CHECK. This is the foundation the
+  offensive/purple pillar (emulation, purple coverage, exploitation chains) needs to become reachable.
+
 - **Governed DAST verification runs execute on the worker (#823).** An approved DAST probe used to run on
   the API request thread. With the Postgres job queue it now runs as a durable, lease-executed job: the
   run route (`POST /engagements/{id}/judgments/{jid}/runtime-verification/proposals/{aid}/run`) enqueues

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -239,6 +239,35 @@ paths:
         "403": {$ref: "#/components/responses/Forbidden"}
         "404": {$ref: "#/components/responses/NotFound"}
 
+  /api/v1/engagements/{id}/offensive-roe:
+    parameters:
+    - $ref: "#/components/parameters/EngagementId"
+    put:
+      tags: [engagements]
+      summary: Set an engagement's offensive rules of engagement
+      description: >
+        Requires the `operate` capability. Records the customer and emergency contacts, the risk
+        ceiling (`low`/`medium`/`high`/`prohibited`, or empty to leave unset), and that the
+        out-of-scope list was reviewed. The offensive governance policy refuses adversary emulation
+        and exploitation chains until these rules of engagement are complete. This replaces the whole
+        rules-of-engagement set: send all four fields, since an omitted field is written as its empty
+        value.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: "#/components/schemas/SetOffensiveRoERequest"}
+      responses:
+        "200":
+          description: The updated engagement
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/Engagement"}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
   /api/v1/engagements/{id}/source:
     parameters:
     - $ref: "#/components/parameters/EngagementId"
@@ -4296,6 +4325,26 @@ components:
           enum: [active, completed, archived]
           description: Target lifecycle status. draft is the creation state and cannot be returned to.
 
+    SetOffensiveRoERequest:
+      type: object
+      description: >
+        Offensive rules of engagement. The offensive governance policy refuses adversary emulation and
+        exploitation chains until every field is set (an empty risk ceiling leaves the pillar refused).
+      properties:
+        customer_contact:
+          type: string
+          description: Who to reach on the customer side when an offensive action goes wrong.
+        emergency_contact:
+          type: string
+          description: Out-of-hours emergency contact for offensive actions.
+        risk_ceiling:
+          type: string
+          enum: ["", low, medium, high, prohibited]
+          description: Highest risk class an offensive action may carry. Empty leaves the pillar refused.
+        exclusions_checked:
+          type: boolean
+          description: The operator confirmed the out-of-scope list was reviewed.
+
     Capability:
       type: object
       required: [key, name, enabled, switch]
@@ -5767,6 +5816,14 @@ components:
           type: string
           description: IANA zone the operator entered the window in; display and audit only.
         live_recon_enabled: {type: boolean}
+        offensive_roe:
+          type: object
+          description: Offensive rules of engagement the governance policy requires before emulation / exploitation.
+          properties:
+            customer_contact: {type: string}
+            emergency_contact: {type: string}
+            risk_ceiling: {type: string, enum: ["", low, medium, high, prohibited]}
+            exclusions_checked: {type: boolean}
         created_at: {type: string, format: date-time}
         updated_at: {type: string, format: date-time}
 

--- a/internal/adapter/httpapi/engagement_handler.go
+++ b/internal/adapter/httpapi/engagement_handler.go
@@ -347,6 +347,30 @@ func (rt *Router) setAuthorizationWindow(w http.ResponseWriter, r *http.Request)
 	writeJSON(w, http.StatusOK, toEngagementView(e))
 }
 
+type setOffensiveRoERequest struct {
+	CustomerContact   string `json:"customer_contact"`
+	EmergencyContact  string `json:"emergency_contact"`
+	RiskCeiling       string `json:"risk_ceiling"` // low|medium|high|prohibited, or empty to leave unset
+	ExclusionsChecked bool   `json:"exclusions_checked"`
+}
+
+// setOffensiveRoE records the offensive rules of engagement the governance policy requires before
+// adversary emulation or exploitation chains may run for this engagement.
+func (rt *Router) setOffensiveRoE(w http.ResponseWriter, r *http.Request) {
+	var req setOffensiveRoERequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid json body"})
+		return
+	}
+	e, err := rt.eng.SetOffensiveRoE(r.Context(), PrincipalFrom(r.Context()), shared.ID(TenantFrom(r.Context())),
+		shared.ID(r.PathValue("id")), req.CustomerContact, req.EmergencyContact, req.RiskCeiling, req.ExclusionsChecked)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, toEngagementView(e))
+}
+
 type transitionRequest struct {
 	Status string `json:"status"` // target lifecycle status: active|completed|archived
 }

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -477,6 +477,12 @@ func TestHostileHarness(t *testing.T) {
 		return rec.Code, rec.Body.String()
 	}
 
+	// Cross-tenant offensive-RoE write: a tenantB operator must not set tenantA's rules of engagement.
+	// The write is tenant-scoped (GetByIDInTenant), so it fails ErrNotFound rather than mutating.
+	if code, _ := sendBody("consultant", "tenantB", http.MethodPut, "/api/v1/engagements/engA/offensive-roe", `{"customer_contact":"x","emergency_contact":"y","risk_ceiling":"low","exclusions_checked":true}`); code != http.StatusNotFound {
+		t.Errorf("cross-tenant offensive-roe write = %d, want 404", code)
+	}
+
 	// Cross-tenant user provisioning: a tenantA admin must not be able to mint an operator (and
 	// receive that operator's API key) inside tenantB.
 	if code, body := sendBody("admin", "tenantA", http.MethodPost, "/api/v1/users", `{"name":"Planted","role":"admin","tenant_id":"other-b"}`); code != http.StatusForbidden || strings.Contains(body, "syn_") {

--- a/internal/adapter/httpapi/resource_view.go
+++ b/internal/adapter/httpapi/resource_view.go
@@ -48,8 +48,11 @@ type engagementView struct {
 	AuthorizedTo     *time.Time `json:"authorized_to"`
 	Timezone         string     `json:"timezone,omitempty"`
 	LiveReconEnabled bool       `json:"live_recon_enabled"`
-	CreatedAt        time.Time  `json:"created_at"`
-	UpdatedAt        time.Time  `json:"updated_at"`
+	// OffensiveRoE is the rules of engagement the offensive governance policy requires before adversary
+	// emulation or exploitation chains may run. Distinct from RoE above (allowed tool classes + blackouts).
+	OffensiveRoE offensiveRoEView `json:"offensive_roe"`
+	CreatedAt    time.Time        `json:"created_at"`
+	UpdatedAt    time.Time        `json:"updated_at"`
 	// List enrichment (listEngagements): open finding counts and the latest scan job, so the table
 	// shows what a row's scan found without a request per row. Absent on single-resource responses
 	// and when the stores are not wired.
@@ -88,6 +91,14 @@ func toRoEView(roe engdom.RoE) roeView {
 	return roeView{AllowedToolClasses: classes, Blackouts: blackouts}
 }
 
+// offensiveRoEView is the serialized offensive rules of engagement.
+type offensiveRoEView struct {
+	CustomerContact   string `json:"customer_contact"`
+	EmergencyContact  string `json:"emergency_contact"`
+	RiskCeiling       string `json:"risk_ceiling"`
+	ExclusionsChecked bool   `json:"exclusions_checked"`
+}
+
 func toEngagementView(e *engdom.Engagement) engagementView {
 	if e == nil {
 		return engagementView{}
@@ -109,8 +120,14 @@ func toEngagementView(e *engdom.Engagement) engagementView {
 		AuthorizedTo:     e.AuthorizedTo,
 		Timezone:         e.Timezone,
 		LiveReconEnabled: e.LiveReconEnabled,
-		CreatedAt:        e.Audit.CreatedAt,
-		UpdatedAt:        e.Audit.UpdatedAt,
+		OffensiveRoE: offensiveRoEView{
+			CustomerContact:   e.CustomerContact,
+			EmergencyContact:  e.EmergencyContact,
+			RiskCeiling:       e.RiskCeiling,
+			ExclusionsChecked: e.ExclusionsChecked,
+		},
+		CreatedAt: e.Audit.CreatedAt,
+		UpdatedAt: e.Audit.UpdatedAt,
 	}
 }
 

--- a/internal/adapter/httpapi/resource_view_contract_test.go
+++ b/internal/adapter/httpapi/resource_view_contract_test.go
@@ -21,7 +21,7 @@ var wireContract = map[string][]string{
 	"engagementView": {
 		"id", "tenant_id", "project_id", "business_asset_id", "name", "client", "status",
 		"scope", "roe", "authorized_from", "authorized_to", "timezone", "live_recon_enabled",
-		"created_at", "updated_at",
+		"offensive_roe", "created_at", "updated_at",
 		// list enrichment, present only on listEngagements rows with the stores wired
 		"findings_count", "last_scan_date", "last_scan_status",
 	},
@@ -32,6 +32,7 @@ var wireContract = map[string][]string{
 	"engagementFindingsView": {"total", "critical", "high", "medium", "low", "info"},
 	"scopeView":              {"in_scope", "out_of_scope"},
 	"roeView":                {"allowed_tool_classes", "blackouts"},
+	"offensiveRoEView":       {"customer_contact", "emergency_contact", "risk_ceiling", "exclusions_checked"},
 	"blackoutView":           {"from", "to"},
 }
 

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -601,6 +601,7 @@ func (rt *Router) routes() *http.ServeMux {
 	mux.HandleFunc("PUT /api/v1/engagements/{id}/authorization-window", rt.authz(userdom.PermOperate, rt.setAuthorizationWindow))
 	mux.HandleFunc("PUT /api/v1/engagements/{id}/roe", rt.authz(userdom.PermOperate, rt.setRoE))
 	mux.HandleFunc("PUT /api/v1/engagements/{id}/live-recon", rt.authz(userdom.PermOperate, rt.setLiveRecon))
+	mux.HandleFunc("PUT /api/v1/engagements/{id}/offensive-roe", rt.authz(userdom.PermOperate, rt.setOffensiveRoE))
 	mux.HandleFunc("GET /api/v1/engagements/{id}/findings", rt.authz(userdom.PermView, rt.withEngTenant(rt.listFindings)))
 	mux.HandleFunc("POST /api/v1/engagements/{id}/findings", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.createFinding)))
 	if rt.detectionProvenance != nil {

--- a/internal/domain/engagement/engagement.go
+++ b/internal/domain/engagement/engagement.go
@@ -73,7 +73,49 @@ type Engagement struct {
 	// explicitly enabled per engagement. Default false (off).
 	LiveReconEnabled bool
 
+	// Offensive rules of engagement. The offensive governance policy (adversary emulation, exploitation
+	// chains) refuses ANY offensive action until these are set, so they gate the whole offensive pillar,
+	// not display. CustomerContact and EmergencyContact are who to reach when an action goes wrong;
+	// RiskCeiling is the highest risk class an action may carry ("low"/"medium"/"high"/"prohibited", empty
+	// = unset = offensive refused); ExclusionsChecked records that an operator reviewed the out-of-scope
+	// list, so an empty exclusion set means "nothing excluded" rather than "nobody looked".
+	CustomerContact   string
+	EmergencyContact  string
+	RiskCeiling       string
+	ExclusionsChecked bool
+
 	Audit shared.Audit
+}
+
+// RiskCeilingValues are the risk classes an engagement may set as its offensive ceiling. They mirror the
+// offensive-policy domain's RiskClass; the engagement stays decoupled by storing the value as a string and
+// letting the offensive-policy layer map and enforce it.
+var RiskCeilingValues = []string{"low", "medium", "high", "prohibited"}
+
+func validRiskCeiling(v string) bool {
+	for _, c := range RiskCeilingValues {
+		if v == c {
+			return true
+		}
+	}
+	return false
+}
+
+// SetOffensiveRoE sets the offensive rules of engagement and stamps UpdatedAt. Contacts are trimmed; an
+// empty contact clears it (which the offensive gate then refuses on). RiskCeiling must be one of
+// RiskCeilingValues or empty (empty leaves the offensive pillar refused). ExclusionsChecked is the
+// operator's explicit confirmation that the out-of-scope list was reviewed.
+func (e *Engagement) SetOffensiveRoE(customerContact, emergencyContact, riskCeiling string, exclusionsChecked bool, now time.Time) error {
+	riskCeiling = strings.TrimSpace(strings.ToLower(riskCeiling))
+	if riskCeiling != "" && !validRiskCeiling(riskCeiling) {
+		return fmt.Errorf("%w: risk_ceiling must be one of low, medium, high, prohibited", shared.ErrValidation)
+	}
+	e.CustomerContact = strings.TrimSpace(customerContact)
+	e.EmergencyContact = strings.TrimSpace(emergencyContact)
+	e.RiskCeiling = riskCeiling
+	e.ExclusionsChecked = exclusionsChecked
+	e.Audit.UpdatedAt = now
+	return nil
 }
 
 // SetLiveRecon toggles whether live reconnaissance may run for this engagement and

--- a/internal/domain/engagement/engagement_test.go
+++ b/internal/domain/engagement/engagement_test.go
@@ -163,3 +163,27 @@ func TestIsAuthorizedAt(t *testing.T) {
 		})
 	}
 }
+
+func TestSetOffensiveRoE(t *testing.T) {
+	e, err := New("e1", "t1", "Eng", "Client", time.Unix(1_700_000_000, 0).UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Unix(1_700_000_100, 0).UTC()
+	if err := e.SetOffensiveRoE("  Ops  ", " +1-555 ", "HIGH", true, now); err != nil {
+		t.Fatalf("SetOffensiveRoE: %v", err)
+	}
+	if e.CustomerContact != "Ops" || e.EmergencyContact != "+1-555" || e.RiskCeiling != "high" || !e.ExclusionsChecked {
+		t.Fatalf("fields not set/normalized: %+v", e)
+	}
+	if !e.Audit.UpdatedAt.Equal(now) {
+		t.Errorf("UpdatedAt not stamped: %v", e.Audit.UpdatedAt)
+	}
+	if err := e.SetOffensiveRoE("Ops", "+1", "bogus", true, now); err == nil {
+		t.Fatal("an unknown risk ceiling was accepted")
+	}
+	// Empty risk ceiling is allowed (leaves the offensive pillar refused, not a validation error).
+	if err := e.SetOffensiveRoE("Ops", "+1", "", false, now); err != nil {
+		t.Fatalf("empty risk ceiling rejected: %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/engagement_repo.go
+++ b/internal/infrastructure/persistence/postgres/engagement_repo.go
@@ -17,7 +17,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
-const engagementCols = `id, tenant_id, project_id, business_asset_id, name, client, status, authorized_from, authorized_to, created_at, updated_at, timezone, roe, live_recon, created_by, updated_by, host_asset_id`
+const engagementCols = `id, tenant_id, project_id, business_asset_id, name, client, status, authorized_from, authorized_to, created_at, updated_at, timezone, roe, live_recon, created_by, updated_by, host_asset_id, customer_contact, emergency_contact, risk_ceiling, exclusions_checked`
 
 // EngagementRepository persists engagements and their scope to PostgreSQL.
 type EngagementRepository struct{ pool *pgxpool.Pool }
@@ -43,10 +43,11 @@ func (r *EngagementRepository) Create(ctx context.Context, e *engagement.Engagem
 			return fmt.Errorf("marshal roe: %w", err)
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO engagements (`+engagementCols+`) VALUES ($1,$2,NULLIF($3,''),NULLIF($4,''),$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,NULLIF($17,''))`,
+			`INSERT INTO engagements (`+engagementCols+`) VALUES ($1,$2,NULLIF($3,''),NULLIF($4,''),$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,NULLIF($17,''),$18,$19,$20,$21)`,
 			e.ID.String(), tenantID.String(), e.ProjectID.String(), e.BusinessAssetID.String(), e.Name, e.Client, string(e.Status),
 			e.AuthorizedFrom, e.AuthorizedTo, e.Audit.CreatedAt, e.Audit.UpdatedAt, e.Timezone, roeJSON, e.LiveReconEnabled,
-			e.Audit.CreatedBy, e.Audit.UpdatedBy, e.HostAssetID.String()); err != nil {
+			e.Audit.CreatedBy, e.Audit.UpdatedBy, e.HostAssetID.String(),
+			e.CustomerContact, e.EmergencyContact, e.RiskCeiling, e.ExclusionsChecked); err != nil {
 			return fmt.Errorf("insert engagement: %w", err)
 		}
 
@@ -111,9 +112,10 @@ func (r *EngagementRepository) Update(ctx context.Context, e *engagement.Engagem
 			return fmt.Errorf("marshal roe: %w", err)
 		}
 		ct, err := tx.Exec(ctx,
-			`UPDATE engagements SET name=$2, client=$3, status=$4, authorized_from=$5, authorized_to=$6, timezone=$7, updated_at=$8, roe=$9, live_recon=$10, updated_by=$11, business_asset_id=NULLIF($12,'') WHERE id=$1`,
+			`UPDATE engagements SET name=$2, client=$3, status=$4, authorized_from=$5, authorized_to=$6, timezone=$7, updated_at=$8, roe=$9, live_recon=$10, updated_by=$11, business_asset_id=NULLIF($12,''), customer_contact=$13, emergency_contact=$14, risk_ceiling=$15, exclusions_checked=$16 WHERE id=$1`,
 			e.ID.String(), e.Name, e.Client, string(e.Status),
-			e.AuthorizedFrom, e.AuthorizedTo, e.Timezone, e.Audit.UpdatedAt, roeJSON, e.LiveReconEnabled, e.Audit.UpdatedBy, e.BusinessAssetID.String())
+			e.AuthorizedFrom, e.AuthorizedTo, e.Timezone, e.Audit.UpdatedAt, roeJSON, e.LiveReconEnabled, e.Audit.UpdatedBy, e.BusinessAssetID.String(),
+			e.CustomerContact, e.EmergencyContact, e.RiskCeiling, e.ExclusionsChecked)
 		if err != nil {
 			return fmt.Errorf("update engagement: %w", err)
 		}
@@ -433,7 +435,7 @@ func scanEngagement(row rowScanner) (*engagement.Engagement, error) {
 		af, at                     pgtype.Timestamptz
 		roeJSON                    []byte
 	)
-	if err := row.Scan(&idStr, &ten, &projectID, &businessAssetID, &e.Name, &e.Client, &st, &af, &at, &e.Audit.CreatedAt, &e.Audit.UpdatedAt, &e.Timezone, &roeJSON, &e.LiveReconEnabled, &e.Audit.CreatedBy, &e.Audit.UpdatedBy, &hostAssetID); err != nil {
+	if err := row.Scan(&idStr, &ten, &projectID, &businessAssetID, &e.Name, &e.Client, &st, &af, &at, &e.Audit.CreatedAt, &e.Audit.UpdatedAt, &e.Timezone, &roeJSON, &e.LiveReconEnabled, &e.Audit.CreatedBy, &e.Audit.UpdatedBy, &hostAssetID, &e.CustomerContact, &e.EmergencyContact, &e.RiskCeiling, &e.ExclusionsChecked); err != nil {
 		return nil, err
 	}
 	if len(roeJSON) > 0 {

--- a/internal/infrastructure/persistence/postgres/migration_0135_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0135_test.go
@@ -1,0 +1,75 @@
+package postgres
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+// TestMigration0135EngagementOffensiveRoE round-trips the offensive rules-of-engagement columns through
+// the engagement repository and asserts the risk_ceiling CHECK constraint rejects an unknown class.
+func TestMigration0135EngagementOffensiveRoE(t *testing.T) {
+	dsn := testDSN(t)
+	ctx := context.Background()
+	if err := MigrateLocked(ctx, dsn); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+
+	suffix := randHex(t)
+	tenant := shared.ID("t-0135-" + suffix)
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants (id, name) VALUES ($1,$1) ON CONFLICT DO NOTHING`, tenant.String()); err != nil {
+		t.Fatalf("seed tenant: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM scope_targets WHERE tenant_id=$1`, tenant.String())
+		_, _ = pool.Exec(ctx, `DELETE FROM engagements WHERE tenant_id=$1`, tenant.String())
+		_, _ = pool.Exec(ctx, `DELETE FROM tenants WHERE id=$1`, tenant.String())
+	})
+
+	repo := NewEngagementRepository(pool)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	eng, err := engagement.New(shared.ID("eng-0135-"+suffix), tenant, "RoE Eng", "Client", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := eng.SetOffensiveRoE("Ops <ops@client.test>", "+1-555-0100", "high", true, now); err != nil {
+		t.Fatal(err)
+	}
+	tctx := shared.WithTenant(ctx, tenant)
+	if err := repo.Create(tctx, eng); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := repo.GetByIDInTenant(tctx, tenant, eng.ID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got.CustomerContact != "Ops <ops@client.test>" || got.EmergencyContact != "+1-555-0100" || got.RiskCeiling != "high" || !got.ExclusionsChecked {
+		t.Fatalf("RoE did not round-trip: %+v", got)
+	}
+	// Update path persists a change too.
+	if err := got.SetOffensiveRoE("Ops2", "+1-555-0200", "medium", true, now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Update(tctx, got); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	again, _ := repo.GetByIDInTenant(tctx, tenant, eng.ID)
+	if again.RiskCeiling != "medium" || again.CustomerContact != "Ops2" {
+		t.Fatalf("RoE update did not persist: %+v", again)
+	}
+
+	// The CHECK constraint rejects an unknown risk class on a direct write.
+	_, cerr := pool.Exec(ctx, `UPDATE engagements SET risk_ceiling='bogus' WHERE id=$1`, eng.ID.String())
+	if cerr == nil || !strings.Contains(strings.ToLower(cerr.Error()), "risk_ceiling") {
+		t.Fatalf("risk_ceiling CHECK did not reject an unknown class: %v", cerr)
+	}
+}

--- a/internal/usecase/engagement/service.go
+++ b/internal/usecase/engagement/service.go
@@ -237,6 +237,34 @@ func (s *Service) SetLiveRecon(ctx context.Context, actor string, tenantID, id s
 	return &cp, nil
 }
 
+// SetOffensiveRoE records the offensive rules of engagement (customer + emergency contact, risk ceiling,
+// exclusions reviewed) that the offensive governance policy requires before adversary emulation or
+// exploitation chains may run. It is tenant-scoped through the repository, so a cross-tenant write returns
+// ErrNotFound. Validation of the fields (risk ceiling in range) lives on the domain mutator.
+func (s *Service) SetOffensiveRoE(ctx context.Context, actor string, tenantID, id shared.ID, customerContact, emergencyContact, riskCeiling string, exclusionsChecked bool) (*domain.Engagement, error) {
+	if err := requireActor(actor); err != nil {
+		return nil, err
+	}
+	e, err := s.repo.GetByIDInTenant(ctx, tenantID, id)
+	if err != nil {
+		return nil, err
+	}
+	now := s.clock.Now()
+	cp := *e
+	if err := cp.SetOffensiveRoE(customerContact, emergencyContact, riskCeiling, exclusionsChecked, now); err != nil {
+		return nil, err
+	}
+	cp.Audit.UpdatedBy = actor
+	if err := s.repo.Update(ctx, &cp); err != nil {
+		return nil, fmt.Errorf("persist offensive roe: %w", err)
+	}
+	meta := map[string]string{"risk_ceiling": cp.RiskCeiling, "exclusions_checked": strconv.FormatBool(cp.ExclusionsChecked)}
+	if err := s.auditChange(ctx, actor, "engagement.offensive_roe.update", id, meta, now); err != nil {
+		return nil, err
+	}
+	return &cp, nil
+}
+
 func (s *Service) SetRoE(ctx context.Context, actor string, tenantID, id shared.ID, roe domain.RoE) (*domain.Engagement, error) {
 	if err := requireActor(actor); err != nil {
 		return nil, err

--- a/internal/usecase/engagement/service_test.go
+++ b/internal/usecase/engagement/service_test.go
@@ -383,3 +383,31 @@ func TestEngagementTenantIsolation(t *testing.T) {
 		t.Errorf("cross-tenant SetLiveRecon must be ErrNotFound, got %v", err)
 	}
 }
+
+func TestSetOffensiveRoE(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
+	repo := newMemRepo()
+	audit := &capAudit{}
+	svc := NewService(repo, fixedClock{now}, fixedIDs{}, audit)
+	e, err := svc.Create(ctx, CreateInput{Name: "Acme", Client: "Acme"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// An unknown risk ceiling is refused.
+	if _, err := svc.SetOffensiveRoE(ctx, "op", "", e.ID, "Ops", "+1", "bogus", true); !errors.Is(err, shared.ErrValidation) {
+		t.Errorf("unknown risk ceiling must be refused, got %v", err)
+	}
+	// A complete RoE is persisted.
+	got, err := svc.SetOffensiveRoE(ctx, "op", "", e.ID, "Ops", "+1", "high", true)
+	if err != nil {
+		t.Fatalf("SetOffensiveRoE: %v", err)
+	}
+	if got.CustomerContact != "Ops" || got.RiskCeiling != "high" || !got.ExclusionsChecked || got.Audit.UpdatedBy != "op" {
+		t.Fatalf("RoE not persisted: %+v", got)
+	}
+	// A cross-tenant write cannot see the engagement.
+	if _, err := svc.SetOffensiveRoE(ctx, "mallory", shared.ID("tenant-B"), e.ID, "X", "Y", "low", true); !errors.Is(err, shared.ErrNotFound) {
+		t.Errorf("cross-tenant SetOffensiveRoE must be ErrNotFound, got %v", err)
+	}
+}

--- a/migrations/0135_engagement_offensive_roe.sql
+++ b/migrations/0135_engagement_offensive_roe.sql
@@ -1,0 +1,20 @@
+-- +goose Up
+-- Offensive rules of engagement on the engagement aggregate. The offensive governance policy (#418)
+-- refuses adversary emulation and exploitation chains until an engagement declares who to contact when an
+-- action goes wrong (customer_contact, emergency_contact), the highest risk class an action may carry
+-- (risk_ceiling), and that the out-of-scope list was reviewed (exclusions_checked). Backward-compatible:
+-- every column defaults to the "unset" value, which the policy then refuses on, so existing engagements
+-- keep working and simply cannot run offensive actions until an operator fills the RoE in.
+ALTER TABLE engagements ADD COLUMN customer_contact   TEXT    NOT NULL DEFAULT '';
+ALTER TABLE engagements ADD COLUMN emergency_contact  TEXT    NOT NULL DEFAULT '';
+ALTER TABLE engagements ADD COLUMN risk_ceiling       TEXT    NOT NULL DEFAULT '';
+ALTER TABLE engagements ADD COLUMN exclusions_checked BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE engagements ADD CONSTRAINT engagements_risk_ceiling_valid
+    CHECK (risk_ceiling IN ('', 'low', 'medium', 'high', 'prohibited'));
+
+-- +goose Down
+ALTER TABLE engagements DROP CONSTRAINT IF EXISTS engagements_risk_ceiling_valid;
+ALTER TABLE engagements DROP COLUMN IF EXISTS exclusions_checked;
+ALTER TABLE engagements DROP COLUMN IF EXISTS risk_ceiling;
+ALTER TABLE engagements DROP COLUMN IF EXISTS emergency_contact;
+ALTER TABLE engagements DROP COLUMN IF EXISTS customer_contact;

--- a/web/src/lib/api.contract.test.ts
+++ b/web/src/lib/api.contract.test.ts
@@ -101,6 +101,7 @@ describe('engagement wire contract', () => {
         blackouts: [{ from: '2026-09-06T00:00:00Z', to: '2026-09-07T00:00:00Z' }],
       },
       liveReconEnabled: true,
+      offensiveRoe: { customerContact: '', emergencyContact: '', riskCeiling: '', exclusionsChecked: false },
       createdAt: '2026-09-05T02:56:56.617935338Z',
       businessAssetId: 'ba-77',
       findingsCount: undefined,

--- a/web/src/lib/api/engagements.ts
+++ b/web/src/lib/api/engagements.ts
@@ -39,6 +39,12 @@ function mapEngagement(r: EngagementWire): Engagement {
       blackouts: (r.roe?.blackouts ?? []).map((b) => ({ from: b?.from ?? '', to: b?.to ?? '' })),
     },
     liveReconEnabled: r.live_recon_enabled ?? false,
+    offensiveRoe: {
+      customerContact: r.offensive_roe?.customer_contact ?? '',
+      emergencyContact: r.offensive_roe?.emergency_contact ?? '',
+      riskCeiling: r.offensive_roe?.risk_ceiling ?? '',
+      exclusionsChecked: r.offensive_roe?.exclusions_checked ?? false,
+    },
     createdAt: r.created_at ?? null,
     businessAssetId: r.business_asset_id ?? '',
     // Optional list-view enrichment; stays undefined when the API omits it.
@@ -116,6 +122,27 @@ export const engagementsApi = {
       await req(`/engagements/${encodeURIComponent(id)}/authorization-window`, {
         method: 'PUT',
         body: JSON.stringify({ authorized_from: authorizedFrom, authorized_to: authorizedTo, timezone }),
+      }),
+    ),
+
+  setOffensiveRoE: async (
+    id: string,
+    roe: {
+      customerContact: string
+      emergencyContact: string
+      riskCeiling: string
+      exclusionsChecked: boolean
+    },
+  ): Promise<Engagement> =>
+    mapEngagement(
+      await req(`/engagements/${encodeURIComponent(id)}/offensive-roe`, {
+        method: 'PUT',
+        body: JSON.stringify({
+          customer_contact: roe.customerContact,
+          emergency_contact: roe.emergencyContact,
+          risk_ceiling: roe.riskCeiling,
+          exclusions_checked: roe.exclusionsChecked,
+        }),
       }),
     ),
 

--- a/web/src/lib/api/wire.ts
+++ b/web/src/lib/api/wire.ts
@@ -47,6 +47,12 @@ export interface EngagementWire {
   authorized_to: string | null
   timezone?: string
   live_recon_enabled: boolean
+  offensive_roe?: {
+    customer_contact?: string
+    emergency_contact?: string
+    risk_ceiling?: string
+    exclusions_checked?: boolean
+  }
   created_at: string
   updated_at: string
   /** List-view enrichment. Not part of `engagementView`; present only where the API adds it. */
@@ -96,6 +102,7 @@ export const ENGAGEMENT_WIRE_KEYS = [
   'authorized_to',
   'timezone',
   'live_recon_enabled',
+  'offensive_roe',
   'created_at',
   'updated_at',
   // List enrichment (listEngagements): present only on list rows with the stores wired.

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -43,6 +43,14 @@ export interface Capability {
   requires: string[]
 }
 
+/** Offensive rules of engagement. riskCeiling is '' | 'low' | 'medium' | 'high' | 'prohibited'. */
+export interface OffensiveRoe {
+  customerContact: string
+  emergencyContact: string
+  riskCeiling: string
+  exclusionsChecked: boolean
+}
+
 export interface Engagement {
   id: string
   name: string
@@ -54,6 +62,9 @@ export interface Engagement {
   authorizedTo: string | null
   roe: RoE
   liveReconEnabled: boolean
+  /** Offensive rules of engagement the governance policy requires before emulation / exploitation.
+   *  Always populated by mapEngagement from the API; optional here so lightweight fixtures may omit it. */
+  offensiveRoe?: OffensiveRoe
   createdAt: string | null
   businessAssetId: string
   /** List-view enrichment. Absent unless the API includes it; the Engagements

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -149,7 +149,7 @@ const CAPABILITIES = [
 export const ENGAGEMENTS = [
   { id: 'eng-001', tenant_id: 'tenant-dev', project_id: '', business_asset_id: 'ba-001', name: 'synapse-ce-audit', client: 'Internal', status: 'active', findings_count: { total: 45, critical: 4, high: 12, medium: 19, low: 10, info: 0 }, last_scan_date: HOUR_AGO, last_scan_status: 'succeeded', scope: { in_scope: [{ kind: 'repo', value: 'https://github.com/KKloudTarus/synapse-ce.git' }], out_of_scope: [] }, roe: { allowed_tool_classes: [], blackouts: [] }, authorized_from: MONTH_AGO, authorized_to: null, timezone: 'UTC', live_recon_enabled: false, created_at: MONTH_AGO, updated_at: MONTH_AGO },
   { id: 'eng-002', tenant_id: 'tenant-dev', project_id: '', business_asset_id: '', name: 'gin-framework-scan', client: 'OSS Review', status: 'completed', findings_count: { total: 3, critical: 0, high: 1, medium: 2, low: 0, info: 0 }, last_scan_date: WEEK_AGO, last_scan_status: 'succeeded', scope: { in_scope: [{ kind: 'repo', value: 'https://github.com/gin-gonic/gin.git' }], out_of_scope: [] }, roe: { allowed_tool_classes: [], blackouts: [] }, authorized_from: WEEK_AGO, authorized_to: null, timezone: 'UTC', live_recon_enabled: false, created_at: WEEK_AGO, updated_at: WEEK_AGO },
-  { id: 'eng-003', tenant_id: 'tenant-dev', project_id: '', business_asset_id: 'ba-002', name: 'api-pentest-q3', client: 'Acme Corp', status: 'active', findings_count: { total: 8, critical: 0, high: 2, medium: 4, low: 2, info: 0 }, last_scan_date: DAY_AGO, last_scan_status: 'failed', scope: { in_scope: [{ kind: 'domain', value: 'api.acme.io' }, { kind: 'url', value: 'https://api.acme.io/v2' }], out_of_scope: [{ kind: 'host', value: '10.0.0.0/8' }] }, roe: { allowed_tool_classes: ['scanner', 'fuzzer'], blackouts: [] }, authorized_from: WEEK_AGO, authorized_to: new Date(Date.now() + 30 * 86400_000).toISOString(), timezone: 'UTC', live_recon_enabled: true, created_at: WEEK_AGO, updated_at: WEEK_AGO },
+  { id: 'eng-003', tenant_id: 'tenant-dev', project_id: '', business_asset_id: 'ba-002', name: 'api-pentest-q3', client: 'Acme Corp', status: 'active', findings_count: { total: 8, critical: 0, high: 2, medium: 4, low: 2, info: 0 }, last_scan_date: DAY_AGO, last_scan_status: 'failed', scope: { in_scope: [{ kind: 'domain', value: 'api.acme.io' }, { kind: 'url', value: 'https://api.acme.io/v2' }], out_of_scope: [{ kind: 'host', value: '10.0.0.0/8' }] }, roe: { allowed_tool_classes: ['scanner', 'fuzzer'], blackouts: [] }, authorized_from: WEEK_AGO, authorized_to: new Date(Date.now() + 30 * 86400_000).toISOString(), timezone: 'UTC', live_recon_enabled: true, offensive_roe: { customer_contact: 'Alex Rivera <alex@acme.io>', emergency_contact: '+1-555-0142 (SOC)', risk_ceiling: 'high', exclusions_checked: true }, created_at: WEEK_AGO, updated_at: WEEK_AGO },
   { id: 'eng-004', tenant_id: 'tenant-dev', project_id: '', business_asset_id: 'ba-004', name: 'payment-gateway-review', client: 'Payments', status: 'active', findings_count: { total: 0, critical: 0, high: 0, medium: 0, low: 0, info: 0 }, last_scan_date: HOUR_AGO, last_scan_status: 'running', scope: { in_scope: [{ kind: 'repo', value: 'https://github.com/internal/payment-service.git' }], out_of_scope: [] }, roe: { allowed_tool_classes: [], blackouts: [] }, authorized_from: DAY_AGO, authorized_to: null, timezone: 'UTC', live_recon_enabled: false, created_at: DAY_AGO, updated_at: DAY_AGO },
   { id: 'eng-005', tenant_id: 'tenant-dev', project_id: '', business_asset_id: 'ba-005', name: 'auth-hardening', client: '', status: 'draft', scope: { in_scope: [{ kind: 'repo', value: 'https://github.com/internal/auth-service.git' }], out_of_scope: [] }, roe: { allowed_tool_classes: [], blackouts: [] }, authorized_from: null, authorized_to: null, timezone: 'UTC', live_recon_enabled: false, created_at: DAY_AGO, updated_at: DAY_AGO },
   { id: 'eng-006', tenant_id: 'tenant-dev', project_id: '', business_asset_id: '', name: 'mobile-app-scan', client: '', status: 'draft', scope: { in_scope: [{ kind: 'repo', value: 'https://github.com/internal/mobile-app.git' }], out_of_scope: [] }, roe: { allowed_tool_classes: [], blackouts: [] }, authorized_from: null, authorized_to: null, timezone: 'UTC', live_recon_enabled: false, created_at: NOW, updated_at: NOW },
@@ -523,6 +523,21 @@ export const handlers = [
   http.patch('/api/v1/engagements/:id', ({ params }) => {
     const eng = ENGAGEMENTS.find(e => e.id === params.id) ?? ENGAGEMENTS[0]
     return HttpResponse.json(eng)
+  }),
+  http.put('/api/v1/engagements/:id/offensive-roe', async ({ params, request }) => {
+    const eng = ENGAGEMENTS.find(e => e.id === params.id) ?? ENGAGEMENTS[0]
+    const body = (await request.json()) as {
+      customer_contact?: string; emergency_contact?: string; risk_ceiling?: string; exclusions_checked?: boolean
+    }
+    return HttpResponse.json({
+      ...eng,
+      offensive_roe: {
+        customer_contact: body.customer_contact ?? '',
+        emergency_contact: body.emergency_contact ?? '',
+        risk_ceiling: body.risk_ceiling ?? '',
+        exclusions_checked: body.exclusions_checked ?? false,
+      },
+    })
   }),
 
   // --- Engagement Findings (raw PascalCase array -- mapFinding expects this) ---

--- a/web/src/pages/EngagementDetail/OffensiveRoeCard.test.tsx
+++ b/web/src/pages/EngagementDetail/OffensiveRoeCard.test.tsx
@@ -1,0 +1,74 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import type { Engagement } from '../../lib/types'
+import { OffensiveRoeCard } from './SettingsTab'
+
+vi.mock('../../lib/api', () => ({
+  api: { setOffensiveRoE: vi.fn() },
+}))
+
+function engagement(over: Partial<Engagement> = {}): Engagement {
+  return {
+    id: 'eng-1',
+    name: 'Acme pentest',
+    client: 'Acme',
+    status: 'active',
+    inScope: [{ kind: 'domain', value: 'app.test' }],
+    outOfScope: [],
+    authorizedFrom: '2026-09-01T00:00:00Z',
+    authorizedTo: '2026-10-01T00:00:00Z',
+    roe: { allowedToolClasses: [], blackouts: [] },
+    liveReconEnabled: false,
+    offensiveRoe: { customerContact: '', emergencyContact: '', riskCeiling: '', exclusionsChecked: false },
+    createdAt: '2026-09-01T00:00:00Z',
+    businessAssetId: '',
+    ...over,
+  }
+}
+
+describe('OffensiveRoeCard', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('shows Incomplete and lists what is missing when the RoE is unset', () => {
+    render(<OffensiveRoeCard eng={engagement()} onUpdated={vi.fn()} />)
+    expect(screen.getByText('Incomplete')).toBeInTheDocument()
+    expect(screen.getByText(/customer contact/)).toBeInTheDocument()
+    expect(screen.getByText(/risk ceiling/)).toBeInTheDocument()
+  })
+
+  it('shows Offensive ready when the RoE, window and scope are all set', () => {
+    render(
+      <OffensiveRoeCard
+        eng={engagement({
+          offensiveRoe: { customerContact: 'Ops', emergencyContact: '+1', riskCeiling: 'high', exclusionsChecked: true },
+        })}
+        onUpdated={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('Offensive ready')).toBeInTheDocument()
+  })
+
+  it('saves the entered rules of engagement through the API', async () => {
+    const updated = engagement({
+      offensiveRoe: { customerContact: 'Ops', emergencyContact: '+1', riskCeiling: 'high', exclusionsChecked: true },
+    })
+    vi.mocked(api.setOffensiveRoE).mockResolvedValue(updated)
+    const onUpdated = vi.fn()
+    render(<OffensiveRoeCard eng={engagement()} onUpdated={onUpdated} />)
+
+    fireEvent.change(screen.getByLabelText('Customer contact'), { target: { value: 'Ops' } })
+    fireEvent.change(screen.getByLabelText('Emergency contact'), { target: { value: '+1' } })
+    fireEvent.click(screen.getByRole('checkbox', { name: /out-of-scope list was reviewed/i }))
+    fireEvent.click(screen.getByRole('button', { name: /save rules/i }))
+
+    await waitFor(() => expect(api.setOffensiveRoE).toHaveBeenCalledTimes(1))
+    expect(api.setOffensiveRoE).toHaveBeenCalledWith('eng-1', {
+      customerContact: 'Ops',
+      emergencyContact: '+1',
+      riskCeiling: '',
+      exclusionsChecked: true,
+    })
+    await waitFor(() => expect(onUpdated).toHaveBeenCalledWith(updated))
+  })
+})

--- a/web/src/pages/EngagementDetail/SettingsTab.tsx
+++ b/web/src/pages/EngagementDetail/SettingsTab.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { AlertTriangle, Plus, Save01, Trash01 } from '@untitledui/icons'
 import { Button, Card, ErrorState, Field, Input, Pill, Select, cn } from '../../components/ui'
+import { Checkbox } from '../../components/base/checkbox/checkbox'
 import { ConfirmDialog } from '../../components/synapse/ConfirmDialog'
 import { useToast } from '../../components/synapse/Toast'
 import { useFetch } from '../../hooks'
@@ -18,6 +19,7 @@ export function SettingsTab({ eng, onUpdated }: { eng: Engagement; onUpdated: (e
       <ScopeEditorCard eng={eng} onUpdated={onUpdated} />
       <WindowEditorCard eng={eng} onUpdated={onUpdated} />
       <RoeEditorCard eng={eng} onUpdated={onUpdated} />
+      <OffensiveRoeCard eng={eng} onUpdated={onUpdated} />
       <LiveReconCard eng={eng} onUpdated={onUpdated} />
     </div>
   )
@@ -341,6 +343,143 @@ export function TargetList({
         <Plus className="size-3.5" /> Add target
       </button>
     </div>
+  )
+}
+
+const RISK_CEILINGS = [
+  { value: '', label: 'Unset (offensive actions refused)' },
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'prohibited', label: 'Prohibited (no offensive actions)' },
+]
+
+// OffensiveRoeCard captures the rules of engagement the offensive governance policy requires before
+// adversary emulation or exploitation chains may run. The readiness pill mirrors the policy's own
+// required-field check, so an operator sees at a glance why offensive actions would be refused.
+export function OffensiveRoeCard({ eng, onUpdated }: { eng: Engagement; onUpdated: (e: Engagement) => void }) {
+  const roe = eng.offensiveRoe ?? { customerContact: '', emergencyContact: '', riskCeiling: '', exclusionsChecked: false }
+  const [customer, setCustomer] = useState(roe.customerContact)
+  const [emergency, setEmergency] = useState(roe.emergencyContact)
+  const [ceiling, setCeiling] = useState(roe.riskCeiling)
+  const [checked, setChecked] = useState(roe.exclusionsChecked)
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const [saved, setSaved] = useState(false)
+
+  useEffect(() => {
+    setCustomer(roe.customerContact)
+    setEmergency(roe.emergencyContact)
+    setCeiling(roe.riskCeiling)
+    setChecked(roe.exclusionsChecked)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [eng.id])
+
+  // Readiness mirrors the offensive policy's required fields: RoE fields here plus the window and scope
+  // captured in the other cards.
+  const windowSet = !!eng.authorizedFrom && !!eng.authorizedTo
+  const scopeSet = eng.inScope.length > 0
+  const roeComplete =
+    roe.customerContact !== '' && roe.emergencyContact !== '' && roe.riskCeiling !== '' && roe.exclusionsChecked
+  const ready = roeComplete && windowSet && scopeSet
+
+  const missing: string[] = []
+  if (roe.customerContact === '') missing.push('customer contact')
+  if (roe.emergencyContact === '') missing.push('emergency contact')
+  if (roe.riskCeiling === '') missing.push('risk ceiling')
+  if (!roe.exclusionsChecked) missing.push('exclusions review')
+  if (!windowSet) missing.push('authorization window')
+  if (!scopeSet) missing.push('in-scope target')
+
+  async function save() {
+    setBusy(true)
+    setErr(null)
+    setSaved(false)
+    try {
+      onUpdated(
+        await api.setOffensiveRoE(eng.id, {
+          customerContact: customer.trim(),
+          emergencyContact: emergency.trim(),
+          riskCeiling: ceiling,
+          exclusionsChecked: checked,
+        }),
+      )
+      setSaved(true)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to save rules of engagement')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Card
+      title="Offensive rules of engagement"
+      actions={
+        <div className="flex items-center gap-2">
+          <Pill className={ready ? 'text-success-primary' : 'text-warning-primary'}>
+            {ready ? 'Offensive ready' : 'Incomplete'}
+          </Pill>
+          <Button loading={busy} onClick={save} variant="secondary-color" className="px-3 py-1.5">
+            <Save01 className="size-4" /> Save rules
+          </Button>
+        </div>
+      }
+    >
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Field label="Customer contact" hint="Who to reach on the customer side">
+          <Input
+            value={customer}
+            onChange={(e) => setCustomer(e.target.value)}
+            placeholder="Name <email> / phone"
+            aria-label="Customer contact"
+          />
+        </Field>
+        <Field label="Emergency contact" hint="Out-of-hours contact">
+          <Input
+            value={emergency}
+            onChange={(e) => setEmergency(e.target.value)}
+            placeholder="Name <email> / phone"
+            aria-label="Emergency contact"
+          />
+        </Field>
+        <Field label="Risk ceiling" hint="Highest risk class an action may carry">
+          <Select
+            value={ceiling}
+            onValueChange={setCeiling}
+            size="sm"
+            aria-label="Risk ceiling"
+            options={RISK_CEILINGS}
+          />
+        </Field>
+        <Field label="Excluded assets reviewed">
+          <div className="pt-1.5">
+            <Checkbox
+              isSelected={checked}
+              onChange={setChecked}
+              label="The out-of-scope list was reviewed"
+            />
+          </div>
+        </Field>
+      </div>
+      {!ready && (
+        <div className="mt-4 flex items-start gap-2 rounded-xl border border-warning-primary/40 bg-warning-primary/10 p-3">
+          <AlertTriangle className="mt-0.5 size-4 shrink-0 text-warning-primary" aria-hidden="true" />
+          <div className="text-xs">
+            <span className="font-semibold text-warning-primary">Offensive actions blocked.</span>{' '}
+            <span className="text-secondary">
+              Adversary emulation and exploitation chains are refused until this engagement's rules of
+              engagement, authorization window and scope are complete.
+            </span>
+            <div className="mt-1.5 text-secondary">
+              <span className="font-medium text-primary">Missing:</span> {missing.join(', ')}
+            </div>
+          </div>
+        </div>
+      )}
+      {saved && <p className="mt-2 text-[11px] text-success-primary">Rules of engagement saved.</p>}
+      {err && <p className="mt-2 text-[11px] text-error-primary">{err}</p>}
+    </Card>
   )
 }
 


### PR DESCRIPTION
Stacked on #834 (base `feat/dast-worker-path`); retarget to `main` once that merges.

## Why

A reachability audit found the offensive/purple pillar (adversary emulation, purple-team coverage, chained exploitation) advertised on the front page and feature guide but unreachable end-to-end. The root cause is here: the offensive governance policy (`internal/usecase/offensivepolicy`) refuses any offensive action until an engagement declares its rules of engagement, and the `Engagement` aggregate did not carry them. The engines, stores, and admitter exist; nothing could authorize a step. This is the keystone that unblocks the pillar.

## What

The `Engagement` aggregate gains the four fields the policy requires: `CustomerContact`, `EmergencyContact`, `RiskCeiling` (`low`/`medium`/`high`/`prohibited`), and `ExclusionsChecked`.

- **API**: `PUT /api/v1/engagements/{id}/offensive-roe` (operate-gated, tenant-scoped, audited) sets them; every engagement response returns them under `offensive_roe` (documented in both the request and the `Engagement` response schema).
- **Persistence**: migration `0135` adds the columns backward-compatibly (defaults leave the pillar refused until an operator fills them in) with a `risk_ceiling` CHECK matching the domain's allowed values. Postgres and memory repos round-trip the fields.
- **UI**: an "Offensive rules of engagement" card on the engagement Settings tab captures the fields with a readiness pill and a blocking callout that lists exactly what is still missing.

The domain mutator validates the risk ceiling and normalizes input; the offensive policy's own missing-field check remains the single source of truth for what an offensive action requires, so an incomplete engagement is still refused server-side.

Complexity: each store op is O(1) on the engagement primary key.

## Not in this PR

The `engagement → offensivepolicy.RulesOfEngagement` mapping and the enforcement wiring land in the emulation vertical that consumes them, so this PR ships no dead code. The real host executor for exploitation stays a deliberate, documented extension point; the pillar is wired with no-host simulation executors, matching the response subsystem (#425).

## Verification

Independent QA and security review both pass (tenant isolation on write verified, cross-tenant `PUT` returns 404 and is now guarded by the hostile harness; RLS; governance non-bypass; migration integrity and column ordering; no injection; contacts never logged). The new UI was viewed in a running browser in light and dark, in both the ready and incomplete states, and scored by an external review, then polished (prominent blocking callout, scannable missing-fields list, design-system checkbox). `make build vet test`, migration `0135` against Postgres, the hostile harness, `pnpm build`, `pnpm typecheck`, and 520 web tests all green.
