### PR TITLE
feat(web): even out the metric strip and rework the attack-path view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Added
 
+- **Dashboard, attack-path, and metric-strip UI polish.** The Security Operations metric strip now spreads evenly across the width and moves each figure's definition into an info tooltip instead of a second line of small print, which also removes the stray "fleet capability checks" line under Coverage gaps. The attack-path view is reworked into a cleaner exposure-to-finding flow with colored node rails, canonical severity badges, relationship-labelled edges, and the "why uncertain" reasons behind a tooltip. `listHosts` degrades to an empty list instead of throwing when the endpoint answers a non-array shape.
+
 - **Cloud posture, write-up drafts, coverage windows, and host retro-hunt reach the dashboard.** Four more routes were wired non-nil in `cmd/synapse-api` but had no UI. New surfaces consume them: a **Cloud Posture** tab runs a bounded read-only CSPM scan (`POST`/`GET /engagements/{id}/cspm/runs`); a **Write-up Drafts** tab lists AI-proposed finding write-ups with reviewer accept/edit/reject under separation of duties (`/engagements/{id}/writeup-drafts`); a **Coverage Windows** page shows the immutable per-asset telemetry coverage revisions with per-class sensor state (`GET /fleet/coverage-windows`); and a host **Timeline** tab re-hunts a window of the host timeline around a pivot (`POST /fleet/assets/{id}/retro-hunt`).
 
 - **Tenant telemetry-privacy governance in the dashboard.** The fleet source-privacy policy routes

--- a/web/src/components/synapse/Metric.tsx
+++ b/web/src/components/synapse/Metric.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { cn } from '../ui'
+import { cn, InfoNote } from '../ui'
 
 export type MetricTone = 'muted' | 'brand' | 'critical' | 'high' | 'medium' | 'low' | 'accent' | 'info' | 'warning' | 'default'
 
