### PR TITLE
feat(web): surface attack paths, SLA, offensive policy, and alerting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Attack paths, SLA policy, offensive policy, and alerting reach the dashboard.** Four capabilities
+  were wired non-nil in `cmd/synapse-api` but had no UI, so operators could not reach them. A new
+  **Attack paths** tab under Vulnerability Intelligence renders the exposure-to-finding graph
+  (`GET /attack-paths`) as an evidence-carrying chain per path with a confident/inferred verdict and the
+  reasons a path is uncertain. Three new Settings tabs cover the rest: **SLA policy** reads the active
+  scoring policy and lets an admin activate a new version (`GET`/`POST /sla/policies`) through an editor
+  that mirrors the server rules; **Offensive policy** renders the read-only technique register
+  (`GET /redteam/policy`) with risk class, blast radius, approval, and legal review; **Alerting** runs the
+  sink self-test (`POST /alerts/test`) and shows the per-count outcome, including the no-acknowledgement
+  (502) case.
+
+
 - **Chained exploitation is reachable as a governed rehearsal.** The exploitation state machine (per-step
   admission through the offensive policy, sealed per-step evidence, a distinct verifier, cleanup
   obligations) and its kill-switch registry existed and were tested, but nothing constructed a chain outside
@@ -40,6 +52,7 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
   `offensive_roe`. Migration `0135` adds the columns backward-compatibly (defaults leave the offensive
   pillar refused until an operator fills them in) with a `risk_ceiling` CHECK. This is the foundation the
   offensive/purple pillar (emulation, purple coverage, exploitation chains) needs to become reachable.
