### PR TITLE
feat(web): dashboards for cloud posture, write-ups, coverage, retro-hunt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Cloud posture, write-up drafts, coverage windows, and host retro-hunt reach the dashboard.** Four more routes were wired non-nil in `cmd/synapse-api` but had no UI. New surfaces consume them: a **Cloud Posture** tab runs a bounded read-only CSPM scan (`POST`/`GET /engagements/{id}/cspm/runs`); a **Write-up Drafts** tab lists AI-proposed finding write-ups with reviewer accept/edit/reject under separation of duties (`/engagements/{id}/writeup-drafts`); a **Coverage Windows** page shows the immutable per-asset telemetry coverage revisions with per-class sensor state (`GET /fleet/coverage-windows`); and a host **Timeline** tab re-hunts a window of the host timeline around a pivot (`POST /fleet/assets/{id}/retro-hunt`).
+
 - **Tenant telemetry-privacy governance in the dashboard.** The fleet source-privacy policy routes
   (`GET /fleet/privacy-policies/active`, `GET/POST /fleet/privacy-policies`, `POST
   /fleet/privacy-policies/activate`) had no UI. A new **Telemetry Privacy** settings page shows the

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,6 +29,7 @@ const QualityProfiles = lazy(() => import('./pages/CodeQuality/QualityProfiles')
 const FleetCoverage = lazy(() => import('./pages/Fleet/FleetCoverage').then(m => ({ default: m.FleetCoverage })))
 const Incidents = lazy(() => import('./pages/Fleet/Incidents').then(m => ({ default: m.Incidents })))
 const Hosts = lazy(() => import('./pages/Fleet/Hosts').then(m => ({ default: m.Hosts })))
+const CoverageWindows = lazy(() => import('./pages/Fleet/CoverageWindows').then(m => ({ default: m.CoverageWindows })))
 const HostDetail = lazy(() => import('./pages/Fleet/HostDetail').then(m => ({ default: m.HostDetail })))
 const IncidentDetail = lazy(() => import('./pages/Fleet/IncidentDetail').then(m => ({ default: m.IncidentDetail })))
 const Rules = lazy(() => import('./pages/Rules/index'))
@@ -103,6 +104,7 @@ function Gate() {
         <Route path="fleet" element={<FleetCoverage />} />
         <Route path="fleet/agents" element={<Navigate to="/fleet" replace />} />
         <Route path="fleet/hosts" element={<Hosts />} />
+        <Route path="fleet/coverage-windows" element={<CoverageWindows />} />
         <Route path="fleet/hosts/:id" element={<HostDetail />} />
         <Route path="fleet/incidents" element={<Incidents />} />
         <Route path="blueteam/response" element={<ResponseOps />} />

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -12,6 +12,7 @@ import {
   Plus,
   Monitor01,
   Server01,
+  Signal01,
   Settings01,
   ShieldTick,
   SlashCircle01,
@@ -86,6 +87,7 @@ const NAV_GROUPS: Array<{
       items: [
         { icon: Server01, label: 'Fleet', to: '/fleet', capability: 'fleet' },
         { icon: Monitor01, label: 'Hosts', to: '/fleet/hosts', capability: 'fleet' },
+        { icon: Signal01, label: 'Coverage Windows', to: '/fleet/coverage-windows', capability: 'fleet' },
         { icon: AlertTriangle, label: 'Incidents', to: '/fleet/incidents' },
         { icon: ShieldTick, label: 'Response', to: '/blueteam/response', capability: 'fleet' },
         { icon: Activity, label: 'Automation Observability', to: '/ai-triage/observability', capability: 'ai_triage' },

--- a/web/src/lib/api/cspm.ts
+++ b/web/src/lib/api/cspm.ts
@@ -1,0 +1,68 @@
+import { req } from './client'
+
+// Cloud posture (CSPM) runs (#... cspm). A bounded, read-only live scan of a cloud account's posture.
+// Targets carry a provider, a root (account/subscription/project), and a vault credential reference
+// (never credential material). The run is durable and executed in an isolated worker; the surface polls
+// its status.
+
+export type CloudProvider = 'aws' | 'azure' | 'gcp'
+
+export type CSPMStatus = 'queued' | 'running' | 'succeeded' | 'partial' | 'failed' | 'cancelled'
+
+export interface CloudTarget {
+  provider: CloudProvider
+  root: string
+  credentialRef: string
+}
+
+export interface CSPMEvidenceRef {
+  scopeKey: string
+  id: string
+  hash: string
+}
+
+export interface CSPMRun {
+  id: string
+  engagementId: string
+  actor: string
+  status: CSPMStatus
+  complete: boolean
+  assets: number
+  findings: number
+  coverageIssues: unknown[]
+  errorCode: string
+  evidenceRefs: CSPMEvidenceRef[]
+  startedAt: string
+  finishedAt: string | null
+}
+
+function mapRun(r: any): CSPMRun {
+  return {
+    id: r?.id ?? '',
+    engagementId: r?.engagement_id ?? '',
+    actor: r?.actor ?? '',
+    status: (r?.status ?? 'queued') as CSPMStatus,
+    complete: r?.complete ?? false,
+    assets: r?.assets ?? 0,
+    findings: r?.findings ?? 0,
+    coverageIssues: Array.isArray(r?.coverage_issues) ? r.coverage_issues : [],
+    errorCode: r?.error_code ?? '',
+    evidenceRefs: Array.isArray(r?.evidence_refs)
+      ? r.evidence_refs.map((e: any): CSPMEvidenceRef => ({ scopeKey: e?.scope_key ?? '', id: e?.id ?? '', hash: e?.hash ?? '' }))
+      : [],
+    startedAt: r?.started_at ?? '',
+    finishedAt: r?.finished_at ?? null,
+  }
+}
+
+export const cspmApi = {
+  runCSPM: async (engagementId: string, targets: CloudTarget[]): Promise<CSPMRun> =>
+    mapRun(
+      await req(`/engagements/${encodeURIComponent(engagementId)}/cspm/runs`, {
+        method: 'POST',
+        body: JSON.stringify({ targets: targets.map((t) => ({ provider: t.provider, root: t.root, credential_ref: t.credentialRef })) }),
+      }),
+    ),
+  getCSPMRun: async (engagementId: string, runId: string): Promise<CSPMRun> =>
+    mapRun(await req(`/engagements/${encodeURIComponent(engagementId)}/cspm/runs/${encodeURIComponent(runId)}`)),
+}

--- a/web/src/lib/api/fleet.ts
+++ b/web/src/lib/api/fleet.ts
@@ -147,6 +147,37 @@ export const fleetApi = {
   },
 
   // Desired-vs-observed capability reconciliation (#633). Rows are snake_case-tagged (ReconciliationRow).
+  // Immutable telemetry coverage-window revisions (#611): one sealed record per asset/agent/host window,
+  // carrying the per-class sensor state and the sample/drop/gap counts the revision was computed from.
+  // Filters are optional; the tenant comes from the authenticated session.
+  listCoverageWindows: async (filters: CoverageWindowFilters = {}): Promise<CoverageWindow[]> => {
+    const qs = new URLSearchParams()
+    if (filters.agentId) qs.set('agent_id', filters.agentId)
+    if (filters.assetId) qs.set('asset_id', filters.assetId)
+    if (filters.hostId) qs.set('host_id', filters.hostId)
+    if (filters.since) qs.set('since', filters.since)
+    if (filters.until) qs.set('until', filters.until)
+    if (filters.limit) qs.set('limit', String(filters.limit))
+    const q = qs.toString()
+    const res = await req(`/fleet/coverage-windows${q ? `?${q}` : ''}`)
+    return (Array.isArray(res?.coverage_windows) ? res.coverage_windows : []).map(mapCoverageWindow)
+  },
+
+  // Re-hunt the endpoint state timeline in [around-before, around+after] on a host asset (#594 B7).
+  retroHunt: async (assetId: string, input: RetroHuntRequest): Promise<RetroHuntResult> =>
+    mapRetroHuntResult(
+      await req(`/fleet/assets/${encodeURIComponent(assetId)}/retro-hunt`, {
+        method: 'POST',
+        body: JSON.stringify({
+          around: input.around,
+          before_seconds: input.beforeSeconds,
+          after_seconds: input.afterSeconds,
+          entity_id: input.entityId ?? '',
+          limit: input.limit ?? 0,
+        }),
+      }),
+    ),
+
   // The route only exists when the desired-capabilities service is wired, so callers degrade gracefully.
   fleetDesiredGaps: async (): Promise<FleetDesiredGap[]> => {
     const res = await req('/fleet/desired-capabilities/gaps')
@@ -163,4 +194,135 @@ export const fleetApi = {
       }),
     )
   },
+}
+
+// --- Coverage windows (#611 immutable telemetry coverage revisions) ---
+
+export interface CoverageWindowFilters {
+  agentId?: string
+  assetId?: string
+  hostId?: string
+  since?: string
+  until?: string
+  limit?: number
+}
+
+export type CoverageClass = 'process' | 'network' | 'file' | 'privilege'
+
+export interface CoverageClassState {
+  class: string
+  hostId: string
+  agentId: string
+  state: string
+  reason: string
+  since: string
+}
+
+export interface CoverageVector {
+  process: number
+  network: number
+  file: number
+  privilege: number
+  reasons: string[]
+}
+
+export interface CoverageWindow {
+  assetId: string
+  agentId: string
+  hostId: string
+  since: string
+  until: string
+  inputDigest: string
+  revision: string
+  createdAt: string
+  states: CoverageClassState[]
+  sampledCount: number
+  truncatedCount: number
+  droppedCount: number
+  gapCount: number
+  batchCount: number
+  coverage: CoverageVector
+}
+
+function mapCoverageWindow(r: any): CoverageWindow {
+  return {
+    assetId: r?.asset_id ?? '',
+    agentId: r?.agent_id ?? '',
+    hostId: r?.host_id ?? '',
+    since: r?.since ?? '',
+    until: r?.until ?? '',
+    inputDigest: r?.input_digest ?? '',
+    revision: r?.revision ?? '',
+    createdAt: r?.created_at ?? '',
+    states: Array.isArray(r?.states)
+      ? r.states.map((s: any): CoverageClassState => ({
+          class: s?.class ?? '',
+          hostId: s?.host_id ?? '',
+          agentId: s?.agent_id ?? '',
+          state: s?.state ?? '',
+          reason: s?.reason ?? '',
+          since: s?.since ?? '',
+        }))
+      : [],
+    sampledCount: r?.sampled_count ?? 0,
+    truncatedCount: r?.truncated_count ?? 0,
+    droppedCount: r?.dropped_count ?? 0,
+    gapCount: r?.gap_count ?? 0,
+    batchCount: r?.batch_count ?? 0,
+    coverage: {
+      process: r?.coverage?.process ?? 0,
+      network: r?.coverage?.network ?? 0,
+      file: r?.coverage?.file ?? 0,
+      privilege: r?.coverage?.privilege ?? 0,
+      reasons: Array.isArray(r?.coverage?.reasons) ? r.coverage.reasons : [],
+    },
+  }
+}
+
+// --- Retro-hunt (#594 B7): re-hunt the endpoint state timeline in a window around a pivot ---
+
+export interface RetroHuntRequest {
+  around: string // RFC3339 pivot time
+  beforeSeconds: number
+  afterSeconds: number
+  entityId?: string
+  limit?: number
+}
+
+export interface TimelineEntry {
+  occurredAt: string
+  entityKind: string
+  entityId: string
+  kind: string
+  eventId: string
+  summary: string
+}
+
+export interface RetroHuntResult {
+  assetId: string
+  from: string
+  to: string
+  entries: TimelineEntry[]
+  truncated: boolean
+}
+
+function mapTimelineEntry(r: any): TimelineEntry {
+  return {
+    occurredAt: r?.OccurredAt ?? r?.occurred_at ?? '',
+    entityKind: r?.EntityKind ?? r?.entity_kind ?? '',
+    entityId: r?.EntityID ?? r?.entity_id ?? '',
+    kind: r?.Kind ?? r?.kind ?? '',
+    eventId: r?.EventID ?? r?.event_id ?? '',
+    summary: r?.Summary ?? r?.summary ?? '',
+  }
+}
+
+export function mapRetroHuntResult(r: any): RetroHuntResult {
+  return {
+    assetId: r?.AssetID ?? r?.asset_id ?? '',
+    from: r?.From ?? r?.from ?? '',
+    to: r?.To ?? r?.to ?? '',
+    entries: Array.isArray(r?.Entries) ? r.Entries.map(mapTimelineEntry) : Array.isArray(r?.entries) ? r.entries.map(mapTimelineEntry) : [],
+    truncated: r?.Truncated ?? r?.truncated ?? false,
+  }
 }

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -42,6 +42,8 @@ import { slaApi } from './sla'
 import { offensivePolicyApi } from './offensivepolicy'
 import { alertingApi } from './alerting'
 import { privacyApi } from './privacy'
+import { writeupApi } from './writeup'
+import { cspmApi } from './cspm'
 
 // projectMeasures was a standalone export in the old api.ts
 export const projectMeasures = codeQualityApi.projectMeasures
@@ -81,4 +83,26 @@ export const api = {
   ...offensivePolicyApi,
   ...alertingApi,
   ...privacyApi,
+  ...writeupApi,
+  ...cspmApi,
 }
+export {
+  type CoverageWindow,
+  type CoverageWindowFilters,
+  type CoverageClass,
+  type CoverageClassState,
+  type CoverageVector,
+} from './fleet'
+export { type WriteupDraft, type WriteupDraftState } from './writeup'
+export {
+  type RetroHuntRequest,
+  type RetroHuntResult,
+  type TimelineEntry,
+} from './fleet'
+export {
+  type CSPMRun,
+  type CSPMStatus,
+  type CloudProvider,
+  type CloudTarget,
+  type CSPMEvidenceRef,
+} from './cspm'

--- a/web/src/lib/api/writeup.ts
+++ b/web/src/lib/api/writeup.ts
@@ -1,0 +1,69 @@
+import { req } from './client'
+
+// AI-proposed finding write-up drafts (#... writeupdraft). An agent proposes description/remediation
+// prose for a finding; a human with review authority edits, then accepts or rejects it. Separation of
+// duties is enforced server-side: the acceptor must not be the proposer. Nothing here renders into a
+// report on its own — an accepted draft becomes eligible to be applied to its finding.
+//
+// The domain Draft carries no JSON tags, so the wire keys are Go PascalCase; this maps them and tolerates
+// a snake_case shape in case tags are added later.
+
+export type WriteupDraftState = 'proposed' | 'accepted' | 'rejected'
+
+export interface WriteupDraft {
+  id: string
+  engagementId: string
+  findingId: string
+  description: string
+  remediation: string
+  state: WriteupDraftState
+  proposedBy: string
+  decidedBy: string
+  createdAt: string
+  updatedAt: string
+}
+
+function mapDraft(r: any): WriteupDraft {
+  return {
+    id: r?.ID ?? r?.id ?? '',
+    engagementId: r?.EngagementID ?? r?.engagement_id ?? '',
+    findingId: r?.FindingID ?? r?.finding_id ?? '',
+    description: r?.Description ?? r?.description ?? '',
+    remediation: r?.Remediation ?? r?.remediation ?? '',
+    state: (r?.State ?? r?.state ?? 'proposed') as WriteupDraftState,
+    proposedBy: r?.ProposedBy ?? r?.proposed_by ?? '',
+    decidedBy: r?.DecidedBy ?? r?.decided_by ?? '',
+    createdAt: r?.CreatedAt ?? r?.created_at ?? '',
+    updatedAt: r?.UpdatedAt ?? r?.updated_at ?? '',
+  }
+}
+
+export const writeupApi = {
+  listWriteupDrafts: async (engagementId: string): Promise<WriteupDraft[]> => {
+    const r = await req(`/engagements/${encodeURIComponent(engagementId)}/writeup-drafts`)
+    return Array.isArray(r?.writeup_drafts) ? r.writeup_drafts.map(mapDraft) : []
+  },
+  editWriteupDraft: async (
+    engagementId: string,
+    draftId: string,
+    body: { description: string; remediation: string },
+  ): Promise<WriteupDraft> =>
+    mapDraft(
+      await req(`/engagements/${encodeURIComponent(engagementId)}/writeup-drafts/${encodeURIComponent(draftId)}/edit`, {
+        method: 'POST',
+        body: JSON.stringify(body),
+      }),
+    ),
+  acceptWriteupDraft: async (engagementId: string, draftId: string): Promise<WriteupDraft> =>
+    mapDraft(
+      await req(`/engagements/${encodeURIComponent(engagementId)}/writeup-drafts/${encodeURIComponent(draftId)}/accept`, {
+        method: 'POST',
+      }),
+    ),
+  rejectWriteupDraft: async (engagementId: string, draftId: string): Promise<WriteupDraft> =>
+    mapDraft(
+      await req(`/engagements/${encodeURIComponent(engagementId)}/writeup-drafts/${encodeURIComponent(draftId)}/reject`, {
+        method: 'POST',
+      }),
+    ),
+}

--- a/web/src/mocks/handlers.ts
+++ b/web/src/mocks/handlers.ts
@@ -497,6 +497,49 @@ const TEAM_MEMBERS = [
 // HANDLERS
 // ============================================================================
 
+// --- Net-new dashboard surfaces (#832 extract): write-up drafts, coverage windows ---
+const WRITEUP_DRAFTS = [
+  {
+    ID: 'draft-001', EngagementID: 'eng-001', FindingID: 'finding-001',
+    Description: 'The application deserializes untrusted session data with a permissive type resolver, allowing an attacker who controls a cookie to instantiate arbitrary gadget chains.',
+    Remediation: 'Pin the deserializer to an allow-list of expected types and sign session payloads. Reject any type outside the allow-list before construction.',
+    State: 'proposed', ProposedBy: 'agent:writer-01', DecidedBy: '', CreatedAt: HOUR_AGO, UpdatedAt: HOUR_AGO,
+  },
+  {
+    ID: 'draft-002', EngagementID: 'eng-001', FindingID: 'finding-003',
+    Description: 'Reflected XSS in the search parameter; the value is echoed into an HTML attribute without encoding.',
+    Remediation: 'Context-encode the parameter for the HTML-attribute sink and add a strict Content-Security-Policy.',
+    State: 'accepted', ProposedBy: 'agent:writer-01', DecidedBy: 'alice', CreatedAt: DAY_AGO, UpdatedAt: HOUR_AGO,
+  },
+]
+
+const COVERAGE_WINDOWS = [
+  {
+    asset_id: 'ba-001', agent_id: 'agent-001', host_id: 'host-web-01',
+    since: DAY_AGO, until: NOW, input_digest: 'sha256:9f1c0a44e7b2', revision: 'rev-0042', created_at: NOW,
+    states: [
+      { class: 'process', host_id: 'host-web-01', agent_id: 'agent-001', state: 'covered', reason: '', since: DAY_AGO },
+      { class: 'network', host_id: 'host-web-01', agent_id: 'agent-001', state: 'covered', reason: '', since: DAY_AGO },
+      { class: 'file', host_id: 'host-web-01', agent_id: 'agent-001', state: 'degraded', reason: 'sampling above target', since: HOUR_AGO },
+      { class: 'privilege', host_id: 'host-web-01', agent_id: 'agent-001', state: 'covered', reason: '', since: DAY_AGO },
+    ],
+    sampled_count: 18420, truncated_count: 12, dropped_count: 3, gap_count: 1, batch_count: 96,
+    coverage: { process: 1, network: 1, file: 1, privilege: 1, reasons: ['file sensor above sampling target for 42m'] },
+  },
+  {
+    asset_id: 'ba-002', agent_id: 'agent-002', host_id: 'host-db-02',
+    since: WEEK_AGO, until: DAY_AGO, input_digest: 'sha256:1abed3390f77', revision: 'rev-0031', created_at: DAY_AGO,
+    states: [
+      { class: 'process', host_id: 'host-db-02', agent_id: 'agent-002', state: 'covered', reason: '', since: WEEK_AGO },
+      { class: 'network', host_id: 'host-db-02', agent_id: 'agent-002', state: 'blind', reason: 'ebpf program failed to load', since: DAY_AGO },
+      { class: 'file', host_id: 'host-db-02', agent_id: 'agent-002', state: 'covered', reason: '', since: WEEK_AGO },
+      { class: 'privilege', host_id: 'host-db-02', agent_id: 'agent-002', state: 'covered', reason: '', since: WEEK_AGO },
+    ],
+    sampled_count: 9280, truncated_count: 0, dropped_count: 141, gap_count: 2, batch_count: 44,
+    coverage: { process: 1, network: 0, file: 1, privilege: 1, reasons: ['network class blind: ebpf load failure', 'kernel 5.4 lacks BTF'] },
+  },
+]
+
 export const handlers = [
   // --- Auth (BFF) ---
   // discoverSession() calls GET /api/auth/session and expects an authenticated
@@ -1509,6 +1552,56 @@ export const handlers = [
     const newUser = { id: `user-${String(TEAM_MEMBERS.length + 1).padStart(3, '0')}`, name: body.name, role: body.role, disabled: false, createdAt: NOW }
     TEAM_MEMBERS.push(newUser as any)
     return HttpResponse.json({ user: newUser, apiKey: `syn_${Math.random().toString(36).slice(2, 18)}_${Math.random().toString(36).slice(2, 10)}` })
+  }),
+
+  // --- Cloud posture, write-up drafts, coverage windows, retro-hunt (wired routes, new UI) ---
+  // Cloud posture (CSPM) run: POST accepts and returns a running run; GET completes it (poll).
+  http.post('/api/v1/engagements/:id/cspm/runs', ({ params }) => HttpResponse.json({
+    id: 'cspm-run-1', engagement_id: params.id, actor: 'you', status: 'running', complete: false,
+    assets: 0, findings: 0, coverage_issues: [], error_code: '', evidence_refs: [], started_at: NOW, finished_at: null,
+  }, { status: 202 })),
+  http.get('/api/v1/engagements/:id/cspm/runs/:rid', ({ params }) => HttpResponse.json({
+    id: params.rid, engagement_id: params.id, actor: 'you', status: 'succeeded', complete: true,
+    assets: 214, findings: 9,
+    coverage_issues: [{ scope: 'aws:123456789012', reason: 'CloudTrail not multi-region' }],
+    error_code: '',
+    evidence_refs: [{ scope_key: 'aws:123456789012', id: 'ev-cspm-1', hash: 'sha256:abcd' }],
+    started_at: NOW, finished_at: NOW,
+  })),
+
+  // --- AI-proposed write-up drafts (PascalCase wire; the domain Draft has no JSON tags) ---
+  http.get('/api/v1/engagements/:id/writeup-drafts', () => HttpResponse.json({ writeup_drafts: WRITEUP_DRAFTS })),
+  http.post('/api/v1/engagements/:id/writeup-drafts/:did/edit', async ({ params, request }) => {
+    const body = (await request.json()) as { description?: string; remediation?: string }
+    const d = WRITEUP_DRAFTS.find((x) => x.ID === params.did) ?? WRITEUP_DRAFTS[0]
+    return HttpResponse.json({ ...d, Description: body.description ?? d.Description, Remediation: body.remediation ?? d.Remediation })
+  }),
+  http.post('/api/v1/engagements/:id/writeup-drafts/:did/accept', ({ params }) => {
+    const d = WRITEUP_DRAFTS.find((x) => x.ID === params.did) ?? WRITEUP_DRAFTS[0]
+    return HttpResponse.json({ ...d, State: 'accepted', DecidedBy: 'you' })
+  }),
+  http.post('/api/v1/engagements/:id/writeup-drafts/:did/reject', ({ params }) => {
+    const d = WRITEUP_DRAFTS.find((x) => x.ID === params.did) ?? WRITEUP_DRAFTS[0]
+    return HttpResponse.json({ ...d, State: 'rejected', DecidedBy: 'you' })
+  }),
+
+  http.get('/api/v1/fleet/coverage-windows', () => HttpResponse.json({ coverage_windows: COVERAGE_WINDOWS })),
+  http.post('/api/v1/fleet/assets/:id/retro-hunt', async ({ params, request }) => {
+    const body = (await request.json()) as { around?: string; before_seconds?: number; after_seconds?: number }
+    const around = body.around ? new Date(body.around) : new Date()
+    const from = new Date(around.getTime() - (body.before_seconds ?? 900) * 1000).toISOString()
+    const to = new Date(around.getTime() + (body.after_seconds ?? 900) * 1000).toISOString()
+    return HttpResponse.json({
+      AssetID: params.id,
+      From: from,
+      To: to,
+      Truncated: false,
+      Entries: [
+        { OccurredAt: from, EntityKind: 'process', EntityID: 'pid-4821', Kind: 'process_exec', EventID: 'ev-1', Summary: 'curl spawned by bash (parent sshd)' },
+        { OccurredAt: around.toISOString(), EntityKind: 'network', EntityID: 'conn-77', Kind: 'egress_connect', EventID: 'ev-2', Summary: 'outbound 443 to 203.0.113.9 (unclassified)' },
+        { OccurredAt: to, EntityKind: 'file', EntityID: '/etc/cron.d/x', Kind: 'file_write', EventID: 'ev-3', Summary: 'new file written under /etc/cron.d' },
+      ],
+    })
   }),
 
   // --- Catch-all fallback ---

--- a/web/src/pages/EngagementDetail/CloudPostureTab.test.tsx
+++ b/web/src/pages/EngagementDetail/CloudPostureTab.test.tsx
@@ -1,0 +1,68 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ToastProvider } from '../../components/synapse/Toast'
+import { api } from '../../lib/api'
+import type { CSPMRun } from '../../lib/api'
+import { CloudPostureTab } from './CloudPostureTab'
+
+vi.mock('../../lib/api', () => ({
+  api: { runCSPM: vi.fn(), getCSPMRun: vi.fn() },
+}))
+
+function succeededRun(): CSPMRun {
+  return {
+    id: 'cspm-run-1',
+    engagementId: 'eng-001',
+    actor: 'you',
+    status: 'succeeded',
+    complete: true,
+    assets: 214,
+    findings: 9,
+    coverageIssues: [{ scope: 'aws:1', reason: 'x' }],
+    errorCode: '',
+    evidenceRefs: [{ scopeKey: 'aws:1', id: 'ev-1', hash: 'sha256:abcd' }],
+    startedAt: '2026-09-01T00:00:00Z',
+    finishedAt: '2026-09-01T00:05:00Z',
+  }
+}
+
+function renderTab() {
+  render(
+    <MemoryRouter>
+      <ToastProvider>
+        <CloudPostureTab engagementId="eng-001" />
+      </ToastProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('CloudPostureTab', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('requires a root and credential reference before running', async () => {
+    renderTab()
+    expect(screen.getByRole('button', { name: /run posture scan/i })).toBeDisabled()
+
+    fireEvent.change(screen.getByLabelText('Target 1 root'), { target: { value: '123456789012' } })
+    fireEvent.change(screen.getByLabelText('Target 1 credential reference'), { target: { value: 'vault://aws-ro' } })
+    await waitFor(() => expect(screen.getByRole('button', { name: /run posture scan/i })).toBeEnabled())
+  })
+
+  it('starts a run and renders its status', async () => {
+    vi.mocked(api.runCSPM).mockResolvedValue(succeededRun())
+    renderTab()
+
+    fireEvent.change(screen.getByLabelText('Target 1 root'), { target: { value: '123456789012' } })
+    fireEvent.change(screen.getByLabelText('Target 1 credential reference'), { target: { value: 'vault://aws-ro' } })
+    fireEvent.click(screen.getByRole('button', { name: /run posture scan/i }))
+
+    await waitFor(() =>
+      expect(api.runCSPM).toHaveBeenCalledWith('eng-001', [
+        { provider: 'aws', root: '123456789012', credentialRef: 'vault://aws-ro' },
+      ]),
+    )
+    expect(await screen.findByText('succeeded')).toBeInTheDocument()
+    expect(screen.getByText('214')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/EngagementDetail/CloudPostureTab.tsx
+++ b/web/src/pages/EngagementDetail/CloudPostureTab.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useRef, useState } from 'react'
+import { AlertTriangle, Cloud01, Play, Plus, Trash01 } from '@untitledui/icons'
+import { Button, Card, ErrorState, Field, Input, Select, cn } from '../../components/ui'
+import { useToast } from '../../components/synapse/Toast'
+import { api } from '../../lib/api'
+import type { CSPMRun, CloudProvider, CloudTarget } from '../../lib/api'
+
+const PROVIDERS: { value: CloudProvider; label: string }[] = [
+  { value: 'aws', label: 'AWS' },
+  { value: 'azure', label: 'Azure' },
+  { value: 'gcp', label: 'GCP' },
+]
+
+const ROOT_HINT: Record<CloudProvider, string> = {
+  aws: 'account id, e.g. 123456789012',
+  azure: 'subscription id',
+  gcp: 'project id',
+}
+
+const ROOT_LABEL: Record<CloudProvider, string> = {
+  aws: 'AWS account',
+  azure: 'Azure subscription',
+  gcp: 'GCP project',
+}
+
+function statusTone(status: CSPMRun['status']): string {
+  switch (status) {
+    case 'succeeded':
+      return 'bg-success-primary/10 text-success-primary ring-1 ring-inset ring-success-primary/25'
+    case 'partial':
+      return 'bg-warning-primary/10 text-warning-primary ring-1 ring-inset ring-warning-primary/25'
+    case 'failed':
+    case 'cancelled':
+      return 'bg-error-primary/10 text-error-primary ring-1 ring-inset ring-error-primary/25'
+    default:
+      return 'bg-brand-primary/10 text-brand-secondary ring-1 ring-inset ring-brand/25'
+  }
+}
+
+function formatWhen(iso: string | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-lg font-semibold tabular-nums text-primary">{value.toLocaleString()}</span>
+      <span className="text-[11px] uppercase tracking-wide text-quaternary">{label}</span>
+    </div>
+  )
+}
+
+function RunStatus({ run, targets }: { run: CSPMRun; targets: CloudTarget[] }) {
+  return (
+    <Card title="Latest run" titleClassName="flex items-center gap-2">
+      {targets.length > 0 && (
+        <div className="mb-3 flex flex-wrap gap-1.5">
+          {targets.map((t, i) => (
+            <span key={i} className="inline-flex items-center gap-1 rounded-md bg-secondary px-2 py-0.5 font-mono text-[11px] text-secondary ring-1 ring-inset ring-secondary">
+              <span className="uppercase text-brand-secondary">{t.provider}</span> {t.root}
+            </span>
+          ))}
+        </div>
+      )}
+      <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+        <span className={cn('inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium capitalize', statusTone(run.status))}>
+          {run.status}
+          {!run.complete && run.status !== 'failed' && <span className="ml-1.5 size-1.5 animate-pulse rounded-full bg-current" aria-hidden />}
+        </span>
+        <Stat label="Assets" value={run.assets} />
+        <Stat label="Findings" value={run.findings} />
+        <Stat label="Coverage issues" value={run.coverageIssues.length} />
+        <Stat label="Evidence" value={run.evidenceRefs.length} />
+        <div className="ml-auto text-right text-xs text-tertiary">
+          <div>started {formatWhen(run.startedAt)}</div>
+          <div>{run.finishedAt ? `finished ${formatWhen(run.finishedAt)}` : 'in progress'}</div>
+        </div>
+      </div>
+      {run.errorCode && (
+        <p className="mt-3 flex items-center gap-1.5 text-xs text-error-primary">
+          <AlertTriangle className="size-3.5 shrink-0" aria-hidden /> {run.errorCode}
+        </p>
+      )}
+      <p className="mt-3 font-mono text-[11px] text-quaternary">run {run.id}</p>
+    </Card>
+  )
+}
+
+export function CloudPostureTab({ engagementId }: { engagementId: string }) {
+  const [targets, setTargets] = useState<CloudTarget[]>([{ provider: 'aws', root: '', credentialRef: '' }])
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+  const [run, setRun] = useState<CSPMRun | null>(null)
+  const [submitted, setSubmitted] = useState<CloudTarget[]>([])
+  const { notify } = useToast()
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // Poll the run until it completes, so the durable worker's progress reaches the surface.
+  useEffect(() => {
+    if (!run || run.complete) {
+      if (pollRef.current) clearInterval(pollRef.current)
+      return
+    }
+    pollRef.current = setInterval(async () => {
+      try {
+        const next = await api.getCSPMRun(engagementId, run.id)
+        setRun(next)
+      } catch {
+        // A transient read error keeps the last known state; the next tick retries.
+      }
+    }, 2500)
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current)
+    }
+  }, [engagementId, run])
+
+  const valid = targets.filter((t) => t.root.trim() !== '' && t.credentialRef.trim() !== '')
+
+  function patch(i: number, p: Partial<CloudTarget>) {
+    setTargets((cur) => cur.map((t, j) => (j === i ? { ...t, ...p } : t)))
+  }
+
+  async function runScan() {
+    setBusy(true)
+    setErr('')
+    try {
+      const cleaned = valid.map((t) => ({ ...t, root: t.root.trim(), credentialRef: t.credentialRef.trim() }))
+      const started = await api.runCSPM(engagementId, cleaned)
+      setSubmitted(cleaned)
+      setRun(started)
+      notify('Cloud posture run accepted.', 'success')
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Failed to start CSPM run'
+      setErr(message)
+      notify(message, 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <Card title="Run cloud posture scan" titleClassName="flex items-center gap-2">
+        <p className="text-xs text-tertiary">
+          A bounded, read-only live scan of a cloud account's posture. Each target names a provider, its
+          root (account, subscription, or project), and a vault credential reference. The reference points
+          at a stored credential; it is never the credential material.
+        </p>
+        <div className="mt-4 space-y-2">
+          {targets.map((t, i) => (
+            <div key={i} className="grid grid-cols-1 items-end gap-2 sm:grid-cols-[8rem_1fr_1fr_auto]">
+              <Field label={i === 0 ? 'Provider' : ''}>
+                <Select value={t.provider} onValueChange={(v) => patch(i, { provider: v as CloudProvider })} options={PROVIDERS} ariaLabel={`Target ${i + 1} provider`} />
+              </Field>
+              <Field label={i === 0 ? ROOT_LABEL[t.provider] : ''}>
+                <Input value={t.root} onChange={(e) => patch(i, { root: e.target.value })} placeholder={ROOT_HINT[t.provider]} className="font-mono" aria-label={`Target ${i + 1} root`} />
+              </Field>
+              <Field label={i === 0 ? 'Credential reference' : ''}>
+                <Input value={t.credentialRef} onChange={(e) => patch(i, { credentialRef: e.target.value })} placeholder="vault reference" className="font-mono" aria-label={`Target ${i + 1} credential reference`} />
+              </Field>
+              <button
+                type="button"
+                onClick={() => setTargets((cur) => (cur.length === 1 ? cur : cur.filter((_, j) => j !== i)))}
+                aria-label={`Remove target ${i + 1}`}
+                disabled={targets.length === 1}
+                className="justify-self-start rounded-md p-2.5 text-quaternary transition-colors hover:bg-secondary hover:text-critical disabled:opacity-40 sm:justify-self-auto"
+              >
+                <Trash01 className="size-4" />
+              </button>
+            </div>
+          ))}
+        </div>
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={() => setTargets((cur) => [...cur, { provider: 'aws', root: '', credentialRef: '' }])}
+            className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs font-medium text-brand-secondary transition-colors hover:bg-secondary"
+          >
+            <Plus className="size-3.5" /> Add target
+          </button>
+          <Button variant="primary" className="ml-auto px-3 py-2" loading={busy} disabled={busy || valid.length === 0} onClick={runScan}>
+            <Play className="size-4" /> Run posture scan
+          </Button>
+        </div>
+        {valid.length === 0 && (
+          <p className="mt-2 text-[11px] text-quaternary">Each target needs a root and a credential reference.</p>
+        )}
+        {err && (
+          <div className="mt-3">
+            <ErrorState message={err} />
+          </div>
+        )}
+      </Card>
+
+      {run ? (
+        <RunStatus run={run} targets={submitted} />
+      ) : (
+        <Card>
+          <div className="flex items-center gap-2 text-sm text-tertiary">
+            <Cloud01 className="size-4 text-quaternary" aria-hidden />
+            No run yet. Add a target above and start a scan; its status and findings appear here.
+          </div>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+export default CloudPostureTab

--- a/web/src/pages/EngagementDetail/WriteupDraftsTab.test.tsx
+++ b/web/src/pages/EngagementDetail/WriteupDraftsTab.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ToastProvider } from '../../components/synapse/Toast'
+import { api } from '../../lib/api'
+import type { WriteupDraft } from '../../lib/api'
+import { WriteupDraftsTab } from './WriteupDraftsTab'
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    listWriteupDrafts: vi.fn(),
+    editWriteupDraft: vi.fn(),
+    acceptWriteupDraft: vi.fn(),
+    rejectWriteupDraft: vi.fn(),
+  },
+}))
+
+function draft(over: Partial<WriteupDraft> = {}): WriteupDraft {
+  return {
+    id: 'draft-001',
+    engagementId: 'eng-001',
+    findingId: 'finding-001',
+    description: 'Deserialization of untrusted data',
+    remediation: 'Pin the type allow-list',
+    state: 'proposed',
+    proposedBy: 'agent:writer-01',
+    decidedBy: '',
+    createdAt: '2026-09-01T00:00:00Z',
+    updatedAt: '2026-09-01T00:00:00Z',
+    ...over,
+  }
+}
+
+function renderTab() {
+  render(
+    <MemoryRouter>
+      <ToastProvider>
+        <WriteupDraftsTab engagementId="eng-001" />
+      </ToastProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('WriteupDraftsTab', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('lists drafts and shows the awaiting-sign-off count', async () => {
+    vi.mocked(api.listWriteupDrafts).mockResolvedValue([
+      draft(),
+      draft({ id: 'draft-002', state: 'accepted', decidedBy: 'alice', description: 'Reflected XSS in search' }),
+    ])
+    renderTab()
+
+    expect(await screen.findByText(/1 awaiting sign-off/)).toBeInTheDocument()
+    expect(screen.getByText('Deserialization of untrusted data')).toBeInTheDocument()
+    expect(screen.getByText('Reflected XSS in search')).toBeInTheDocument()
+    expect(screen.getByText('accepted')).toBeInTheDocument()
+  })
+
+  it('accepts a proposed draft', async () => {
+    vi.mocked(api.listWriteupDrafts).mockResolvedValue([draft()])
+    vi.mocked(api.acceptWriteupDraft).mockResolvedValue(draft({ state: 'accepted', decidedBy: 'you' }))
+    renderTab()
+
+    fireEvent.click(await screen.findByRole('button', { name: /accept/i }))
+    await waitFor(() => expect(api.acceptWriteupDraft).toHaveBeenCalledWith('eng-001', 'draft-001'))
+  })
+
+  it('only offers accept/edit/reject on a proposed draft', async () => {
+    vi.mocked(api.listWriteupDrafts).mockResolvedValue([draft({ state: 'accepted', decidedBy: 'alice' })])
+    renderTab()
+
+    await screen.findByText('accepted')
+    expect(screen.queryByRole('button', { name: /accept/i })).not.toBeInTheDocument()
+  })
+})

--- a/web/src/pages/EngagementDetail/WriteupDraftsTab.tsx
+++ b/web/src/pages/EngagementDetail/WriteupDraftsTab.tsx
@@ -1,0 +1,192 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { Check, CpuChip01, Edit03, FileX02, ShieldTick, X } from '@untitledui/icons'
+import { Button, Card, EmptyState, ErrorState, Pill, Spinner, cn } from '../../components/ui'
+import { useToast } from '../../components/synapse/Toast'
+import { useFetch } from '../../hooks'
+import { api } from '../../lib/api'
+import type { WriteupDraft } from '../../lib/api'
+
+function formatWhen(iso: string): string {
+  if (!iso) return ''
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? '' : d.toLocaleString()
+}
+
+function stateTone(state: WriteupDraft['state']): string {
+  switch (state) {
+    case 'accepted':
+      return 'bg-success-primary/10 text-success-primary ring-1 ring-inset ring-success-primary/25'
+    case 'rejected':
+      return 'bg-error-primary/10 text-error-primary ring-1 ring-inset ring-error-primary/25'
+    default:
+      return 'bg-brand-primary/10 text-brand-secondary ring-1 ring-inset ring-brand/25'
+  }
+}
+
+function shortId(id: string): string {
+  return id.length > 10 ? `${id.slice(0, 8)}…` : id
+}
+
+function DraftCard({
+  draft,
+  onChanged,
+}: {
+  draft: WriteupDraft
+  onChanged: (d: WriteupDraft) => void
+}) {
+  const [editing, setEditing] = useState(false)
+  const [description, setDescription] = useState(draft.description)
+  const [remediation, setRemediation] = useState(draft.remediation)
+  const [busy, setBusy] = useState<'save' | 'accept' | 'reject' | null>(null)
+  const { notify } = useToast()
+  const proposed = draft.state === 'proposed'
+
+  async function run(kind: 'save' | 'accept' | 'reject') {
+    setBusy(kind)
+    try {
+      let updated: WriteupDraft
+      if (kind === 'save') updated = await api.editWriteupDraft(draft.engagementId, draft.id, { description, remediation })
+      else if (kind === 'accept') updated = await api.acceptWriteupDraft(draft.engagementId, draft.id)
+      else updated = await api.rejectWriteupDraft(draft.engagementId, draft.id)
+      onChanged(updated)
+      if (kind === 'save') setEditing(false)
+      notify(kind === 'save' ? 'Draft revised.' : kind === 'accept' ? 'Draft accepted.' : 'Draft rejected.', 'success')
+    } catch (e) {
+      notify(e instanceof Error ? e.message : `Failed to ${kind} draft`, 'error')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  return (
+    <Card>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className={cn('inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium capitalize', stateTone(draft.state))}>
+          {draft.state}
+        </span>
+        <span className="inline-flex items-center gap-1 text-xs text-tertiary">
+          <CpuChip01 className="size-3.5 text-quaternary" aria-hidden /> proposed by <span className="font-mono text-secondary">{draft.proposedBy || 'agent'}</span>
+        </span>
+        <Link
+          to={`/engagements/${encodeURIComponent(draft.engagementId)}/findings#finding-${encodeURIComponent(draft.findingId)}`}
+          className="font-mono text-xs text-brand-secondary underline-offset-2 hover:underline"
+          title="Open the finding this draft is about"
+        >
+          {shortId(draft.findingId)}
+        </Link>
+        {draft.decidedBy && (
+          <span className="ml-auto text-xs text-tertiary">
+            {draft.state} by <span className="text-secondary">{draft.decidedBy}</span>
+            {formatWhen(draft.updatedAt) && <span className="text-quaternary"> · {formatWhen(draft.updatedAt)}</span>}
+          </span>
+        )}
+      </div>
+
+      {editing ? (
+        <div className="mt-3 space-y-3">
+          <label className="block">
+            <span className="mb-1 block text-[11px] font-semibold uppercase tracking-wider text-tertiary">Description</span>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={4}
+              aria-label="Draft description"
+              className="input-inset w-full rounded-lg border border-secondary bg-secondary px-3 py-2 text-sm text-primary outline-none focus:border-brand focus:ring-2 focus:ring-brand/40"
+            />
+          </label>
+          <label className="block">
+            <span className="mb-1 block text-[11px] font-semibold uppercase tracking-wider text-tertiary">Remediation</span>
+            <textarea
+              value={remediation}
+              onChange={(e) => setRemediation(e.target.value)}
+              rows={4}
+              aria-label="Draft remediation"
+              className="input-inset w-full rounded-lg border border-secondary bg-secondary px-3 py-2 text-sm text-primary outline-none focus:border-brand focus:ring-2 focus:ring-brand/40"
+            />
+          </label>
+          <div className="flex gap-2">
+            <Button loading={busy === 'save'} onClick={() => run('save')} variant="secondary-color" className="px-3 py-1.5">
+              <Check className="size-4" /> Save revision
+            </Button>
+            <Button
+              variant="secondary"
+              className="px-3 py-1.5"
+              disabled={busy !== null}
+              onClick={() => {
+                setDescription(draft.description)
+                setRemediation(draft.remediation)
+                setEditing(false)
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-3 space-y-3">
+          <div>
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-tertiary">Description</span>
+            <p className="mt-1 whitespace-pre-wrap text-sm text-secondary">{draft.description || <span className="text-quaternary">—</span>}</p>
+          </div>
+          <div>
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-tertiary">Remediation</span>
+            <p className="mt-1 whitespace-pre-wrap text-sm text-secondary">{draft.remediation || <span className="text-quaternary">—</span>}</p>
+          </div>
+        </div>
+      )}
+
+      {proposed && !editing && (
+        <div className="mt-4 flex flex-wrap gap-2 border-t border-secondary pt-3">
+          <Button variant="secondary-color" className="px-3 py-1.5" loading={busy === 'accept'} disabled={busy !== null} onClick={() => run('accept')}>
+            <Check className="size-4" /> Accept
+          </Button>
+          <Button variant="secondary" className="px-3 py-1.5" disabled={busy !== null} onClick={() => setEditing(true)}>
+            <Edit03 className="size-4" /> Edit
+          </Button>
+          <Button variant="secondary" className="px-3 py-1.5 text-error-primary" loading={busy === 'reject'} disabled={busy !== null} onClick={() => run('reject')}>
+            <X className="size-4" /> Reject
+          </Button>
+        </div>
+      )}
+    </Card>
+  )
+}
+
+export function WriteupDraftsTab({ engagementId }: { engagementId: string }) {
+  const { data, loading, error, refetch } = useFetch(() => api.listWriteupDrafts(engagementId), { deps: [engagementId] })
+  const drafts = data ?? []
+  const proposed = drafts.filter((d) => d.state === 'proposed').length
+
+  if (loading) return <Spinner label="Loading write-up drafts…" />
+  if (error) return <ErrorState message={error} />
+  if (drafts.length === 0)
+    return (
+      <EmptyState
+        icon={FileX02}
+        title="No write-up drafts"
+        hint="When an agent proposes finding description or remediation prose, it appears here for a reviewer to edit, accept, or reject."
+      />
+    )
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <h2 className="text-sm font-semibold text-primary">AI-proposed write-up drafts</h2>
+        {proposed > 0 && <Pill className="bg-brand-primary/10 text-brand-secondary ring-1 ring-inset ring-brand/25">{proposed} awaiting sign-off</Pill>}
+      </div>
+      <p className="flex items-start gap-2 rounded-lg border border-secondary bg-secondary/20 p-3 text-xs text-tertiary">
+        <ShieldTick className="mt-0.5 size-4 shrink-0 text-brand-secondary" aria-hidden />
+        Separation of duties: the reviewer who accepts a draft must be someone other than the proposing
+        agent. Accepting makes the draft eligible to be applied to its finding; it renders nothing on its own.
+      </p>
+      <div className="space-y-3">
+        {drafts.map((d) => (
+          <DraftCard key={d.id} draft={d} onChanged={() => refetch()} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default WriteupDraftsTab

--- a/web/src/pages/EngagementDetail/index.tsx
+++ b/web/src/pages/EngagementDetail/index.tsx
@@ -44,6 +44,8 @@ import { CredentialsTab } from './CredentialsTab'
 import { DetectionsTab } from './DetectionsTab'
 import { ImportedFindingsTab } from './ImportedFindingsTab'
 import { DataGovernanceTab } from './DataGovernanceTab'
+import { WriteupDraftsTab } from './WriteupDraftsTab'
+import { CloudPostureTab } from './CloudPostureTab'
 import { EvidenceTab } from './EvidenceTab'
 import { SettingsTab } from './SettingsTab'
 import { JudgmentReviewTab } from './ReviewsTab'
@@ -71,10 +73,12 @@ export type Tab =
   | 'purple'
   | 'rehearsal'
   | 'agent'
+  | 'cspm'
   | 'detections'
   | 'reviews'
   | 'evidence'
   | 'data-governance'
+  | 'writeup-drafts'
   | 'settings'
 
 export interface SubTabDefinition {
@@ -130,6 +134,7 @@ export const TAB_GROUPS: TabGroupDefinition[] = [
       { id: 'purple', label: 'Purple Coverage' },
       { id: 'rehearsal', label: 'Chain Rehearsal' },
       { id: 'agent', label: 'Agent' },
+      { id: 'cspm', label: 'Cloud Posture' },
     ],
   },
   {
@@ -148,6 +153,7 @@ export const TAB_GROUPS: TabGroupDefinition[] = [
       { id: 'quality', label: 'Code Quality' },
       { id: 'credentials', label: 'Credentials' },
       { id: 'data-governance', label: 'Data governance' },
+      { id: 'writeup-drafts', label: 'Write-up Drafts' },
     ],
   },
   {
@@ -533,6 +539,8 @@ export function EngagementDetail() {
         {tab === 'detections' && <DetectionsTab key={id} engagementId={id} />}
         {tab === 'imported' && <ImportedFindingsTab key={id} engagementId={id} />}
         {tab === 'data-governance' && <DataGovernanceTab key={id} engagementId={id} />}
+        {tab === 'writeup-drafts' && <WriteupDraftsTab key={id} engagementId={id} />}
+        {tab === 'cspm' && <CloudPostureTab key={id} engagementId={id} />}
         {tab === 'reviews' && <JudgmentReviewTab key={id} engagementId={id} />}
         {tab === 'evidence' && <EvidenceTab key={id} engagementId={id} />}
         {tab === 'credentials' && <CredentialsTab key={id} engagementId={id} />}

--- a/web/src/pages/Fleet/CoverageWindows.test.tsx
+++ b/web/src/pages/Fleet/CoverageWindows.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import type { CoverageWindow } from '../../lib/api'
+import { CoverageWindows } from './CoverageWindows'
+
+vi.mock('../../lib/api', () => ({
+  api: { listCoverageWindows: vi.fn() },
+}))
+
+function windowFixture(over: Partial<CoverageWindow> = {}): CoverageWindow {
+  return {
+    assetId: 'ba-001',
+    agentId: 'agent-001',
+    hostId: 'host-web-01',
+    since: '2026-09-01T00:00:00Z',
+    until: '2026-09-02T00:00:00Z',
+    inputDigest: 'sha256:9f1c0a44e7b2',
+    revision: 'rev-0042',
+    createdAt: '2026-09-02T00:00:00Z',
+    states: [
+      { class: 'network', hostId: 'host-web-01', agentId: 'agent-001', state: 'blind', reason: 'ebpf load failed', since: '2026-09-01T12:00:00Z' },
+    ],
+    sampledCount: 18420,
+    truncatedCount: 12,
+    droppedCount: 3,
+    gapCount: 2,
+    batchCount: 96,
+    coverage: { process: 1, network: 0, file: 1, privilege: 1, reasons: ['network class blind'] },
+    ...over,
+  }
+}
+
+describe('CoverageWindows', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('renders sealed windows with their gap count and a blind class state', async () => {
+    vi.mocked(api.listCoverageWindows).mockResolvedValue([windowFixture()])
+    render(<CoverageWindows />)
+
+    expect(await screen.findByText(/2 gaps/)).toBeInTheDocument()
+    expect(screen.getByText('rev-0042')).toBeInTheDocument()
+    expect(screen.getByText('blind')).toBeInTheDocument()
+    expect(screen.getByText(/network class blind/)).toBeInTheDocument()
+  })
+
+  it('shows an empty state when no windows match', async () => {
+    vi.mocked(api.listCoverageWindows).mockResolvedValue([])
+    render(<CoverageWindows />)
+    expect(await screen.findByText('No coverage windows')).toBeInTheDocument()
+  })
+})

--- a/web/src/pages/Fleet/CoverageWindows.tsx
+++ b/web/src/pages/Fleet/CoverageWindows.tsx
@@ -1,0 +1,181 @@
+import { useState } from 'react'
+import { AlertTriangle, SearchLg, Signal01 } from '@untitledui/icons'
+import { Button, Card, EmptyState, ErrorState, Field, Input, Pill, Spinner, cn } from '../../components/ui'
+import { useFetch } from '../../hooks'
+import { api } from '../../lib/api'
+import type { CoverageVector, CoverageWindow } from '../../lib/api'
+
+const CLASSES: { key: keyof Pick<CoverageVector, 'process' | 'network' | 'file' | 'privilege'>; label: string }[] = [
+  { key: 'process', label: 'Process' },
+  { key: 'network', label: 'Network' },
+  { key: 'file', label: 'File' },
+  { key: 'privilege', label: 'Privilege' },
+]
+
+function shortId(id: string): string {
+  if (!id) return '—'
+  return id.length > 12 ? `${id.slice(0, 10)}…` : id
+}
+
+function formatWhen(iso: string): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString()
+}
+
+function stateTone(state: string): string {
+  const s = state.toLowerCase()
+  if (s.includes('covered') || s.includes('healthy') || s.includes('active')) return 'text-success-primary bg-success-primary/10 ring-success-primary/25'
+  if (s.includes('degrad') || s.includes('partial') || s.includes('stale')) return 'text-warning-primary bg-warning-primary/10 ring-warning-primary/25'
+  if (s.includes('blind') || s.includes('gap') || s.includes('lost') || s.includes('none')) return 'text-error-primary bg-error-primary/10 ring-error-primary/25'
+  return 'text-tertiary bg-secondary ring-secondary'
+}
+
+function CoverageDot({ label, value }: { label: string; value: number }) {
+  const covered = value > 0
+  return (
+    <div className="flex items-center gap-1.5" title={`${label}: ${covered ? 'covered' : 'no coverage'}`}>
+      <span className={cn('size-2.5 rounded-full', covered ? 'bg-success-primary' : 'bg-error-primary/70')} aria-hidden />
+      <span className={cn('text-xs', covered ? 'font-medium text-secondary' : 'text-quaternary')}>{label}</span>
+    </div>
+  )
+}
+
+function Stat({ label, value, warn }: { label: string; value: number; warn?: boolean }) {
+  return (
+    <div className="flex flex-col">
+      <span className={cn('text-sm font-semibold tabular-nums', warn && value > 0 ? 'text-error-primary' : 'text-primary')}>{value}</span>
+      <span className="text-[11px] uppercase tracking-wide text-quaternary">{label}</span>
+    </div>
+  )
+}
+
+function WindowCard({ w }: { w: CoverageWindow }) {
+  return (
+    <Card>
+      <div className="flex flex-wrap items-start justify-between gap-x-6 gap-y-3">
+        <div className="min-w-0 space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono text-sm font-semibold text-primary">{shortId(w.assetId)}</span>
+            {w.revision && <Pill className="font-mono">{shortId(w.revision)}</Pill>}
+            {w.gapCount > 0 && (
+              <Pill className="bg-error-primary/10 text-error-primary ring-1 ring-inset ring-error-primary/25">
+                <AlertTriangle className="mr-1 inline size-3" /> {w.gapCount} gap{w.gapCount === 1 ? '' : 's'}
+              </Pill>
+            )}
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-0.5 text-xs text-tertiary">
+            <span>agent <span className="font-mono text-secondary">{shortId(w.agentId)}</span></span>
+            <span>host <span className="font-mono text-secondary">{shortId(w.hostId)}</span></span>
+          </div>
+          <div className="text-xs text-quaternary">
+            {formatWhen(w.since)} → {formatWhen(w.until)} · sealed {formatWhen(w.createdAt)}
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+          {CLASSES.map((c) => (
+            <CoverageDot key={c.key} label={c.label} value={w.coverage[c.key]} />
+          ))}
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-wrap items-center gap-x-8 gap-y-3 border-t border-secondary pt-3">
+        <Stat label="Sampled" value={w.sampledCount} />
+        <Stat label="Batches" value={w.batchCount} />
+        <Stat label="Truncated" value={w.truncatedCount} warn />
+        <Stat label="Dropped" value={w.droppedCount} warn />
+        <Stat label="Gaps" value={w.gapCount} warn />
+      </div>
+
+      {w.states.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {w.states.map((s, i) => (
+            <span
+              key={`${s.class}-${i}`}
+              className={cn('inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs ring-1 ring-inset', stateTone(s.state))}
+              title={s.reason || undefined}
+            >
+              <span className="font-medium capitalize">{s.class}</span>
+              <span className="opacity-80">{s.state}</span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {w.coverage.reasons.length > 0 && (
+        <p className="mt-2 text-xs text-tertiary">{w.coverage.reasons.join(' · ')}</p>
+      )}
+      {w.inputDigest && (
+        <p className="mt-2 font-mono text-[11px] text-quaternary">input {shortId(w.inputDigest)}</p>
+      )}
+    </Card>
+  )
+}
+
+export function CoverageWindows() {
+  const [asset, setAsset] = useState('')
+  const [agent, setAgent] = useState('')
+  const [applied, setApplied] = useState<{ assetId?: string; agentId?: string }>({})
+
+  const { data, loading, error } = useFetch(() => api.listCoverageWindows({ ...applied, limit: 100 }), {
+    deps: [applied.assetId, applied.agentId],
+  })
+
+  const windows = data ?? []
+
+  return (
+    <div className="mx-auto max-w-[1600px] animate-fade-in space-y-6 pb-12">
+      <header>
+        <h1 className="flex items-center gap-2 text-2xl font-bold tracking-tight text-primary sm:text-display-xs">
+          <Signal01 className="size-6 text-brand-secondary" aria-hidden /> Coverage windows
+        </h1>
+        <p className="mt-1 text-sm text-secondary">
+          Immutable telemetry-coverage revisions per asset. Each window seals the per-class sensor state and
+          the sample, drop, and gap counts it was computed from, so coverage over time is auditable.
+        </p>
+      </header>
+
+      <Card title="Filters">
+        <div className="flex flex-wrap items-end gap-3">
+          <div className="min-w-56 flex-1">
+            <Field label="Asset id">
+              <Input value={asset} onChange={(e) => setAsset(e.target.value)} placeholder="asset id" className="font-mono" aria-label="Filter by asset id" />
+            </Field>
+          </div>
+          <div className="min-w-56 flex-1">
+            <Field label="Agent id">
+              <Input value={agent} onChange={(e) => setAgent(e.target.value)} placeholder="agent id" className="font-mono" aria-label="Filter by agent id" />
+            </Field>
+          </div>
+          <Button
+            variant="secondary-color"
+            className="px-3 py-2"
+            onClick={() => setApplied({ assetId: asset.trim() || undefined, agentId: agent.trim() || undefined })}
+          >
+            <SearchLg className="size-4" /> Apply
+          </Button>
+        </div>
+      </Card>
+
+      {loading ? (
+        <Spinner label="Loading coverage windows…" />
+      ) : error ? (
+        <ErrorState message={error} />
+      ) : windows.length === 0 ? (
+        <EmptyState
+          icon={Signal01}
+          title="No coverage windows"
+          hint="A window is sealed when the fleet reconciles an agent's telemetry into a coverage revision. None match this filter yet."
+        />
+      ) : (
+        <div className="space-y-3">
+          {windows.map((w) => (
+            <WindowCard key={`${w.assetId}-${w.revision}-${w.createdAt}`} w={w} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default CoverageWindows

--- a/web/src/pages/Fleet/HostDetail.tsx
+++ b/web/src/pages/Fleet/HostDetail.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { ArrowLeft, Copy01, SearchSm } from '@untitledui/icons'
 import { api } from '../../lib/api'
+import type { RetroHuntResult } from '../../lib/api'
 import type { HostFinding, HostPackages, HostVulnerabilities, Severity } from '../../lib/types'
 import { Button, Card, Input, Pill, SevBadge, cn } from '../../components/ui'
 import { FeatureDisabledState, isFeatureDisabledMessage } from '../../components/synapse/FeatureDisabledState'
@@ -12,7 +13,7 @@ import { useFetch } from '../../hooks'
 import { formatFleetTime } from './fleetShared'
 import { HostScanBadge, hostDegraded, hostFindingAdvisory, hostFindingPackage, hostOS, hostScanState, hostShortName, reportedPackages } from './hostShared'
 
-type Tab = 'vulnerabilities' | 'packages' | 'coverage'
+type Tab = 'vulnerabilities' | 'packages' | 'coverage' | 'retrohunt'
 type SeverityFilter = 'all' | Severity | 'unrated'
 const RATED: Severity[] = ['critical', 'high', 'medium', 'low']
 type FixFilter = 'all' | 'fixable' | 'unfixed'
@@ -314,6 +315,116 @@ function PackagesBody({ assetId }: { assetId: string }) {
   )
 }
 
+function toLocalInput(d: Date): string {
+  return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16)
+}
+
+export function RetroHuntBody({ assetId }: { assetId: string }) {
+  const localZone = (() => {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || 'local'
+    } catch {
+      return 'local'
+    }
+  })()
+  const [around, setAround] = useState(() => toLocalInput(new Date()))
+  const [beforeMin, setBeforeMin] = useState(15)
+  const [afterMin, setAfterMin] = useState(15)
+  const [entityId, setEntityId] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+  const [result, setResult] = useState<RetroHuntResult | null>(null)
+
+  async function run() {
+    setBusy(true)
+    setErr('')
+    try {
+      const iso = around ? new Date(around).toISOString() : ''
+      const res = await api.retroHunt(assetId, {
+        around: iso,
+        beforeSeconds: Math.max(0, Math.round(beforeMin * 60)),
+        afterSeconds: Math.max(0, Math.round(afterMin * 60)),
+        entityId: entityId.trim() || undefined,
+        limit: 500,
+      })
+      setResult(res)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Retro-hunt failed')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      <p className="text-xs text-tertiary">
+        Re-hunt this host's endpoint state timeline in a window around a pivot time, optionally scoped to
+        one entity. The window is anchored to the pivot; a capped window is reported as truncated.
+      </p>
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-tertiary">
+            Pivot time <span className="font-normal normal-case text-quaternary">({localZone})</span>
+          </span>
+          <Input type="datetime-local" value={around} onChange={(e) => setAround(e.target.value)} aria-label="Retro-hunt pivot time" />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-tertiary">Look back (min)</span>
+          <Input type="number" min={0} value={beforeMin} onChange={(e) => setBeforeMin(Number(e.target.value) || 0)} className="w-28" aria-label="Retro-hunt look-back minutes" />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-tertiary">Look forward (min)</span>
+          <Input type="number" min={0} value={afterMin} onChange={(e) => setAfterMin(Number(e.target.value) || 0)} className="w-28" aria-label="Retro-hunt look-forward minutes" />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-tertiary">Entity (optional)</span>
+          <Input value={entityId} onChange={(e) => setEntityId(e.target.value)} placeholder="entity id" className="w-48 font-mono" aria-label="Retro-hunt entity id" />
+        </label>
+        <Button variant="primary" className="px-3 py-2" loading={busy} disabled={busy || (beforeMin === 0 && afterMin === 0)} onClick={run}>
+          <SearchSm className="size-4" /> Hunt
+        </Button>
+      </div>
+      {beforeMin === 0 && afterMin === 0 && (
+        <p className="text-xs text-warning-primary">Set a non-zero look-back or look-forward; a zero-width window is rejected.</p>
+      )}
+      {err && <OperationalState tone="error" title="Retro-hunt failed" detail={err} />}
+      {result && !err && (
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-tertiary">
+            <span>{formatFleetTime(result.from)} → {formatFleetTime(result.to)}</span>
+            <Pill>{result.entries.length} transition{result.entries.length === 1 ? '' : 's'}</Pill>
+            {result.truncated ? (
+              <Pill className="bg-warning-primary/10 text-warning-primary ring-1 ring-inset ring-warning-primary/25">
+                truncated — window capped
+              </Pill>
+            ) : (
+              <Pill className="bg-success-primary/10 text-success-primary ring-1 ring-inset ring-success-primary/25">complete window</Pill>
+            )}
+          </div>
+          {result.entries.length === 0 ? (
+            <p className="text-sm text-tertiary">No endpoint transitions in this window.</p>
+          ) : (
+            <ol className="relative space-y-2 border-l border-secondary pl-4">
+              {result.entries.map((en) => (
+                <li key={en.eventId || `${en.occurredAt}-${en.entityId}`} className="relative">
+                  <span className="absolute -left-[21px] top-1.5 size-2 rounded-full bg-brand-solid" aria-hidden />
+                  <div className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5">
+                    <span className="inline-block w-40 shrink-0 font-mono text-xs tabular-nums text-secondary">{formatFleetTime(en.occurredAt)}</span>
+                    <span className="text-sm font-medium text-primary">{en.kind}</span>
+                    {en.entityKind && <Pill className="capitalize">{en.entityKind}</Pill>}
+                    {en.entityId && <span className="font-mono text-xs text-quaternary">{en.entityId}</span>}
+                  </div>
+                  {en.summary && <p className="mt-0.5 text-sm text-tertiary">{en.summary}</p>}
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
 export function HostDetail() {
   const { id = '' } = useParams()
   const [tab, setTab] = useState<Tab>('vulnerabilities')
@@ -375,7 +486,7 @@ export function HostDetail() {
 
       <Card bodyClass="p-0">
         <div className="flex items-center gap-1 border-b border-secondary px-2" role="tablist" aria-label="Host views">
-          {([['vulnerabilities', `Vulnerabilities`, host.findings.length], ['packages', 'Packages', host.packages || reported], ['coverage', 'Coverage gaps', Number(a.coverage_gaps ?? '0') || 0]] as [Tab, string, number][]).map(([value, label, count]) => (
+          {([['vulnerabilities', `Vulnerabilities`, host.findings.length], ['packages', 'Packages', host.packages || reported], ['coverage', 'Coverage gaps', Number(a.coverage_gaps ?? '0') || 0], ['retrohunt', 'Timeline', null]] as [Tab, string, number | null][]).map(([value, label, count]) => (
             <button
               key={value}
               type="button"
@@ -384,11 +495,20 @@ export function HostDetail() {
               onClick={() => setTab(value)}
               className={cn('-mb-px border-b-2 px-3 py-2.5 text-sm font-semibold transition-colors', tab === value ? 'border-brand-solid text-primary' : 'border-transparent text-tertiary hover:text-primary')}
             >
-              {label} <span className="ml-1 font-mono text-xs tabular-nums text-quaternary">{count.toLocaleString()}</span>
+              {label}{' '}
+              {count !== null && <span className="font-mono text-xs tabular-nums text-quaternary">{count.toLocaleString()}</span>}
             </button>
           ))}
         </div>
-        {tab === 'vulnerabilities' ? <VulnerabilitiesBody host={host} /> : tab === 'packages' ? <PackagesBody assetId={host.asset.id} /> : <CoverageBody host={host} />}
+        {tab === 'vulnerabilities' ? (
+          <VulnerabilitiesBody host={host} />
+        ) : tab === 'packages' ? (
+          <PackagesBody assetId={host.asset.id} />
+        ) : tab === 'retrohunt' ? (
+          <RetroHuntBody assetId={host.asset.id} />
+        ) : (
+          <CoverageBody host={host} />
+        )}
       </Card>
     </div>
   )

--- a/web/src/pages/Fleet/RetroHuntBody.test.tsx
+++ b/web/src/pages/Fleet/RetroHuntBody.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import type { RetroHuntResult } from '../../lib/api'
+import { RetroHuntBody } from './HostDetail'
+
+vi.mock('../../lib/api', () => ({
+  api: { retroHunt: vi.fn() },
+}))
+
+function result(): RetroHuntResult {
+  return {
+    assetId: 'ba-001',
+    from: '2026-09-01T11:45:00Z',
+    to: '2026-09-01T12:15:00Z',
+    truncated: true,
+    entries: [
+      { occurredAt: '2026-09-01T11:50:00Z', entityKind: 'process', entityId: 'pid-4821', kind: 'process_exec', eventId: 'ev-1', summary: 'curl spawned by bash' },
+      { occurredAt: '2026-09-01T12:00:00Z', entityKind: 'network', entityId: 'conn-77', kind: 'egress_connect', eventId: 'ev-2', summary: 'outbound 443' },
+    ],
+  }
+}
+
+describe('RetroHuntBody', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('hunts the timeline window and renders the transitions and truncation', async () => {
+    vi.mocked(api.retroHunt).mockResolvedValue(result())
+    render(<RetroHuntBody assetId="ba-001" />)
+
+    fireEvent.click(screen.getByRole('button', { name: /hunt/i }))
+
+    await waitFor(() => expect(api.retroHunt).toHaveBeenCalled())
+    const [assetId, req] = vi.mocked(api.retroHunt).mock.calls[0]
+    expect(assetId).toBe('ba-001')
+    // 15 minutes look-back/forward defaults => 900 seconds.
+    expect(req.beforeSeconds).toBe(900)
+    expect(req.afterSeconds).toBe(900)
+
+    expect(await screen.findByText('process_exec')).toBeInTheDocument()
+    expect(screen.getByText('egress_connect')).toBeInTheDocument()
+    expect(screen.getByText(/window capped/)).toBeInTheDocument()
+    expect(screen.getByText(/2 transitions/)).toBeInTheDocument()
+  })
+
+  it('blocks a zero-width window', () => {
+    render(<RetroHuntBody assetId="ba-001" />)
+    fireEvent.change(screen.getByLabelText('Retro-hunt look-back minutes'), { target: { value: '0' } })
+    fireEvent.change(screen.getByLabelText('Retro-hunt look-forward minutes'), { target: { value: '0' } })
+    expect(screen.getByText(/zero-width window is rejected/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /hunt/i })).toBeDisabled()
+  })
+})


### PR DESCRIPTION
## What

Four more routes were wired non-nil in `cmd/synapse-api/main.go` but had no dashboard surface. Each now has a UI that consumes the existing route.

- **Cloud Posture** — an Offensive tab runs a bounded, read-only CSPM scan (`POST`/`GET /engagements/{id}/cspm/runs`) and polls it to a terminal state (credential is a vault reference, never material).
- **Write-up Drafts** — a Governance tab lists AI-proposed finding write-ups with reviewer accept/edit/reject under separation of duties (`/engagements/{id}/writeup-drafts`).
- **Coverage Windows** — a Fleet page shows the immutable per-asset telemetry coverage revisions with per-class sensor state and the sample/drop/gap counts each was sealed from (`GET /fleet/coverage-windows`).
- **Retro-hunt** — a host **Timeline** tab re-hunts a window of the host timeline around a pivot (`POST /fleet/assets/{id}/retro-hunt`).

## Provenance

Extracted from the 6-surface contributor branch behind #832. Two of its surfaces (attack paths, SLA policy) duplicated what already landed via #839, so only these four net-new surfaces are taken here, rebased onto `main`, with the duplicate SLA/attack-path files, wiring, and mocks dropped. #832 is superseded by this PR plus #839.

## Tests / review

- One `*.test.tsx` per surface; `pnpm typecheck` + `pnpm build` clean; full web suite green (569 tests).
- Reviewed in the real dev UI and scored by Codex (Coverage Windows 7, Write-up Drafts 7.5, Cloud Posture 6). Codex's follow-up polish notes (cloud-posture empty-state structure, filter padding) are left for the surface author to pick up; nothing blocking.
- Retro-hunt renders inside the host-detail page, which has a pre-existing MSW mock gap (host detail was never mocked on `main`), so it is verified by its component test rather than a dev screenshot.
