### PR TITLE
refactor(web): move alerting and SLA fine print into tooltips

### DIFF
--- a/web/src/pages/Settings/Alerting.tsx
+++ b/web/src/pages/Settings/Alerting.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { AlertTriangle, BellRinging01, CheckCircle, Send01 } from '@untitledui/icons'
-import { Button, Card, EmptyState, cn } from '../../components/ui'
+import { Button, Card, EmptyState, InfoNote, cn } from '../../components/ui'
 import { useToast } from '../../components/synapse/Toast'
 import { useFetch } from '../../hooks'
 import { api, AlertNotEnabledError } from '../../lib/api'
@@ -10,9 +10,9 @@ function OutcomeStat({ value, label, tone, hint }: { value: number; label: strin
   return (
     <div className="flex items-center gap-3 rounded-lg border border-secondary bg-primary px-3 py-2">
       <span className={cn('text-xl font-bold tabular-nums', tone)}>{value}</span>
-      <span className="flex flex-col leading-tight">
-        <span className="text-sm font-medium text-primary">{label}</span>
-        <span className="text-xs text-tertiary">{hint}</span>
+      <span className="inline-flex items-center gap-1 text-sm font-medium text-primary">
+        {label}
+        <InfoNote label={label}>{hint}</InfoNote>
       </span>
     </div>
   )
@@ -91,7 +91,12 @@ export function Alerting() {
             )
           }
         >
-          {ranAt && <p className="mb-3 text-xs text-tertiary">Tested at {ranAt}. The API reports per-sink counts, not individual sink identities.</p>}
+          {ranAt && (
+            <p className="mb-3 inline-flex items-center gap-1 text-xs text-tertiary">
+              Tested at {ranAt}
+              <InfoNote label="About these counts">The API reports per-sink counts, not individual sink identities.</InfoNote>
+            </p>
+          )}
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
             <OutcomeStat value={result.outcome.delivered} label="Delivered" hint="sinks that acknowledged" tone="text-success-primary" />
             <OutcomeStat value={result.outcome.failed} label="Failed" hint="sinks that refused" tone={result.outcome.failed > 0 ? 'text-error-primary' : 'text-tertiary'} />

--- a/web/src/pages/Settings/SLAPolicy.tsx
+++ b/web/src/pages/Settings/SLAPolicy.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { AlertTriangle, CheckCircle, Scales02, Save01 } from '@untitledui/icons'
-import { Button, Card, EmptyState, ErrorState, Field, Input, Pill, Spinner, cn } from '../../components/ui'
+import { Button, Card, EmptyState, ErrorState, Field, InfoNote, Input, Pill, Spinner, cn } from '../../components/ui'
 import { useToast } from '../../components/synapse/Toast'
 import { useFetch } from '../../hooks'
 import { api } from '../../lib/api'
@@ -230,8 +230,10 @@ function ActivateForm({ seed, canAdmin, onDone }: { seed: SLAConfig; canAdmin: b
         </div>
 
         <div>
-          <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-tertiary">Due windows (days)</h3>
-          <p className="mb-2 text-xs text-quaternary">Windows are edited in whole or fractional days; a policy set out-of-band with sub-day precision is rounded to the day view here.</p>
+          <h3 className="mb-2 inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-tertiary">
+            Due windows (days)
+            <InfoNote label="Due windows">Windows are edited in whole or fractional days; a policy set out-of-band with sub-day precision is rounded to the day view here.</InfoNote>
+          </h3>
           <div className="overflow-x-auto">
             <table className="w-full min-w-[24rem] text-sm">
               <thead>


### PR DESCRIPTION
## What

Follows the metric-strip change (#843): explanatory fine print belongs in an info tooltip on the label, not as a second line of small print — which reads as "AI vibe".

- **Alerting**: each outcome figure's definition (delivered / failed / audit-failed / rule matched) and the per-sink-counts caveat move into info tooltips; the value and the test timestamp remain the readout.
- **SLA policy**: the sub-day-rounding note on the due-windows editor moves into a tooltip on the section heading.

Fleet coverage is a data-table surface (compact by nature); the metric-strip tooltip change from #843 already tightened its summary, so no further text was forced into fine print there.

## Testing
`pnpm typecheck` clean; Alerting + SLA test suites pass.