+
 
 - **Governed DAST verification runs execute on the worker (#823).** An approved DAST probe used to run on
   the API request thread. With the Postgres job queue it now runs as a durable, lease-executed job: the

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,6 +43,9 @@ const AITriageObservability = lazy(() => import('./pages/AITriage/AITriageObserv
 const VulnerabilityIntelligence = lazy(() => import('./pages/VulnerabilityIntelligence').then(m => ({ default: m.VulnerabilityIntelligence })))
 const VulnerabilityAdvisoryPage = lazy(() => import('./pages/VulnerabilityIntelligence/VulnIntelAdvisories').then(m => ({ default: m.VulnerabilityAdvisoryPage })))
 const Team = lazy(() => import('./pages/Settings/Team').then(m => ({ default: m.Team })))
+const SLAPolicy = lazy(() => import('./pages/Settings/SLAPolicy').then(m => ({ default: m.SLAPolicy })))
+const OffensivePolicy = lazy(() => import('./pages/Settings/OffensivePolicy').then(m => ({ default: m.OffensivePolicy })))
+const Alerting = lazy(() => import('./pages/Settings/Alerting').then(m => ({ default: m.Alerting })))
 const ProjectOverviewPage = lazy(() => import('./pages/CodeQuality/ProjectOverviewPage').then(m => ({ default: m.ProjectOverviewPage })))
 const ProjectAnalysisPage = lazy(() => import('./pages/CodeQuality/ProjectAnalysisPage').then(m => ({ default: m.ProjectAnalysisPage })))
 const ProjectActivityPage = lazy(() => import('./pages/CodeQuality/ProjectActivityPage').then(m => ({ default: m.ProjectActivityPage })))
@@ -110,6 +113,9 @@ function Gate() {
           <Route path="team" element={<Team />} />
           <Route path="connectors" element={<Connectors />} />
           <Route path="config" element={<SettingsConfig />} />
+          <Route path="sla" element={<SLAPolicy />} />
+          <Route path="offensive-policy" element={<OffensivePolicy />} />
+          <Route path="alerting" element={<Alerting />} />
         </Route>
         <Route path="audit" element={<Navigate to="/settings" replace />} />
         <Route path="team" element={<Navigate to="/settings/team" replace />} />

--- a/web/src/lib/api/alerting.test.ts
+++ b/web/src/lib/api/alerting.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { api, AlertNotEnabledError } from '.'
+
+describe('alerting testAlert', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+  function respond(body: unknown, status = 200) {
+    fetchSpy.mockResolvedValueOnce({ ok: status < 400, status, json: async () => body } as unknown as Response)
+  }
+
+  it('maps a 200 acknowledged outcome', async () => {
+    respond({ outcome: { matched: true, delivered: 2, failed: 0, audit_failed: 0 } })
+    const r = await api.testAlert()
+    expect(r.acknowledged).toBe(true)
+    expect(r.outcome).toEqual({ matched: true, delivered: 2, failed: 0, auditFailed: 0 })
+  })
+
+  it('reads the outcome from a 502 no-acknowledgement body', async () => {
+    respond({ error: 'no alert sink acknowledged the test alert', outcome: { matched: true, delivered: 0, failed: 3, audit_failed: 1 } }, 502)
+    const r = await api.testAlert()
+    expect(r.acknowledged).toBe(false)
+    expect(r.error).toContain('no alert sink acknowledged')
+    expect(r.outcome).toEqual({ matched: true, delivered: 0, failed: 3, auditFailed: 1 })
+  })
+
+  it('throws AlertNotEnabledError on 404', async () => {
+    respond({ error: 'not found' }, 404)
+    await expect(api.testAlert()).rejects.toBeInstanceOf(AlertNotEnabledError)
+  })
+})

--- a/web/src/lib/api/alerting.ts
+++ b/web/src/lib/api/alerting.ts
@@ -1,0 +1,60 @@
+import { ApiError, req } from './client'
+
+/**
+ * Operator alerting self-test. POST /alerts/test delivers one synthetic alert to every configured sink so
+ * an operator can prove the alert path works before relying on it. 200 with an Outcome when at least one
+ * sink acknowledged; 502 with the same Outcome plus an error when none did. `audit_failed` counts sinks
+ * that delivered but whose audit write failed. Route registers only when alerting is wired (a 404 means
+ * "not enabled"); the POST also requires the administer permission.
+ *
+ * SOURCE OF TRUTH: `internal/usecase/alerting/service.go` (`Outcome`), handler `alert_handler.go`.
+ */
+
+export interface AlertTestOutcome {
+  matched: boolean
+  delivered: number
+  failed: number
+  auditFailed: number
+}
+
+export interface AlertTestResult {
+  acknowledged: boolean
+  outcome: AlertTestOutcome
+  error?: string
+}
+
+function mapOutcome(o: any): AlertTestOutcome {
+  return {
+    matched: o?.matched === true,
+    delivered: o?.delivered ?? 0,
+    failed: o?.failed ?? 0,
+    auditFailed: o?.audit_failed ?? 0,
+  }
+}
+
+export class AlertNotEnabledError extends Error {
+  constructor() {
+    super('Alerting is not enabled in this deployment.')
+    this.name = 'AlertNotEnabledError'
+  }
+}
+
+export const alertingApi = {
+  /**
+   * Sends the synthetic test alert. Resolves with acknowledged=false and the outcome when the server
+   * answers 502 (no sink acknowledged), so the caller can render the per-sink counts either way. Throws
+   * AlertNotEnabledError on 404.
+   */
+  testAlert: async (): Promise<AlertTestResult> => {
+    try {
+      const r = await req('/alerts/test', { method: 'POST' })
+      return { acknowledged: true, outcome: mapOutcome(r?.outcome) }
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 404) throw new AlertNotEnabledError()
+      if (e instanceof ApiError && e.status === 502 && (e.body as { outcome?: unknown })?.outcome) {
+        return { acknowledged: false, outcome: mapOutcome((e.body as { outcome?: unknown }).outcome), error: e.message }
+      }
+      throw e
+    }
+  },
+}

--- a/web/src/lib/api/attackpaths.test.ts
+++ b/web/src/lib/api/attackpaths.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { api } from '.'
+
+// Exercises the REAL attackPaths mapper (page tests mock the barrel and never run it). Nested
+// asset.Asset / finding.Finding arrive PascalCase (no Go json tags); the mapper must read that.
+describe('attackPaths mapper', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+  function respond(body: unknown, status = 200) {
+    fetchSpy.mockResolvedValueOnce({ ok: status < 400, status, json: async () => body } as unknown as Response)
+  }
+
+  it('reads PascalCase asset/finding nodes and step evidence', async () => {
+    respond({
+      paths: [
+        {
+          id: 'ap-1',
+          confident: true,
+          uncertainties: [],
+          nodes: [
+            { asset: { asset: { ID: 'a-edge', TenantID: 't', Kind: 'host', Key: 'edge', Name: 'edge-gw-01' } } },
+            { finding: { input: { target: { ID: 'f-1', Kind: 'canonical' }, finding: { ID: 'f-1', Title: 'RCE', Severity: 'CRITICAL' }, reachability: 'reachable', confirmed: true, external: false } } },
+          ],
+          steps: [{ from: 'a-edge', to: 'f-1', kind: 'hosts', observed: true, toFinding: true, evidence: [{ producer: 'sca', provenance: 'ev', confidence: 'observed' }] }],
+        },
+      ],
+      bounds: { truncated: true, pathsHit: true, lengthHit: false, wallClockHit: false, maxLength: 8, maxPaths: 100 },
+    })
+    const r = await api.attackPaths()
+    expect(r).not.toBeNull()
+    const p = r!.paths[0]
+    expect(p.nodes[0]).toMatchObject({ id: 'a-edge', kind: 'asset', label: 'edge-gw-01', sublabel: 'host' })
+    expect(p.nodes[1]).toMatchObject({ id: 'f-1', kind: 'finding', label: 'RCE', severity: 'critical', reachability: 'reachable', confirmed: true })
+    expect(p.steps[0]).toMatchObject({ from: 'a-edge', to: 'f-1', kind: 'hosts', observed: true, toFinding: true, evidenceCount: 1 })
+    expect(r!.bounds.truncated).toBe(true)
+    expect(r!.bounds.pathsHit).toBe(true)
+  })
+
+  it('falls back to asset Key when Name is empty and defaults bounds', async () => {
+    respond({ paths: [{ id: 'ap-2', confident: false, uncertainties: ['inferred_edge'], nodes: [{ asset: { asset: { ID: 'a', TenantID: 't', Kind: 'container_image', Key: 'sha256:x', Name: '' } } }], steps: [] }] })
+    const r = await api.attackPaths()
+    expect(r!.paths[0].nodes[0].label).toBe('sha256:x')
+    expect(r!.paths[0].uncertainties).toEqual(['inferred_edge'])
+    expect(r!.bounds.truncated).toBe(false)
+  })
+
+  it('returns null when the route is not registered (404)', async () => {
+    respond({ error: 'not found' }, 404)
+    expect(await api.attackPaths()).toBeNull()
+  })
+
+  it('encodes the finding query params', async () => {
+    respond({ paths: [], bounds: {} })
+    await api.attackPaths({ finding: 'f-9', findingKind: 'imported' })
+    const url = String(fetchSpy.mock.calls[0][0])
+    expect(url).toContain('/attack-paths?')
+    expect(url).toContain('finding=f-9')
+    expect(url).toContain('finding_kind=imported')
+  })
+})

--- a/web/src/lib/api/attackpaths.ts
+++ b/web/src/lib/api/attackpaths.ts
@@ -1,0 +1,152 @@
+import { ApiError, req } from './client'
+
+/**
+ * Attack paths (tenant-wide) join estate assets to findings through evidence-carrying edges. The graph
+ * traversal is bounded server-side (max length, max paths, wall clock); `bounds.truncated` says the
+ * returned set is partial. A path is `confident` only when every edge is observed and the terminal
+ * finding is confirmed-reachable; otherwise `uncertainties` names why. The route registers only when the
+ * attack-path service is wired, so the client treats a 404 as "not enabled in this deployment".
+ *
+ * SOURCE OF TRUTH: `internal/domain/attackpath/{graph,score,traverse}.go` and the handler in
+ * `internal/adapter/httpapi/attackpath_handler.go`. Note the nested `asset.Asset` and `finding.Finding`
+ * carry no JSON tags, so they arrive PascalCase; the mappers below read both cases defensively.
+ */
+
+export type AttackPathNodeKind = 'asset' | 'finding'
+
+export interface AttackPathNode {
+  id: string
+  kind: AttackPathNodeKind
+  label: string
+  sublabel: string
+  severity?: string
+  reachability?: string
+  confirmed?: boolean
+  external?: boolean
+}
+
+export interface AttackPathStep {
+  from: string
+  to: string
+  kind: string
+  observed: boolean
+  toFinding: boolean
+  evidenceCount: number
+}
+
+export interface AttackPath {
+  id: string
+  confident: boolean
+  uncertainties: string[]
+  nodes: AttackPathNode[]
+  steps: AttackPathStep[]
+}
+
+export interface AttackPathBounds {
+  truncated: boolean
+  lengthHit: boolean
+  pathsHit: boolean
+  wallClockHit: boolean
+  maxLength: number
+  maxPaths: number
+}
+
+export interface AttackPathResult {
+  paths: AttackPath[]
+  bounds: AttackPathBounds
+}
+
+export interface AttackPathQuery {
+  target?: string
+  entrypoint?: string
+  finding?: string
+  findingKind?: 'canonical' | 'imported'
+}
+
+function assetLabel(a: any): { id: string; label: string; sublabel: string } {
+  const id = a?.ID ?? a?.id ?? ''
+  const name = a?.Name ?? a?.name ?? ''
+  const key = a?.Key ?? a?.key ?? ''
+  const kind = a?.Kind ?? a?.kind ?? 'asset'
+  return { id, label: name || key || id, sublabel: String(kind) }
+}
+
+function mapNode(n: any): AttackPathNode | null {
+  if (n?.asset) {
+    const { id, label, sublabel } = assetLabel(n.asset.asset ?? n.asset.Asset)
+    return { id, kind: 'asset', label, sublabel }
+  }
+  if (n?.finding) {
+    const input = n.finding.input ?? n.finding.Input ?? {}
+    const f = input.finding ?? input.Finding ?? {}
+    const target = input.target ?? input.Target ?? {}
+    const id = target.ID ?? target.id ?? f.ID ?? f.id ?? ''
+    const title = f.Title ?? f.title ?? id
+    const severity = String(f.Severity ?? f.severity ?? '').toLowerCase() || undefined
+    return {
+      id,
+      kind: 'finding',
+      label: title,
+      sublabel: severity ? `${severity} finding` : 'finding',
+      severity,
+      reachability: input.reachability ?? input.Reachability ?? undefined,
+      confirmed: input.confirmed ?? input.Confirmed ?? undefined,
+      external: input.external ?? input.External ?? undefined,
+    }
+  }
+  return null
+}
+
+function mapStep(s: any): AttackPathStep {
+  return {
+    from: s?.from ?? '',
+    to: s?.to ?? '',
+    kind: s?.kind ?? '',
+    observed: s?.observed === true,
+    toFinding: s?.toFinding === true,
+    evidenceCount: Array.isArray(s?.evidence) ? s.evidence.length : 0,
+  }
+}
+
+function mapPath(p: any): AttackPath {
+  return {
+    id: p?.id ?? '',
+    confident: p?.confident === true,
+    uncertainties: Array.isArray(p?.uncertainties) ? p.uncertainties.map(String) : [],
+    nodes: Array.isArray(p?.nodes) ? p.nodes.map(mapNode).filter((n: AttackPathNode | null): n is AttackPathNode => n !== null) : [],
+    steps: Array.isArray(p?.steps) ? p.steps.map(mapStep) : [],
+  }
+}
+
+function mapBounds(b: any): AttackPathBounds {
+  return {
+    truncated: b?.truncated === true,
+    lengthHit: b?.lengthHit === true,
+    pathsHit: b?.pathsHit === true,
+    wallClockHit: b?.wallClockHit === true,
+    maxLength: b?.maxLength ?? 0,
+    maxPaths: b?.maxPaths ?? 0,
+  }
+}
+
+export const attackPathsApi = {
+  /** null when the deployment does not expose attack paths (route 404). */
+  attackPaths: async (query: AttackPathQuery = {}): Promise<AttackPathResult | null> => {
+    const p = new URLSearchParams()
+    if (query.target) p.set('target', query.target)
+    if (query.entrypoint) p.set('entrypoint', query.entrypoint)
+    if (query.finding) p.set('finding', query.finding)
+    if (query.findingKind) p.set('finding_kind', query.findingKind)
+    const qs = p.toString()
+    try {
+      const r = await req(`/attack-paths${qs ? `?${qs}` : ''}`)
+      return {
+        paths: Array.isArray(r?.paths) ? r.paths.map(mapPath) : [],
+        bounds: mapBounds(r?.bounds),
+      }
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 404) return null
+      throw e
+    }
+  },
+}

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -2,6 +2,10 @@ export class ApiError extends Error {
   constructor(
     public status: number,
     message: string,
+    // The parsed JSON error body, when the server sent one. Some endpoints attach structured detail
+    // alongside the message (e.g. /alerts/test returns { error, outcome } on 502); callers that need it
+    // read err.body, while the common `err.status === 404` checks are unaffected.
+    public body?: unknown,
   ) {
     super(message)
     this.name = 'ApiError'
@@ -93,13 +97,14 @@ export async function req(path: string, init?: RequestInit): Promise<any> {
   if (res.status === 401 && onUnauthorized) onUnauthorized()
   if (!res.ok) {
     let msg = `HTTP ${res.status}`
+    let body: unknown
     try {
-      const body = await res.json()
-      if (body?.error) msg = body.error
+      body = await res.json()
+      if ((body as { error?: string })?.error) msg = (body as { error: string }).error
     } catch {
       /* non-JSON error body */
     }
-    throw new ApiError(res.status, msg)
+    throw new ApiError(res.status, msg, body)
   }
   if (res.status === 204) return null
   return res.json()

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -9,6 +9,10 @@ export { type Connector, type ConnectorCreate, type ConnectorProvider } from './
 export { type ResponseRecord, type ResponsePlan, type ResponseKind, type ResponseState, type HaltResult, type PurpleVerdict, type PurpleCoverageRow, type PurpleWorkItem } from './blueteam'
 export { type RiskStory, type RiskFinding, type RiskExposure, type RiskPath, type RiskDetection, type RiskAssetFacts } from './riskstory'
 export { type ReconcileRun, type ReconcileCounts, type ReconcileState, type ReconcileDiff, type ReconcileDiffClass, type ReconcileDiffCursor, type ReconcileDiffPage } from './vulnerability'
+export { type AttackPathResult, type AttackPath, type AttackPathNode, type AttackPathStep, type AttackPathBounds, type AttackPathQuery, type AttackPathNodeKind } from './attackpaths'
+export { type SLAPoliciesView, type SLAPolicy, type SLAConfig, type SLAWeights, type SLAThresholds, type SLADueRange, type SLADueRanges, type SLADueTier, type SLAActivateResult, nsToDays, daysToNs } from './sla'
+export { type OffensivePolicy, type OffensiveTechnique, type OffensiveLegalReview } from './offensivepolicy'
+export { type AlertTestResult, type AlertTestOutcome, AlertNotEnabledError } from './alerting'
 
 import { authApi, teamApi } from './auth'
 import { auditApi } from './audit'
@@ -31,6 +35,10 @@ import { capabilitiesApi } from './capabilities'
 import { connectorsApi } from './connectors'
 import { blueteamApi } from './blueteam'
 import { riskStoryApi } from './riskstory'
+import { attackPathsApi } from './attackpaths'
+import { slaApi } from './sla'
+import { offensivePolicyApi } from './offensivepolicy'
+import { alertingApi } from './alerting'
 
 // projectMeasures was a standalone export in the old api.ts
 export const projectMeasures = codeQualityApi.projectMeasures
@@ -65,4 +73,8 @@ export const api = {
   ...connectorsApi,
   ...blueteamApi,
   ...riskStoryApi,
+  ...attackPathsApi,
+  ...slaApi,
+  ...offensivePolicyApi,
+  ...alertingApi,
 }

--- a/web/src/lib/api/offensivepolicy.test.ts
+++ b/web/src/lib/api/offensivepolicy.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { api } from '.'
+
+describe('offensivePolicy mapper', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+  function respond(body: unknown, status = 200) {
+    fetchSpy.mockResolvedValueOnce({ ok: status < 400, status, json: async () => body } as unknown as Response)
+  }
+
+  it('reads the snake_case register DTO', async () => {
+    respond({
+      legal_review: { reviewed: true, date: '2026-08-01', owner: 'sec', counsel_reviewed: true, counsel_date: '2026-08-04' },
+      techniques: [
+        { technique: 'recon.port_scan', taxonomy_ref: 'TA0043', disruption: 'none', reversibility: 'reversible', risk_class: 'low', approval: 'auto', blast_radius: 'read_only', production_safe: true, prohibited: false },
+        { technique: 'impact.data_destruction', taxonomy_ref: 'T1485', disruption: 'high', reversibility: 'irreversible', risk_class: 'prohibited', approval: '', blast_radius: 'destructive', production_safe: false, prohibited: true },
+      ],
+      prohibited: 1,
+      production_safe: 1,
+    })
+    const r = await api.offensivePolicy()
+    expect(r!.legalReview).toMatchObject({ reviewed: true, counselReviewed: true, owner: 'sec', counselDate: '2026-08-04' })
+    expect(r!.techniques[0]).toMatchObject({ technique: 'recon.port_scan', taxonomyRef: 'TA0043', riskClass: 'low', blastRadius: 'read_only', productionSafe: true, prohibited: false })
+    expect(r!.techniques[1]).toMatchObject({ riskClass: 'prohibited', prohibited: true, productionSafe: false })
+    expect(r!.prohibited).toBe(1)
+    expect(r!.productionSafe).toBe(1)
+  })
+
+  it('returns null when the register is not loaded (404)', async () => {
+    respond({ error: 'not found' }, 404)
+    expect(await api.offensivePolicy()).toBeNull()
+  })
+})

--- a/web/src/lib/api/offensivepolicy.ts
+++ b/web/src/lib/api/offensivepolicy.ts
@@ -1,0 +1,77 @@
+import { ApiError, req } from './client'
+
+/**
+ * Offensive policy register (read-only), showing exactly what the running binary enforces for offensive
+ * techniques: for each classified technique its disruption, reversibility, risk class, approval mode,
+ * blast radius, and whether the binary treats it as production-safe or prohibited. The legal-review block
+ * records whether counsel signed off. This is the loaded register, identical for every operator; there is
+ * no write path here. Route registers only when the register is wired, so a 404 means "not enabled".
+ *
+ * SOURCE OF TRUTH: `internal/adapter/httpapi/offensive_policy_handler.go` (`offensivePolicyDTO`).
+ */
+
+export interface OffensiveTechnique {
+  technique: string
+  taxonomyRef: string
+  disruption: string
+  reversibility: string
+  riskClass: string
+  approval: string
+  blastRadius: string
+  productionSafe: boolean
+  prohibited: boolean
+}
+
+export interface OffensiveLegalReview {
+  reviewed: boolean
+  date: string
+  owner: string
+  counselReviewed: boolean
+  counselDate: string
+}
+
+export interface OffensivePolicy {
+  legalReview: OffensiveLegalReview
+  techniques: OffensiveTechnique[]
+  prohibited: number
+  productionSafe: number
+}
+
+function mapTechnique(t: any): OffensiveTechnique {
+  return {
+    technique: t?.technique ?? '',
+    taxonomyRef: t?.taxonomy_ref ?? '',
+    disruption: t?.disruption ?? '',
+    reversibility: t?.reversibility ?? '',
+    riskClass: t?.risk_class ?? '',
+    approval: t?.approval ?? '',
+    blastRadius: t?.blast_radius ?? '',
+    productionSafe: t?.production_safe === true,
+    prohibited: t?.prohibited === true,
+  }
+}
+
+export const offensivePolicyApi = {
+  /** null when the deployment does not expose the offensive policy register (route 404). */
+  offensivePolicy: async (): Promise<OffensivePolicy | null> => {
+    try {
+      const r = await req('/redteam/policy')
+      const lr = r?.legal_review ?? {}
+      return {
+        legalReview: {
+          reviewed: lr.reviewed === true,
+          date: lr.date ?? '',
+          owner: lr.owner ?? '',
+          counselReviewed: lr.counsel_reviewed === true,
+          counselDate: lr.counsel_date ?? '',
+        },
+        techniques: Array.isArray(r?.techniques) ? r.techniques.map(mapTechnique) : [],
+        prohibited: r?.prohibited ?? 0,
+        productionSafe: r?.production_safe ?? 0,
+      }
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 404) return null
+      throw e
+    }
+  },
+}

--- a/web/src/lib/api/sla.test.ts
+++ b/web/src/lib/api/sla.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { api, daysToNs, nsToDays } from '.'
+import type { SLAConfig } from '.'
+
+const DAY = 86_400_000_000_000
+
+function policyWire() {
+  return {
+    tenant_id: 'tenant-dev',
+    sha256: 'deadbeef',
+    created_by: 'admin@dev',
+    created_at: '2026-08-01T00:00:00Z',
+    config: {
+      version: 'sla-v1',
+      weights: { severity: 35, exploitability: 25, threat_intel: 10, exposure: 15, criticality: 15, feasibility_relief: 15 },
+      thresholds: { emergency: 85, critical: 70, high: 50, medium: 30 },
+      due_ranges: {
+        emergency: { mitigate_within: 1 * DAY, remediate_within: 7 * DAY },
+        critical: { mitigate_within: 3 * DAY, remediate_within: 15 * DAY },
+        high: { mitigate_within: 7 * DAY, remediate_within: 30 * DAY },
+        medium: { mitigate_within: 30 * DAY, remediate_within: 90 * DAY },
+        low: { mitigate_within: 90 * DAY, remediate_within: 180 * DAY },
+        exception: { mitigate_within: 30 * DAY, remediate_within: 180 * DAY },
+      },
+    },
+  }
+}
+
+describe('sla mapper', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch')
+  })
+  function respond(body: unknown, status = 200) {
+    fetchSpy.mockResolvedValueOnce({ ok: status < 400, status, json: async () => body } as unknown as Response)
+  }
+
+  it('maps snake_case weights and ns due-ranges into days', async () => {
+    respond({ active: policyWire(), policies: [policyWire()] })
+    const r = await api.slaPolicies()
+    expect(r!.active!.config.weights).toMatchObject({ threatIntel: 10, feasibilityRelief: 15, severity: 35 })
+    expect(r!.active!.config.dueRanges.emergency).toEqual({ mitigateDays: 1, remediateDays: 7 })
+    expect(r!.active!.config.dueRanges.low).toEqual({ mitigateDays: 90, remediateDays: 180 })
+    expect(r!.active!.createdBy).toBe('admin@dev')
+  })
+
+  it('nsToDays/daysToNs round-trip exactly on day-granular values', () => {
+    for (const d of [0, 1, 3, 7, 15, 30, 90, 180, 365]) {
+      expect(nsToDays(daysToNs(d))).toBe(d)
+    }
+  })
+
+  it('treats a zero/empty active policy as none', async () => {
+    respond({ active: { tenant_id: '', created_by: '', created_at: '0001-01-01T00:00:00Z', config: { version: '', weights: {}, thresholds: {}, due_ranges: {} } }, policies: [] })
+    const r = await api.slaPolicies()
+    expect(r!.active).toBeNull()
+  })
+
+  it('POST activate sends day windows back as nanoseconds', async () => {
+    respond({ policy: policyWire(), created: true }, 201)
+    const cfg: SLAConfig = {
+      version: 'sla-v2',
+      weights: { severity: 40, exploitability: 20, threatIntel: 10, exposure: 15, criticality: 15, feasibilityRelief: 10 },
+      thresholds: { emergency: 90, critical: 70, high: 50, medium: 30 },
+      dueRanges: {
+        emergency: { mitigateDays: 1, remediateDays: 5 },
+        critical: { mitigateDays: 2, remediateDays: 10 },
+        high: { mitigateDays: 7, remediateDays: 30 },
+        medium: { mitigateDays: 30, remediateDays: 90 },
+        low: { mitigateDays: 90, remediateDays: 180 },
+        exception: { mitigateDays: 30, remediateDays: 180 },
+      },
+    }
+    const res = await api.activateSLAPolicy(cfg)
+    expect(res.created).toBe(true)
+    const body = JSON.parse(String((fetchSpy.mock.calls[0][1] as RequestInit).body))
+    expect(body.config.weights.threat_intel).toBe(10)
+    expect(body.config.due_ranges.emergency).toEqual({ mitigate_within: 1 * DAY, remediate_within: 5 * DAY })
+    expect(body.config.version).toBe('sla-v2')
+  })
+
+  it('returns null when SLA governance is not enabled (404)', async () => {
+    respond({ error: 'not found' }, 404)
+    expect(await api.slaPolicies()).toBeNull()
+  })
+})

