### PR TITLE
feat(governance): enforce regional residency and encryption-at-rest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
             exit 1
           fi
 
+      - name: Check AWS staging security and data-governance invariants
+        run: bash deploy/aws/staging/tests/static.sh
+
       - name: Build
         run: go build ./...
 

--- a/deploy/aws/staging/README.md
+++ b/deploy/aws/staging/README.md
@@ -14,6 +14,29 @@ The remote state reveals infrastructure metadata and can contain provider-manage
 
 The wrappers initialize the configured remote backend but never create a backend. `provision.sh` refuses to apply without an explicit confirmation. `teardown.sh` also refuses to destroy until the supplied `expires_at` has passed and a second explicit confirmation is supplied.
 
+## Regional residency and encryption at rest
+
+This stack is the reference implementation for the remaining deployment controls in privacy/data-governance issue #635. It is deliberately **single-region**: `aws_region` is validated as `us-east-1`, the AWS provider consumes only that value, and the configured Availability Zones must belong to the same region. PostgreSQL, the evidence bucket, ECR, EKS, and the native execution-worker tier are therefore created in one governed region. This stack creates no cross-region replica, replication rule, or secondary datastore. A deployment that needs another residency boundary must use a separate environment/state/backend in that region rather than sharing this state.
+
+Durable storage is encrypted with one customer-managed, rotating KMS key owned by this stack:
+
+- RDS PostgreSQL sets `storage_encrypted = true` and uses the governed KMS key; its managed master secret and Performance Insights data use the same key.
+- The evidence S3 bucket uses SSE-KMS with the governed key and bucket-key support.
+- The private ECR repository uses KMS encryption with the governed key.
+- Native worker root EBS volumes are encrypted with the governed key.
+
+The static test fails if any of those resources falls back to provider-default encryption or loses the shared key binding. Verify the source posture with:
+
+```bash
+./scripts/test.sh
+terraform output deployment_region
+terraform output data_kms_key_arn
+```
+
+`deployment_region` and `data_kms_key_arn` are non-secret evidence outputs intended for deployment review. They do not prove the state of a separately managed backend or an external service that is not created by this stack; those must be governed and audited independently.
+
+The Helm production chart complements this infrastructure boundary: its API/data-processing placement must carry `topology.kubernetes.io/region`, its migration Job inherits that region, and in-cluster execution is rejected if its region differs. Database traffic remains `sslmode=verify-full`, object-store transport requires TLS in production, and the public ingress terminates TLS.
+
 ## Private worker grant authority
 
 Terraform places the native Auto Scaling Group in dedicated private worker subnets and creates a dedicated frontend security group for the internal egress-grant NLB. Its only ingress rule references the native worker security group on TCP/443; it does not admit the shared private-subnet CIDRs. The NLB may forward only to the API pod port configured by `worker_grant_authority_backend_port`.