@@ -17,10 +17,10 @@ const VALUE_TONE: Record<MetricTone, string> = {
 }
 
 /**
- * One operational figure: a small uppercase label over a tabular number, with an optional one-line
- * hint. It has no frame and no icon; several of them sit in a MetricStrip. The tone colours the value
- * only when the figure is a risk signal (critical, high), so colour keeps meaning "attention" rather
- * than decorating every number.
+ * One operational figure: a small uppercase label over a tabular number. The optional hint is a
+ * definition of the figure, not part of the readout, so it lives behind an info tooltip on the label
+ * rather than as a second line of small print under the value. That keeps every metric the same height
+ * (so a row of them stays aligned) and stops fine print from cluttering the strip.
  */
 export function Metric({
   label,
@@ -37,21 +37,40 @@ export function Metric({
 }) {
   const shown = typeof value === 'number' ? value.toLocaleString() : value
   const zero = value === 0 || value === '0'
+  const long = typeof shown === 'string' && shown.length > 6
   return (
     <div aria-label={`${label}: ${shown}`} className={cn('min-w-0', className)}>
-      <div className="truncate text-[11px] font-semibold uppercase tracking-wide text-quaternary">{label}</div>
-      <div className={cn('mt-1 font-mono text-2xl font-semibold tabular-nums leading-none', zero ? 'text-tertiary' : VALUE_TONE[tone])}>{shown}</div>
-      {hint && <div className="mt-1 truncate text-xs text-tertiary" title={hint}>{hint}</div>}
+      <div className="flex items-center gap-1">
+        <span className="truncate text-[11px] font-semibold uppercase tracking-wide text-quaternary">{label}</span>
+        {hint && <InfoNote label={label}>{hint}</InfoNote>}
+      </div>
+      <div
+        className={cn(
+          'mt-1.5 truncate font-mono font-semibold tabular-nums leading-none',
+          long ? 'text-lg' : 'text-2xl',
+          zero ? 'text-tertiary' : VALUE_TONE[tone],
+        )}
+        title={typeof shown === 'string' ? shown : undefined}
+      >
+        {shown}
+      </div>
     </div>
   )
 }
 
-/** A single row of metrics that sits under a page title in place of a row of cards. */
+/**
+ * A row of metrics under a page title, in place of a row of cards. Uses an even auto-fit grid so any
+ * number of metrics spreads across the full width in equal columns instead of clustering to the left
+ * with ragged trailing space.
+ */
 export function MetricStrip({ children, className, ariaLabel }: { children: ReactNode; className?: string; ariaLabel?: string }) {
   return (
     <section
       aria-label={ariaLabel}
-      className={cn('flex flex-wrap items-end gap-x-10 gap-y-4 border-b border-secondary pb-4', className)}
+      className={cn(
+        'grid grid-cols-[repeat(auto-fit,minmax(8.5rem,1fr))] gap-x-6 gap-y-5 border-b border-secondary pb-4',
+        className,
+      )}
     >
       {children}
     </section>

--- a/web/src/lib/api/fleet.ts
+++ b/web/src/lib/api/fleet.ts
@@ -91,7 +91,13 @@ function mapFleetCoverageRow(raw: any): FleetCoverageRow {
 }
 
 export const fleetApi = {
-  listHosts: async (): Promise<HostRow[]> => ((await req('/assets/hosts')) ?? []).map(mapHostRow),
+  listHosts: async (): Promise<HostRow[]> => {
+    // The endpoint answers a bare JSON array; guard against any non-array shape (an error body,
+    // an object envelope) so a malformed response degrades to "no hosts" instead of crashing on .map.
+    const res = await req('/assets/hosts')
+    const rows = Array.isArray(res) ? res : Array.isArray(res?.hosts) ? res.hosts : []
+    return rows.map(mapHostRow)
+  },
 
   hostVulnerabilities: async (assetId: string): Promise<HostVulnerabilities> => {
     const raw = await req(`/assets/${encodeURIComponent(assetId)}/vulnerabilities`)

--- a/web/src/pages/Dashboard/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard/Dashboard.test.tsx
@@ -132,11 +132,12 @@ describe('Dashboard', () => {
     expect(screen.getByLabelText(/Coverage gaps: N\/A/i)).toBeInTheDocument()
   })
 
-  it('labels the coverage tile Fleet disabled when the fleet routes are absent', async () => {
+  it('blanks the coverage tile and explains in the tooltip when fleet routes are absent', async () => {
     vi.mocked(api.fleetCoverageSummary).mockRejectedValue(new ApiError(404, 'HTTP 404'))
     renderDashboard()
 
-    expect(await screen.findByLabelText('Coverage gaps: Fleet disabled')).toBeInTheDocument()
+    // Fleet-disabled shows an em dash; the reason lives in the tile's info tooltip, not as a value.
+    expect(await screen.findByLabelText('Coverage gaps: —')).toBeInTheDocument()
     expect(screen.getByText(/SYNAPSE_FLEET_ENABLED=true/)).toBeInTheDocument()
     expect(screen.queryByLabelText(/Coverage gaps: N\/A/i)).not.toBeInTheDocument()
   })

--- a/web/src/pages/Dashboard/DashboardPage.tsx
+++ b/web/src/pages/Dashboard/DashboardPage.tsx
@@ -83,8 +83,12 @@ export const DashboardPage: FC = () => {
         <Metric label="Active engagements" value={activeEngagements} />
         <Metric
           label="Coverage gaps"
-          value={fleetDisabled ? 'Fleet disabled' : (coverageGaps ?? 'N/A')}
-          hint={fleetDisabled ? 'Set SYNAPSE_FLEET_ENABLED=true to measure agent coverage.' : 'fleet capability checks'}
+          value={fleetDisabled ? '—' : (coverageGaps ?? 'N/A')}
+          hint={
+            fleetDisabled
+              ? 'Fleet is disabled. Set SYNAPSE_FLEET_ENABLED=true to measure agent coverage.'
+              : 'Assets missing an expected fleet-agent capability (process, network, file, or privilege telemetry).'
+          }
           tone={fleetDisabled ? 'muted' : coverageGaps ? 'warning' : 'muted'}
         />
         <Metric label="Needs attention" value={attention.length} tone={attention.length ? 'warning' : 'muted'} />

--- a/web/src/pages/VulnerabilityIntelligence/VulnIntelAttackPaths.test.tsx
+++ b/web/src/pages/VulnerabilityIntelligence/VulnIntelAttackPaths.test.tsx
@@ -38,9 +38,10 @@ describe('AttackPathsTab', () => {
     vi.mocked(api.attackPaths).mockResolvedValue(RESULT as never)
     render(<AttackPathsTab />)
     expect(await screen.findByText('CVE-2026-1337 RCE')).toBeInTheDocument()
-    expect(screen.getByText('Confident')).toBeInTheDocument()
-    expect(screen.getByText('Inferred')).toBeInTheDocument()
-    // The inferred path names its reason.
+    // "Confident"/"Inferred" appear as both a summary stat label and a per-path badge.
+    expect(screen.getAllByText('Confident').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Inferred').length).toBeGreaterThan(0)
+    // The inferred path names its reason (in the "why uncertain" tooltip).
     expect(screen.getByText('Inferred edge (not observed)')).toBeInTheDocument()
   })
 

--- a/web/src/pages/VulnerabilityIntelligence/VulnIntelAttackPaths.tsx
+++ b/web/src/pages/VulnerabilityIntelligence/VulnIntelAttackPaths.tsx
@@ -9,7 +9,8 @@ import {
   SearchLg,
   Target04,
 } from '@untitledui/icons'
-import { Card, EmptyState, ErrorState, Pill, Spinner, cn } from '../../components/ui'
+import { Card, EmptyState, ErrorState, InfoNote, Pill, SevBadge, Spinner, cn } from '../../components/ui'
+import type { Severity } from '../../lib/types'
 import { useFetch } from '../../hooks'
 import { api } from '../../lib/api'
 import type { AttackPath, AttackPathNode, AttackPathResult, AttackPathStep } from '../../lib/api'
@@ -37,38 +38,45 @@ function humanKind(kind: string): string {
   return kind ? kind.replace(/[_-]+/g, ' ') : 'reaches'
 }
 
-function NodeChip({ node }: { node: AttackPathNode }) {
+function NodeChip({ node, terminal }: { node: AttackPathNode; terminal: boolean }) {
   const isFinding = node.kind === 'finding'
   return (
     <div
       className={cn(
-        'flex flex-col gap-1 rounded-lg border px-3 py-2',
-        isFinding ? 'min-w-[12rem] max-w-[22rem] border-error-primary/30 bg-error-primary/5' : 'min-w-[9rem] max-w-[16rem] border-secondary bg-secondary/30',
+        'relative flex w-[12.5rem] shrink-0 flex-col gap-1.5 overflow-hidden rounded-xl border bg-primary px-3.5 py-3 shadow-xs',
+        isFinding ? 'border-error-primary/40' : 'border-secondary',
       )}
     >
-      <div className="flex items-start gap-1.5">
-        {isFinding ? (
-          <span className={cn('mt-1 size-2 shrink-0 rounded-full', sevDot(node.severity))} aria-hidden />
-        ) : (
-          <Cube01 className="mt-0.5 size-3.5 shrink-0 text-tertiary" aria-hidden />
-        )}
-        <span
-          className={cn('text-sm font-semibold text-primary', isFinding ? 'break-words' : 'truncate')}
-          title={node.label}
-        >
-          {node.label}
-        </span>
-      </div>
+      {/* Left rail: a colored spine marks entry assets vs the terminal finding at a glance. */}
+      <span
+        className={cn('absolute inset-y-0 left-0 w-1', isFinding ? sevDot(node.severity) : terminal ? 'bg-brand-solid' : 'bg-utility-gray-300')}
+        aria-hidden
+      />
       <div className="flex items-center gap-1.5">
-        {isFinding && <Target04 className="size-3 shrink-0 text-error-primary" aria-hidden />}
-        <span className="truncate text-xs capitalize text-tertiary">{node.sublabel}</span>
-      </div>
-      {isFinding && node.reachability && (
-        <span className="text-[11px] font-medium uppercase tracking-wide text-quaternary">
-          {node.confirmed ? '' : 'unconfirmed '}
-          {node.reachability.replace(/_/g, ' ')}
+        {isFinding ? (
+          <Target04 className="size-4 shrink-0 text-error-primary" aria-hidden />
+        ) : (
+          <Cube01 className="size-4 shrink-0 text-tertiary" aria-hidden />
+        )}
+        <span className="truncate text-[11px] font-semibold uppercase tracking-wide text-quaternary">
+          {isFinding ? 'Finding' : 'Asset'}
         </span>
-      )}
+      </div>
+      <span className="line-clamp-2 text-sm font-semibold leading-snug text-primary" title={node.label}>
+        {node.label}
+      </span>
+      <div className="flex flex-wrap items-center gap-1">
+        {isFinding && node.severity && <SevBadge sev={node.severity as Severity} />}
+        {isFinding ? (
+          node.reachability && (
+            <span className="truncate text-xs capitalize text-tertiary">
+              {node.confirmed ? 'reachable' : `unconfirmed ${node.reachability.replace(/_/g, ' ')}`}
+            </span>
+          )
+        ) : (
+          <span className="truncate text-xs capitalize text-tertiary">{node.sublabel}</span>
+        )}
+      </div>
     </div>
   )
 }
@@ -76,75 +84,65 @@ function NodeChip({ node }: { node: AttackPathNode }) {
 function StepConnector({ step }: { step: AttackPathStep }) {
   const inferred = !step.observed
   return (
-    <div className="flex shrink-0 flex-col items-center justify-center px-1 py-2" aria-hidden>
-      <span
-        className={cn(
-          'mb-1 max-w-[8rem] truncate text-center text-[10px] font-medium uppercase tracking-wide',
-          inferred ? 'text-warning-primary' : 'text-tertiary',
-        )}
-        title={humanKind(step.kind)}
-      >
+    <div
+      className="flex w-24 shrink-0 flex-col items-center justify-center gap-1 self-center px-1"
+      title={`${humanKind(step.kind)} — ${inferred ? 'inferred edge, not directly observed' : 'observed edge'}`}
+    >
+      <span className={cn('max-w-full truncate text-center text-[11px] font-medium capitalize', inferred ? 'text-warning-primary' : 'text-secondary')}>
         {humanKind(step.kind)}
       </span>
-      <span
-        className={cn(
-          'flex items-center gap-1 border-t-2 pt-0.5',
-          inferred ? 'border-warning-primary/50 border-dashed' : 'border-secondarystrong',
-        )}
-      >
-        <ArrowNarrowRight
-          className={cn('size-4', inferred ? 'text-warning-primary' : 'text-quaternary')}
-        />
+      <span className="relative flex w-full items-center">
+        <span className={cn('h-0 flex-1 border-t-2', inferred ? 'border-dashed border-warning-primary/60' : 'border-solid border-brand-solid/50')} />
+        <ArrowNarrowRight className={cn('-ml-1 size-4 shrink-0', inferred ? 'text-warning-primary' : 'text-brand-solid')} aria-hidden />
       </span>
-      <span className="mt-0.5 text-[10px] text-quaternary">{inferred ? 'inferred' : 'observed'}</span>
     </div>
   )
 }
 
 function PathRow({ path, index }: { path: AttackPath; index: number }) {
+  const reasons = path.uncertainties.map((u) => UNCERTAINTY_LABEL[u] ?? u.replace(/_/g, ' '))
   return (
-    <div className="rounded-xl border border-secondary bg-primary p-4">
-      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <span className="inline-flex size-6 items-center justify-center rounded-md bg-secondary text-xs font-bold tabular-nums text-tertiary">
+    <div className="rounded-xl border border-secondary bg-secondary/20 p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <span className="inline-flex items-center gap-2 text-sm font-semibold text-primary">
+          <span className="inline-flex size-6 items-center justify-center rounded-md bg-brand-primary/10 text-xs font-bold tabular-nums text-brand-secondary">
             {index + 1}
           </span>
-          <span className="font-mono text-xs text-quaternary" title={path.id}>
-            {path.id.length > 14 ? `${path.id.slice(0, 12)}…` : path.id}
-          </span>
-        </div>
+          Path {index + 1}
+        </span>
         {path.confident ? (
           <Pill className="text-success-primary">
             <CheckCircle className="mr-1 inline size-3.5" aria-hidden />
             Confident
           </Pill>
         ) : (
-          <Pill className="text-warning-primary">
-            <AlertTriangle className="mr-1 inline size-3.5" aria-hidden />
-            Inferred
-          </Pill>
+          <span className="inline-flex items-center gap-1">
+            <Pill className="text-warning-primary">
+              <AlertTriangle className="mr-1 inline size-3.5" aria-hidden />
+              Inferred
+            </Pill>
+            {reasons.length > 0 && (
+              <InfoNote label="Why this path is uncertain">
+                <span className="mb-1 block font-semibold text-secondary">Why this path is uncertain</span>
+                <ul className="list-disc space-y-0.5 pl-4">
+                  {reasons.map((r) => (
+                    <li key={r}>{r}</li>
+                  ))}
+                </ul>
+              </InfoNote>
+            )}
+          </span>
         )}
       </div>
 
-      <div className="flex flex-wrap items-stretch gap-y-2 overflow-x-auto">
+      <div className="flex items-stretch overflow-x-auto pb-1">
         {path.nodes.map((node, i) => (
           <div key={`${node.id}-${i}`} className="flex items-stretch">
-            <NodeChip node={node} />
+            <NodeChip node={node} terminal={i === path.nodes.length - 1} />
             {i < path.steps.length && i < path.nodes.length - 1 && <StepConnector step={path.steps[i]} />}
           </div>
         ))}
       </div>
-
-      {!path.confident && path.uncertainties.length > 0 && (
-        <div className="mt-3 flex flex-wrap items-center gap-1.5 border-t border-secondary pt-3">
-          <span className="text-[11px] font-semibold uppercase tracking-wide text-quaternary">Why uncertain</span>
-          {path.uncertainties.map((u) => (
-            <Pill key={u} className="text-warning-primary">
-              {UNCERTAINTY_LABEL[u] ?? u.replace(/_/g, ' ')}
-            </Pill>
-          ))}
-        </div>
-      )}
     </div>
   )
 }
@@ -189,21 +187,29 @@ export function AttackPathsTab() {
   return (
     <div className="space-y-6">
       <Card title="Attack path exposure" titleClassName="flex items-center gap-2">
-        <div className="flex flex-wrap items-center gap-x-8 gap-y-4">
-          <div className="flex items-baseline gap-2">
-            <span className="text-4xl font-bold tabular-nums text-primary">{paths.length}</span>
-            <span className="text-sm text-tertiary">exposure-to-finding path{paths.length === 1 ? '' : 's'}</span>
+        <div className="grid max-w-xl grid-cols-3 gap-3">
+          <div className="rounded-lg border border-secondary bg-primary px-4 py-3">
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-quaternary">Paths</div>
+            <div className="mt-1 font-mono text-2xl font-semibold tabular-nums text-primary">{paths.length}</div>
           </div>
-          <div className="flex flex-col gap-1.5">
-            <div className="flex items-center gap-2">
-              <CheckCircle className="size-4 text-success-primary" aria-hidden />
-              <span className="text-sm font-semibold text-primary">{confidentCount}</span>
-              <span className="text-xs text-tertiary">confident (every edge observed, finding confirmed-reachable)</span>
+          <div className="rounded-lg border border-secondary bg-primary px-4 py-3">
+            <div className="flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wide text-quaternary">
+              Confident
+              <InfoNote label="What confident means">Every edge is observed and the terminal finding is confirmed-reachable.</InfoNote>
             </div>
-            <div className="flex items-center gap-2">
-              <HelpCircle className="size-4 text-warning-primary" aria-hidden />
-              <span className="text-sm font-semibold text-primary">{paths.length - confidentCount}</span>
-              <span className="text-xs text-tertiary">inferred (at least one edge or reachability unconfirmed)</span>
+            <div className="mt-1 inline-flex items-center gap-1.5 font-mono text-2xl font-semibold tabular-nums text-success-primary">
+              <CheckCircle className="size-5" aria-hidden />
+              {confidentCount}
+            </div>
+          </div>
+          <div className="rounded-lg border border-secondary bg-primary px-4 py-3">
+            <div className="flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wide text-quaternary">
+              Inferred
+              <InfoNote label="What inferred means">At least one edge, or the finding&apos;s reachability, is unconfirmed.</InfoNote>
+            </div>
+            <div className="mt-1 inline-flex items-center gap-1.5 font-mono text-2xl font-semibold tabular-nums text-warning-primary">
+              <HelpCircle className="size-5" aria-hidden />
+              {paths.length - confidentCount}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## What

Dashboard and attack-path UI feedback: the metric strips were unbalanced and the screens carried too much fine print ("AI vibe").

- **Metric strip evened out.** Each figure's definition moves from a second line of small print into an info tooltip on the label, so every metric is the same height and a row of them stays aligned. `MetricStrip` uses an even auto-fit grid so any number of metrics spreads across the full width instead of clustering left. Shared across the dashboard, fleet, and incident strips.
- **Dashboard Coverage gaps tile** drops the stray "fleet capability checks" line; fleet-disabled shows an em dash with the reason in the tooltip.
- **Attack paths reworked** into a cleaner exposure→finding flow: colored node rails (asset vs severity-coloured finding), canonical `SevBadge` severity, relationship-labelled edges (solid observed / dashed inferred), and the "why uncertain" reasons behind a tooltip on the Inferred badge instead of a bottom row of tiny pills.
- **`listHosts` hardened** to degrade to an empty list instead of throwing when the endpoint answers a non-array shape (the `((intermediate value) ?? []).map is not a function` crash).

## Testing

Verified against a **real `synapse-api` backend** (in-memory) with a real recorded scan, and against the mock, in both themes. `pnpm typecheck` + `pnpm build` clean, full web suite green (569 tests).