--- a/web/src/lib/api/sla.ts
+++ b/web/src/lib/api/sla.ts
@@ -1,0 +1,168 @@
+import { ApiError, req } from './client'
+
+/**
+ * SLA remediation policy (tenant-wide). A Policy is an immutable, tenant-owned config version; activating
+ * another one only moves the active pointer, so historical assessments keep the exact version they were
+ * scored under. The scoring Config is fully declarative: factor Weights (each the MAX points that factor
+ * contributes; the five positive weights sum to 100), score Thresholds mapping 0..100 to a tier (strictly
+ * descending, positive), and per-tier DueRanges. Durations arrive as int64 nanoseconds; the client works
+ * in days at the edge. Routes register only with the SLA use case wired, so a 404 means "not enabled".
+ *
+ * SOURCE OF TRUTH: `internal/domain/sla/{config,assessment}.go`, handler `sla_handler.go`
+ * (`listSLAPolicies`, `activateSLAPolicy`).
+ */
+
+export interface SLAWeights {
+  severity: number
+  exploitability: number
+  threatIntel: number
+  exposure: number
+  criticality: number
+  feasibilityRelief: number
+}
+
+export interface SLAThresholds {
+  emergency: number
+  critical: number
+  high: number
+  medium: number
+}
+
+export interface SLADueRange {
+  mitigateDays: number
+  remediateDays: number
+}
+
+export type SLADueTier = 'emergency' | 'critical' | 'high' | 'medium' | 'low' | 'exception'
+
+export type SLADueRanges = Record<SLADueTier, SLADueRange>
+
+export interface SLAConfig {
+  version: string
+  weights: SLAWeights
+  thresholds: SLAThresholds
+  dueRanges: SLADueRanges
+}
+
+export interface SLAPolicy {
+  tenantId: string
+  config: SLAConfig
+  sha256: string
+  createdBy: string
+  createdAt: string
+}
+
+export interface SLAPoliciesView {
+  active: SLAPolicy | null
+  policies: SLAPolicy[]
+}
+
+const NS_PER_DAY = 24 * 60 * 60 * 1_000_000_000
+
+export function nsToDays(ns: number): number {
+  return Math.round((ns / NS_PER_DAY) * 100) / 100
+}
+
+export function daysToNs(days: number): number {
+  return Math.round(days * NS_PER_DAY)
+}
+
+const DUE_TIERS: SLADueTier[] = ['emergency', 'critical', 'high', 'medium', 'low', 'exception']
+
+function mapDueRange(r: any): SLADueRange {
+  return { mitigateDays: nsToDays(r?.mitigate_within ?? 0), remediateDays: nsToDays(r?.remediate_within ?? 0) }
+}
+
+function mapConfig(c: any): SLAConfig {
+  const w = c?.weights ?? {}
+  const t = c?.thresholds ?? {}
+  const d = c?.due_ranges ?? {}
+  const dueRanges = {} as SLADueRanges
+  for (const tier of DUE_TIERS) dueRanges[tier] = mapDueRange(d[tier])
+  return {
+    version: c?.version ?? '',
+    weights: {
+      severity: w.severity ?? 0,
+      exploitability: w.exploitability ?? 0,
+      threatIntel: w.threat_intel ?? 0,
+      exposure: w.exposure ?? 0,
+      criticality: w.criticality ?? 0,
+      feasibilityRelief: w.feasibility_relief ?? 0,
+    },
+    thresholds: {
+      emergency: t.emergency ?? 0,
+      critical: t.critical ?? 0,
+      high: t.high ?? 0,
+      medium: t.medium ?? 0,
+    },
+    dueRanges,
+  }
+}
+
+function mapPolicy(p: any): SLAPolicy | null {
+  if (!p || typeof p !== 'object') return null
+  // A real Policy always carries a config version (sla.NewPolicy requires a non-empty version). The zero
+  // Policy the server sends for `active` when nothing is activated has an empty Config, hence an empty
+  // version. Detect it by that: Go's zero time.Time marshals to "0001-01-01T00:00:00Z", not "", so
+  // created_at cannot be used to spot an absent policy.
+  if (!p.config?.version) return null
+  const createdBy = p.created_by ?? ''
+  const createdAt = p.created_at ?? ''
+  return {
+    tenantId: p.tenant_id ?? '',
+    config: mapConfig(p.config),
+    sha256: p.sha256 ?? '',
+    createdBy,
+    createdAt,
+  }
+}
+
+function toConfigWire(c: SLAConfig): Record<string, unknown> {
+  const due: Record<string, unknown> = {}
+  for (const tier of DUE_TIERS) {
+    due[tier] = { mitigate_within: daysToNs(c.dueRanges[tier].mitigateDays), remediate_within: daysToNs(c.dueRanges[tier].remediateDays) }
+  }
+  return {
+    version: c.version,
+    weights: {
+      severity: c.weights.severity,
+      exploitability: c.weights.exploitability,
+      threat_intel: c.weights.threatIntel,
+      exposure: c.weights.exposure,
+      criticality: c.weights.criticality,
+      feasibility_relief: c.weights.feasibilityRelief,
+    },
+    thresholds: {
+      emergency: c.thresholds.emergency,
+      critical: c.thresholds.critical,
+      high: c.thresholds.high,
+      medium: c.thresholds.medium,
+    },
+    due_ranges: due,
+  }
+}
+
+export interface SLAActivateResult {
+  policy: SLAPolicy | null
+  created: boolean
+}
+
+export const slaApi = {
+  /** null when the deployment does not expose SLA governance (route 404). */
+  slaPolicies: async (): Promise<SLAPoliciesView | null> => {
+    try {
+      const r = await req('/sla/policies')
+      return {
+        active: mapPolicy(r?.active),
+        policies: Array.isArray(r?.policies) ? r.policies.map(mapPolicy).filter((p: SLAPolicy | null): p is SLAPolicy => p !== null) : [],
+      }
+    } catch (e) {
+      if (e instanceof ApiError && e.status === 404) return null
+      throw e
+    }
+  },
+  activateSLAPolicy: async (config: SLAConfig): Promise<SLAActivateResult> => {
+    const r = await req('/sla/policies', { method: 'POST', body: JSON.stringify({ config: toConfigWire(config) }) })
+    return { policy: mapPolicy(r?.policy), created: r?.created === true }
+  },
+}

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -4,6 +4,26 @@ import { http, HttpResponse } from 'msw'
 // TIMESTAMPS
 // ============================================================================
 const NOW = new Date().toISOString()
+const SLA_DAY_NS = 86400000000000
+const SLA_POLICY = {
+  tenant_id: 'tenant-dev',
+  sha256: 'a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff00',
+  created_by: 'admin@dev',
+  created_at: NOW,
+  config: {
+    version: 'sla-v1',
+    weights: { severity: 35, exploitability: 25, threat_intel: 10, exposure: 15, criticality: 15, feasibility_relief: 15 },
+    thresholds: { emergency: 85, critical: 70, high: 50, medium: 30 },
+    due_ranges: {
+      emergency: { mitigate_within: 1 * SLA_DAY_NS, remediate_within: 7 * SLA_DAY_NS },
+      critical: { mitigate_within: 3 * SLA_DAY_NS, remediate_within: 15 * SLA_DAY_NS },
+      high: { mitigate_within: 7 * SLA_DAY_NS, remediate_within: 30 * SLA_DAY_NS },
+      medium: { mitigate_within: 30 * SLA_DAY_NS, remediate_within: 90 * SLA_DAY_NS },
+      low: { mitigate_within: 90 * SLA_DAY_NS, remediate_within: 180 * SLA_DAY_NS },
+      exception: { mitigate_within: 30 * SLA_DAY_NS, remediate_within: 180 * SLA_DAY_NS },
+    },
+  },
+}
 const HOUR_AGO = new Date(Date.now() - 3600_000).toISOString()
 const DAY_AGO = new Date(Date.now() - 86400_000).toISOString()
 const WEEK_AGO = new Date(Date.now() - 7 * 86400_000).toISOString()
