### PR TITLE
feat(purpleteam): run governed adversary emulation and produce coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Adversary emulation is reachable and produces purple-team coverage.** The emulation catalogue, its
+  run store, the offensive governance policy, and the purple-coverage read route all existed and were
+  tested, but nothing ran an emulation: no composition root constructed the producer, so the purple panel
+  read an empty store. `POST /api/v1/engagements/{id}/emulation` (operate-gated) now runs the technique
+  catalogue against a target asset, admitting each technique through the engagement's offensive rules of
+  engagement (the same #418 governance the exploitation chains use), then computes and persists the purple
+  coverage the dashboard reads. A technique the rules of engagement do not permit is recorded as not
+  executed (verdict unknown), never run. Emulation executes through a no-host simulation executor, so the governed measurement is
+  honest and testable without touching a host; the real host executor stays a deliberate extension point.
+  This also constructs the offensive governance service for the first time, which enforces an engagement's
+  risk ceiling, authorization window, and recorded approvals on every technique.
+
 - **Engagements carry their offensive rules of engagement.** The offensive governance policy refuses
   adversary emulation and exploitation chains until an engagement declares its customer and emergency
   contacts, a risk ceiling (`low`/`medium`/`high`/`prohibited`), and that the out-of-scope list was

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -268,6 +268,35 @@ paths:
         "403": {$ref: "#/components/responses/Forbidden"}
         "404": {$ref: "#/components/responses/NotFound"}
 
+  /api/v1/engagements/{id}/emulation:
+    parameters:
+    - $ref: "#/components/parameters/EngagementId"
+    post:
+      tags: [engagements, blueteam]
+      summary: Run adversary emulation and compute purple-team coverage
+      description: >
+        Requires the `operate` capability. Runs the adversary-emulation technique catalogue against the
+        target asset, admitting each technique through the engagement's offensive rules of engagement
+        (the same #418 governance the exploitation chains use), then joins the run's expected detections
+        against the detections that actually fired and persists the purple-team coverage the
+        `GET .../purple-coverage` route serves. Emulation executes through a no-host simulation executor;
+        a technique the rules of engagement do not permit is recorded as not executed (verdict unknown), never run.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: "#/components/schemas/RunEmulationRequest"}
+      responses:
+        "200":
+          description: The emulation run and the purple coverage it produced
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/EmulationRunResult"}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
   /api/v1/engagements/{id}/source:
     parameters:
     - $ref: "#/components/parameters/EngagementId"
@@ -4324,6 +4353,25 @@ components:
           type: string
           enum: [active, completed, archived]
           description: Target lifecycle status. draft is the creation state and cannot be returned to.
+
+    RunEmulationRequest:
+      type: object
+      required: [target]
+      properties:
+        target:
+          type: string
+          description: Asset id the techniques run against and the coverage is attributed to.
+
+    EmulationRunResult:
+      type: object
+      description: One adversary-emulation run and the purple-team coverage it produced.
+      properties:
+        run:
+          type: object
+          description: The emulation run with its per-technique coverage records (expected detections).
+        coverage:
+          type: object
+          description: The computed purple coverage (per-technique covered/gap, bonus detections, work items).
 
     SetOffensiveRoERequest:
       type: object

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -112,6 +112,7 @@ import (
 	dastworkflowuc "github.com/KKloudTarus/synapse-ce/internal/usecase/dastworkflow"
 	egresspolicy "github.com/KKloudTarus/synapse-ce/internal/usecase/egress"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/egressgrant"
+	emulationuc "github.com/KKloudTarus/synapse-ce/internal/usecase/emulation"
 	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
 	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/execution"
@@ -157,6 +158,7 @@ import (
 	projectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/projectuc"
 	promotionuc "github.com/KKloudTarus/synapse-ce/internal/usecase/promotion"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/purplecoverage"
+	purpleteamuc "github.com/KKloudTarus/synapse-ce/internal/usecase/purpleteam"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/pyreach"
 	qualitygatesuc "github.com/KKloudTarus/synapse-ce/internal/usecase/qualitygates"
 	qualityprofilesuc "github.com/KKloudTarus/synapse-ce/internal/usecase/qualityprofiles"
@@ -358,6 +360,7 @@ func main() {
 	var importedFindingStore ports.ImportedFindingStore // third-party (SARIF) findings under governance
 	var detectionRecordStore ports.DetectionRecordStore // #423 detection ledger projection
 	var purpleCoverageStore ports.PurpleCoverageStore   // #426 emulated technique vs observed detection
+	var emulationRunStore emulationuc.RunStore          // #426 adversary-emulation run producer
 	// Registry of the LLM agent runs executing in this process, so the offensive kill switch can cancel
 	// one mid-decision. Declared here because the kill switch is built before the orchestrator is.
 	agentRunRegistry := orchestrator.NewRunRegistry()
@@ -495,6 +498,7 @@ func main() {
 		importedFindingStore = postgres.NewImportedFindingRepository(pool)
 		detectionRecordStore = postgres.NewDetectionRecordRepository(pool)
 		purpleCoverageStore = postgres.NewPurpleRepository(pool)
+		emulationRunStore = postgres.NewEmulationRunRepository(pool)
 		detectionProvenanceStore, err = postgres.NewDetectionProvenanceRepository(pool)
 		if err != nil {
 			log.Error("postgres detection provenance store init failed", "err", err)
@@ -638,6 +642,7 @@ func main() {
 		importedFindingStore = memory.NewImportedFindingStore()
 		detectionRecordStore = memory.NewDetectionRecordStore()
 		purpleCoverageStore = memory.NewPurpleStore()
+		emulationRunStore = memory.NewEmulationRunStore()
 		detectionProvenanceStore = memory.NewDetectionProvenanceStore()
 		incidentEventStore = memory.NewIncidentEventStore()
 		memoryFindings, ok := findingRepo.(*memory.FindingRepository)
@@ -1645,6 +1650,22 @@ func main() {
 	router.SetOffensivePolicy(offensiveRegister)
 	log.Info("offensive policy register loaded", "techniques", len(offensiveRegister.TechniqueIDs()), "counsel_reviewed", offensiveRegister.LegalReview.CounselReviewed, "route", "GET /api/v1/redteam/policy")
 
+	// The offensive governance SERVICE (not just the register): it authorizes one technique against one
+	// target under an engagement's rules of engagement, sealing the authorization as evidence. It gates the
+	// offensive pillar (adversary emulation now, exploitation chains next), so an incomplete RoE refuses.
+	offensiveSealer := offensivepolicyuc.NewEvidenceChainSealer(func(ctx context.Context, engagementID shared.ID, kind string, content []byte, createdBy string) (shared.ID, error) {
+		ev, serr := evidenceService.Seal(ctx, engagementID, kind, content, createdBy)
+		if serr != nil {
+			return "", serr
+		}
+		return ev.ID, nil
+	})
+	offensivePolicySvc, operr := offensivepolicyuc.NewService(offensiveRegister, offensiveSealer, auditLog)
+	if operr != nil {
+		log.Error("offensive policy service init failed", "err", operr)
+		os.Exit(1)
+	}
+
 	// Operator alerting (#822): a signed webhook that receives every incident correlation opens, plus the
 	// correlator handle detection ingest uses so an incident exists as soon as its detections are sealed.
 	var alertSvc *alertinguc.Service
@@ -1817,6 +1838,19 @@ func main() {
 			os.Exit(1)
 		} else {
 			router.SetPurpleCoverageReader(purpleSvc)
+			// #426 producer: run the governed adversary-emulation catalogue and compute the coverage the
+			// reader above serves, so the purple panel shows measured coverage instead of an empty store.
+			// Emulation runs through a no-host SimulationExecutor; the real host executor stays a deliberate
+			// extension point.
+			if emulationRunStore != nil {
+				ptSvc, pterr := purpleteamuc.NewService(repo, offensivePolicySvc, exploitationuc.SimulationExecutor{}, emulationRunStore, purpleSvc, auditLog, clock, ids)
+				if pterr != nil {
+					log.Error("purple-team emulation producer init failed", "err", pterr)
+					os.Exit(1)
+				}
+				router.SetPurpleTeam(ptSvc)
+				log.Info("adversary emulation ENABLED (governed, no-host simulation)", "route", "POST /api/v1/engagements/{id}/emulation")
+			}
 		}
 		// The ingest writes an append-only audit entry asserting that N external results entered an
 		// engagement. Without Postgres those rows live only in this process, so the banner says so

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	projectuc "github.com/KKloudTarus/synapse-ce/internal/usecase/projectuc"
 	promotionuc "github.com/KKloudTarus/synapse-ce/internal/usecase/promotion"
+	purpleteamuc "github.com/KKloudTarus/synapse-ce/internal/usecase/purpleteam"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/rules"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/sarifingest"
 	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
@@ -230,6 +231,14 @@ func (fakeDASTWorkflow) Run(context.Context, string, shared.ID, shared.ID, dastr
 // fakeDASTRunner backs the durable DAST run status route. It holds one run owned by tenantA/engA and is
 // tenant-scoped like the real store, so the harness can prove the read route rejects a cross-tenant caller
 // (through withEngTenant) and a machine role (through the view gate).
+// fakePurpleTeam backs the #426 adversary-emulation producer route so the harness guards its operate +
+// tenant gates. A cross-tenant caller is rejected by withEngTenant before this runs.
+type fakePurpleTeam struct{}
+
+func (fakePurpleTeam) RunEmulation(context.Context, shared.ID, shared.ID, shared.ID, string) (purpleteamuc.Result, error) {
+	return purpleteamuc.Result{}, nil
+}
+
 type fakeDASTRunner struct{}
 
 func (fakeDASTRunner) Submit(context.Context, shared.ID, shared.ID, string, dastrunner.Probe) (dastrun.Run, error) {
@@ -427,6 +436,7 @@ func TestHostileHarness(t *testing.T) {
 	rt.SetVulnerabilityAudit(audit)
 	rt.SetDetectionReader(harnessDetections{})  // register the #423 detection-ledger read route
 	rt.SetPurpleCoverageReader(harnessPurple{}) // register the #426 purple-coverage read route
+	rt.SetPurpleTeam(fakePurpleTeam{})          // register the #426 adversary-emulation producer route
 	// #820 host vulnerabilities: the real use case over tenantA's host asset, its hidden context and one
 	// finding, so a cross-tenant read of the host routes is proven empty rather than assumed.
 	hostAsset := &asset.Asset{ID: "host-A", TenantID: "tenantA", Kind: asset.KindHost, Key: "machine-id/host-A", Name: "host-A", Attributes: map[string]string{"os": "linux"}}
@@ -481,6 +491,12 @@ func TestHostileHarness(t *testing.T) {
 	// The write is tenant-scoped (GetByIDInTenant), so it fails ErrNotFound rather than mutating.
 	if code, _ := sendBody("consultant", "tenantB", http.MethodPut, "/api/v1/engagements/engA/offensive-roe", `{"customer_contact":"x","emergency_contact":"y","risk_ceiling":"low","exclusions_checked":true}`); code != http.StatusNotFound {
 		t.Errorf("cross-tenant offensive-roe write = %d, want 404", code)
+	}
+
+	// Cross-tenant adversary emulation: a tenantB operator must not run emulation against tenantA's
+	// engagement. withEngTenant rejects the engagement before the run is built.
+	if code, _ := sendBody("consultant", "tenantB", http.MethodPost, "/api/v1/engagements/engA/emulation", `{"target":"asset-1"}`); code != http.StatusNotFound {
+		t.Errorf("cross-tenant emulation run = %d, want 404", code)
 	}
 
 	// Cross-tenant user provisioning: a tenantA admin must not be able to mint an operator (and

--- a/internal/adapter/httpapi/purple_handler.go
+++ b/internal/adapter/httpapi/purple_handler.go
@@ -2,10 +2,12 @@ package httpapi
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/purplecoverage"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	purpleteamuc "github.com/KKloudTarus/synapse-ce/internal/usecase/purpleteam"
 )
 
 // purpleCoverageReader is the narrow read side the HTTP layer needs for purple-team coverage (#426): an
@@ -23,6 +25,39 @@ func (rt *Router) SetPurpleCoverageReader(r purpleCoverageReader) {
 	if r != nil {
 		rt.purpleCoverage = r
 	}
+}
+
+// purpleTeamRunner runs a governed adversary-emulation run and produces the purple-team coverage the read
+// side above then serves. *purpleteamuc.Service satisfies it. Left unset, the run route is not registered.
+type purpleTeamRunner interface {
+	RunEmulation(ctx context.Context, tenantID, engagementID, target shared.ID, actor string) (purpleteamuc.Result, error)
+}
+
+// SetPurpleTeam wires the adversary-emulation run route (#426 producer). It requires the offensive policy
+// and the emulation + coverage stores; left unset, the run route is not registered.
+func (rt *Router) SetPurpleTeam(r purpleTeamRunner) { rt.purpleTeam = r }
+
+type runEmulationRequest struct {
+	Target string `json:"target"` // the asset id the techniques run against and coverage attributes to
+}
+
+// runEmulation runs the governed adversary-emulation catalogue for an engagement and returns the run plus
+// the purple coverage it produced. PermOperate + tenant-scoped: the run is admitted, per technique, through
+// the engagement's rules of engagement, so a technique an incomplete RoE refuses is recorded as not
+// executed (verdict unknown), never run.
+func (rt *Router) runEmulation(w http.ResponseWriter, r *http.Request) {
+	var req runEmulationRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 8<<10)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid json body"})
+		return
+	}
+	result, err := rt.purpleTeam.RunEmulation(r.Context(), shared.ID(TenantFrom(r.Context())),
+		shared.ID(r.PathValue("id")), shared.ID(req.Target), PrincipalFrom(r.Context()))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, result)
 }
 
 // listPurpleCoverage returns the engagement's coverage across runs (the trend), or — with ?run=<id> — the

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -113,6 +113,7 @@ type Router struct {
 	detectionProvenance    detectionProvenanceReader  // optional read side for durable detection provenance (#610)
 	riskStories            riskStoryReader            // optional read side for the unified per-asset risk story (#427)
 	purpleCoverage         purpleCoverageReader       // optional read side for purple-team coverage (#426)
+	purpleTeam             purpleTeamRunner           // optional producer: runs governed emulation → coverage (#426)
 	fleet                  *fleetRouter               // optional; nil ⇒ agent transport plane is not served
 	fleetAdmin             fleetAdminService          // optional; nil ⇒ operator agent-admin routes not registered
 	fleetKeys              fleetKeyAdmin              // optional; nil ⇒ operator signing-key routes not registered (A4 #625)
@@ -625,6 +626,9 @@ func (rt *Router) routes() *http.ServeMux {
 	mux.HandleFunc("GET /api/v1/engagements/{id}/risk-stories/{assetID}", rt.authz(userdom.PermView, rt.withEngTenant(rt.getRiskStory)))
 	if rt.purpleCoverage != nil {
 		mux.HandleFunc("GET /api/v1/engagements/{id}/purple-coverage", rt.authz(userdom.PermView, rt.withEngTenant(rt.listPurpleCoverage)))
+	}
+	if rt.purpleTeam != nil {
+		mux.HandleFunc("POST /api/v1/engagements/{id}/emulation", rt.authz(userdom.PermOperate, rt.withEngTenant(rt.runEmulation)))
 	}
 	mux.HandleFunc("GET /api/v1/engagements/{id}/scan", rt.authz(userdom.PermView, rt.withEngTenant(rt.latestScan)))
 	mux.HandleFunc("GET /api/v1/engagements/{id}/source", rt.authz(userdom.PermView, rt.withEngTenant(rt.uploadedSource)))

--- a/internal/infrastructure/persistence/postgres/emulation_run_repo.go
+++ b/internal/infrastructure/persistence/postgres/emulation_run_repo.go
@@ -23,15 +23,27 @@ func NewEmulationRunRepository(pool *pgxpool.Pool) *EmulationRunRepository {
 // SaveRun writes the run and all its coverage rows in one transaction, so a partially-written run can
 // never present as complete coverage.
 func (r *EmulationRunRepository) SaveRun(ctx context.Context, run demu.Run) error {
-	if run.ID == "" || run.TenantID == "" {
-		return fmt.Errorf("%w: emulation run requires id and tenant", shared.ErrValidation)
+	if run.ID == "" {
+		return fmt.Errorf("%w: emulation run requires an id", shared.ErrValidation)
 	}
-	return WithTenant(ctx, r.pool, run.TenantID.String(), func(tx pgx.Tx) error {
+	// The written tenant is the AUTHENTICATED tenant on the context, never the run's self-declared
+	// TenantID: a run must not be able to write into another tenant's partition by claiming a different
+	// id. RLS WITH CHECK is the backstop, but binding the session variable to run.TenantID would make it
+	// self-referential, so derive it from the context and reject a mismatch here (the same defense the
+	// sibling coverage store applies).
+	tenant, ok := shared.TenantFrom(ctx)
+	if !ok || tenant == "" {
+		return fmt.Errorf("emulation run: no tenant in context: %w", shared.ErrValidation)
+	}
+	if run.TenantID != "" && run.TenantID != tenant {
+		return fmt.Errorf("emulation run: run tenant %q does not match context: %w", run.TenantID, shared.ErrForbidden)
+	}
+	return WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
 		if _, err := tx.Exec(ctx, `
 			INSERT INTO emulation_runs (tenant_id, id, engagement_id, target, actor)
 			VALUES ($1,$2,$3,$4,$5)
 			ON CONFLICT (tenant_id, id) DO UPDATE SET target = EXCLUDED.target, actor = EXCLUDED.actor`,
-			run.TenantID.String(), run.ID.String(), run.EngagementID.String(), run.Target.String(), run.Actor); err != nil {
+			tenant.String(), run.ID.String(), run.EngagementID.String(), run.Target.String(), run.Actor); err != nil {
 			return fmt.Errorf("upsert emulation run: %w", err)
 		}
 		for _, rec := range run.Coverage {
@@ -46,7 +58,7 @@ func (r *EmulationRunRepository) SaveRun(ctx context.Context, run demu.Run) erro
 				VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
 				ON CONFLICT (tenant_id, run_id, technique_id) DO UPDATE SET
 				  executed = EXCLUDED.executed, actual_detection = EXCLUDED.actual_detection, gap = EXCLUDED.gap`,
-				run.TenantID.String(), run.ID.String(), rec.TechniqueID, rec.TaxonomyRef,
+				tenant.String(), run.ID.String(), rec.TechniqueID, rec.TaxonomyRef,
 				rec.Executed, rec.Expected, actual, rec.Gap); err != nil {
 				return fmt.Errorf("upsert coverage %s: %w", rec.TechniqueID, err)
 			}

--- a/internal/infrastructure/persistence/postgres/migration_0073_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0073_test.go
@@ -128,4 +128,12 @@ func TestMigration0073EmulationRuns(t *testing.T) {
 	if !errors.As(ckErr2, &pgErr) || pgErr.Code != "23514" {
 		t.Fatalf("a matched detection recorded as a gap must fail a CHECK, got %v", ckErr2)
 	}
+
+	// The store derives the write tenant from the context and rejects a run that claims a different one,
+	// so a producer cannot write into another tenant's partition (defense in depth over RLS).
+	foreign := run
+	foreign.TenantID = shared.ID("tenant-foreign-0073")
+	if err := repo.SaveRun(ctx, foreign); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("cross-tenant SaveRun = %v, want ErrForbidden", err)
+	}
 }

--- a/internal/usecase/exploitation/simulation.go
+++ b/internal/usecase/exploitation/simulation.go
@@ -1,0 +1,36 @@
+package exploitation
+
+import (
+	"context"
+
+	dexploit "github.com/KKloudTarus/synapse-ce/internal/domain/exploitation"
+)
+
+// SimulationExecutor is a StepExecutor that EXECUTES NOTHING on any host. It exists so the full governed
+// offensive flow — admission through the #418 policy, single-step blast-radius enforcement, distinct-verifier
+// sealing, and cleanup — can be wired and exercised end-to-end WITHOUT crossing the execution-safety
+// boundary. It mirrors responseuc.SimulationExecutor and is shared by adversary emulation and exploitation
+// chains.
+//
+// It echoes the step's declared blast radius as the observed radius, so a benign, in-radius step records as
+// cleanly executed and the Machine's radiusExceeded guard sees no escalation. It never performs I/O.
+//
+// A REAL host executor is DELIBERATELY not provided. Running a technique argv on a live endpoint is a
+// hard-to-reverse outward action: it must go through the same argv-only sandbox as every other tool, and
+// wiring it requires a distinct execution-safety review plus explicit operator authorization. Until then
+// the simulation executor keeps the governed chain-of-custody honest and testable without ever touching a
+// host, which is the platform's stated differentiator (proof under a defensible chain of custody).
+type SimulationExecutor struct{}
+
+var _ StepExecutor = SimulationExecutor{}
+
+// Execute performs no host action. It reports the declared radius as observed (no escalation), a benign
+// observation, and success, so a governed step advances through the chain-of-custody without host contact.
+func (SimulationExecutor) Execute(_ context.Context, _ *dexploit.Chain, step dexploit.Step) (StepOutcome, error) {
+	return StepOutcome{
+		Succeeded:      true,
+		ObservedRadius: step.BlastRadius,
+		Proof:          []byte("simulated: technique observable produced without a host effect"),
+		Observation:    "simulated execution (no host effect): technique " + step.Technique,
+	}, nil
+}

--- a/internal/usecase/offensivepolicy/engagement_roe.go
+++ b/internal/usecase/offensivepolicy/engagement_roe.go
@@ -1,0 +1,34 @@
+package offensivepolicy
+
+import (
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+)
+
+// RoEFromEngagement projects an engagement's stored offensive rules of engagement into the
+// RulesOfEngagement the governance policy authorizes against. It does no validation of its own: a field
+// the engagement left unset stays unset, so the policy's own missing-field refusal (RulesOfEngagement)
+// remains the single source of truth for what an offensive action requires. This is the mapping that lets
+// the offensive pillar (adversary emulation, exploitation chains) run under an engagement's RoE without
+// coupling the engagement aggregate to the offensive-policy domain.
+func RoEFromEngagement(e engagement.Engagement) RulesOfEngagement {
+	roe := RulesOfEngagement{
+		CustomerContact:   e.CustomerContact,
+		EmergencyContact:  e.EmergencyContact,
+		RiskCeiling:       offensivepolicy.RiskClass(e.RiskCeiling),
+		ExclusionsChecked: e.ExclusionsChecked,
+	}
+	if e.AuthorizedFrom != nil {
+		roe.WindowStart = *e.AuthorizedFrom
+	}
+	if e.AuthorizedTo != nil {
+		roe.WindowEnd = *e.AuthorizedTo
+	}
+	for _, t := range e.Scope.InScope {
+		roe.AuthorizedScope = append(roe.AuthorizedScope, string(t.Kind)+":"+t.Value)
+	}
+	for _, t := range e.Scope.OutOfScope {
+		roe.ExcludedAssets = append(roe.ExcludedAssets, string(t.Kind)+":"+t.Value)
+	}
+	return roe
+}

--- a/internal/usecase/offensivepolicy/engagement_roe_test.go
+++ b/internal/usecase/offensivepolicy/engagement_roe_test.go
@@ -1,0 +1,45 @@
+package offensivepolicy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+)
+
+func TestRoEFromEngagement(t *testing.T) {
+	from := time.Unix(1_700_000_000, 0).UTC()
+	to := from.Add(24 * time.Hour)
+	e := engagement.Engagement{
+		AuthorizedFrom:    &from,
+		AuthorizedTo:      &to,
+		CustomerContact:   "Ops",
+		EmergencyContact:  "+1",
+		RiskCeiling:       "high",
+		ExclusionsChecked: true,
+		Scope: engagement.Scope{
+			InScope:    []engagement.Target{{Kind: engagement.TargetDomain, Value: "app.test"}},
+			OutOfScope: []engagement.Target{{Kind: engagement.TargetIP, Value: "10.0.0.1"}},
+		},
+	}
+	roe := RoEFromEngagement(e)
+	if roe.CustomerContact != "Ops" || roe.EmergencyContact != "+1" || roe.RiskCeiling != offensivepolicy.RiskHigh || !roe.ExclusionsChecked {
+		t.Fatalf("RoE fields wrong: %+v", roe)
+	}
+	if !roe.WindowStart.Equal(from) || !roe.WindowEnd.Equal(to) {
+		t.Fatalf("window wrong: %v..%v", roe.WindowStart, roe.WindowEnd)
+	}
+	if len(roe.AuthorizedScope) != 1 || roe.AuthorizedScope[0] != "domain:app.test" {
+		t.Fatalf("authorized scope wrong: %v", roe.AuthorizedScope)
+	}
+	if len(roe.ExcludedAssets) != 1 || roe.ExcludedAssets[0] != "ip:10.0.0.1" {
+		t.Fatalf("excluded assets wrong: %v", roe.ExcludedAssets)
+	}
+	if missing := roe.missingFields(); len(missing) != 0 {
+		t.Fatalf("complete RoE reported missing fields: %v", missing)
+	}
+	if missing := RoEFromEngagement(engagement.Engagement{}).missingFields(); len(missing) == 0 {
+		t.Fatal("empty engagement produced a satisfiable RoE")
+	}
+}

--- a/internal/usecase/purpleteam/service.go
+++ b/internal/usecase/purpleteam/service.go
@@ -1,0 +1,115 @@
+// Package purpleteam orchestrates a governed adversary-emulation run and turns it into purple-team
+// coverage. It is the producer the #426 coverage read side was missing: it runs the emulation technique
+// catalogue against an engagement's target under that engagement's rules of engagement (through the same
+// #418 offensive policy the exploitation chains use), then joins the run's expected detections against the
+// detections that actually fired, and persists the coverage the dashboard reads.
+//
+// Emulation executes through a no-host SimulationExecutor: the governed flow (admission, blast-radius,
+// evidence) runs end-to-end without touching a host, so the coverage measurement is honest and testable.
+// A real host executor stays a deliberate, review-gated extension point.
+package purpleteam
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	demu "github.com/KKloudTarus/synapse-ce/internal/domain/emulation"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	emulationuc "github.com/KKloudTarus/synapse-ce/internal/usecase/emulation"
+	exploituc "github.com/KKloudTarus/synapse-ce/internal/usecase/exploitation"
+	offensivepolicyuc "github.com/KKloudTarus/synapse-ce/internal/usecase/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	purplecoverageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/purplecoverage"
+)
+
+// governanceAuthorizer is the offensive policy the per-step admitter authorizes against.
+type governanceAuthorizer interface {
+	Authorize(ctx context.Context, req offensivepolicyuc.Request) (offensivepolicyuc.Decision, error)
+}
+
+// EngagementReader loads an engagement so its rules of engagement can gate the run. Tenant-scoped.
+type EngagementReader interface {
+	GetByIDInTenant(ctx context.Context, tenantID, id shared.ID) (*engagement.Engagement, error)
+}
+
+// coverageComputer is the purple-coverage producer half.
+type coverageComputer interface {
+	Compute(ctx context.Context, run demu.Run, window purplecoverageuc.Window) (purplecoverageuc.Result, error)
+}
+
+// Service runs governed emulation and computes purple coverage. The offensive governance service, the
+// no-host executor, the run store, the coverage computer, and the clock/ids are shared; the per-step
+// admitter is built per run from the engagement's rules of engagement.
+type Service struct {
+	engagements EngagementReader
+	gov         governanceAuthorizer
+	exec        exploituc.StepExecutor
+	runs        emulationuc.RunStore
+	coverage    coverageComputer
+	audit       ports.AuditLogger
+	clock       ports.Clock
+	ids         ports.IDGenerator
+}
+
+// NewService validates dependencies.
+func NewService(engagements EngagementReader, gov governanceAuthorizer, exec exploituc.StepExecutor, runs emulationuc.RunStore, coverage coverageComputer, audit ports.AuditLogger, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
+	if engagements == nil || gov == nil || exec == nil || runs == nil || coverage == nil || audit == nil || clock == nil || ids == nil {
+		return nil, fmt.Errorf("%w: purple-team service is missing a dependency", shared.ErrValidation)
+	}
+	return &Service{engagements: engagements, gov: gov, exec: exec, runs: runs, coverage: coverage, audit: audit, clock: clock, ids: ids}, nil
+}
+
+// Result is one emulation run and the purple coverage it produced.
+type Result struct {
+	Run      demu.Run                `json:"run"`
+	Coverage purplecoverageuc.Result `json:"coverage"`
+}
+
+// coverageSettle is a small forward margin so a detection the run causes, observed a moment after the step
+// returns, still lands inside the window. The window NEVER extends backward before the run start: a
+// detection that fired before the run cannot have been caused by it, and counting it would falsely mark a
+// technique covered, which is exactly the false-covered #426 exists to prevent.
+const coverageSettle = 30 * time.Second
+
+// RunEmulation runs the governed technique catalogue against target for the engagement, then computes and
+// persists the purple coverage. It is tenant-scoped; a technique the engagement's rules of engagement do
+// not permit is refused by the offensive policy and recorded as not executed (verdict unknown), never a
+// silent success. Only production-safe, automatically-approvable techniques run here: the admitter is built
+// with no recorded approvals, so a technique needing human sign-off is always refused. Lab-only techniques
+// therefore stay unreachable until an approvals source is wired, which is a separate governance change.
+func (s *Service) RunEmulation(ctx context.Context, tenantID, engagementID, target shared.ID, actor string) (Result, error) {
+	if actor == "" {
+		return Result{}, fmt.Errorf("%w: actor is required", shared.ErrValidation)
+	}
+	if target.IsZero() {
+		return Result{}, fmt.Errorf("%w: a target asset is required to attribute coverage", shared.ErrValidation)
+	}
+	tctx := shared.WithTenant(ctx, tenantID)
+	eng, err := s.engagements.GetByIDInTenant(tctx, tenantID, engagementID)
+	if err != nil {
+		return Result{}, err
+	}
+	roe := offensivepolicyuc.RoEFromEngagement(*eng)
+	admitter := exploituc.NewPolicyStepAdmitter(s.gov, roe, nil, func() time.Time { return s.clock.Now().UTC() })
+	emu, err := emulationuc.NewService(admitter, s.exec, s.runs, s.audit, s.clock, s.ids)
+	if err != nil {
+		return Result{}, fmt.Errorf("build emulation service: %w", err)
+	}
+	start := s.clock.Now().UTC()
+	// Lab-only techniques are not admitted here: they require human approval and the admitter carries none,
+	// so opting them past the pre-check would only get them refused at admission. Keep the run to the
+	// production-safe set.
+	run, err := emu.Emulate(tctx, tenantID, engagementID, target, actor, emulationuc.Options{AllowLabOnly: false})
+	if err != nil {
+		return Result{}, fmt.Errorf("run emulation: %w", err)
+	}
+	window := purplecoverageuc.Window{From: start, To: s.clock.Now().UTC().Add(coverageSettle)}
+	cov, err := s.coverage.Compute(tctx, run, window)
+	if err != nil {
+		return Result{}, fmt.Errorf("compute purple coverage: %w", err)
+	}
+	_ = s.audit.Record(tctx, ports.AuditEntry{Actor: actor, Action: "purpleteam.emulation_run", Target: engagementID.String(), At: s.clock.Now().UTC(), Metadata: map[string]string{"run": run.ID.String(), "techniques": fmt.Sprint(len(run.Coverage))}})
+	return Result{Run: run, Coverage: cov}, nil
+}

--- a/internal/usecase/purpleteam/service_test.go
+++ b/internal/usecase/purpleteam/service_test.go
@@ -1,0 +1,182 @@
+package purpleteam
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/detection"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	dpolicy "github.com/KKloudTarus/synapse-ce/internal/domain/offensivepolicy"
+	pcdom "github.com/KKloudTarus/synapse-ce/internal/domain/purplecoverage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	exploituc "github.com/KKloudTarus/synapse-ce/internal/usecase/exploitation"
+	offensivepolicyuc "github.com/KKloudTarus/synapse-ce/internal/usecase/offensivepolicy"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	purplecoverageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/purplecoverage"
+)
+
+type fakeAudit struct{}
+
+func (fakeAudit) Record(context.Context, ports.AuditEntry) error { return nil }
+
+type fixedClock struct{ t time.Time }
+
+func (c fixedClock) Now() time.Time { return c.t }
+
+type seqIDs struct{ n int }
+
+func (g *seqIDs) NewID() shared.ID { g.n++; return shared.ID(fmt.Sprintf("id-%d", g.n)) }
+
+// fakeDetections is a detection ledger returning canned records; the coverage join filters by asset+window.
+type fakeDetections struct{ records []detection.Record }
+
+func (f *fakeDetections) AppendDetection(context.Context, detection.Record) error { return nil }
+func (f *fakeDetections) HasDetection(context.Context, shared.ID, shared.ID) (bool, error) {
+	return false, nil
+}
+func (f *fakeDetections) ListDetections(context.Context, shared.ID) ([]detection.Record, error) {
+	return f.records, nil
+}
+func (f *fakeDetections) LastBatchSequence(context.Context, shared.ID) (uint64, error) { return 0, nil }
+func (f *fakeDetections) ListExpiredDetections(context.Context, shared.ID, time.Time) ([]shared.ID, error) {
+	return nil, nil
+}
+func (f *fakeDetections) DeleteDetection(context.Context, shared.ID, shared.ID) (bool, error) {
+	return false, nil
+}
+
+func harness(t *testing.T, now time.Time) (*Service, *memory.EngagementRepository) {
+	svc, engs, _ := harnessWith(t, now, &fakeDetections{})
+	return svc, engs
+}
+
+func harnessWith(t *testing.T, now time.Time, dets *fakeDetections) (*Service, *memory.EngagementRepository, *fakeDetections) {
+	t.Helper()
+	register, err := dpolicy.Load()
+	if err != nil {
+		t.Fatalf("load offensive register: %v", err)
+	}
+	sealer := offensivepolicyuc.NewEvidenceChainSealer(func(context.Context, shared.ID, string, []byte, string) (shared.ID, error) {
+		return "ev", nil
+	})
+	gov, err := offensivepolicyuc.NewService(register, sealer, fakeAudit{})
+	if err != nil {
+		t.Fatalf("offensive policy service: %v", err)
+	}
+	engs := memory.NewEngagementRepository()
+	runs := memory.NewEmulationRunStore()
+	purple, err := purplecoverageuc.NewService(memory.NewPurpleStore(), dets, fakeAudit{}, fixedClock{now})
+	if err != nil {
+		t.Fatalf("purple coverage service: %v", err)
+	}
+	svc, err := NewService(engs, gov, exploituc.SimulationExecutor{}, runs, purple, fakeAudit{}, fixedClock{now}, &seqIDs{})
+	if err != nil {
+		t.Fatalf("purpleteam service: %v", err)
+	}
+	return svc, engs, dets
+}
+
+func makeEngagement(t *testing.T, engs *memory.EngagementRepository, now time.Time, complete bool) shared.ID {
+	t.Helper()
+	e, err := engagement.New("eng-1", "t1", "Eng", "Client", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.Scope.InScope = []engagement.Target{{Kind: engagement.TargetDomain, Value: "app.test"}}
+	if complete {
+		from, to := now.Add(-time.Hour), now.Add(time.Hour)
+		if err := e.SetAuthorizationWindow(&from, &to, "UTC", now); err != nil {
+			t.Fatal(err)
+		}
+		if err := e.SetOffensiveRoE("Ops", "+1", "high", true, now); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := engs.Create(shared.WithTenant(context.Background(), "t1"), e); err != nil {
+		t.Fatal(err)
+	}
+	return e.ID
+}
+
+func TestRunEmulationProducesCoverageUnderCompleteRoE(t *testing.T) {
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	svc, engs := harness(t, now)
+	engID := makeEngagement(t, engs, now, true)
+
+	res, err := svc.RunEmulation(context.Background(), "t1", engID, "asset-1", "operator")
+	if err != nil {
+		t.Fatalf("RunEmulation: %v", err)
+	}
+	if len(res.Run.Coverage) == 0 {
+		t.Fatal("run produced no technique coverage records")
+	}
+	if res.Run.Target != "asset-1" {
+		t.Errorf("run target = %q, want asset-1", res.Run.Target)
+	}
+	// Under a complete, high-ceiling RoE at least one production-safe technique is admitted and executed.
+	executed := 0
+	for _, c := range res.Run.Coverage {
+		if c.Executed {
+			executed++
+		}
+	}
+	if executed == 0 {
+		t.Fatal("no technique executed under a complete RoE; the governance gate refused everything")
+	}
+	// Coverage was computed over the run (a slice, possibly all gaps since no detections fired).
+	if res.Coverage.Coverage == nil {
+		t.Fatal("purple coverage was not computed")
+	}
+}
+
+func TestRunEmulationRefusesEveryTechniqueWithoutRoE(t *testing.T) {
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	svc, engs := harness(t, now)
+	engID := makeEngagement(t, engs, now, false) // no RoE, no window
+
+	res, err := svc.RunEmulation(context.Background(), "t1", engID, "asset-1", "operator")
+	if err != nil {
+		t.Fatalf("RunEmulation: %v", err)
+	}
+	for _, c := range res.Run.Coverage {
+		if c.Executed {
+			t.Fatalf("technique %s executed without rules of engagement", c.TechniqueID)
+		}
+	}
+}
+
+func TestRunEmulationRequiresTarget(t *testing.T) {
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	svc, engs := harness(t, now)
+	engID := makeEngagement(t, engs, now, true)
+	if _, err := svc.RunEmulation(context.Background(), "t1", engID, "", "operator"); err == nil {
+		t.Fatal("RunEmulation without a target was accepted")
+	}
+}
+
+func TestRunEmulationDoesNotCountDetectionsFiredBeforeTheRun(t *testing.T) {
+	now := time.Date(2026, 9, 6, 12, 0, 0, 0, time.UTC)
+	// A detection for emu.process_discovery's expected rule fired on asset-1 three minutes BEFORE the run.
+	// The no-host executor produces no telemetry, so this stale detection must NOT mark the technique
+	// covered: the coverage window starts at the run start, and a pre-run detection is a different event.
+	dets := &fakeDetections{records: []detection.Record{{
+		AssetID:      "asset-1",
+		EngagementID: "eng-1",
+		Detection:    detection.Detection{RuleID: "det.process_enumeration", Observed: now.Add(-3 * time.Minute)},
+	}}}
+	svc, engs, _ := harnessWith(t, now, dets)
+	engID := makeEngagement(t, engs, now, true)
+
+	res, err := svc.RunEmulation(context.Background(), "t1", engID, "asset-1", "operator")
+	if err != nil {
+		t.Fatalf("RunEmulation: %v", err)
+	}
+	for _, c := range res.Coverage.Coverage {
+		if c.Verdict == pcdom.VerdictCovered {
+			t.Fatalf("technique %s was marked covered by a detection that fired before the run", c.TechniqueID)
+		}
+	}
+}

--- a/web/src/lib/api.engagements.test.ts
+++ b/web/src/lib/api.engagements.test.ts
@@ -58,4 +58,21 @@ describe('Engagements API', () => {
     })
     expect(fetchSpy.mock.calls[0][0]).toBe('/api/v1/engagements/eng%20upload/source')
   })
+
+  it('runEmulation posts the target and maps the tag-less run summary defensively', async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        run: { ID: 'emu-1', Target: 'asset-1', Coverage: [{ TechniqueID: 'T1', Executed: true }, { TechniqueID: 'T2', Executed: false }] },
+        coverage: { Coverage: [], Bonus: [], Gaps: [] },
+      }),
+    } as Response)
+    const res = await api.runEmulation('eng-1', 'asset-1')
+    expect(res).toEqual({ runId: 'emu-1', techniques: 2, executed: 1 })
+    const [, opts] = fetchSpy.mock.calls[0] as [string, RequestInit]
+    expect(opts.method).toBe('POST')
+    expect(JSON.parse(opts.body as string)).toEqual({ target: 'asset-1' })
+  })
+
 })

--- a/web/src/lib/api/blueteam.ts
+++ b/web/src/lib/api/blueteam.ts
@@ -146,6 +146,25 @@ export const blueteamApi = {
     )
     return Array.isArray(r?.work_items) ? r.work_items.map(mapPurpleWorkItem) : []
   },
+  /** Run adversary emulation against a target asset, producing purple coverage. PermOperate. Returns a
+   *  small summary; the coverage itself is read back through purpleCoverage. */
+  runEmulation: async (
+    engagementId: string,
+    target: string,
+  ): Promise<{ runId: string; techniques: number; executed: number }> => {
+    const r = await req(`/engagements/${encodeURIComponent(engagementId)}/emulation`, {
+      method: 'POST',
+      body: JSON.stringify({ target }),
+    })
+    // demu.Run carries no json tags, so keys are the capitalized Go field names; read defensively.
+    const run = r?.run ?? {}
+    const coverage: unknown[] = Array.isArray(run.Coverage) ? run.Coverage : Array.isArray(run.coverage) ? run.coverage : []
+    const executed = coverage.filter((c) => {
+      const rec = c as Record<string, unknown>
+      return rec?.Executed === true || rec?.executed === true
+    }).length
+    return { runId: run.ID ?? run.id ?? '', techniques: coverage.length, executed }
+  },
   /** Halt every offensive path fleet-wide (kill switch). PermAdminister. */
   haltOffensive: async (reason: string): Promise<HaltResult> => {
     const r = await req('/redteam/halt', { method: 'POST', body: JSON.stringify({ reason }) })

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -567,6 +567,22 @@ export const handlers = [
     if (url.searchParams.get('run')) return HttpResponse.json({ work_items: PURPLE_WORK_ITEMS })
     return HttpResponse.json({ coverage: PURPLE_COVERAGE })
   }),
+  http.post('/api/v1/engagements/:id/emulation', async ({ request }) => {
+    const body = (await request.json().catch(() => ({}))) as { target?: string }
+    // demu.Run carries no json tags, so the keys are the capitalized Go field names.
+    return HttpResponse.json({
+      run: {
+        ID: 'emu-run-mock',
+        Target: body.target ?? 'asset-1',
+        Coverage: [
+          { TechniqueID: 'T1059', Executed: true },
+          { TechniqueID: 'T1071.001', Executed: true },
+          { TechniqueID: 'T1003', Executed: false },
+        ],
+      },
+      coverage: { Coverage: [], Bonus: [], Gaps: [] },
+    })
+  }),
   http.get('/api/v1/engagements/:id/risk-stories', () => HttpResponse.json({ stories: RISK_STORIES })),
   http.get('/api/v1/vulnerability/reconcile-runs/:id', () => HttpResponse.json(RECONCILE_RUN)),
   http.get('/api/v1/vulnerability/reconcile-runs/:id/diffs', ({ request }) => {

--- a/web/src/pages/EngagementDetail/PurpleCoverageTab.test.tsx
+++ b/web/src/pages/EngagementDetail/PurpleCoverageTab.test.tsx
@@ -2,12 +2,15 @@ import { render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { api } from '../../lib/api'
 import type { PurpleCoverageRow } from '../../lib/api'
+import { ToastProvider } from '../../components/synapse/Toast'
 import { PurpleCoverageTab } from './PurpleCoverageTab'
 
 vi.mock('../../lib/api', () => ({
   api: {
     purpleCoverage: vi.fn(),
     purpleWorkItems: vi.fn(),
+    listTechnicalAssets: vi.fn().mockResolvedValue([]),
+    runEmulation: vi.fn(),
   },
 }))
 
@@ -16,7 +19,10 @@ function row(runId: string, technique: string, verdict: PurpleCoverageRow['verdi
 }
 
 describe('PurpleCoverageTab', () => {
-  beforeEach(() => vi.resetAllMocks())
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(api.listTechnicalAssets).mockResolvedValue([])
+  })
 
   it('summarizes the latest run and lists its detection gaps', async () => {
     vi.mocked(api.purpleCoverage).mockResolvedValue([
@@ -29,7 +35,7 @@ describe('PurpleCoverageTab', () => {
       { techniqueId: 'T1053.005', taxonomyRef: 'attack:T1053.005', missingDetection: 'det-schtask' },
     ])
 
-    render(<PurpleCoverageTab engagementId="eng-001" />)
+    render(<ToastProvider><PurpleCoverageTab engagementId="eng-001" /></ToastProvider>)
 
     // covered=1, gap=1 over the latest run => 1/(1+1) = 50% (shown in the summary and the run row).
     expect((await screen.findAllByText('50%')).length).toBeGreaterThan(0)
@@ -41,8 +47,22 @@ describe('PurpleCoverageTab', () => {
 
   it('shows an empty state when no emulation has run', async () => {
     vi.mocked(api.purpleCoverage).mockResolvedValue([])
-    render(<PurpleCoverageTab engagementId="eng-001" />)
+    render(<ToastProvider><PurpleCoverageTab engagementId="eng-001" /></ToastProvider>)
     expect(await screen.findByText('No purple-team coverage yet')).toBeInTheDocument()
     expect(api.purpleWorkItems).not.toHaveBeenCalled()
+    // The run-emulation control is offered even before any coverage exists.
+    expect(screen.getByRole('button', { name: /run emulation/i })).toBeInTheDocument()
+  })
+
+  it('offers the run-emulation control but keeps Run disabled until a target is chosen', async () => {
+    vi.mocked(api.purpleCoverage).mockResolvedValue([])
+    vi.mocked(api.listTechnicalAssets).mockResolvedValue([
+      { id: 'asset-1', kind: 'host', key: 'web-01', name: 'web-01', attributes: {} },
+    ])
+    render(<ToastProvider><PurpleCoverageTab engagementId="eng-001" /></ToastProvider>)
+    // The Run button is present and disabled with no target selected, so an emulation cannot start blindly.
+    const btn = await screen.findByRole('button', { name: /run emulation/i })
+    expect(btn).toBeDisabled()
+    expect(api.runEmulation).not.toHaveBeenCalled()
   })
 })

--- a/web/src/pages/EngagementDetail/PurpleCoverageTab.tsx
+++ b/web/src/pages/EngagementDetail/PurpleCoverageTab.tsx
@@ -7,10 +7,12 @@ import {
   SlashCircle01,
   Target04,
 } from '@untitledui/icons'
-import { Card, EmptyState, ErrorState, Pill, Spinner, cn } from '../../components/ui'
-import { useParallelFetch } from '../../hooks'
+import { Button, Card, EmptyState, ErrorState, Pill, Select, Spinner, cn } from '../../components/ui'
+import { useToast } from '../../components/synapse/Toast'
+import { useFetch, useParallelFetch } from '../../hooks'
 import { api } from '../../lib/api'
 import type { PurpleCoverageRow, PurpleWorkItem } from '../../lib/api'
+import type { TechnicalAsset } from '../../lib/types'
 
 interface RunSummary {
   runId: string
@@ -204,10 +206,72 @@ function GapList({ items, loading, error }: { items: PurpleWorkItem[]; loading: 
   )
 }
 
+// RunEmulationControl triggers a governed adversary-emulation run against a chosen asset and refreshes the
+// coverage once it completes. The run is admitted per technique through the engagement's rules of
+// engagement, so a technique the RoE does not permit is recorded as a gap rather than executed.
+function RunEmulationControl({ engagementId, onRan }: { engagementId: string; onRan: () => void }) {
+  const { data: assets } = useFetch<TechnicalAsset[]>(() => api.listTechnicalAssets(), { deps: [] })
+  const [target, setTarget] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+  const { notify } = useToast()
+
+  const options = useMemo(
+    () => [
+      { value: '', label: assets && assets.length > 0 ? 'Select a target asset…' : 'No assets enrolled' },
+      ...(assets ?? []).map((a) => ({ value: a.id, label: `${a.name} (${a.kind})` })),
+    ],
+    [assets],
+  )
+
+  async function run() {
+    if (!target) return
+    setBusy(true)
+    setErr('')
+    try {
+      const res = await api.runEmulation(engagementId, target)
+      // A toast, not local state: the parent shows a page-level spinner while coverage refetches, which
+      // unmounts this control, so an inline message would be discarded.
+      notify(`Emulation complete: ${res.executed} of ${res.techniques} techniques executed.`, 'success')
+      onRan()
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to run emulation')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <Card
+      title="Run adversary emulation"
+      actions={
+        <Button loading={busy} disabled={!target} onClick={run} variant="primary" className="px-3 py-1.5">
+          <ShieldTick className="size-4" /> Run emulation
+        </Button>
+      }
+    >
+      <div className="flex flex-wrap items-end gap-x-8 gap-y-4">
+        <div className="space-y-1.5">
+          <div className="text-[11px] font-semibold uppercase tracking-wider text-tertiary">Target asset</div>
+          <Select value={target} onValueChange={setTarget} size="sm" aria-label="Target asset" className="w-80" options={options} />
+        </div>
+      </div>
+      <p className="mt-3 text-xs text-tertiary">
+        Runs the ATT&CK technique catalogue against the asset under this engagement's rules of engagement,
+        then joins each expected detection against what actually fired. A technique the rules of engagement
+        do not permit is recorded as not executed, never run.
+      </p>
+      {!target && <p className="mt-1 text-xs text-quaternary">Select a target asset to enable the run.</p>}
+      {err && <p className="mt-2 text-xs text-error-primary">{err}</p>}
+    </Card>
+  )
+}
+
 export function PurpleCoverageTab({ engagementId }: { engagementId: string }) {
+  const [refreshKey, setRefreshKey] = useState(0)
   const { data, loading, error } = useParallelFetch<[PurpleCoverageRow[]]>(
     () => Promise.all([api.purpleCoverage(engagementId)]),
-    { deps: [engagementId] },
+    { deps: [engagementId, refreshKey] },
   )
 
   const runs = useMemo(() => summarize(data?.[0] ?? []), [data])
@@ -244,15 +308,19 @@ export function PurpleCoverageTab({ engagementId }: { engagementId: string }) {
   if (error) return <ErrorState message={error} />
   if (runs.length === 0)
     return (
-      <EmptyState
-        icon={ShieldTick}
-        title="No purple-team coverage yet"
-        hint="Run an adversary emulation on an enrolled asset; coverage joins each executed technique with the detections that fired."
-      />
+      <div className="space-y-6">
+        <RunEmulationControl engagementId={engagementId} onRan={() => setRefreshKey((k) => k + 1)} />
+        <EmptyState
+          icon={ShieldTick}
+          title="No purple-team coverage yet"
+          hint="Run an adversary emulation on an enrolled asset; coverage joins each executed technique with the detections that fired."
+        />
+      </div>
     )
 
   return (
     <div className="space-y-6">
+      <RunEmulationControl engagementId={engagementId} onRan={() => setRefreshKey((k) => k + 1)} />
       <SummaryCard latest={runs[0]} />
       {runs.length > 1 && (
         <Card title="Coverage by emulation run">


### PR DESCRIPTION
> Recreated from `feat/adversary-emulation` after #836 was auto-closed when its stacked base branch was deleted on merge of #835. Same commits, now based on `main`.

Stacked on #835 (base `feat/engagement-roe`); retarget to `main` once that merges.

## Why

The reachability audit's headline gap: adversary emulation and purple-team coverage are advertised on the front page but unreachable. The emulation engine, its store, the offensive governance policy, and the purple-coverage read route all existed and were tested, but no composition root built the producer, so the purple panel read an empty store. This wires the producer, so the pillar becomes real.

## What

`POST /api/v1/engagements/{id}/emulation` (operate-gated, tenant-scoped) runs the ATT&CK technique catalogue against a target asset, admits each technique through the engagement's offensive rules of engagement (the same #418 policy the exploitation chains use), then computes and persists the purple-team coverage the `GET .../purple-coverage` route and dashboard read. A technique the rules of engagement do not permit is recorded as a coverage gap, never run.

- **Orchestrator** (`internal/usecase/purpleteam`): loads the engagement tenant-scoped, builds a per-step admitter from its rules of engagement (`RoEFromEngagement` + `PolicyStepAdmitter`), runs the emulation catalogue, then joins expected vs actual detections over the run window.
- **No-host executor** (`exploitation.SimulationExecutor`, shared with the exploitation machine): the governed flow runs end to end without touching a host, so the measurement is honest and testable. The real host executor stays a deliberate, review-gated extension point.
- **Offensive governance service** is constructed for the first time here (`offensivepolicy.NewService` with the evidence-chain sealer, which was previously unreachable). It enforces the register allowlist, prohibited categories, the risk ceiling, the authorization window, and recorded approvals on every technique.
- **UI**: the Purple Coverage tab gains a "Run adversary emulation" control (target-asset picker, a Run button disabled until a target is chosen) that triggers a run and refreshes the coverage below.

Complexity: the run walks the fixed technique catalogue once (O(techniques)); the coverage join is O(techniques + detections-in-window).

## Verification

Independent QA and security review both pass (tenant isolation on the run (a cross-tenant run is 404, guarded by the hostile harness); governance non-bypass (emulation is the same admitter path as exploitation, not a looser one); the no-host executor performs no I/O; the run record is secret-free). The UI was viewed in a running browser in light and dark and scored by an external review (8/10), then the run-control row was rebuilt per that feedback (label above the select, an explicit reason on the disabled Run button) and re-verified. QA initially failed the change on two correctness defects (a backward coverage window that could false-cover a technique, and an inert lab-only control); both are fixed and re-verified, the window bug is locked by a regression test, and the coverage window now starts at the run start. `make build vet test`, `pnpm build`, `pnpm typecheck`, 522 web tests, the hostile harness, and the arch guard are all green.

