### PR TITLE
fix(deploy): repair duplicated properties block in helm values schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,14 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Fixed
 
+- **The production Helm chart's values schema parses again.** A merge of the external CI/CD
+  integrations work duplicated the top-level `properties` block in
+  `deploy/helm/synapse/values.schema.json`, leaving malformed JSON that made `helm lint` and `helm
+  template` fail on every install of the production chart. The schema is restored to one block that
+  keeps the strict posture (`objectStore.useSSL` fixed to `true`, `worker.integrationScheduler`
+  required, the `existingSecrets.egressGrant.authorityToken` secret) together with the newer
+  `execution` and `egressBroker` definitions. The chart lints under `--strict` and renders against
+  `tests/production-values.yaml` again.
 - **The running-process projection retires exited processes.** The agent reports only live processes
   and the store upserted them, so a process that exited between reports lingered as running forever and
   the behavior baseline's process-count feature climbed every sweep, self-poisoning into false drift. A

--- a/deploy/helm/synapse/values.schema.json
+++ b/deploy/helm/synapse/values.schema.json
@@ -15,24 +15,6 @@
     "ingress"
   ],
   "properties": {
-    "nameOverride": {"type": "string"},
-    "fullnameOverride": {"type": "string"},
-    "image": {"$ref": "#/definitions/image"},
-    "web": {"type": "object", "additionalProperties": false, "required": ["replicaCount", "image", "resources"], "properties": {"replicaCount": {"type": "integer", "minimum": 2}, "image": {"$ref": "#/definitions/image"}, "resources": {"$ref": "#/definitions/resources"}}},
-    "api": {"type": "object", "additionalProperties": false, "required": ["replicaCount", "metrics", "grantAuthority", "resources", "nodeSelector", "tolerations", "affinity"], "properties": {"replicaCount": {"type": "integer", "minimum": 2}, "nodeSelector": {"type": "object"}, "tolerations": {"type": "array"}, "affinity": {"type": "object"}, "metrics": {"type": "object", "additionalProperties": false, "required": ["enabled", "port", "monitoringNamespace"], "properties": {"enabled": {"type": "boolean"}, "port": {"type": "integer", "minimum": 1024, "maximum": 65535}, "monitoringNamespace": {"type": "string", "minLength": 1}}}, "grantAuthority": {"type": "object", "additionalProperties": false, "required": ["enabled", "port", "servicePort", "annotations", "networkPolicySourceCIDRs"], "properties": {"enabled": {"type": "boolean"}, "port": {"type": "integer", "minimum": 1024, "maximum": 65535}, "servicePort": {"const": 443}, "annotations": {"type": "object", "additionalProperties": {"type": "string"}}, "networkPolicySourceCIDRs": {"$ref": "#/definitions/nonEmptyCIDRList"}}}, "resources": {"$ref": "#/definitions/resources"}}},
-    "worker": {"type": "object", "additionalProperties": false, "required": ["enabled", "replicaCount", "resources", "nodeSelector", "tolerations", "affinity", "integrationScheduler"], "properties": {"enabled": {"type": "boolean"}, "replicaCount": {"type": "integer", "minimum": 1, "maximum": 64}, "nodeSelector": {"type": "object"}, "tolerations": {"type": "array"}, "affinity": {"type": "object"}, "integrationScheduler": {"type": "object", "additionalProperties": false, "required": ["enabled", "poll", "dispatchLimit", "maxQueueDepth"], "properties": {"enabled": {"type": "boolean"}, "poll": {"type": "string", "pattern": "^[1-9][0-9]*(ms|s|m|h)$"}, "dispatchLimit": {"type": "integer", "minimum": 1, "maximum": 1000}, "maxQueueDepth": {"type": "integer", "minimum": 1, "maximum": 100000}}}, "resources": {"$ref": "#/definitions/resources"}}},
-    "migration": {"type": "object", "additionalProperties": false, "required": ["resources"], "properties": {"resources": {"$ref": "#/definitions/resources"}}},
-    "serviceAccount": {"type": "object", "additionalProperties": false, "required": ["create", "name"], "properties": {"create": {"type": "boolean"}, "name": {"type": "string"}, "annotations": {"type": "object", "additionalProperties": {"type": "string"}}}},
-    "podSecurityContext": {"type": "object"},
-    "containerSecurityContext": {"type": "object"},
-    "existingSecrets": {"type": "object", "additionalProperties": false, "required": ["apiToken", "database", "objectStore", "cryptography", "egressGrant"], "properties": {"apiToken": {"$ref": "#/definitions/secretRef"}, "database": {"type": "object", "additionalProperties": false, "required": ["runtime", "migration"], "properties": {"runtime": {"$ref": "#/definitions/secretRef"}, "migration": {"$ref": "#/definitions/secretRef"}}}, "objectStore": {"type": "object", "additionalProperties": false, "required": ["accessKey", "secretKey"], "properties": {"accessKey": {"$ref": "#/definitions/secretRef"}, "secretKey": {"$ref": "#/definitions/secretRef"}}}, "cryptography": {"type": "object", "additionalProperties": false, "required": ["vaultMasterKey", "evidenceSigningSeed", "measureCursorSecret"], "properties": {"vaultMasterKey": {"$ref": "#/definitions/secretRef"}, "evidenceSigningSeed": {"$ref": "#/definitions/secretRef"}, "measureCursorSecret": {"$ref": "#/definitions/secretRef"}}}, "egressGrant": {"type": "object", "additionalProperties": false, "required": ["issuerToken", "signingSeed"], "properties": {"issuerToken": {"$ref": "#/definitions/secretRef"}, "signingSeed": {"$ref": "#/definitions/secretRef"}}}, "oidc": {"type": "object", "additionalProperties": false, "required": ["clientSecret"], "properties": {"clientSecret": {"$ref": "#/definitions/secretRef"}}}}},
-    "externalDatabase": {"type": "object", "additionalProperties": false, "required": ["sslMode", "caBundle"], "properties": {"sslMode": {"const": "verify-full"}, "caBundle": {"type": "object", "additionalProperties": false, "required": ["secretName", "key"], "properties": {"secretName": {"type": "string", "minLength": 1}, "key": {"type": "string", "minLength": 1}}}}},
-    "oidc": {"type": "object", "additionalProperties": false, "required": ["enabled"], "properties": {"enabled": {"type": "boolean"}, "issuer": {"type": "string"}, "clientID": {"type": "string"}, "redirectURL": {"type": "string"}, "frontendURL": {"type": "string"}, "tenantID": {"type": "string"}, "groupRoleMapping": {"type": "array", "items": {"type": "string", "pattern": "^[^=]+=(admin|consultant|reviewer|readonly|member)$"}}, "transactionTTL": {"type": "string"}, "sessionTTL": {"type": "string"}}},
-    "objectStore": {"type": "object", "additionalProperties": false, "required": ["endpoint", "bucket", "useSSL"], "properties": {"endpoint": {"type": "string", "minLength": 1}, "bucket": {"type": "string", "minLength": 1}, "useSSL": {"const": true}}},
-    "sandbox": {"type": "object", "additionalProperties": false, "required": ["enabled", "hostUsers", "userNamespacesRequired"], "properties": {"enabled": {"const": true}, "hostUsers": {"type": "boolean"}, "userNamespacesRequired": {"const": true}}},
-    "ingress": {"type": "object", "additionalProperties": false, "required": ["enabled", "annotations", "className", "host", "tls"], "properties": {"enabled": {"const": true}, "annotations": {"type": "object", "additionalProperties": {"type": "string"}}, "className": {"type": "string"}, "host": {"type": "string", "minLength": 1}, "tls": {"type": "object", "additionalProperties": false, "required": ["secretName"], "properties": {"secretName": {"type": "string", "minLength": 1}}}}},
-    "networkPolicy": {"type": "object", "additionalProperties": false, "required": ["ingressControllerNamespace", "allowInternetEgress", "runtimeEgress"], "properties": {"ingressControllerNamespace": {"type": "string", "minLength": 1}, "allowInternetEgress": {"type": "boolean"}, "runtimeEgress": {"type": "object", "additionalProperties": false, "required": ["database", "objectStore", "oidc"], "properties": {"database": {"$ref": "#/definitions/cidrList"}, "objectStore": {"$ref": "#/definitions/cidrList"}, "oidc": {"$ref": "#/definitions/cidrList"}}}}},
-    "topologySpreadConstraints": {"type": "array", "minItems": 1}
     "nameOverride": {
       "type": "string"
     },
@@ -159,7 +141,8 @@
         "resources",
         "nodeSelector",
         "tolerations",
-        "affinity"
+        "affinity",
+        "integrationScheduler"
       ],
       "properties": {
         "enabled": {
@@ -178,6 +161,35 @@
         },
         "affinity": {
           "type": "object"
+        },
+        "integrationScheduler": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "enabled",
+            "poll",
+            "dispatchLimit",
+            "maxQueueDepth"
+          ],
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "poll": {
+              "type": "string",
+              "pattern": "^[1-9][0-9]*(ms|s|m|h)$"
+            },
+            "dispatchLimit": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000
+            },
+            "maxQueueDepth": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100000
+            }
+          }
         },
         "resources": {
           "$ref": "#/definitions/resources"
@@ -412,7 +424,7 @@
           "minLength": 1
         },
         "useSSL": {
-          "type": "boolean"
+          "const": true
         }
       }
     },