@@ -508,6 +528,70 @@ export const handlers = [
   }),
   http.post('/api/v1/blueteam/response/:id/revert', () => HttpResponse.json({ id: 'resp-1', kind: 'isolate_host', target: 'host-web-01', state: 'reverted', approver: 'alice' })),
   http.post('/api/v1/redteam/halt', () => HttpResponse.json({ halted: true, within_bound: true, duration_ms: 42, orders_halted: ['ord-1'], chains_halted: [] })),
+
+  // --- Attack paths (tenant-wide). Nested asset.Asset / finding.Finding carry no JSON tags, so they are
+  //     PascalCase on the wire; the mapper reads both cases. ---
+  http.get('/api/v1/attack-paths', () =>
+    HttpResponse.json({
+      paths: [
+        {
+          id: 'ap-confident-1',
+          confident: true,
+          uncertainties: [],
+          nodes: [
+            { asset: { asset: { ID: 'a-edge', TenantID: 'tenant-dev', Kind: 'host', Key: 'edge-gw-01', Name: 'edge-gw-01' } } },
+            { asset: { asset: { ID: 'a-api', TenantID: 'tenant-dev', Kind: 'container_image', Key: 'sha256:api', Name: 'checkout-api' } } },
+            { finding: { input: { target: { ID: 'f-1', Kind: 'canonical' }, finding: { ID: 'f-1', Title: 'CVE-2026-1337 RCE in checkout-api', Severity: 'critical' }, reachability: 'reachable', confirmed: true, external: false } } },
+          ],
+          steps: [
+            { from: 'a-edge', to: 'a-api', kind: 'routes_to', observed: true, toFinding: false, evidence: [{ producer: 'recon', provenance: 'ev-101', confidence: 'observed' }] },
+            { from: 'a-api', to: 'f-1', kind: 'hosts_finding', observed: true, toFinding: true, evidence: [{ producer: 'sca', provenance: 'ev-102', confidence: 'observed' }] },
+          ],
+        },
+        {
+          id: 'ap-inferred-2',
+          confident: false,
+          uncertainties: ['inferred_edge', 'unconfirmed_reachability'],
+          nodes: [
+            { asset: { asset: { ID: 'a-edge', TenantID: 'tenant-dev', Kind: 'host', Key: 'edge-gw-01', Name: 'edge-gw-01' } } },
+            { finding: { input: { target: { ID: 'f-2', Kind: 'canonical' }, finding: { ID: 'f-2', Title: 'Exposed admin console', Severity: 'high' }, reachability: 'reachable', confirmed: false, external: false } } },
+          ],
+          steps: [
+            { from: 'a-edge', to: 'f-2', kind: 'exposes', observed: false, toFinding: true, evidence: [{ producer: 'inference', provenance: 'ev-201', confidence: 'inferred' }] },
+          ],
+        },
+      ],
+      bounds: { maxLength: 8, maxPaths: 100, maxDuration: 0, truncated: false, lengthHit: false, pathsHit: false, targetPathsHit: false, findingPathsHit: false, wallClockHit: false },
+    }),
+  ),
+
+  // --- SLA remediation policy (tenant-wide). Durations are int64 nanoseconds. ---
+  http.get('/api/v1/sla/policies', () => HttpResponse.json({ active: SLA_POLICY, policies: [SLA_POLICY] })),
+  http.post('/api/v1/sla/policies', async ({ request }) => {
+    const b = (await request.json().catch(() => ({}))) as { config?: unknown }
+    return HttpResponse.json(
+      { policy: { ...SLA_POLICY, config: b?.config ?? SLA_POLICY.config, created_by: 'you', created_at: NOW }, created: true },
+      { status: 201 },
+    )
+  }),
+
+  // --- Offensive policy register (read-only). ---
+  http.get('/api/v1/redteam/policy', () =>
+    HttpResponse.json({
+      legal_review: { reviewed: true, date: '2026-08-01', owner: 'security-lead', counsel_reviewed: true, counsel_date: '2026-08-04' },
+      techniques: [
+        { technique: 'recon.port_scan', taxonomy_ref: 'TA0043', disruption: 'none', reversibility: 'reversible', risk_class: 'low', approval: 'auto', blast_radius: 'read_only', production_safe: true, prohibited: false },
+        { technique: 'access.credential_spray', taxonomy_ref: 'T1110.003', disruption: 'low', reversibility: 'reversible', risk_class: 'medium', approval: 'operator', blast_radius: 'state_changing', production_safe: false, prohibited: false },
+        { technique: 'impact.service_stop', taxonomy_ref: 'T1489', disruption: 'high', reversibility: 'reversible', risk_class: 'high', approval: 'dual_control', blast_radius: 'state_changing', production_safe: false, prohibited: false },
+        { technique: 'impact.data_destruction', taxonomy_ref: 'T1485', disruption: 'high', reversibility: 'irreversible', risk_class: 'prohibited', approval: '', blast_radius: 'destructive', production_safe: false, prohibited: true },
+      ],
+      prohibited: 1,
+      production_safe: 1,
+    }),
+  ),
+
+  // --- Alerting self-test. ---
+  http.post('/api/v1/alerts/test', () => HttpResponse.json({ outcome: { matched: true, delivered: 2, failed: 0, audit_failed: 0 } })),
 
   // --- Dashboard ---
   http.get('/api/v1/dashboard/security-operations', () => HttpResponse.json(DASHBOARD)),