--- a/deploy/aws/staging/outputs.tf
+++ b/deploy/aws/staging/outputs.tf
@@ -1,3 +1,13 @@
+output "deployment_region" {
+  description = "Governed AWS region containing the staging control plane, PostgreSQL, evidence bucket, and native execution tier."
+  value       = var.aws_region
+}
+
+output "data_kms_key_arn" {
+  description = "Customer-managed rotating KMS key used by RDS, evidence S3, ECR, and native worker root volumes."
+  value       = aws_kms_key.staging.arn
+}
+
 output "eks_cluster_name" {
   description = "EKS cluster name."
   value       = aws_eks_cluster.staging.name

--- a/deploy/aws/staging/tests/static.sh
+++ b/deploy/aws/staging/tests/static.sh
@@ -26,6 +26,24 @@ for required in 'manage_master_user_password\s*=\s*true' 'storage_encrypted\s*=\
   perl -0777 -ne "BEGIN { \$found = 0 } \$found = 1 if /$required/; END { exit !\$found }" -- ./*.tf || fail "missing required security control: $required"
 done
 
+# #635 data-governance posture: all durable AWS data planes and native worker disks
+# use the same rotating customer-managed KMS key. Do not accept provider-default
+# encryption here because it would make key ownership and rotation unverifiable.
+for required in \
+  'resource\s+"aws_ecr_repository"\s+"app".*?encryption_type\s*=\s*"KMS".*?kms_key\s*=\s*aws_kms_key\.staging\.arn' \
+  'resource\s+"aws_s3_bucket_server_side_encryption_configuration"\s+"evidence".*?kms_master_key_id\s*=\s*aws_kms_key\.staging\.arn.*?sse_algorithm\s*=\s*"aws:kms"' \
+  'resource\s+"aws_db_instance"\s+"postgres".*?storage_encrypted\s*=\s*true.*?kms_key_id\s*=\s*aws_kms_key\.staging\.arn' \
+  'resource\s+"aws_launch_template"\s+"worker".*?encrypted\s*=\s*true.*?kms_key_id\s*=\s*aws_kms_key\.staging\.arn'; do
+  perl -0777 -ne "BEGIN { \$found = 0 } \$found = 1 if /$required/s; END { exit !\$found }" -- ./*.tf || fail "missing governed KMS wiring: $required"
+done
+
+# This reference stack is deliberately single-region. The provider consumes one validated
+# aws_region value and every configured AZ must belong to that same region. Cross-region
+# replication is therefore an explicit separate deployment, never an accidental default.
+grep -Fq 'region = var.aws_region' versions.tf || fail "AWS provider must use the governed aws_region variable"
+perl -0777 -ne 'exit !(/variable\s+"aws_region"\s*\{.*?condition\s*=\s*var\.aws_region\s*==\s*"us-east-1"/s)' variables.tf || fail "staging aws_region must remain explicitly constrained"
+perl -0777 -ne 'exit !(/variable\s+"availability_zones"\s*\{.*?startswith\(az,\s*"us-east-1"\)/s)' variables.tf || fail "availability zones must remain inside the governed region"
+
 for required in 'http_tokens\s*=\s*"required"' 'associate_public_ip_address\s*=\s*false' 'encrypted\s*=\s*true' 'AmazonSSMManagedInstanceCore' 'aws_autoscaling_group" "worker' 'aws_imagebuilder_image" "worker' 'referenced_security_group_id\s*=\s*aws_security_group.worker.id' 'aws_security_group" "grant_authority_nlb' 'aws_subnet" "worker' 'AWSServiceRoleForAutoScaling' 'kms:GrantIsForAWSResource'; do
   perl -0777 -ne "BEGIN { \$found = 0 } \$found = 1 if /$required/; END { exit !\$found }" -- ./*.tf || fail "missing native worker control: $required"
 done
@@ -39,4 +57,4 @@ grep -Fq 'update-ca-trust extract' worker.tf || fail "AMI must install the pinne
 grep -Fq 'worker_trust_anchor_sha256' worker.tf || fail "AMI must verify the private trust anchor digest"
 grep -Fq 'cidrhost(cidr, 4)' locals.tf || fail "grant NLB output must match the fixed private addresses assigned by Helm"
 
-printf '%s\n' 'static security checks passed'
+printf '%s\n' 'static security and data-governance checks passed'

--- a/deploy/helm/synapse/README.md
+++ b/deploy/helm/synapse/README.md
@@ -8,6 +8,7 @@ This chart deploys Synapse. `execution.mode` selects the tool-execution placemen
 - A Linux amd64 node runtime that permits unprivileged user namespaces. Bubblewrap is installed in the production image and Synapse supplies its own default-deny seccomp BPF filter. The chart does not request privileged mode, `SYS_ADMIN`, host networking, or host mounts.
 - Pre-created, split Secrets named by `existingSecrets` and a pre-created TLS Secret named by `ingress.tls.secretName`. The chart never renders Secret data.
 - Digest-qualified production images. Tags are rejected by `values.schema.json`.
+- For production execution modes, nodes in the control-plane data region must carry the standard `topology.kubernetes.io/region` label and `api.nodeSelector.topology.kubernetes.io/region` must select that governed region.
 
 ## First install
 
@@ -50,6 +51,32 @@ helm template synapse deploy/helm/synapse -f deploy/helm/synapse/values-dev.yaml
 
 Its image digests are the all-zero placeholders from `values.yaml`: they satisfy the schema and will not pull. Pass real digests on install. Replica counts stay at the schema floor of two API and two web replicas even in development, because a single replica cannot prove the rollout path the chart is built around.
 
+## Regional data-governance contract
+
+A production Helm release is a **single-tenant regional cell**. The API explicitly sets `SYNAPSE_SINGLE_TENANT=true`; serve a tenant from exactly one governed cell, and use a separate release, datastore, Terraform state/backend, and region when a different residency boundary is required. The chart does not route tenant data between regions inside one cell.
+
+Production modes (`externalNative` and `inClusterBroker`) must set `api.nodeSelector.topology.kubernetes.io/region` to the governed region containing the durable data plane. The migration Job automatically inherits that selector because schema changes operate on tenant-owned durable state. In `inClusterBroker`, the execution broker/worker selector must declare the **same** region; a mismatched or missing region fails Helm rendering.
+
+Helm cannot query the physical region or encryption configuration of an external PostgreSQL or S3-compatible endpoint. Operators must therefore place those services in the same governed region and verify their at-rest encryption outside the chart. `deploy/aws/staging` is the reference implementation: it provisions the database, evidence bucket, control plane and native worker tier from one AWS provider region and binds RDS, S3, ECR and worker EBS storage to one rotating customer-managed KMS key. Its static tests fail when that contract is weakened.
+
+The chart enforces the transport half of the boundary independently: production object-store traffic requires TLS, database DSNs use `sslmode=verify-full` with an operator-supplied CA, ingress uses a TLS Secret, and the native-worker grant authority is an internal TLS-terminating NLB.
+
+Example production placement:
+
+```yaml
+api:
+  nodeSelector:
+    synapse.example/runtime: control-plane
+    topology.kubernetes.io/region: us-east-1
+
+egressBroker:
+  nodeSelector:
+    synapse.dev/execution-node: "true"
+    topology.kubernetes.io/region: us-east-1
+```
+
+The second selector matters only for `inClusterBroker`. `externalNative` workers live outside Kubernetes; the supported AWS Terraform deployment keeps them in the same provider region instead.
+
 ## Install
 
 Copy the production test values as a starting point, replace only references and non-secret endpoints, and use your secret-management controller for the referenced Secrets:
@@ -68,6 +95,7 @@ The migration hook uses the separate owner DSN Secret. API and worker set `SYNAP
 helm lint --strict deploy/helm/synapse -f deploy/helm/synapse/tests/production-values.yaml
 helm template synapse deploy/helm/synapse -f deploy/helm/synapse/tests/production-values.yaml --kube-version 1.29.0
 (cd deploy/helm/synapse && sh testdata/render_test.sh)
+(cd deploy/helm/synapse && sh testdata/data_governance_test.sh)
 ```
 
 NetworkPolicy starts with namespace-wide default deny, allows ingress only from the configured ingress-controller namespace, permits DNS plus TLS/PostgreSQL egress, and grants HTTP/S recon egress only to the worker. Configure an FQDN-aware CNI or egress gateway with managed PostgreSQL/S3 and authorized-target allowlists before production use.

--- a/deploy/helm/synapse/templates/api.yaml
+++ b/deploy/helm/synapse/templates/api.yaml
@@ -50,6 +50,10 @@ spec:
             {{- end }}
           env:
             {{- include "synapse.runtimeEnv" . | nindent 12 }}
+            # A production Helm release is a single-tenant regional cell: tenant
+            # routing cannot move data across residency boundaries inside one cell.
+            - name: SYNAPSE_SINGLE_TENANT
+              value: "true"
             - name: SYNAPSE_HTTP_ADDR
               value: ":8080"
             - name: SYNAPSE_METRICS_ENABLED

--- a/deploy/helm/synapse/templates/data-governance.yaml
+++ b/deploy/helm/synapse/templates/data-governance.yaml
@@ -1,0 +1,21 @@
+{{- /*
+Production data-governance guard (#635).
+
+The chart cannot introspect an external PostgreSQL or S3-compatible service, so residency is
+anchored to the standard Kubernetes region label on the control-plane data-processing tier.
+The supported AWS deployment supplies the database, evidence bucket, and native execution tier
+from the same Terraform provider region and tests KMS encryption separately.
+*/ -}}
+{{- $mode := include "synapse.executionMode" . -}}
+{{- if or (eq $mode "externalNative") (eq $mode "inClusterBroker") -}}
+{{- $dataRegion := default "" (index .Values.api.nodeSelector "topology.kubernetes.io/region") | trim -}}
+{{- if eq $dataRegion "" -}}
+{{- fail "production execution.mode requires api.nodeSelector[\"topology.kubernetes.io/region\"] to pin the control-plane data-processing tier to its governed data region" -}}
+{{- end -}}
+{{- if eq $mode "inClusterBroker" -}}
+{{- $executionRegion := default "" (index .Values.egressBroker.nodeSelector "topology.kubernetes.io/region") | trim -}}
+{{- if ne $executionRegion $dataRegion -}}
+{{- fail (printf "execution.mode=inClusterBroker requires egressBroker.nodeSelector[\"topology.kubernetes.io/region\"]=%q to match the control-plane data region (got %q)" $dataRegion $executionRegion) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/synapse/templates/migration.yaml
+++ b/deploy/helm/synapse/templates/migration.yaml
@@ -1,3 +1,4 @@
+{{- $dataRegion := default "" (index .Values.api.nodeSelector "topology.kubernetes.io/region") | trim -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -22,6 +23,12 @@ spec:
       restartPolicy: Never
       serviceAccountName: {{ include "synapse.serviceAccountName" . }}
       automountServiceAccountToken: false
+      {{- if $dataRegion }}
+      # The migration job handles tenant-owned durable state, so keep it in the same
+      # governed region as the API rather than allowing the scheduler to place it freely.
+      nodeSelector:
+        topology.kubernetes.io/region: {{ $dataRegion | quote }}
+      {{- end }}
       securityContext:
         {{- include "synapse.podSecurityContext" . | nindent 8 }}
       containers:

--- a/deploy/helm/synapse/testdata/data_governance_test.sh
+++ b/deploy/helm/synapse/testdata/data_governance_test.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env sh
+set -eu
+chart_dir=$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)
+values="$chart_dir/tests/production-values.yaml"
+out=$(mktemp)
+trap 'rm -f "$out"' EXIT
+
+# A production deployment must declare one governed Kubernetes region for the
+# control-plane data-processing tier. The migration job must inherit that region.
+helm template synapse "$chart_dir" -f "$values" --kube-version 1.29.0 >"$out"
+grep -q 'topology.kubernetes.io/region: "us-east-1"' "$out"
+awk '
+  /^---$/ { kind=""; migrate=0; region=0; next }
+  /^kind: Job$/ { kind="Job" }
+  /app\.kubernetes\.io\/component: migrate/ { migrate=1 }
+  /topology\.kubernetes\.io\/region: "us-east-1"/ { region=1 }
+  { if (kind == "Job" && migrate && region) ok=1 }
+  END { exit ok ? 0 : 1 }
+' "$out" || {
+  printf '%s\n' 'expected the migration Job to inherit the governed data region' >&2
+  exit 1
+}
+
+# A regional cell is intentionally single-tenant. This makes tenant assignment a
+# deployment boundary rather than allowing one process to route data across regions.
+awk '/name: SYNAPSE_SINGLE_TENANT/{getline; if ($0 ~ /value: "true"/) ok=1} END{exit ok?0:1}' "$out"
+
+if helm template synapse "$chart_dir" -f "$values" --kube-version 1.29.0 \
+  --set 'api.nodeSelector.topology\.kubernetes\.io/region=' >/dev/null 2>&1; then
+  printf '%s\n' 'expected production render without a governed data region to fail' >&2
+  exit 1
+fi
+
+# In-cluster execution handles tenant data too, so its broker/worker region must
+# match the control-plane region exactly.
+if helm template synapse "$chart_dir" -f "$values" --kube-version 1.29.0 \
+  --set execution.mode=inClusterBroker \
+  --set egressBroker.enabled=true \
+  --set egressBroker.grantAuthorityURL=https://grant.internal.example \
+  --set egressBroker.grantPublicKey=Zm9vYmFyZm9vYmFyZm9vYmFyZm9vYmFyMzJieXRlcw== \
+  --set 'egressBroker.nodeSelector.topology\.kubernetes\.io/region=eu-west-1' >/dev/null 2>&1; then
+  printf '%s\n' 'expected cross-region in-cluster execution placement to fail' >&2
+  exit 1
+fi
+
+printf '%s\n' 'data governance chart checks passed'

--- a/deploy/helm/synapse/tests/chart_test.go
+++ b/deploy/helm/synapse/tests/chart_test.go
@@ -7,17 +7,21 @@ import (
 	"testing"
 )
 
-func TestProductionChartRendersWithRequiredSecurityPosture(t *testing.T) {
+func TestProductionChartSecurityAndDataGovernance(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("the shell chart test is covered by Helm CI on Linux")
+		t.Skip("the shell chart tests are covered by Helm CI on Linux")
 	}
 	chartDir, err := filepath.Abs("..")
 	if err != nil {
 		t.Fatal(err)
 	}
-	cmd := exec.Command("sh", filepath.Join(chartDir, "testdata", "render_test.sh"))
-	cmd.Dir = chartDir
-	if output, err := cmd.CombinedOutput(); err != nil {
-		t.Fatalf("chart render test failed: %v\n%s", err, output)
+	for _, script := range []string{"render_test.sh", "data_governance_test.sh"} {
+		t.Run(script, func(t *testing.T) {
+			cmd := exec.Command("sh", filepath.Join(chartDir, "testdata", script))
+			cmd.Dir = chartDir
+			if output, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("chart test %s failed: %v\n%s", script, err, output)
+			}
+		})
 	}
 }

--- a/deploy/helm/synapse/tests/production-values.yaml
+++ b/deploy/helm/synapse/tests/production-values.yaml
@@ -7,6 +7,7 @@ image:
 api:
   nodeSelector:
     synapse.example/runtime: control-plane
+    topology.kubernetes.io/region: us-east-1
   grantAuthority:
     enabled: true
     annotations:
@@ -29,6 +30,10 @@ web:
   image:
     repository: registry.example.invalid/synapse-web
     digest: sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+egressBroker:
+  nodeSelector:
+    synapse.dev/execution-node: "true"
+    topology.kubernetes.io/region: us-east-1
 objectStore:
   endpoint: s3.example.internal:443
   bucket: synapse-evidence


### PR DESCRIPTION
## Summary

Completes the remaining deployment/infrastructure work for #635: regional data residency and encryption-at-rest for the supported AWS/Helm deployment path.

The deployment contract is explicit: a production release is a single-tenant regional cell, and governed AWS data stores use the same rotating customer-managed KMS key.

## Changes

* Define the production Helm release as a single-tenant regional cell.
* Require the API data plane to be pinned with `topology.kubernetes.io/region`.
* Pin the migration Job to the same governed region.
* Reject an in-cluster execution tier configured for a different region.
* Set `SYNAPSE_SINGLE_TENANT=true` for production Helm deployments.
* Expose the AWS deployment region and governed KMS key as Terraform outputs.
* Verify RDS, evidence S3, ECR, and native-worker EBS use the governed customer-managed KMS key.
* Require KMS key rotation.
* Run the AWS staging security/data-governance invariant check in CI.
* Add Helm render/test coverage for the regional-cell rules.
* Document the single-tenant regional-cell residency and encryption contract.

## Verification

* Linux Go CI: **PASS**

  * AWS staging security/data-governance invariants
  * build
  * vet
  * `go test ./...`
  * PostgreSQL integration rerun
  * CGO-disabled build

* Frontend CI: **PASS**

  * tests
  * typecheck
  * build

### Existing baseline failures

The remaining red CI jobs reproduce failures already present on the exact `main` base and are unrelated to this PR:

* `golangci-lint`: the same six existing findings on `main`; none are in this PR's changed files.
* Windows Go test: existing `internal/infrastructure/acquire` failure:
  `TestGitAuthInjectsTokenViaAskpassNotArgv`
  (`git_private_auth_test.go:73`, Windows cannot find the generated `askpass` executable).

This PR does not modify those areas.

Closes #635