### PR DESCRIPTION
## What

A merge of the external CI/CD integrations work concatenated two copies of the top-level `properties` block in `deploy/helm/synapse/values.schema.json`. The result was invalid JSON (`invalid character '"' after object key:value pair`), so `helm lint` and `helm template` failed on every install of the production chart, and `go test ./deploy/helm/synapse/tests/` failed.

## Fix

Restore the schema to a single `properties` block, taking the correct union of the two duplicated versions:

- Drop the stale duplicate block (18 keys), keep the pretty-printed one.
- `objectStore.useSSL` back to `const: true` (a reformat in the execution-modes commit silently relaxed it from the hardened `const: true` to `boolean`).
- `worker.integrationScheduler` restored as a required property (dropped by the same reformat; the integration scheduler is a shipped feature and `values.yaml` sets it).
- Keep the newer `execution` and `egressBroker` definitions and `existingSecrets.egressGrant.authorityToken`.

## Verification

- `go test ./deploy/helm/synapse/tests/` passes (`render_test.sh` + `data_governance_test.sh`, `helm lint --strict -f tests/production-values.yaml`, negative assertions on `invalid-tag-values.yaml`).
- `go test ./...` is green except the environment-gated `internal/infrastructure/sandbox` `*Live` tests (bubblewrap needs privileges this container lacks; they pass in CI).
- JSON parses, no duplicate keys, 20 top-level properties.