--- a/web/src/pages/Settings/Alerting.test.tsx
+++ b/web/src/pages/Settings/Alerting.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api, AlertNotEnabledError } from '../../lib/api'
+import { Alerting } from './Alerting'
+
+vi.mock('../../lib/api', () => ({
+  api: { testAlert: vi.fn(), me: vi.fn() },
+  AlertNotEnabledError: class AlertNotEnabledError extends Error {
+    constructor() {
+      super('Alerting is not enabled in this deployment.')
+      this.name = 'AlertNotEnabledError'
+    }
+  },
+}))
+
+describe('Alerting', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('an admin sends a test alert and sees the per-sink outcome', async () => {
+    vi.mocked(api.me).mockResolvedValue({ role: 'admin' } as never)
+    vi.mocked(api.testAlert).mockResolvedValue({ acknowledged: true, outcome: { matched: true, delivered: 2, failed: 0, auditFailed: 0 } } as never)
+    render(<Alerting />)
+    fireEvent.click(await screen.findByRole('button', { name: /Send test alert/ }))
+    await waitFor(() => expect(api.testAlert).toHaveBeenCalledTimes(1))
+    expect(await screen.findByText('Acknowledged')).toBeInTheDocument()
+    expect(screen.getByText('Delivered')).toBeInTheDocument()
+  })
+
+  it('renders the no-acknowledgement outcome on a 502-style result', async () => {
+    vi.mocked(api.me).mockResolvedValue({ role: 'admin' } as never)
+    vi.mocked(api.testAlert).mockResolvedValue({ acknowledged: false, error: 'no alert sink acknowledged the test alert', outcome: { matched: true, delivered: 0, failed: 2, auditFailed: 0 } } as never)
+    render(<Alerting />)
+    fireEvent.click(await screen.findByRole('button', { name: /Send test alert/ }))
+    expect(await screen.findByText('No acknowledgement')).toBeInTheDocument()
+    expect(screen.getByText(/no alert sink acknowledged/)).toBeInTheDocument()
+  })
+
+  it('disables the action for a non-admin', async () => {
+    vi.mocked(api.me).mockResolvedValue({ role: 'member' } as never)
+    render(<Alerting />)
+    expect(await screen.findByRole('button', { name: /Send test alert/ })).toBeDisabled()
+  })
+
+  it('shows a not-enabled state when the route is absent', async () => {
+    vi.mocked(api.me).mockResolvedValue({ role: 'admin' } as never)
+    vi.mocked(api.testAlert).mockRejectedValue(new AlertNotEnabledError())
+    render(<Alerting />)
+    fireEvent.click(await screen.findByRole('button', { name: /Send test alert/ }))
+    expect(await screen.findByText('Alerting is not enabled')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/Settings/Alerting.tsx
+++ b/web/src/pages/Settings/Alerting.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react'
+import { AlertTriangle, BellRinging01, CheckCircle, Send01 } from '@untitledui/icons'
+import { Button, Card, EmptyState, cn } from '../../components/ui'
+import { useToast } from '../../components/synapse/Toast'
+import { useFetch } from '../../hooks'
+import { api, AlertNotEnabledError } from '../../lib/api'
+import type { AlertTestResult } from '../../lib/api'
+
+function OutcomeStat({ value, label, tone, hint }: { value: number; label: string; tone: string; hint: string }) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-secondary bg-primary px-3 py-2">
+      <span className={cn('text-xl font-bold tabular-nums', tone)}>{value}</span>
+      <span className="flex flex-col leading-tight">
+        <span className="text-sm font-medium text-primary">{label}</span>
+        <span className="text-xs text-tertiary">{hint}</span>
+      </span>
+    </div>
+  )
+}
+
+export function Alerting() {
+  const { notify } = useToast()
+  const { data: me } = useFetch(() => api.me(), { deps: [] })
+  const canAdmin = me?.role === 'admin' || me?.role === 'owner'
+  const [result, setResult] = useState<AlertTestResult | null>(null)
+  const [ranAt, setRanAt] = useState('')
+  const [notEnabled, setNotEnabled] = useState(false)
+  const [sending, setSending] = useState(false)
+
+  async function send() {
+    if (!canAdmin) return
+    setSending(true)
+    try {
+      const res = await api.testAlert()
+      setResult(res)
+      setRanAt(new Date().toLocaleString())
+      if (res.acknowledged) notify(`Test alert delivered to ${res.outcome.delivered} sink${res.outcome.delivered === 1 ? '' : 's'}.`, 'success')
+      else notify(res.error || 'No sink acknowledged the test alert.', 'error')
+    } catch (e) {
+      if (e instanceof AlertNotEnabledError) {
+        setNotEnabled(true)
+        return
+      }
+      notify(e instanceof Error ? e.message : 'Failed to send test alert.', 'error')
+    } finally {
+      setSending(false)
+    }
+  }
+
+  if (notEnabled)
+    return (
+      <EmptyState
+        icon={BellRinging01}
+        title="Alerting is not enabled"
+        hint="This deployment has no alert delivery configured. Configure at least one alert sink to use the self-test."
+      />
+    )
+
+  return (
+    <div className="space-y-6">
+      <Card title="Alert delivery self-test" titleClassName="flex items-center gap-2">
+        <p className="text-sm text-secondary">
+          Send one synthetic alert to every configured sink to prove the path works before you rely on it. The
+          test alert is clearly marked and carries no real finding. It succeeds when at least one sink
+          acknowledges delivery.
+        </p>
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <Button variant="primary" loading={sending} disabled={!canAdmin} onClick={send}>
+            <Send01 className="size-4" aria-hidden />
+            Send test alert
+          </Button>
+          {!canAdmin && <span className="text-sm text-tertiary">Sending a test alert needs the administer permission.</span>}
+        </div>
+      </Card>
+
+      {result && (
+        <Card
+          title="Last test result"
+          titleClassName="flex items-center gap-2"
+          actions={
+            result.acknowledged ? (
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-success-primary/25 bg-success-primary/10 px-2.5 py-1 text-xs font-semibold text-success-primary">
+                <CheckCircle className="size-3.5" aria-hidden />
+                Acknowledged
+              </span>
+            ) : (
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-error-primary/25 bg-error-primary/10 px-2.5 py-1 text-xs font-semibold text-error-primary">
+                <AlertTriangle className="size-3.5" aria-hidden />
+                No acknowledgement
+              </span>
+            )
+          }
+        >
+          {ranAt && <p className="mb-3 text-xs text-tertiary">Tested at {ranAt}. The API reports per-sink counts, not individual sink identities.</p>}
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <OutcomeStat value={result.outcome.delivered} label="Delivered" hint="sinks that acknowledged" tone="text-success-primary" />
+            <OutcomeStat value={result.outcome.failed} label="Failed" hint="sinks that refused" tone={result.outcome.failed > 0 ? 'text-error-primary' : 'text-tertiary'} />
+            <OutcomeStat value={result.outcome.auditFailed} label="Audit failed" hint="delivered, audit write failed" tone={result.outcome.auditFailed > 0 ? 'text-warning-primary' : 'text-tertiary'} />
+            <OutcomeStat value={result.outcome.matched ? 1 : 0} label="Rule matched" hint="test alert matched a routing rule" tone="text-brand-secondary" />
+          </div>
+          {!result.acknowledged && (
+            <p className="mt-3 text-sm text-error-primary">
+              {result.error || 'Every configured sink refused the test alert.'} Check sink credentials and connectivity.
+            </p>
+          )}
+        </Card>
+      )}
+    </div>
+  )
+}
+
+export default Alerting

--- a/web/src/pages/Settings/OffensivePolicy.test.tsx
+++ b/web/src/pages/Settings/OffensivePolicy.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import { OffensivePolicy } from './OffensivePolicy'
+
+vi.mock('../../lib/api', () => ({ api: { offensivePolicy: vi.fn() } }))
+
+const POLICY = {
+  legalReview: { reviewed: true, date: '2026-08-01', owner: 'security-lead', counselReviewed: true, counselDate: '2026-08-04' },
+  techniques: [
+    { technique: 'recon.port_scan', taxonomyRef: 'TA0043', disruption: 'none', reversibility: 'reversible', riskClass: 'low', approval: 'auto', blastRadius: 'read_only', productionSafe: true, prohibited: false },
+    { technique: 'impact.data_destruction', taxonomyRef: 'T1485', disruption: 'high', reversibility: 'irreversible', riskClass: 'prohibited', approval: '', blastRadius: 'destructive', productionSafe: false, prohibited: true },
+  ],
+  prohibited: 1,
+  productionSafe: 1,
+}
+
+describe('OffensivePolicy', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('renders the technique register with risk class and prohibited state', async () => {
+    vi.mocked(api.offensivePolicy).mockResolvedValue(POLICY as never)
+    render(<OffensivePolicy />)
+    expect(await screen.findByText('recon.port_scan')).toBeInTheDocument()
+    expect(screen.getByText('impact.data_destruction')).toBeInTheDocument()
+    expect(screen.getByText('Prohibited')).toBeInTheDocument()
+    expect(screen.getByText('Prod-safe')).toBeInTheDocument()
+    // Legal review is surfaced.
+    expect(screen.getByText('Policy reviewed')).toBeInTheDocument()
+    expect(screen.getByText('Counsel signed off')).toBeInTheDocument()
+  })
+
+  it('says so when the register is not loaded', async () => {
+    vi.mocked(api.offensivePolicy).mockResolvedValue(null as never)
+    render(<OffensivePolicy />)
+    expect(await screen.findByText('Offensive policy is not enabled')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/Settings/OffensivePolicy.tsx
+++ b/web/src/pages/Settings/OffensivePolicy.tsx
@@ -1,0 +1,188 @@
+import { useMemo, useState } from 'react'
+import { CheckCircle, ShieldZap, SlashCircle01, XCircle } from '@untitledui/icons'
+import { Card, EmptyState, ErrorState, Pill, Spinner, cn } from '../../components/ui'
+import { useFetch } from '../../hooks'
+import { api } from '../../lib/api'
+import type { OffensivePolicy as OffensivePolicyDTO, OffensiveTechnique } from '../../lib/api'
+
+const RISK_TONE: Record<string, string> = {
+  prohibited: 'text-error-primary bg-error-primary/10 border-error-primary/25',
+  high: 'text-error-primary bg-error-primary/10 border-error-primary/25',
+  medium: 'text-warning-primary bg-warning-primary/10 border-warning-primary/25',
+  low: 'text-success-primary bg-success-primary/10 border-success-primary/25',
+}
+
+function riskTone(risk: string): string {
+  return RISK_TONE[risk.toLowerCase()] ?? 'text-tertiary bg-secondary border-secondary'
+}
+
+function humanize(v: string): string {
+  return v ? v.replace(/[_-]+/g, ' ') : '—'
+}
+
+function LegalReviewCard({ policy }: { policy: OffensivePolicyDTO }) {
+  const lr = policy.legalReview
+  return (
+    <Card title="Legal review" titleClassName="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-3">
+        <StatusPill ok={lr.reviewed} label="Policy reviewed" off="Not reviewed" />
+        <StatusPill ok={lr.counselReviewed} label="Counsel signed off" off="Counsel pending" />
+      </div>
+      <dl className="mt-4 grid grid-cols-2 gap-x-6 gap-y-2 text-sm sm:grid-cols-4">
+        <div>
+          <dt className="text-xs text-tertiary">Owner</dt>
+          <dd className="text-primary">{lr.owner || '—'}</dd>
+        </div>
+        <div>
+          <dt className="text-xs text-tertiary">Reviewed</dt>
+          <dd className="text-primary">{lr.date || '—'}</dd>
+        </div>
+        <div>
+          <dt className="text-xs text-tertiary">Counsel date</dt>
+          <dd className="text-primary">{lr.counselDate || '—'}</dd>
+        </div>
+      </dl>
+    </Card>
+  )
+}
+
+function StatusPill({ ok, label, off }: { ok: boolean; label: string; off: string }) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold',
+        ok ? 'border-success-primary/25 bg-success-primary/10 text-success-primary' : 'border-warning-primary/25 bg-warning-primary/10 text-warning-primary',
+      )}
+    >
+      {ok ? <CheckCircle className="size-3.5" aria-hidden /> : <SlashCircle01 className="size-3.5" aria-hidden />}
+      {ok ? label : off}
+    </span>
+  )
+}
+
+function StatTile({ value, label, tone }: { value: number; label: string; tone: string }) {
+  return (
+    <div className="flex items-baseline gap-2 rounded-lg border border-secondary bg-primary px-3 py-2">
+      <span className={cn('text-lg font-bold tabular-nums', tone)}>{value}</span>
+      <span className="text-xs text-tertiary">{label}</span>
+    </div>
+  )
+}
+
+function TechniqueRow({ t }: { t: OffensiveTechnique }) {
+  return (
+    <tr className="border-t border-secondary align-top">
+      <td className="py-2 pr-3">
+        <div className="font-mono text-sm font-semibold text-primary">{t.technique}</div>
+        {t.taxonomyRef && <div className="font-mono text-xs text-quaternary">{t.taxonomyRef}</div>}
+      </td>
+      <td className="py-2 pr-3">
+        <span className={cn('inline-flex items-center rounded border px-1.5 py-0.5 text-xs font-bold capitalize', riskTone(t.riskClass))}>
+          {t.riskClass || '—'}
+        </span>
+      </td>
+      <td className="py-2 pr-3 text-sm capitalize text-secondary">{humanize(t.disruption)}</td>
+      <td className="py-2 pr-3 text-sm capitalize text-secondary">{humanize(t.reversibility)}</td>
+      <td className="py-2 pr-3 text-sm capitalize text-secondary">{humanize(t.blastRadius)}</td>
+      <td className="py-2 pr-3 text-sm capitalize text-secondary">{t.approval ? humanize(t.approval) : '—'}</td>
+      <td className="py-2 text-right">
+        {t.prohibited ? (
+          <Pill className="text-error-primary"><XCircle className="mr-1 inline size-3.5" aria-hidden />Prohibited</Pill>
+        ) : t.productionSafe ? (
+          <Pill className="text-success-primary"><CheckCircle className="mr-1 inline size-3.5" aria-hidden />Prod-safe</Pill>
+        ) : (
+          <Pill>Lab only</Pill>
+        )}
+      </td>
+    </tr>
+  )
+}
+
+export function OffensivePolicy() {
+  const { data, loading, error } = useFetch<OffensivePolicyDTO | null>(() => api.offensivePolicy(), { deps: [] })
+  const [risk, setRisk] = useState('all')
+
+  const risks = useMemo(() => {
+    const set = new Set<string>()
+    for (const t of data?.techniques ?? []) if (t.riskClass) set.add(t.riskClass.toLowerCase())
+    return ['all', ...[...set].sort()]
+  }, [data])
+
+  const visible = useMemo(
+    () => (data?.techniques ?? []).filter((t) => risk === 'all' || t.riskClass.toLowerCase() === risk),
+    [data, risk],
+  )
+
+  if (loading) return <Spinner label="Loading offensive policy…" />
+  if (error) return <ErrorState message={error} />
+  if (data === null)
+    return (
+      <EmptyState
+        icon={ShieldZap}
+        title="Offensive policy is not enabled"
+        hint="This deployment did not load an offensive technique register. The register is what the running binary enforces before any offensive step is admitted."
+      />
+    )
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-tertiary">
+        The technique register the running binary enforces before any offensive step runs. Read-only; it ships with the binary.
+      </p>
+
+      <LegalReviewCard policy={data} />
+
+      <div className="flex flex-wrap gap-2">
+        <StatTile value={data.techniques.length} label="classified techniques" tone="text-primary" />
+        <StatTile value={data.productionSafe} label="production-safe" tone="text-success-primary" />
+        <StatTile value={data.prohibited} label="prohibited" tone="text-error-primary" />
+      </div>
+
+      <Card
+        title="Technique register"
+        actions={
+          risks.length > 2 ? (
+            <div className="flex flex-wrap gap-1">
+              {risks.map((r) => (
+                <button
+                  key={r}
+                  type="button"
+                  onClick={() => setRisk(r)}
+                  className={cn(
+                    'rounded-md px-2 py-1 text-xs font-semibold capitalize transition-colors',
+                    risk === r ? 'bg-brand-primary/10 text-brand-secondary' : 'text-tertiary hover:bg-secondary hover:text-primary',
+                  )}
+                >
+                  {r}
+                </button>
+              ))}
+            </div>
+          ) : undefined
+        }
+      >
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[44rem] text-left">
+            <thead>
+              <tr className="text-xs font-medium text-tertiary">
+                <th className="pb-2 pr-3">Technique</th>
+                <th className="pb-2 pr-3">Risk</th>
+                <th className="pb-2 pr-3">Disruption</th>
+                <th className="pb-2 pr-3">Reversibility</th>
+                <th className="pb-2 pr-3">Blast radius</th>
+                <th className="pb-2 pr-3">Approval</th>
+                <th className="pb-2 text-right">Deployment</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((t) => (
+                <TechniqueRow key={t.technique} t={t} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    </div>
+  )
+}
+
+export default OffensivePolicy

--- a/web/src/pages/Settings/SLAPolicy.test.tsx
+++ b/web/src/pages/Settings/SLAPolicy.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import { SLAPolicy } from './SLAPolicy'
+
+vi.mock('../../lib/api', () => ({ api: { slaPolicies: vi.fn(), activateSLAPolicy: vi.fn(), me: vi.fn() } }))
+
+const POLICY = {
+  tenantId: 'tenant-dev',
+  sha256: 'a1b2c3d4e5f6ffff',
+  createdBy: 'admin@dev',
+  createdAt: '2026-08-01T00:00:00Z',
+  config: {
+    version: 'sla-v1',
+    weights: { severity: 35, exploitability: 25, threatIntel: 10, exposure: 15, criticality: 15, feasibilityRelief: 15 },
+    thresholds: { emergency: 85, critical: 70, high: 50, medium: 30 },
+    dueRanges: {
+      emergency: { mitigateDays: 1, remediateDays: 7 },
+      critical: { mitigateDays: 3, remediateDays: 15 },
+      high: { mitigateDays: 7, remediateDays: 30 },
+      medium: { mitigateDays: 30, remediateDays: 90 },
+      low: { mitigateDays: 90, remediateDays: 180 },
+      exception: { mitigateDays: 30, remediateDays: 180 },
+    },
+  },
+}
+
+describe('SLAPolicy', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('renders the active policy factors and tier windows', async () => {
+    vi.mocked(api.me).mockResolvedValue({ role: 'admin' } as never)
+    vi.mocked(api.slaPolicies).mockResolvedValue({ active: POLICY, policies: [POLICY] } as never)
+    render(<SLAPolicy />)
+    expect(await screen.findByText('Active policy')).toBeInTheDocument()
+    expect(screen.getAllByText('sla-v1').length).toBeGreaterThan(0)
+    // Positive weight sum is 100 and flagged green as the recommended sum.
+    expect(screen.getAllByText('100').length).toBeGreaterThan(0)
+  })
+
+  it('an admin can activate a policy version', async () => {
+    vi.mocked(api.me).mockResolvedValue({ role: 'admin' } as never)
+    vi.mocked(api.slaPolicies).mockResolvedValue({ active: POLICY, policies: [POLICY] } as never)
+    vi.mocked(api.activateSLAPolicy).mockResolvedValue({ policy: POLICY, created: true } as never)
+    render(<SLAPolicy />)
+    await screen.findByText('Activate a policy version')
+    fireEvent.click(screen.getByRole('button', { name: /Activate/ }))
+    await waitFor(() => expect(api.activateSLAPolicy).toHaveBeenCalledTimes(1))
+    expect(vi.mocked(api.activateSLAPolicy).mock.calls[0][0]).toMatchObject({ version: 'sla-v1' })
+  })
+
+  it('blocks activation when thresholds are not strictly descending', async () => {
+    vi.mocked(api.me).mockResolvedValue({ role: 'admin' } as never)
+    vi.mocked(api.slaPolicies).mockResolvedValue({ active: POLICY, policies: [POLICY] } as never)
+    render(<SLAPolicy />)
+    await screen.findByText('Activate a policy version')
+    // Push medium above high so the ladder is no longer descending.
+    fireEvent.change(screen.getByLabelText('Medium'), { target: { value: '60' } })
+    expect(screen.getByText(/strictly descending and positive/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Activate/ })).toBeDisabled()
+  })
+
+  it('disables activation for a non-admin', async () => {
+    vi.mocked(api.me).mockResolvedValue({ role: 'member' } as never)
+    vi.mocked(api.slaPolicies).mockResolvedValue({ active: POLICY, policies: [POLICY] } as never)
+    render(<SLAPolicy />)
+    await screen.findByText('Activate a policy version')
+    expect(screen.getByRole('button', { name: /Activate/ })).toBeDisabled()
+    expect(screen.getByText(/needs the administer permission/)).toBeInTheDocument()
+  })
+
+  it('says so when SLA governance is not enabled', async () => {
+    vi.mocked(api.me).mockResolvedValue({ role: 'admin' } as never)
+    vi.mocked(api.slaPolicies).mockResolvedValue(null as never)
+    render(<SLAPolicy />)
+    expect(await screen.findByText('SLA governance is not enabled')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/Settings/SLAPolicy.tsx
+++ b/web/src/pages/Settings/SLAPolicy.tsx
@@ -1,0 +1,322 @@
+import { useMemo, useState } from 'react'
+import { AlertTriangle, CheckCircle, Scales02, Save01 } from '@untitledui/icons'
+import { Button, Card, EmptyState, ErrorState, Field, Input, Pill, Spinner, cn } from '../../components/ui'
+import { useToast } from '../../components/synapse/Toast'
+import { useFetch } from '../../hooks'
+import { api } from '../../lib/api'
+import type { SLAConfig, SLADueTier, SLAPoliciesView, SLAPolicy } from '../../lib/api'
+
+const DUE_TIERS: SLADueTier[] = ['emergency', 'critical', 'high', 'medium', 'low', 'exception']
+
+// Mirrors sla.DefaultConfig() in internal/domain/sla/config.go, the reproducible floor when no policy is
+// active. Used to seed the editor so an admin starts from the shipped defaults, not an empty form.
+const DEFAULT_CONFIG: SLAConfig = {
+  version: 'sla-v1',
+  weights: { severity: 35, exploitability: 25, threatIntel: 10, exposure: 15, criticality: 15, feasibilityRelief: 15 },
+  thresholds: { emergency: 85, critical: 70, high: 50, medium: 30 },
+  dueRanges: {
+    emergency: { mitigateDays: 1, remediateDays: 7 },
+    critical: { mitigateDays: 3, remediateDays: 15 },
+    high: { mitigateDays: 7, remediateDays: 30 },
+    medium: { mitigateDays: 30, remediateDays: 90 },
+    low: { mitigateDays: 90, remediateDays: 180 },
+    exception: { mitigateDays: 30, remediateDays: 180 },
+  },
+}
+
+const WEIGHT_FIELDS: { key: keyof SLAConfig['weights']; label: string }[] = [
+  { key: 'severity', label: 'Severity' },
+  { key: 'exploitability', label: 'Exploitability' },
+  { key: 'threatIntel', label: 'Threat intel' },
+  { key: 'exposure', label: 'Exposure' },
+  { key: 'criticality', label: 'Criticality' },
+  { key: 'feasibilityRelief', label: 'Feasibility relief' },
+]
+
+const THRESHOLD_FIELDS: { key: keyof SLAConfig['thresholds']; label: string }[] = [
+  { key: 'emergency', label: 'Emergency' },
+  { key: 'critical', label: 'Critical' },
+  { key: 'high', label: 'High' },
+  { key: 'medium', label: 'Medium' },
+]
+
+function validateConfig(c: SLAConfig): string | null {
+  if (!c.version.trim()) return 'A version label is required.'
+  for (const f of WEIGHT_FIELDS) if (c.weights[f.key] < 0) return `${f.label} weight cannot be negative.`
+  const t = c.thresholds
+  if (!(t.emergency > t.critical && t.critical > t.high && t.high > t.medium && t.medium > 0))
+    return 'Thresholds must be strictly descending and positive: emergency > critical > high > medium > 0.'
+  for (const tier of DUE_TIERS) {
+    const r = c.dueRanges[tier]
+    if (r.mitigateDays < 0 || r.remediateDays < 0) return `${tier} due range cannot be negative.`
+    if (r.mitigateDays > r.remediateDays) return `${tier}: mitigate window must be ≤ remediate window.`
+  }
+  return null
+}
+
+function shortHash(h: string): string {
+  return h ? `${h.slice(0, 10)}…` : '—'
+}
+
+function formatWhen(iso: string): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+
+function ActivePolicyCard({ policy }: { policy: SLAPolicy }) {
+  const c = policy.config
+  const positiveSum = WEIGHT_FIELDS.filter((f) => f.key !== 'feasibilityRelief').reduce((n, f) => n + c.weights[f.key], 0)
+  return (
+    <Card title="Active policy" titleClassName="flex items-center gap-2" actions={<Pill className="font-mono text-brand-secondary">{c.version}</Pill>}>
+      <dl className="mb-5 grid grid-cols-2 gap-x-6 gap-y-2 text-sm sm:grid-cols-4">
+        <div>
+          <dt className="text-xs text-tertiary">Digest</dt>
+          <dd className="font-mono text-primary" title={policy.sha256}>{shortHash(policy.sha256)}</dd>
+        </div>
+        <div>
+          <dt className="text-xs text-tertiary">Activated by</dt>
+          <dd className="text-primary">{policy.createdBy || '—'}</dd>
+        </div>
+        <div>
+          <dt className="text-xs text-tertiary">Activated at</dt>
+          <dd className="text-primary">{formatWhen(policy.createdAt)}</dd>
+        </div>
+        <div>
+          <dt className="text-xs text-tertiary">Positive weight sum</dt>
+          <dd className={cn('font-semibold tabular-nums', positiveSum === 100 ? 'text-success-primary' : 'text-warning-primary')}>{positiveSum}</dd>
+        </div>
+      </dl>
+
+      <div className="grid gap-5 lg:grid-cols-2">
+        <div>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-tertiary">Factor weights (max points)</h3>
+          <ul className="space-y-1.5">
+            {WEIGHT_FIELDS.map((f) => {
+              const v = c.weights[f.key]
+              return (
+                <li key={f.key} className="flex items-center gap-3">
+                  <span className="w-32 shrink-0 text-sm text-secondary">{f.label}</span>
+                  <span className="h-2 flex-1 overflow-hidden rounded-full bg-secondary">
+                    <span className="block h-full rounded-full bg-brand-solid" style={{ width: `${Math.min(100, v)}%` }} />
+                  </span>
+                  <span className="w-8 shrink-0 text-right text-sm font-semibold tabular-nums text-primary">{v}</span>
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+        <div>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-tertiary">Tier thresholds & due windows</h3>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-left text-xs text-tertiary">
+                  <th className="pb-1 font-medium">Tier</th>
+                  <th className="pb-1 text-right font-medium">Score ≥</th>
+                  <th className="pb-1 text-right font-medium">Mitigate</th>
+                  <th className="pb-1 text-right font-medium">Remediate</th>
+                </tr>
+              </thead>
+              <tbody>
+                {DUE_TIERS.map((tier) => {
+                  const score =
+                    tier === 'emergency' || tier === 'critical' || tier === 'high' || tier === 'medium'
+                      ? c.thresholds[tier]
+                      : undefined
+                  const r = c.dueRanges[tier]
+                  return (
+                    <tr key={tier} className="border-t border-secondary">
+                      <td className="py-1 capitalize text-primary">{tier}</td>
+                      <td className="py-1 text-right tabular-nums text-secondary">{score ?? '—'}</td>
+                      <td className="py-1 text-right tabular-nums text-secondary">{r.mitigateDays}d</td>
+                      <td className="py-1 text-right tabular-nums text-secondary">{r.remediateDays}d</td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+function num(v: string): number {
+  const n = Number(v)
+  return Number.isFinite(n) ? n : 0
+}
+
+function ActivateForm({ seed, canAdmin, onDone }: { seed: SLAConfig; canAdmin: boolean; onDone: () => void }) {
+  const { notify } = useToast()
+  const [config, setConfig] = useState<SLAConfig>(seed)
+  const [submitting, setSubmitting] = useState(false)
+  const invalid = useMemo(() => validateConfig(config), [config])
+  const positiveSum = WEIGHT_FIELDS.filter((f) => f.key !== 'feasibilityRelief').reduce((n, f) => n + config.weights[f.key], 0)
+
+  function setWeight(k: keyof SLAConfig['weights'], v: number) {
+    setConfig((c) => ({ ...c, weights: { ...c.weights, [k]: v } }))
+  }
+  function setThreshold(k: keyof SLAConfig['thresholds'], v: number) {
+    setConfig((c) => ({ ...c, thresholds: { ...c.thresholds, [k]: v } }))
+  }
+  function setDue(tier: SLADueTier, field: 'mitigateDays' | 'remediateDays', v: number) {
+    setConfig((c) => ({ ...c, dueRanges: { ...c.dueRanges, [tier]: { ...c.dueRanges[tier], [field]: v } } }))
+  }
+
+  async function submit() {
+    if (invalid || !canAdmin) return
+    setSubmitting(true)
+    try {
+      const res = await api.activateSLAPolicy(config)
+      notify(res.created ? `Activated policy ${config.version}.` : `Policy ${config.version} is already active.`, 'success')
+      onDone()
+    } catch (e) {
+      notify(e instanceof Error ? e.message : 'Failed to activate policy.', 'error')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <Card
+      title="Activate a policy version"
+      titleClassName="flex items-center gap-2"
+      actions={
+        <Button variant="primary" loading={submitting} disabled={!!invalid || !canAdmin} onClick={submit}>
+          <Save01 className="size-4" aria-hidden />
+          Activate
+        </Button>
+      }
+    >
+      {!canAdmin && (
+        <p className="mb-4 rounded-lg border border-secondary bg-secondary/40 px-3 py-2 text-sm text-tertiary">
+          Activating a policy needs the administer permission. You can review the values but not apply them.
+        </p>
+      )}
+      <fieldset disabled={!canAdmin} className="space-y-6">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <Field label="Version label" htmlFor="sla-version" hint="Recorded on every assessment scored under this policy.">
+            <Input id="sla-version" value={config.version} onChange={(e) => setConfig((c) => ({ ...c, version: e.target.value }))} />
+          </Field>
+          <div className="flex items-end">
+            <p className={cn('text-sm', positiveSum === 100 ? 'text-success-primary' : 'text-warning-primary')}>
+              Positive weights sum to <span className="font-semibold tabular-nums">{positiveSum}</span> (100 recommended so a maxed finding scores 100).
+            </p>
+          </div>
+        </div>
+
+        <div>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-tertiary">Factor weights</h3>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+            {WEIGHT_FIELDS.map((f) => (
+              <Field key={f.key} label={f.label} htmlFor={`w-${f.key}`}>
+                <Input id={`w-${f.key}`} type="number" min={0} value={config.weights[f.key]} onChange={(e) => setWeight(f.key, num(e.target.value))} />
+              </Field>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-tertiary">Tier thresholds (score ≥)</h3>
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+            {THRESHOLD_FIELDS.map((f) => (
+              <Field key={f.key} label={f.label} htmlFor={`t-${f.key}`}>
+                <Input id={`t-${f.key}`} type="number" min={0} value={config.thresholds[f.key]} onChange={(e) => setThreshold(f.key, num(e.target.value))} />
+              </Field>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-tertiary">Due windows (days)</h3>
+          <p className="mb-2 text-xs text-quaternary">Windows are edited in whole or fractional days; a policy set out-of-band with sub-day precision is rounded to the day view here.</p>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[24rem] text-sm">
+              <thead>
+                <tr className="text-left text-xs text-tertiary">
+                  <th className="pb-1 font-medium">Tier</th>
+                  <th className="pb-1 font-medium">Mitigate within</th>
+                  <th className="pb-1 font-medium">Remediate within</th>
+                </tr>
+              </thead>
+              <tbody>
+                {DUE_TIERS.map((tier) => (
+                  <tr key={tier} className="border-t border-secondary">
+                    <td className="py-1.5 pr-3 capitalize text-primary">{tier}</td>
+                    <td className="py-1.5 pr-3">
+                      <Input aria-label={`${tier} mitigate days`} type="number" min={0} value={config.dueRanges[tier].mitigateDays} onChange={(e) => setDue(tier, 'mitigateDays', num(e.target.value))} />
+                    </td>
+                    <td className="py-1.5">
+                      <Input aria-label={`${tier} remediate days`} type="number" min={0} value={config.dueRanges[tier].remediateDays} onChange={(e) => setDue(tier, 'remediateDays', num(e.target.value))} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        {invalid && (
+          <div className="flex items-start gap-2 rounded-lg border border-warning-primary/30 bg-warning-primary/10 px-3 py-2 text-sm text-warning-primary">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden />
+            <span>{invalid}</span>
+          </div>
+        )}
+      </fieldset>
+    </Card>
+  )
+}
+
+export function SLAPolicy() {
+  const { data: me } = useFetch(() => api.me(), { deps: [] })
+  const canAdmin = me?.role === 'admin' || me?.role === 'owner'
+  const { data, loading, error, refetch } = useFetch<SLAPoliciesView | null>(() => api.slaPolicies(), { deps: [] })
+
+  if (loading) return <Spinner label="Loading SLA policy…" />
+  if (error) return <ErrorState message={error} />
+  if (data === null)
+    return (
+      <EmptyState
+        icon={Scales02}
+        title="SLA governance is not enabled"
+        hint="This deployment does not expose risk-based remediation SLAs. Enable the SLA use case to score findings into due-date tiers."
+      />
+    )
+
+  const seed = data.active?.config ?? DEFAULT_CONFIG
+  const history = data.policies.filter((p) => p.sha256 !== data.active?.sha256)
+
+  return (
+    <div className="space-y-6">
+      {data.active ? (
+        <ActivePolicyCard policy={data.active} />
+      ) : (
+        <div className="flex items-center gap-2 rounded-xl border border-dashed border-secondary bg-secondary/20 px-4 py-3 text-sm text-tertiary">
+          <CheckCircle className="size-4 text-brand-secondary" aria-hidden />
+          No stored policy is active. Findings are scored against the built-in default (<span className="font-mono">{DEFAULT_CONFIG.version}</span>) until you activate one.
+        </div>
+      )}
+
+      <ActivateForm seed={seed} canAdmin={canAdmin} onDone={refetch} />
+
+      {history.length > 0 && (
+        <Card title="Previous versions">
+          <ul className="divide-y divide-secondary">
+            {history.map((p) => (
+              <li key={p.sha256} className="flex flex-wrap items-center gap-x-4 gap-y-1 py-2 text-sm">
+                <Pill className="font-mono text-secondary">{p.config.version}</Pill>
+                <span className="font-mono text-xs text-quaternary" title={p.sha256}>{shortHash(p.sha256)}</span>
+                <span className="text-tertiary">by {p.createdBy || '—'}</span>
+                <span className="ml-auto text-xs text-quaternary">{formatWhen(p.createdAt)}</span>
+              </li>
+            ))}
+          </ul>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+export default SLAPolicy

--- a/web/src/pages/Settings/Settings.tsx
+++ b/web/src/pages/Settings/Settings.tsx
@@ -5,6 +5,9 @@ const TABS = [
   { label: 'Audit', to: '/settings', end: true },
   { label: 'Team', to: '/settings/team' },
   { label: 'Connectors', to: '/settings/connectors' },
+  { label: 'SLA policy', to: '/settings/sla' },
+  { label: 'Offensive policy', to: '/settings/offensive-policy' },
+  { label: 'Alerting', to: '/settings/alerting' },
   { label: 'Config', to: '/settings/config' },
 ]
 

--- a/web/src/pages/VulnerabilityIntelligence/VulnIntelAttackPaths.test.tsx
+++ b/web/src/pages/VulnerabilityIntelligence/VulnIntelAttackPaths.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import { AttackPathsTab } from './VulnIntelAttackPaths'
+
+vi.mock('../../lib/api', () => ({ api: { attackPaths: vi.fn() } }))
+
+const RESULT = {
+  bounds: { truncated: false, lengthHit: false, pathsHit: false, wallClockHit: false, maxLength: 8, maxPaths: 100 },
+  paths: [
+    {
+      id: 'ap-confident-1',
+      confident: true,
+      uncertainties: [],
+      nodes: [
+        { id: 'a-edge', kind: 'asset', label: 'edge-gw-01', sublabel: 'host' },
+        { id: 'f-1', kind: 'finding', label: 'CVE-2026-1337 RCE', sublabel: 'critical finding', severity: 'critical', reachability: 'reachable', confirmed: true },
+      ],
+      steps: [{ from: 'a-edge', to: 'f-1', kind: 'hosts_finding', observed: true, toFinding: true, evidenceCount: 1 }],
+    },
+    {
+      id: 'ap-inferred-2',
+      confident: false,
+      uncertainties: ['inferred_edge', 'unconfirmed_reachability'],
+      nodes: [
+        { id: 'a-edge', kind: 'asset', label: 'edge-gw-01', sublabel: 'host' },
+        { id: 'f-2', kind: 'finding', label: 'Exposed admin console', sublabel: 'high finding', severity: 'high', reachability: 'reachable', confirmed: false },
+      ],
+      steps: [{ from: 'a-edge', to: 'f-2', kind: 'exposes', observed: false, toFinding: true, evidenceCount: 1 }],
+    },
+  ],
+}
+
+describe('AttackPathsTab', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('renders confident and inferred paths with why-uncertain', async () => {
+    vi.mocked(api.attackPaths).mockResolvedValue(RESULT as never)
+    render(<AttackPathsTab />)
+    expect(await screen.findByText('CVE-2026-1337 RCE')).toBeInTheDocument()
+    expect(screen.getByText('Confident')).toBeInTheDocument()
+    expect(screen.getByText('Inferred')).toBeInTheDocument()
+    // The inferred path names its reason.
+    expect(screen.getByText('Inferred edge (not observed)')).toBeInTheDocument()
+  })
+
+  it('filters paths by node label', async () => {
+    vi.mocked(api.attackPaths).mockResolvedValue(RESULT as never)
+    render(<AttackPathsTab />)
+    await screen.findByText('CVE-2026-1337 RCE')
+    fireEvent.change(screen.getByLabelText('Filter attack paths'), { target: { value: 'admin console' } })
+    expect(screen.getByText('Exposed admin console')).toBeInTheDocument()
+    expect(screen.queryByText('CVE-2026-1337 RCE')).not.toBeInTheDocument()
+  })
+
+  it('confident-only toggle hides inferred paths', async () => {
+    vi.mocked(api.attackPaths).mockResolvedValue(RESULT as never)
+    render(<AttackPathsTab />)
+    await screen.findByText('CVE-2026-1337 RCE')
+    fireEvent.click(screen.getByLabelText('Confident only'))
+    expect(screen.queryByText('Exposed admin console')).not.toBeInTheDocument()
+    expect(screen.getByText('CVE-2026-1337 RCE')).toBeInTheDocument()
+  })
+
+  it('says so when attack paths are not enabled', async () => {
+    vi.mocked(api.attackPaths).mockResolvedValue(null as never)
+    render(<AttackPathsTab />)
+    expect(await screen.findByText('Attack paths are not enabled')).toBeInTheDocument()
+  })
+
+  it('shows an empty state when no paths exist', async () => {
+    vi.mocked(api.attackPaths).mockResolvedValue({ paths: [], bounds: RESULT.bounds } as never)
+    render(<AttackPathsTab />)
+    expect(await screen.findByText('No attack paths derived yet')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/VulnerabilityIntelligence/VulnIntelAttackPaths.tsx
+++ b/web/src/pages/VulnerabilityIntelligence/VulnIntelAttackPaths.tsx
@@ -1,0 +1,263 @@
+import { useMemo, useState } from 'react'
+import {
+  AlertTriangle,
+  ArrowNarrowRight,
+  CheckCircle,
+  Cube01,
+  Dataflow03,
+  HelpCircle,
+  SearchLg,
+  Target04,
+} from '@untitledui/icons'
+import { Card, EmptyState, ErrorState, Pill, Spinner, cn } from '../../components/ui'
+import { useFetch } from '../../hooks'
+import { api } from '../../lib/api'
+import type { AttackPath, AttackPathNode, AttackPathResult, AttackPathStep } from '../../lib/api'
+
+const SEV_DOT: Record<string, string> = {
+  critical: 'bg-error-solid',
+  high: 'bg-error-primary',
+  medium: 'bg-warning-solid',
+  low: 'bg-brand-solid',
+  info: 'bg-utility-gray-400',
+}
+
+const UNCERTAINTY_LABEL: Record<string, string> = {
+  inferred_edge: 'Inferred edge (not observed)',
+  missing_reachability: 'Reachability not analyzed',
+  unknown_reachability: 'Reachability unknown',
+  unconfirmed_reachability: 'Reachability unconfirmed',
+}
+
+function sevDot(sev?: string): string {
+  return (sev && SEV_DOT[sev]) || 'bg-utility-gray-400'
+}
+
+function humanKind(kind: string): string {
+  return kind ? kind.replace(/[_-]+/g, ' ') : 'reaches'
+}
+
+function NodeChip({ node }: { node: AttackPathNode }) {
+  const isFinding = node.kind === 'finding'
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-1 rounded-lg border px-3 py-2',
+        isFinding ? 'min-w-[12rem] max-w-[22rem] border-error-primary/30 bg-error-primary/5' : 'min-w-[9rem] max-w-[16rem] border-secondary bg-secondary/30',
+      )}
+    >
+      <div className="flex items-start gap-1.5">
+        {isFinding ? (
+          <span className={cn('mt-1 size-2 shrink-0 rounded-full', sevDot(node.severity))} aria-hidden />
+        ) : (
+          <Cube01 className="mt-0.5 size-3.5 shrink-0 text-tertiary" aria-hidden />
+        )}
+        <span
+          className={cn('text-sm font-semibold text-primary', isFinding ? 'break-words' : 'truncate')}
+          title={node.label}
+        >
+          {node.label}
+        </span>
+      </div>
+      <div className="flex items-center gap-1.5">
+        {isFinding && <Target04 className="size-3 shrink-0 text-error-primary" aria-hidden />}
+        <span className="truncate text-xs capitalize text-tertiary">{node.sublabel}</span>
+      </div>
+      {isFinding && node.reachability && (
+        <span className="text-[11px] font-medium uppercase tracking-wide text-quaternary">
+          {node.confirmed ? '' : 'unconfirmed '}
+          {node.reachability.replace(/_/g, ' ')}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function StepConnector({ step }: { step: AttackPathStep }) {
+  const inferred = !step.observed
+  return (
+    <div className="flex shrink-0 flex-col items-center justify-center px-1 py-2" aria-hidden>
+      <span
+        className={cn(
+          'mb-1 max-w-[8rem] truncate text-center text-[10px] font-medium uppercase tracking-wide',
+          inferred ? 'text-warning-primary' : 'text-tertiary',
+        )}
+        title={humanKind(step.kind)}
+      >
+        {humanKind(step.kind)}
+      </span>
+      <span
+        className={cn(
+          'flex items-center gap-1 border-t-2 pt-0.5',
+          inferred ? 'border-warning-primary/50 border-dashed' : 'border-secondarystrong',
+        )}
+      >
+        <ArrowNarrowRight
+          className={cn('size-4', inferred ? 'text-warning-primary' : 'text-quaternary')}
+        />
+      </span>
+      <span className="mt-0.5 text-[10px] text-quaternary">{inferred ? 'inferred' : 'observed'}</span>
+    </div>
+  )
+}
+
+function PathRow({ path, index }: { path: AttackPath; index: number }) {
+  return (
+    <div className="rounded-xl border border-secondary bg-primary p-4">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <span className="inline-flex size-6 items-center justify-center rounded-md bg-secondary text-xs font-bold tabular-nums text-tertiary">
+            {index + 1}
+          </span>
+          <span className="font-mono text-xs text-quaternary" title={path.id}>
+            {path.id.length > 14 ? `${path.id.slice(0, 12)}…` : path.id}
+          </span>
+        </div>
+        {path.confident ? (
+          <Pill className="text-success-primary">
+            <CheckCircle className="mr-1 inline size-3.5" aria-hidden />
+            Confident
+          </Pill>
+        ) : (
+          <Pill className="text-warning-primary">
+            <AlertTriangle className="mr-1 inline size-3.5" aria-hidden />
+            Inferred
+          </Pill>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-stretch gap-y-2 overflow-x-auto">
+        {path.nodes.map((node, i) => (
+          <div key={`${node.id}-${i}`} className="flex items-stretch">
+            <NodeChip node={node} />
+            {i < path.steps.length && i < path.nodes.length - 1 && <StepConnector step={path.steps[i]} />}
+          </div>
+        ))}
+      </div>
+
+      {!path.confident && path.uncertainties.length > 0 && (
+        <div className="mt-3 flex flex-wrap items-center gap-1.5 border-t border-secondary pt-3">
+          <span className="text-[11px] font-semibold uppercase tracking-wide text-quaternary">Why uncertain</span>
+          {path.uncertainties.map((u) => (
+            <Pill key={u} className="text-warning-primary">
+              {UNCERTAINTY_LABEL[u] ?? u.replace(/_/g, ' ')}
+            </Pill>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function pathMatches(path: AttackPath, needle: string): boolean {
+  if (!needle) return true
+  const q = needle.toLowerCase()
+  return path.nodes.some((n) => n.label.toLowerCase().includes(q) || n.sublabel.toLowerCase().includes(q))
+}
+
+export function AttackPathsTab() {
+  const { data, loading, error, refetch } = useFetch<AttackPathResult | null>(() => api.attackPaths(), { deps: [] })
+  const [filter, setFilter] = useState('')
+  const [confidentOnly, setConfidentOnly] = useState(false)
+
+  const paths = useMemo(() => data?.paths ?? [], [data])
+  const confidentCount = useMemo(() => paths.filter((p) => p.confident).length, [paths])
+  const visible = useMemo(
+    () => paths.filter((p) => (!confidentOnly || p.confident) && pathMatches(p, filter)),
+    [paths, filter, confidentOnly],
+  )
+
+  if (loading) return <Spinner label="Deriving attack paths…" />
+  if (error) return <ErrorState message={error} />
+  if (data === null)
+    return (
+      <EmptyState
+        icon={Dataflow03}
+        title="Attack paths are not enabled"
+        hint="This deployment does not expose the attack-path graph. Enable the estate graph service to correlate exposure assets with reachable findings."
+      />
+    )
+  if (paths.length === 0)
+    return (
+      <EmptyState
+        icon={Dataflow03}
+        title="No attack paths derived yet"
+        hint="Attack paths connect an exposure-facing asset to a reachable finding through evidence-carrying edges. Add assets, asset edges, and confirmed findings, and paths appear here."
+      />
+    )
+
+  return (
+    <div className="space-y-6">
+      <Card title="Attack path exposure" titleClassName="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-x-8 gap-y-4">
+          <div className="flex items-baseline gap-2">
+            <span className="text-4xl font-bold tabular-nums text-primary">{paths.length}</span>
+            <span className="text-sm text-tertiary">exposure-to-finding path{paths.length === 1 ? '' : 's'}</span>
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <div className="flex items-center gap-2">
+              <CheckCircle className="size-4 text-success-primary" aria-hidden />
+              <span className="text-sm font-semibold text-primary">{confidentCount}</span>
+              <span className="text-xs text-tertiary">confident (every edge observed, finding confirmed-reachable)</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <HelpCircle className="size-4 text-warning-primary" aria-hidden />
+              <span className="text-sm font-semibold text-primary">{paths.length - confidentCount}</span>
+              <span className="text-xs text-tertiary">inferred (at least one edge or reachability unconfirmed)</span>
+            </div>
+          </div>
+        </div>
+        {data.bounds.truncated && (
+          <div className="mt-4 flex items-start gap-2 rounded-lg border border-warning-primary/30 bg-warning-primary/10 px-3 py-2 text-xs text-warning-primary">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden />
+            <span>
+              Traversal hit a bound and the set is partial
+              {data.bounds.pathsHit ? ` (max ${data.bounds.maxPaths} paths)` : data.bounds.lengthHit ? ` (max length ${data.bounds.maxLength})` : data.bounds.wallClockHit ? ' (wall-clock limit)' : ''}
+              . Narrow the estate or query a specific target to see the rest.
+            </span>
+          </div>
+        )}
+      </Card>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="relative min-w-[16rem] flex-1">
+          <SearchLg className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-quaternary" aria-hidden />
+          <input
+            type="search"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            placeholder="Filter by asset or finding…"
+            aria-label="Filter attack paths"
+            className="input-inset w-full rounded-lg border border-secondary bg-secondary py-2 pl-9 pr-3 text-sm text-primary outline-none transition-colors placeholder:text-quaternary focus:border-brand focus:ring-2 focus:ring-brand/40"
+          />
+        </div>
+        <label className="flex items-center gap-2 text-sm text-secondary">
+          <input
+            type="checkbox"
+            checked={confidentOnly}
+            onChange={(e) => setConfidentOnly(e.target.checked)}
+            className="size-4 rounded border-secondary text-brand-solid focus:ring-2 focus:ring-brand/40"
+          />
+          Confident only
+        </label>
+        <button
+          type="button"
+          onClick={() => refetch()}
+          className="rounded-lg border border-secondary px-3 py-2 text-sm font-semibold text-secondary transition-colors hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {visible.length === 0 ? (
+        <EmptyState icon={SearchLg} title="No paths match" hint="Clear the filter or the confident-only toggle." />
+      ) : (
+        <div className="space-y-3">
+          {visible.map((path, i) => (
+            <PathRow key={path.id || i} path={path} index={i} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/pages/VulnerabilityIntelligence/index.tsx
+++ b/web/src/pages/VulnerabilityIntelligence/index.tsx
@@ -7,8 +7,9 @@ import { OverviewTab } from './VulnIntelOverview'
 import { VulnerabilitiesTab } from './VulnIntelAdvisories'
 import { SourcesTab } from './VulnIntelSources'
 import { SyncRunsTab } from './VulnIntelSyncRuns'
+import { AttackPathsTab } from './VulnIntelAttackPaths'
 
-const TABS = ['overview', 'vulnerabilities', 'sources', 'sync-runs'] as const
+const TABS = ['overview', 'vulnerabilities', 'sources', 'sync-runs', 'attack-paths'] as const
 type Tab = (typeof TABS)[number]
 
 export function VulnerabilityIntelligence() {
@@ -85,8 +86,13 @@ export function VulnerabilityIntelligence() {
       {tab === 'vulnerabilities' && <VulnerabilitiesTab params={params} updateSearch={updateSearch} canOperate={!!canOperate} idempotencyKey={idempotencyKey} finishAction={finishAction} />}
       {tab === 'sources' && <SourcesTab params={params} updateSearch={updateSearch} canOperate={!!canOperate} canAdmin={!!canAdmin} idempotencyKey={idempotencyKey} finishAction={finishAction} />}
       {tab === 'sync-runs' && <SyncRunsTab params={params} updateSearch={updateSearch} />}
+      {tab === 'attack-paths' && <AttackPathsTab />}
     </div>
   )
 }
 
-function tabLabel(tab: Tab) { return tab === 'sync-runs' ? 'Sync runs' : tab.charAt(0).toUpperCase() + tab.slice(1) }
+function tabLabel(tab: Tab) {
+  if (tab === 'sync-runs') return 'Sync runs'
+  if (tab === 'attack-paths') return 'Attack paths'
+  return tab.charAt(0).toUpperCase() + tab.slice(1)
+}


### PR DESCRIPTION
## What

Four backend capabilities were wired non-nil in `cmd/synapse-api/main.go` but had no dashboard surface, so an operator could not reach them. This adds a UI for each, consuming the existing route.

- **Attack paths** — new tab under Vulnerability Intelligence. Renders `GET /attack-paths` as an evidence-carrying chain per path (exposure asset → … → finding), with a confident/inferred verdict and the reasons a path is uncertain. Filter by asset/finding, confident-only toggle, bounds/truncation banner.
- **SLA policy** — new Settings tab. Reads `GET /sla/policies` (active policy factors, tier thresholds, due windows) and lets an admin activate a new version via `POST /sla/policies` through a validated editor that mirrors the server rules (weights ≥ 0, thresholds strictly descending and positive, mitigate ≤ remediate).
- **Offensive policy** — new read-only Settings tab. Renders the technique register from `GET /redteam/policy`: risk class, disruption, reversibility, blast radius, approval mode, production-safe/prohibited, and the legal-review block.
- **Alerting** — new Settings tab. Runs the sink self-test `POST /alerts/test` and shows the per-count outcome (delivered/failed/audit-failed/rule-matched), including the 502 no-acknowledgement case.

Shared change: `ApiError` now carries the parsed error body, so `/alerts/test` can read the `outcome` returned alongside a 502. It already parsed the body for the message; this attaches it. No other consumer depends on it.

## Tests

- One `*.test.tsx` per surface (16 tests): rendering, 404-not-enabled, empty, filters, admin gating, SLA validation blocking, the 502 outcome.
- Full web suite green (533 tests), `pnpm typecheck` and `pnpm build` clean.
- Verified in light and dark themes against the real dev server; UI reviewed by Codex and the flagged issues (title truncation, oversized tiles, heavy intro) fixed.

## Complexity

All four are read views (plus two guarded POSTs). Attack-path rendering is O(paths × nodes); the server bounds the path set. No new dependency.
