### PR TITLE
fix(assessment): retain supported IaC findings across scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -298,6 +298,14 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Fixed
 
+- **Assessment Cycle scans retain every supported IaC family.** Native observation
+  preparation now accepts Dockerfile, Compose, GitHub Actions and ARM findings in
+  addition to Terraform, CloudFormation and Kubernetes (including rendered Helm).
+  Findings without approved resource identity remain provisional and require review
+  on every re-scan, including repeated source fingerprints;
+  incomplete IaC coverage cannot imply Fixed. Repository paths reject URL locators
+  before normalization so embedded credentials cannot enter source identities.
+
 - **The running-process projection retires exited processes.** The agent reports only live processes
   and the store upserted them, so a process that exited between reports lingered as running forever and
   the behavior baseline's process-count feature climbed every sweep, self-poisoning into false drift. A

--- a/docs/guide/assessment-lifecycle-operations.md
+++ b/docs/guide/assessment-lifecycle-operations.md
@@ -25,6 +25,29 @@ Assessment lifecycle rollout is additive and fail-closed. Apply migrations first
   freezes the root-to-selected-head path and generates a JSON report. Reopen
   supersedes the old manifest; it does not rewrite or remove its report/history.
 
+### Troubleshooting IaC scan finalization
+
+The error `prepare redacted native observation: validation error: IaC config kind is unsupported`
+can occur on pre-fix builds with native Snapshot capture enabled: the scanner emits
+Dockerfile, Compose, GitHub Actions and ARM findings, but the original lineage
+adapter recognized only Terraform, CloudFormation and Kubernetes. The failure can
+mark a job failed at 100% after detection, before the scan result and Findings are
+saved; an earlier immutable evidence-ledger append may already exist.
+
+The fixed adapter retains all seven scanner families (Helm findings use Kubernetes).
+The four newly accepted families have no approved resource-identity adapter yet,
+so their observations are provisional and produce `needs_review` candidates, not
+trusted cross-Snapshot matches. Repeated source fingerprints retain a review
+candidate in each new Snapshot; same-Snapshot replay does not duplicate evidence
+or reopen an explicitly resolved candidate. IaC coverage remains partial; a later
+scan with no IaC finding does not prove Fixed. Unknown families and unsafe paths still fail
+validation instead of silently dropping findings.
+
+After upgrading the API and worker, start a new scan in the same non-completed
+Engagement using available source input and valid scan authorization. Do not rewrite
+the failed job or delete sealed evidence. No migration or new Re-test Engagement is
+required for this fix. Disabling Snapshot capture is not a data-repair step.
+
 Large closure reference cohorts (over 256 per kind) are represented as hashed
 `*_set` references with source kind, exact count and earliest expiry. Report
 generation resolves the complete ordered set at the manifest's as-of time. A

--- a/internal/infrastructure/persistence/postgres/finding_lineage_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/finding_lineage_repo_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -650,6 +651,113 @@ func TestPostgresIaCMatcherAddressParityAndTenantIsolation(t *testing.T) {
 	}
 	if provisional.Candidate.Reason != findinglineage.ReasonInsufficientAnchor {
 		t.Fatalf("provisional IaC candidate=%+v", provisional.Candidate)
+	}
+
+	// The same unsupported semantic anchor must remain reviewable in every
+	// snapshot, even when the source-scoped provisional fingerprint matches.
+	assessmentID := shared.ID(fmt.Sprintf("lineage-assessment-iac-%d", suffix))
+	snapshotIDs := []shared.ID{snapshotID}
+	for number := 2; number <= 3; number++ {
+		runID := shared.ID(fmt.Sprintf("iac-repeat-run-%d-%d", suffix, number))
+		run := postgresNativeRun(t, tenantID, assessmentID, runID, strings.Repeat(fmt.Sprint(number), 64))
+		sealPostgresNativeRun(t, ctx, NewScanRunStore(pool), &run, time.Now().UTC())
+		snapshot := postgresAssessmentSnapshot(t, tenantID, cycleID, assessmentID,
+			fmt.Sprintf("iac-repeat-snapshot-%d-%d", suffix, number), fmt.Sprintf("iac-repeat-request-%d-%d", suffix, number), run)
+		stored, created, err := NewAssessmentSnapshotRepository(pool).CreateFinalizedCAS(ctx, snapshot, int64(number-1))
+		if err != nil || !created || stored.SnapshotNumber != number {
+			t.Fatalf("create repeated IaC snapshot=%+v created=%v err=%v", stored, created, err)
+		}
+		snapshotIDs = append(snapshotIDs, stored.ID)
+	}
+	for _, config := range []struct {
+		kind lineageuc.IaCConfigKind
+		rule string
+		path string
+	}{
+		{lineageuc.IaCDockerfile, "dockerfile-user-root", "Dockerfile"},
+		{lineageuc.IaCCompose, "compose-privileged", "compose.yaml"},
+		{lineageuc.IaCGitHubActions, "gha-permissions-write-all", ".github/workflows/ci.yml"},
+		{lineageuc.IaCARM, "arm-storage-public-blob", "azuredeploy.json"},
+	} {
+		t.Run(string(config.kind), func(t *testing.T) {
+			plan, err := matcher.Build(lineageuc.IaCFingerprintInputV1{
+				TargetIdentityCanonical: "repo:example", RuleKey: config.rule, RepoPath: config.path,
+			})
+			if err != nil || !plan.ProvisionalIdentity || plan.ReasonCode != "resource_identity_unavailable" {
+				t.Fatalf("unadapted IaC family plan=%+v err=%v", plan, err)
+			}
+			var identityID shared.ID
+			observationIDs, candidateIDs := make(map[shared.ID]bool), make(map[shared.ID]bool)
+			for index, currentSnapshotID := range snapshotIDs {
+				input := plan.Apply(lineageuc.CorrelateInput{
+					TenantID: tenantID, CycleID: cycleID, SnapshotID: currentSnapshotID,
+					InputTrusted: true, OwnershipValidated: true, RedactionComplete: true,
+					Observation: lineageuc.ObservationInput{
+						SourceFindingID: "iac-repeat-" + string(config.kind), Severity: shared.SeverityHigh,
+						Location: config.path + ":2", ObservedAt: clock.now.Add(time.Duration(index) * time.Second),
+						ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "iac-matcher-test"},
+					}, Actor: "integration-test",
+				})
+				result, err := service.Correlate(ctx, input)
+				if err != nil || result.Outcome != lineageuc.OutcomeReview || result.Identity == nil || result.Observation == nil || result.Candidate == nil {
+					t.Fatalf("snapshot %d lost provisional review: result=%+v err=%v", index+1, result, err)
+				}
+				if index == 0 {
+					identityID = result.Identity.ID
+				}
+				if result.Identity.ID != identityID || observationIDs[result.Observation.ID] || candidateIDs[result.Candidate.ID] {
+					t.Fatalf("snapshot %d must reuse identity but retain distinct observation/review: %+v", index+1, result)
+				}
+				observationIDs[result.Observation.ID], candidateIDs[result.Candidate.ID] = true, true
+				storedIdentity, err := repository.GetIdentity(ctx, tenantID, cycleID, identityID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var fields struct {
+					ConfigKind string `json:"config_kind"`
+				}
+				if err := json.Unmarshal(storedIdentity.CanonicalIdentityFields, &fields); err != nil || fields.ConfigKind != string(config.kind) {
+					t.Fatalf("config family lost on PostgreSQL roundtrip: kind=%q err=%v", fields.ConfigKind, err)
+				}
+				storedObservation, err := repository.GetObservation(ctx, tenantID, cycleID, result.Observation.ID)
+				if err != nil || storedObservation.SnapshotID != currentSnapshotID || storedObservation.IdentityID != identityID || storedObservation.SourceFindingID != input.Observation.SourceFindingID {
+					t.Fatalf("observation retention=%+v err=%v", storedObservation, err)
+				}
+				for range 2 {
+					replay, err := service.Correlate(ctx, input)
+					if err != nil || replay.Identity == nil || replay.Identity.ID != identityID || replay.Observation == nil || replay.Observation.ID != result.Observation.ID {
+						t.Fatalf("snapshot %d replay=%+v err=%v", index+1, replay, err)
+					}
+				}
+				storedCandidate, err := repository.GetCandidate(ctx, tenantID, cycleID, result.Candidate.ID)
+				if err != nil || storedCandidate.SnapshotID != currentSnapshotID || storedCandidate.Status != findinglineage.CandidateOpen || storedCandidate.Reason != findinglineage.ReasonInsufficientAnchor {
+					t.Fatalf("review must remain open after observation replay: %+v err=%v", storedCandidate, err)
+				}
+				if _, err := repository.GetIdentity(ctx, otherTenantID, cycleID, identityID); !errors.Is(err, shared.ErrNotFound) {
+					t.Fatalf("cross-tenant provisional identity read=%v", err)
+				}
+				if _, err := repository.GetObservation(ctx, otherTenantID, cycleID, result.Observation.ID); !errors.Is(err, shared.ErrNotFound) {
+					t.Fatalf("cross-tenant provisional observation read=%v", err)
+				}
+				if _, err := repository.GetCandidate(ctx, otherTenantID, cycleID, result.Candidate.ID); !errors.Is(err, shared.ErrNotFound) {
+					t.Fatalf("cross-tenant provisional candidate read=%v", err)
+				}
+			}
+		})
+	}
+	for index, currentSnapshotID := range snapshotIDs {
+		wantObservations, wantCandidates := 4, 4
+		if index == 0 {
+			wantObservations, wantCandidates = 6, 5 // Original Terraform and Kubernetes cases above.
+		}
+		observations, err := repository.ListObservationsBySnapshot(ctx, tenantID, cycleID, currentSnapshotID)
+		if err != nil || len(observations) != wantObservations {
+			t.Fatalf("snapshot %d replay duplicated/lost observations: count=%d want=%d err=%v", index+1, len(observations), wantObservations, err)
+		}
+		candidates, err := repository.ListOpenCandidatesBySnapshot(ctx, tenantID, cycleID, currentSnapshotID)
+		if err != nil || len(candidates) != wantCandidates {
+			t.Fatalf("snapshot %d replay duplicated/lost review candidates: count=%d want=%d err=%v", index+1, len(candidates), wantCandidates, err)
+		}
 	}
 }
 

--- a/internal/usecase/findinglineage/backfill_test.go
+++ b/internal/usecase/findinglineage/backfill_test.go
@@ -154,6 +154,91 @@ func TestFindingLineageBackfillDryRunIsResumableAndWriteFree(t *testing.T) {
 	}
 }
 
+func TestFindingLineageBackfillRetainsAllNativeIaCFamiliesForReview(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 9, 8, 6, 0, 0, 0, time.UTC)
+	clock, ids, audit := fixedBackfillClock{now}, &backfillIDs{}, noOpBackfillAudit{}
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	snapshot := backfillSnapshot(t, now)
+	if _, _, err := snapshots.CreateLegacyProjection(ctx, snapshot); err != nil {
+		t.Fatal(err)
+	}
+	repository := memory.NewFindingLineageRepository()
+	lineage, err := lineageuc.NewService(repository, memory.NewTenantTransactionRunner(), audit, clock, ids, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := memory.NewFindingLineageBackfillRepository()
+	var rows []ports.FindingLineageBackfillSourceRow
+	for index, test := range []struct{ rule, path string }{
+		{"dockerfile-run-as-root", "Dockerfile"},
+		{"compose-privileged", "compose.yaml"},
+		{"gha-permissions-write-all", ".github/workflows/ci.yaml"},
+		{"arm-storage-https-only-off", "azure/template.json"},
+	} {
+		rows = append(rows, backfillSource(shared.ID(fmt.Sprintf("iac-%d", index)), finding.KindMisconfig,
+			"misconfig:"+test.rule+":"+test.path+":42", test.rule, "", now, snapshot))
+	}
+	store.SetSources("tenant", rows)
+	runner, err := lineageuc.NewFindingLineageBackfillRunner(lineage, store, store, snapshots, occurrenceBackfillStore{}, emptyJudgmentStore{}, ids, clock, audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := runner.RunBackfill(ctx, lineageuc.FindingLineageBackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "worker", BatchSize: 2})
+	if err != nil {
+		t.Fatalf("scanner-supported IaC findings aborted backfill: %v", err)
+	}
+	if run.State != ports.FindingLineageBackfillCompleted || run.ProcessedCount != len(rows) || run.ProvisionalCandidateCount != len(rows) || run.ObservationCreatedCount != 0 || run.SkippedCount != 0 {
+		t.Fatalf("scanner-supported findings were discarded or declared fully matched: %+v", run)
+	}
+	observations, err := repository.ListObservationsBySnapshot(ctx, "tenant", "cycle", snapshot.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidates, err := repository.ListOpenCandidatesBySnapshot(ctx, "tenant", "cycle", snapshot.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(observations) != len(rows) || len(candidates) != len(rows) {
+		t.Fatalf("provisional evidence was not retained: observations=%d candidates=%d", len(observations), len(candidates))
+	}
+	for _, row := range rows {
+		item, err := store.GetFindingLineageBackfillItem(ctx, "tenant", run.ID, row.FindingID)
+		if err != nil || item.Outcome != lineageuc.BackfillOutcomeProvisionalCandidate || item.ReasonCode != "resource_identity_unavailable" {
+			t.Fatalf("finding %s did not retain an explicit review outcome: item=%+v err=%v", row.FindingID, item, err)
+		}
+		found := false
+		for _, observation := range observations {
+			if observation.SourceFindingID == row.FindingID.String() {
+				found = true
+				if observation.ProducerKind != "iac" || observation.FindingKind != "misconfig" || !strings.HasSuffix(observation.Location, ":42") || observation.IdentityID.IsZero() {
+					t.Fatalf("wrong retained observation: %+v", observation)
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("finding %s lost its immutable observation", row.FindingID)
+		}
+	}
+	for _, candidate := range candidates {
+		if candidate.Reason != "insufficient_anchor" {
+			t.Fatalf("unsupported semantic matching must remain needs_review: %+v", candidate)
+		}
+	}
+	replayed, err := runner.RunBackfill(ctx, lineageuc.FindingLineageBackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "replay-worker", BatchSize: 3})
+	if err != nil || replayed.ProvisionalCandidateCount != len(rows) || replayed.SkippedCount != 0 {
+		t.Fatalf("replay changed backfill outcomes: %+v err=%v", replayed, err)
+	}
+	observations, err = repository.ListObservationsBySnapshot(ctx, "tenant", "cycle", snapshot.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidates, err = repository.ListOpenCandidatesBySnapshot(ctx, "tenant", "cycle", snapshot.ID)
+	if err != nil || len(observations) != len(rows) || len(candidates) != len(rows) {
+		t.Fatalf("replay duplicated lineage records: observations=%d candidates=%d err=%v", len(observations), len(candidates), err)
+	}
+}
+
 func TestFindingLineageBackfillRedactsMalformedSecretBeforePersistence(t *testing.T) {
 	now := time.Date(2026, 9, 1, 4, 0, 0, 0, time.UTC)
 	clock, ids, audit := fixedBackfillClock{now}, &backfillIDs{}, &recordingBackfillAudit{}

--- a/internal/usecase/findinglineage/iac_matcher.go
+++ b/internal/usecase/findinglineage/iac_matcher.go
@@ -23,10 +23,18 @@ const (
 	IaCTerraform      IaCConfigKind = "terraform"
 	IaCCloudFormation IaCConfigKind = "cloudformation"
 	IaCKubernetes     IaCConfigKind = "kubernetes"
+	IaCDockerfile     IaCConfigKind = "dockerfile"
+	IaCCompose        IaCConfigKind = "compose"
+	IaCGitHubActions  IaCConfigKind = "github_actions"
+	IaCARM            IaCConfigKind = "arm"
 )
 
 func (kind IaCConfigKind) Valid() bool {
-	return kind == IaCTerraform || kind == IaCCloudFormation || kind == IaCKubernetes
+	switch kind {
+	case IaCTerraform, IaCCloudFormation, IaCKubernetes, IaCDockerfile, IaCCompose, IaCGitHubActions, IaCARM:
+		return true
+	}
+	return false
 }
 
 type IaCRuleAliasSetV1 struct {
@@ -106,7 +114,7 @@ func (matcher IaCMatcherV1) Build(input IaCFingerprintInputV1) (IaCMatchPlanV1, 
 		}
 	}
 	configKind := input.ConfigKind
-	if !configKind.Valid() {
+	if configKind == "" {
 		configKind = inferIaCConfigKind(ruleKey)
 	}
 	if !configKind.Valid() {
@@ -130,11 +138,14 @@ func (matcher IaCMatcherV1) Build(input IaCFingerprintInputV1) (IaCMatchPlanV1, 
 	}
 
 	fields := map[string]domain.CanonicalValue{
-		"config_kind":               domain.Text(string(configKind)),
-		"producer_matcher_version":  domain.Integer(IaCMatcherVersionV1),
-		"rule_alias_graph_version":  domain.Integer(SASTRuleAliasSchemaVersionV1),
-		"resource_adapter_version":  domain.Integer(1),
-		"resource_identity_grammar": domain.Text(string(configKind) + "_v1"),
+		"config_kind":              domain.Text(string(configKind)),
+		"producer_matcher_version": domain.Integer(IaCMatcherVersionV1),
+		"rule_alias_graph_version": domain.Integer(SASTRuleAliasSchemaVersionV1),
+	}
+	resourceIdentityUnavailable := resourceReason == "resource_identity_unavailable"
+	if !resourceIdentityUnavailable {
+		fields["resource_adapter_version"] = domain.Integer(1)
+		fields["resource_identity_grammar"] = domain.Text(string(configKind) + "_v1")
 	}
 	if normalizedPath != "" {
 		fields["repo_path"] = domain.Text(normalizedPath)
@@ -170,12 +181,19 @@ func (matcher IaCMatcherV1) Build(input IaCFingerprintInputV1) (IaCMatchPlanV1, 
 		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "missing_repo_path", true, true
 	case primaryRule == "":
 		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "missing_rule_key", true, true
+	case resourceIdentityUnavailable:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, resourceReason, true, true
 	case semanticAnchor == "":
 		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "missing_semantic_config_anchor", true, true
 	case resourceReason != "":
 		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, resourceReason, true, true
 	case legacy.kind == iacLegacyValid:
 		plan.ReasonCode = "legacy_iac_structured"
+	}
+	if resourceIdentityUnavailable && !plan.SkipInput {
+		// Even a caller-supplied semantic digest or alias conflict cannot promote
+		// an unadapted config family to a trusted cross-snapshot identity.
+		plan.ProvisionalIdentity, plan.Ambiguous = true, true
 	}
 	return plan, nil
 }
@@ -196,6 +214,11 @@ func (plan IaCMatchPlanV1) Apply(input CorrelateInput) CorrelateInput {
 
 func normalizeIaCResourceAnchor(kind IaCConfigKind, input IaCFingerprintInputV1) (domain.CanonicalValue, string, error) {
 	switch kind {
+	case IaCDockerfile, IaCCompose, IaCGitHubActions, IaCARM:
+		// These are supported scan producers, but their native findings do not yet
+		// expose approved semantic resource identities. Retain the redacted
+		// observation for review without inventing resource anchors or grammar.
+		return domain.CanonicalValue{}, "resource_identity_unavailable", nil
 	case IaCTerraform:
 		if strings.TrimSpace(input.TerraformAddress) == "" {
 			return domain.CanonicalValue{}, "missing_terraform_address", nil
@@ -438,6 +461,14 @@ func inferIaCConfigKind(rule string) IaCConfigKind {
 		return IaCCloudFormation
 	case strings.HasPrefix(rule, "kubernetes-"):
 		return IaCKubernetes
+	case strings.HasPrefix(rule, "dockerfile-"):
+		return IaCDockerfile
+	case strings.HasPrefix(rule, "compose-"):
+		return IaCCompose
+	case strings.HasPrefix(rule, "gha-"):
+		return IaCGitHubActions
+	case strings.HasPrefix(rule, "arm-"):
+		return IaCARM
 	}
 	return ""
 }

--- a/internal/usecase/findinglineage/iac_matcher_test.go
+++ b/internal/usecase/findinglineage/iac_matcher_test.go
@@ -244,3 +244,150 @@ func TestIaCMatcherV1TerraformGrammarCollisionAndPersistence(t *testing.T) {
 		}
 	}
 }
+
+func TestIaCMatcherV1RecognizesEveryNativeConfigFamily(t *testing.T) {
+	matcher, err := NewIaCMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, scenario := range []struct {
+		rule string
+		kind IaCConfigKind
+	}{
+		{"terraform-public-instance", "terraform"},
+		{"cloudformation-rds-public", "cloudformation"},
+		{"kubernetes-privileged", "kubernetes"},
+		{"dockerfile-run-as-root", "dockerfile"},
+		{"compose-privileged", "compose"},
+		{"gha-pull-request-target", "github_actions"},
+		{"arm-storage-public-blob", "arm"},
+	} {
+		t.Run(string(scenario.kind), func(t *testing.T) {
+			for _, legacy := range []bool{false, true} {
+				input := IaCFingerprintInputV1{TargetIdentityCanonical: "repo:example", RuleKey: scenario.rule, RepoPath: "infra/config.yaml"}
+				if legacy {
+					input.RuleKey, input.RepoPath = "", ""
+					input.LegacyDedupKey = "misconfig:" + scenario.rule + ":infra/config.yaml:42"
+					input.LegacySourceValidated = true
+				}
+				plan, err := matcher.Build(input)
+				if err != nil {
+					t.Fatalf("legacy=%v: %v", legacy, err)
+				}
+				fingerprint, err := domain.CanonicalizeFingerprintV1(plan.FingerprintInput)
+				if err != nil || !strings.Contains(string(fingerprint.Bytes), `"config_kind":"`+string(scenario.kind)+`"`) {
+					t.Fatalf("canonical=%s err=%v", fingerprint.Bytes, err)
+				}
+				if !plan.ProvisionalIdentity || !plan.Ambiguous || plan.ReviewReason != domain.ReasonInsufficientAnchor || plan.SkipInput {
+					t.Fatalf("source-only input became trusted or was dropped: %+v", plan)
+				}
+			}
+		})
+	}
+}
+
+func TestIaCMatcherV1UnadaptedConfigFamiliesStayProvisional(t *testing.T) {
+	matcher, err := NewIaCMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fingerprints := map[string]IaCConfigKind{}
+	for _, kind := range []IaCConfigKind{"dockerfile", "compose", "github_actions", "arm"} {
+		t.Run(string(kind), func(t *testing.T) {
+			for _, digest := range []string{"", strings.Repeat("a", 64)} {
+				plan, err := matcher.Build(IaCFingerprintInputV1{
+					TargetIdentityCanonical: "repo:example", ConfigKind: kind, RuleKey: "shared-rule", RepoPath: "infra/config.yaml",
+					SemanticConfigAnchorDigest: digest,
+				})
+				if err != nil || !plan.ProvisionalIdentity || !plan.Ambiguous || plan.ReviewReason != domain.ReasonInsufficientAnchor || plan.ReasonCode != "resource_identity_unavailable" || plan.SkipInput {
+					t.Fatalf("unadapted config promoted or dropped: %+v err=%v", plan, err)
+				}
+				if _, exists := plan.FingerprintInput.IdentityFields["resource_anchor"]; exists {
+					t.Fatal("unadapted config invented a resource anchor")
+				}
+				for _, key := range []string{"resource_adapter_version", "resource_identity_grammar"} {
+					if _, exists := plan.FingerprintInput.IdentityFields[key]; exists {
+						t.Fatalf("unadapted config claimed %s", key)
+					}
+				}
+				if digest == "" {
+					if _, exists := plan.FingerprintInput.IdentityFields["semantic_config_anchor"]; exists {
+						t.Fatal("unadapted config invented a semantic anchor")
+					}
+				}
+				fingerprint, err := domain.CanonicalizeFingerprintV1(plan.FingerprintInput)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if previous, exists := fingerprints[fingerprint.Fingerprint]; exists {
+					t.Fatalf("same-file config kinds collapsed: %s and %s", previous, kind)
+				}
+				fingerprints[fingerprint.Fingerprint] = kind
+				applied := plan.Apply(CorrelateInput{InputTrusted: true})
+				if !applied.ProvisionalIdentity || applied.ReviewReason != domain.ReasonInsufficientAnchor || applied.ProducerKind != "iac" || applied.FindingKind != "misconfig" {
+					t.Fatalf("conservative plan lost at correlation boundary: %+v", applied)
+				}
+			}
+		})
+	}
+}
+
+func TestIaCMatcherV1UnadaptedConfigValidationStillFailsClosed(t *testing.T) {
+	matcher, err := NewIaCMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, kind := range []IaCConfigKind{"dockerfile", "compose", "github_actions", "arm"} {
+		for _, scenario := range []struct {
+			name string
+			edit func(*IaCFingerprintInputV1)
+		}{
+			{"parent-path", func(input *IaCFingerprintInputV1) { input.RepoPath = "../config.yaml" }},
+			{"absolute-path", func(input *IaCFingerprintInputV1) { input.RepoPath = "/tmp/config.yaml" }},
+			{"backslash-path", func(input *IaCFingerprintInputV1) { input.RepoPath = `infra\config.yaml` }},
+			{"sensitive-path", func(input *IaCFingerprintInputV1) { input.RepoPath = "token=never-retain-me/config.yaml" }},
+			{"sensitive-rule", func(input *IaCFingerprintInputV1) { input.RuleKey = "token=never-retain-me" }},
+			{"sensitive-target", func(input *IaCFingerprintInputV1) { input.TargetIdentityCanonical = "token=never-retain-me" }},
+			{"invalid-digest", func(input *IaCFingerprintInputV1) { input.SemanticConfigAnchorDigest = "token=never-retain-me" }},
+			{"raw-runtime", func(input *IaCFingerprintInputV1) { input.RuntimeResourceID = "never-retain-me" }},
+			{"raw-rendered", func(input *IaCFingerprintInputV1) { input.RenderedValue = "never-retain-me" }},
+			{"raw-offsets", func(input *IaCFingerprintInputV1) { input.RawOffsets = map[string]int{"line": 42} }},
+		} {
+			t.Run(string(kind)+"/"+scenario.name, func(t *testing.T) {
+				input := IaCFingerprintInputV1{TargetIdentityCanonical: "repo:example", ConfigKind: kind, RuleKey: "shared-rule", RepoPath: "infra/config.yaml"}
+				scenario.edit(&input)
+				if _, err := matcher.Build(input); (!errors.Is(err, shared.ErrValidation) && !errors.Is(err, domain.ErrSensitiveInput)) || strings.Contains(err.Error(), "never-retain-me") {
+					t.Fatalf("unsafe input accepted or leaked: %v", err)
+				}
+			})
+		}
+	}
+	for _, input := range []IaCFingerprintInputV1{
+		{TargetIdentityCanonical: "repo:example", RuleKey: "unknown-rule", RepoPath: "config.yaml"},
+		{TargetIdentityCanonical: "repo:example", ConfigKind: "unknown", RuleKey: "terraform-public-instance", RepoPath: "config.yaml"},
+		{TargetIdentityCanonical: "repo:example", ConfigKind: "unknown", RuleKey: "dockerfile-run-as-root", RepoPath: "config.yaml"},
+	} {
+		if _, err := matcher.Build(input); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("unsupported kind accepted: kind=%q rule=%q err=%v", input.ConfigKind, input.RuleKey, err)
+		}
+	}
+}
+
+func TestIaCMatcherV1UnadaptedConfigAliasConflictDoesNotPromoteIdentity(t *testing.T) {
+	matcher, err := NewIaCMatcherV1([]IaCRuleAliasSetV1{
+		{Primary: "config:a", Aliases: []string{"config:shared"}},
+		{Primary: "config:b", Aliases: []string{"config:shared"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, kind := range []IaCConfigKind{IaCDockerfile, IaCCompose, IaCGitHubActions, IaCARM} {
+		plan, err := matcher.Build(IaCFingerprintInputV1{
+			TargetIdentityCanonical: "repo:example", ConfigKind: kind, RuleKey: "config:shared", RepoPath: "infra/config.yaml",
+			SemanticConfigAnchorDigest: strings.Repeat("a", 64),
+		})
+		if err != nil || !plan.ProvisionalIdentity || !plan.Ambiguous || plan.ReviewReason != domain.ReasonMerge || plan.ReasonCode != "rule_alias_conflict" {
+			t.Fatalf("alias conflict lost conservative identity: kind=%s plan=%+v err=%v", kind, plan, err)
+		}
+	}
+}

--- a/internal/usecase/findinglineage/native_evidence_test.go
+++ b/internal/usecase/findinglineage/native_evidence_test.go
@@ -1,0 +1,145 @@
+package findinglineage_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
+)
+
+func TestBuildNativeEvidenceRecordIaCScannerFamilies(t *testing.T) {
+	for _, test := range []struct{ name, rule, path, configKind string }{
+		{"terraform", "terraform-public-instance", "infra/main.tf", "terraform"},
+		{"cloudformation", "cloudformation-rds-public", "infra/template.yaml", "cloudformation"},
+		{"kubernetes", "kubernetes-host-network", "deploy/pod.yaml", "kubernetes"},
+		{"helm", "kubernetes-host-network", "charts/service/Chart.yaml", "kubernetes"},
+		{"dockerfile", "dockerfile-run-as-root", "Dockerfile", "dockerfile"},
+		{"compose", "compose-privileged", "compose.yaml", "compose"},
+		{"github_actions", "gha-permissions-write-all", ".github/workflows/ci.yaml", "github_actions"},
+		{"arm", "arm-storage-https-only-off", "azure/template.json", "arm"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			now := time.Date(2026, 9, 8, 5, 0, 0, 0, time.UTC)
+			item := finding.Finding{
+				ID: "source-" + shared.ID(test.name), Kind: finding.KindMisconfig,
+				RuleKey: test.rule, DedupKey: "misconfig:" + test.rule + ":" + test.path + ":42",
+				Title: "private-source-title", Description: "private-source-description-and-rendered-value",
+				Status: finding.StatusRemediated, Assignee: "private-workflow-assignee",
+				Severity: shared.SeverityHigh, RiskScore: 7.5, Reachability: "unknown",
+				SourceLocation: &finding.SourceLocation{File: test.path, StartLine: 42, EndLine: 44},
+				Audit:          shared.Audit{CreatedAt: now},
+			}
+			record, err := lineageuc.BuildNativeEvidenceRecord(item, "repo:example", nil)
+			if err != nil {
+				t.Fatalf("scanner-supported %s finding aborted native evidence: %v", test.name, err)
+			}
+			if !record.InputTrusted || !record.OwnershipValidated || !record.RedactionComplete || record.ProducerKind != "iac" || record.FindingKind != "misconfig" {
+				t.Fatalf("invalid retained namespace or trust flags: %+v", record)
+			}
+			if !record.ProvisionalIdentity || record.ReviewReason != domain.ReasonInsufficientAnchor {
+				t.Fatalf("finding without semantic/resource anchors was treated as definitive: %+v", record)
+			}
+			fingerprint, err := domain.CanonicalizeFingerprintV1(record.FingerprintInput)
+			if err != nil {
+				t.Fatalf("native observation has no valid canonical identity: %v", err)
+			}
+			var fields map[string]any
+			if err := json.Unmarshal(fingerprint.IdentityFields, &fields); err != nil {
+				t.Fatal(err)
+			}
+			if fields["config_kind"] != test.configKind || fields["repo_path"] != test.path || fields["rule_key"] != test.rule {
+				t.Fatalf("wrong canonical scanner family: %s", fingerprint.IdentityFields)
+			}
+			for _, key := range []string{"resource_anchor", "semantic_config_anchor", "legacy_dedup_key", "raw_offsets", "start_line", "end_line"} {
+				if _, exists := fields[key]; exists {
+					t.Fatalf("invented or observation-only identity field %q: %s", key, fingerprint.IdentityFields)
+				}
+			}
+			if record.Observation.Location != test.path+":42" || record.Observation.SourceFindingID != item.ID.String() || record.Observation.Severity != shared.SeverityHigh || record.Observation.RiskScoreMilli == nil || *record.Observation.RiskScoreMilli != 7500 {
+				t.Fatalf("safe observed attributes were lost: %+v", record.Observation)
+			}
+			payload, err := json.Marshal(lineageuc.NativeEvidence{Version: lineageuc.NativeEvidenceVersion, Records: []lineageuc.CorrelateInput{record}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, forbidden := range []string{item.Title, item.Description, item.Assignee, item.DedupKey, string(item.Status)} {
+				if strings.Contains(string(payload), forbidden) {
+					t.Fatalf("raw finding or mutable workflow field leaked into evidence: %q", forbidden)
+				}
+			}
+
+			// A source-line move changes observed location, never the coarse identity.
+			moved := item
+			moved.DedupKey = "misconfig:" + test.rule + ":" + test.path + ":900"
+			moved.SourceLocation = &finding.SourceLocation{File: test.path, StartLine: 900, EndLine: 902}
+			movedRecord, err := lineageuc.BuildNativeEvidenceRecord(moved, "repo:example", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			movedFingerprint, err := domain.CanonicalizeFingerprintV1(movedRecord.FingerprintInput)
+			if err != nil || movedFingerprint.Fingerprint != fingerprint.Fingerprint || movedRecord.Observation.Location != test.path+":900" {
+				t.Fatalf("line movement polluted native identity: first=%s moved=%s err=%v", fingerprint.Fingerprint, movedFingerprint.Fingerprint, err)
+			}
+			legacy := item
+			legacy.SourceLocation = nil
+			legacyRecord, err := lineageuc.BuildNativeEvidenceRecord(legacy, "repo:example", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			legacyFingerprint, err := domain.CanonicalizeFingerprintV1(legacyRecord.FingerprintInput)
+			if err != nil || legacyFingerprint.Fingerprint != fingerprint.Fingerprint || legacyRecord.Observation.Location != record.Observation.Location {
+				t.Fatalf("legacy source range changed retained identity: first=%s legacy=%s err=%v", fingerprint.Fingerprint, legacyFingerprint.Fingerprint, err)
+			}
+
+			repository := memory.NewFindingLineageRepository()
+			service, err := lineageuc.NewService(repository, memory.NewTenantTransactionRunner(), noOpBackfillAudit{}, fixedBackfillClock{now}, &backfillIDs{}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			record.TenantID, record.CycleID, record.SnapshotID, record.Actor = "tenant", "cycle", "snapshot", "scanner"
+			// The projector binds scanner provenance only after selecting a sealed run.
+			record.Observation.ScannerProvenance = domain.ScannerProvenance{ToolName: "iac", ScanRunID: "run", LaneKey: "iac"}
+			result, err := service.Correlate(context.Background(), record)
+			if err != nil || result.Outcome != lineageuc.OutcomeReview || result.Observation == nil || result.Identity == nil || result.Candidate == nil || result.Skip != nil {
+				t.Fatalf("native finding was not retained for explicit review: result=%+v err=%v", result, err)
+			}
+			if result.Candidate.Reason != domain.ReasonInsufficientAnchor {
+				t.Fatalf("wrong review reason: %+v", result.Candidate)
+			}
+		})
+	}
+}
+
+func TestBuildNativeEvidenceRecordIaCUnknownOrUnsafeInputStillFails(t *testing.T) {
+	for _, test := range []struct{ name, rule, path string }{
+		{"unknown_family", "unknown-platform-rule", "config.yaml"},
+		{"traversal", "dockerfile-run-as-root", "../Dockerfile"},
+		{"absolute_path", "compose-privileged", "/private/compose.yaml"},
+		{"credential_locator", "gha-unpinned-action", "https://user:private-test-marker@example.test/ci.yaml"},
+		{"sensitive_rule", "arm-password=private-test-marker", "template.json"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			item := finding.Finding{
+				ID: "source", Kind: finding.KindMisconfig, RuleKey: test.rule,
+				DedupKey:       fmt.Sprintf("misconfig:%s:%s:1", test.rule, test.path),
+				SourceLocation: &finding.SourceLocation{File: test.path, StartLine: 1, EndLine: 1},
+			}
+			_, err := lineageuc.BuildNativeEvidenceRecord(item, "repo:example", nil)
+			if !errors.Is(err, shared.ErrValidation) && !errors.Is(err, domain.ErrSensitiveInput) {
+				t.Fatalf("unsafe/unknown input did not fail validation: %v", err)
+			}
+			if strings.Contains(err.Error(), "private-test-marker") {
+				t.Fatalf("validation error exposed untrusted source material: %v", err)
+			}
+		})
+	}
+}

--- a/internal/usecase/findinglineage/sast_matcher.go
+++ b/internal/usecase/findinglineage/sast_matcher.go
@@ -427,7 +427,9 @@ func normalizeSourceRepoPath(producer, value string) (string, error) {
 	if value == "" {
 		return "", fmt.Errorf("%w: %s repository path is required", shared.ErrValidation, producer)
 	}
-	if !utf8.ValidString(value) || len(value) > 2048 || strings.Contains(value, "\\") || path.IsAbs(value) || len(value) >= 2 && value[1] == ':' {
+	// Reject URL locators before path.Clean collapses the scheme separator and
+	// obscures URL userinfo. Source identities accept repository-relative paths.
+	if !utf8.ValidString(value) || len(value) > 2048 || strings.Contains(value, "\\") || strings.Contains(value, "://") || path.IsAbs(value) || len(value) >= 2 && value[1] == ':' {
 		return "", fmt.Errorf("%w: %s repository path must be a bounded relative slash path", shared.ErrValidation, producer)
 	}
 	for _, part := range strings.Split(value, "/") {

--- a/internal/usecase/findinglineage/service.go
+++ b/internal/usecase/findinglineage/service.go
@@ -264,6 +264,23 @@ func (service *Service) Correlate(ctx context.Context, input CorrelateInput) (Re
 			}
 			identities = withoutExcluded(identities, excluded)
 			if len(identities) == 1 {
+				if input.ProvisionalIdentity {
+					// A repeated source finding can reuse its provisional identity,
+					// but an exact coarse fingerprint does not supply a missing
+					// resource anchor. Keep review visible in every new snapshot.
+					observation, observationErr := service.observation(input, identities[0].ID)
+					if observationErr != nil {
+						return observationErr
+					}
+					if appendErr := service.repository.AppendObservation(txCtx, observation); appendErr != nil {
+						return appendErr
+					}
+					result, err = service.review(txCtx, input, sourceHash, fingerprint, input.ReviewReason, domain.MethodFingerprint, identities, input.ReviewRefs)
+					if err == nil {
+						result.Identity, result.Observation = &identities[0], &observation
+					}
+					return err
+				}
 				result, err = service.link(txCtx, input, identities[0], domain.MethodFingerprint, "exact_fingerprint", sourceHash)
 				return err
 			}

--- a/internal/usecase/findinglineage/service_test.go
+++ b/internal/usecase/findinglineage/service_test.go
@@ -21,6 +21,7 @@ func TestCorrelatePrecedenceTable(t *testing.T) {
 		trustedSource bool
 		fingerprint   string
 		alias         bool
+		provisional   bool
 		wantMethod    domain.MatchMethod
 		wantIdentity  shared.ID
 		wantOutcome   Outcome
@@ -30,6 +31,9 @@ func TestCorrelatePrecedenceTable(t *testing.T) {
 		{name: "fingerprint", fingerprint: "fingerprint", alias: true, wantMethod: domain.MethodFingerprint, wantIdentity: "identity-fingerprint", wantOutcome: OutcomeMatched},
 		{name: "alias", fingerprint: "unique-alias", alias: true, wantMethod: domain.MethodAlias, wantIdentity: "identity-alias", wantOutcome: OutcomeMatched},
 		{name: "new identity", fingerprint: "unique-new", wantMethod: domain.MethodNewIdentity, wantOutcome: OutcomeCreated},
+		{name: "provisional override", withOverride: true, trustedSource: true, fingerprint: "fingerprint", alias: true, provisional: true, wantMethod: domain.MethodOverride, wantIdentity: "identity-override", wantOutcome: OutcomeMatched},
+		{name: "provisional trusted producer", trustedSource: true, fingerprint: "fingerprint", alias: true, provisional: true, wantMethod: domain.MethodProducerID, wantIdentity: "identity-producer", wantOutcome: OutcomeMatched},
+		{name: "provisional approved alias", fingerprint: "unique-alias", alias: true, provisional: true, wantMethod: domain.MethodAlias, wantIdentity: "identity-alias", wantOutcome: OutcomeMatched},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
 			repository := memory.NewFindingLineageRepository()
@@ -71,6 +75,10 @@ func TestCorrelatePrecedenceTable(t *testing.T) {
 			}
 
 			input := correlateInput(testCase.name, testCase.fingerprint)
+			if testCase.provisional {
+				input.ProvisionalIdentity = true
+				input.ReviewReason = domain.ReasonInsufficientAnchor
+			}
 			if testCase.trustedSource {
 				input.Observation.SourceFindingID = "trusted-source"
 				input.TrustedProducerID = true
@@ -93,6 +101,76 @@ func TestCorrelatePrecedenceTable(t *testing.T) {
 			}
 			if len(audit.entries) != 1 {
 				t.Fatalf("audit entries=%d", len(audit.entries))
+			}
+		})
+	}
+}
+
+func TestCorrelateProvisionalIaCRemainsInReviewAcrossSnapshots(t *testing.T) {
+	for _, rule := range []string{"dockerfile-run-as-root", "compose-privileged", "gha-permissions-write-all", "arm-storage-public-blob"} {
+		t.Run(rule, func(t *testing.T) {
+			ctx := context.Background()
+			repository := memory.NewFindingLineageRepository()
+			clock := fixedClock{now: time.Date(2026, 9, 8, 14, 0, 0, 0, time.UTC)}
+			service, err := NewService(repository, memory.NewTenantTransactionRunner(), &collectingAudit{}, clock, &sequenceIDs{}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			matcher, err := NewIaCMatcherV1(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan, err := matcher.Build(IaCFingerprintInputV1{TargetIdentityCanonical: "repo:example", RuleKey: rule, RepoPath: "infra/config.yaml"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var identityID shared.ID
+			var lastInput CorrelateInput
+			var lastCandidate domain.MatchCandidate
+			for index := 1; index <= 3; index++ {
+				input := plan.Apply(correlateInput(fmt.Sprintf("provisional-%d", index), "unused"))
+				input.Observation.SourceFindingID = "same-source-finding"
+				input.Observation.Location = "infra/config.yaml:42"
+				input.Observation.ObservedAt = clock.now.Add(time.Duration(index) * time.Minute)
+				result, err := service.Correlate(ctx, input)
+				if err != nil || result.Outcome != OutcomeReview || result.Identity == nil || result.Observation == nil || result.Candidate == nil {
+					t.Fatalf("snapshot %d promoted provisional evidence: result=%+v err=%v", index, result, err)
+				}
+				if identityID.IsZero() {
+					identityID = result.Identity.ID
+				}
+				if result.Identity.ID != identityID || result.Candidate.SnapshotID != input.SnapshotID || result.Candidate.Reason != domain.ReasonInsufficientAnchor || result.Reason != "resource_identity_unavailable" {
+					t.Fatalf("snapshot %d lost stable identity or explicit review: %+v", index, result)
+				}
+				replayed, err := service.Correlate(ctx, input)
+				if err != nil || replayed.Observation == nil || replayed.Observation.ID != result.Observation.ID || replayed.Identity == nil || replayed.Identity.ID != identityID {
+					t.Fatalf("snapshot %d source replay changed evidence: %+v err=%v", index, replayed, err)
+				}
+				observations, err := repository.ListObservationsBySnapshot(ctx, "tenant", "cycle", input.SnapshotID)
+				if err != nil || len(observations) != 1 {
+					t.Fatalf("snapshot %d replay duplicated observations: count=%d err=%v", index, len(observations), err)
+				}
+				candidates, err := repository.ListOpenCandidatesBySnapshot(ctx, "tenant", "cycle", input.SnapshotID)
+				if err != nil || len(candidates) != 1 || candidates[0].ID != result.Candidate.ID {
+					t.Fatalf("snapshot %d replay lost or duplicated review: %+v err=%v", index, candidates, err)
+				}
+				lastInput, lastCandidate = input, *result.Candidate
+			}
+			// A source replay must not reopen a candidate explicitly resolved by a
+			// reviewer. Future snapshots are independent evidence boundaries.
+			if _, _, _, err := service.ResolveCandidate(ctx, ResolveInput{
+				TenantID: "tenant", CycleID: "cycle", CandidateID: lastCandidate.ID,
+				EventID: "dismiss-provisional", Action: domain.ResolutionDismiss,
+				Actor: "reviewer", Reason: "review completed", ExpectedVersion: lastCandidate.Version,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := service.Correlate(ctx, lastInput); err != nil {
+				t.Fatal(err)
+			}
+			candidates, err := repository.ListOpenCandidatesBySnapshot(ctx, "tenant", "cycle", lastInput.SnapshotID)
+			if err != nil || len(candidates) != 0 {
+				t.Fatalf("source replay reopened a resolved candidate: %+v err=%v", candidates, err)
 			}
 		})
 	}

--- a/internal/usecase/findinglineage/source_repo_path_test.go
+++ b/internal/usecase/findinglineage/source_repo_path_test.go
@@ -1,0 +1,45 @@
+package findinglineage
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestNormalizeSourceRepoPathRejectsURLsBeforeCleaning(t *testing.T) {
+	for _, input := range []string{
+		"https://user:private-test-marker@example.test/ci.yaml",
+		"http://example.test/ci.yaml",
+		"ssh://git@example.test/repo/config.yaml",
+		"file:///private/config.yaml",
+		"custom://example.test/config.yaml",
+	} {
+		t.Run(strings.SplitN(input, ":", 2)[0], func(t *testing.T) {
+			got, err := normalizeSourceRepoPath("IaC", input)
+			if !errors.Is(err, shared.ErrValidation) || got != "" {
+				t.Fatalf("URL accepted as a repository path: got=%q err=%v", got, err)
+			}
+			if strings.Contains(err.Error(), input) || strings.Contains(err.Error(), "private-test-marker") {
+				t.Fatal("validation error exposed the rejected locator")
+			}
+		})
+	}
+}
+
+func TestNormalizeSourceRepoPathPreservesRelativePathNormalization(t *testing.T) {
+	for _, test := range []struct{ input, want string }{
+		{" ./infra//main.tf ", "infra/main.tf"},
+		{"src/Cafe\u0301.yaml", "src/Café.yaml"},
+		{".github/workflows/CI.yaml", ".github/workflows/CI.yaml"},
+		{"infra/a:b.yaml", "infra/a:b.yaml"},
+	} {
+		t.Run(test.want, func(t *testing.T) {
+			got, err := normalizeSourceRepoPath("IaC", test.input)
+			if err != nil || got != test.want {
+				t.Fatalf("relative path normalization changed: got=%q want=%q err=%v", got, test.want, err)
+			}
+		})
+	}
+}

--- a/internal/usecase/sca/assessment_iac_scan_test.go
+++ b/internal/usecase/sca/assessment_iac_scan_test.go
@@ -1,0 +1,355 @@
+package sca
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	cmpdom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	snapshotdom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	linedom "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/misconfig"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	comparisonuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcomparison"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentlifecycle"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// The fixtures are inert parser input, never deployed or executed. In particular,
+// the real IaC scanner uses New() without opting into Helm or any host command.
+func assessmentIaCWorkspace(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	files := map[string]string{
+		"Dockerfile":               "FROM alpine:latest\nUSER root\n",
+		"compose.yaml":             "services:\n  web:\n    image: nginx:latest\n    privileged: true\n",
+		".github/workflows/ci.yml": "name: ci\non: pull_request\npermissions: write-all\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n",
+		"azuredeploy.json": `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [{"type":"Microsoft.Storage/storageAccounts","apiVersion":"2023-01-01","name":"fixturestore","location":"eastus","properties":{"allowBlobPublicAccess":true,"supportsHttpsTrafficOnly":false}}]
+}`,
+		"main.tf":             "resource \"aws_s3_bucket\" \"fixture\" {\n  acl = \"public-read\"\n}\n",
+		"cloudformation.yaml": "AWSTemplateFormatVersion: '2010-09-09'\nResources:\n  FixtureBucket:\n    Type: AWS::S3::Bucket\n    Properties:\n      AccessControl: PublicRead\n",
+		"pod.yaml":            "apiVersion: v1\nkind: Pod\nmetadata:\n  name: fixture\nspec:\n  containers:\n    - name: app\n      image: nginx:latest\n      securityContext:\n        privileged: true\n",
+	}
+	for name, content := range files {
+		path := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+type assessmentIaCAcquirer struct {
+	*fakeAcquirer
+	commit string
+}
+
+func (acquirer *assessmentIaCAcquirer) Acquire(ctx context.Context, request ports.AcquireRequest) (*ports.Workspace, error) {
+	workspace, err := acquirer.fakeAcquirer.Acquire(ctx, request)
+	if err == nil {
+		workspace.Commit = acquirer.commit
+	}
+	return workspace, err
+}
+
+func TestAssessmentIaCMixedScanPersistsAllFamiliesAndNeverInfersFixed(t *testing.T) {
+	for _, mode := range []string{"synchronous", "durable-job"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx := shared.WithTenant(context.Background(), "iac-scan-tenant")
+			clock := &fakeClock{t: time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)}
+			ids := idgen.RandomID{}
+			audit := &fakeAudit{}
+			transactions := memory.NewTenantTransactionRunner()
+			engagements := memory.NewEngagementRepository()
+			assessment, err := engdom.New("iac-assessment", "iac-scan-tenant", "Mixed IaC scan", "", clock.t)
+			if err != nil {
+				t.Fatal(err)
+			}
+			request := ports.AcquireRequest{Kind: ports.TargetGit, Value: "https://example.com/fixture/repository.git"}
+			assessment.Scope.InScope = []engdom.Target{{Kind: engdom.TargetRepo, Value: request.Value}}
+			if err := assessment.Transition(engdom.StatusActive, clock.t); err != nil {
+				t.Fatal(err)
+			}
+			if err := engagements.Create(ctx, assessment); err != nil {
+				t.Fatal(err)
+			}
+			cycles := memory.NewAssessmentCycleRepository()
+			cycleService, err := cycleuc.NewService(cycles, engagements, nil, nil, transactions, ids, clock, audit)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cycle, _, err := cycleService.CreateInitialCycle(ctx, cycleuc.CreateInitialCycleInput{TenantID: assessment.TenantID, RootAssessmentID: assessment.ID, Name: "Mixed IaC cycle", BoundaryKind: cycledom.BoundaryStandalone, Actor: "tester"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			findings := memory.NewFindingRepository()
+			runs := memory.NewScanRunStore()
+			results := memory.NewScanResultStore()
+			jobs := memory.NewScanJobStore()
+			evidenceService, err := evidenceuc.NewService(&fakeEvidence{}, nil, audit, clock, ids)
+			if err != nil {
+				t.Fatal(err)
+			}
+			acquirer := &assessmentIaCAcquirer{fakeAcquirer: &fakeAcquirer{dir: assessmentIaCWorkspace(t)}, commit: strings.Repeat("a", 40)}
+			scanner := misconfig.New()
+			rawIaC, err := scanner.ScanConfigs(ctx, acquirer.dir)
+			if err != nil || len(rawIaC) == 0 {
+				t.Fatalf("fixture scan: findings=%d err=%v", len(rawIaC), err)
+			}
+			scaFinding := vulnerability.RawFinding{Source: "static", AdvisoryID: "CVE-2026-1234", Component: "fixture-package", Version: "1.0.0", Ecosystem: "npm", PackagePURL: "pkg:npm/fixture-package@1.0.0", Severity: shared.SeverityHigh}
+			service := NewService(engagements, findings, memory.NewScanRepository(), results, jobs, runs, evidenceService, ids, ports.Provenance{}, clock, audit, shared.SeverityInfo, 0, acquirer, &fakeDetector{}, staticSBOM{doc: &sbom.SBOM{Components: []sbom.Component{{Name: scaFinding.Component, Version: scaFinding.Version, PURL: scaFinding.PackagePURL}}}}, []ports.DetectionSource{staticVuln{scaFinding}}, nil, fakeLic{}, nil)
+			service.SetMisconfigScanner(scanner)
+			service.SetScanRunProvenance(runs, transactions)
+			snapshots := memory.NewAssessmentSnapshotRepository()
+			lineageStore := memory.NewFindingLineageRepository()
+			lineage, err := lineageuc.NewService(lineageStore, transactions, audit, clock, ids, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			projector, err := lineageuc.NewShadowProjector(lineage, cycles, snapshots, findings, func(string) bool { return true })
+			if err != nil {
+				t.Fatal(err)
+			}
+			projector.SetNativeEvidence(runs, runs)
+			finalizer, err := snapshotuc.NewService(snapshots, cycles, engagements, runs, transactions, ids, clock, audit)
+			if err != nil {
+				t.Fatal(err)
+			}
+			finalizer.SetFinalizationObserver(projector)
+			verification, err := comparisonuc.NewRetestVerificationReader(lineageStore, snapshots, memory.NewRetestRepository())
+			if err != nil {
+				t.Fatal(err)
+			}
+			comparisons := memory.NewAssessmentComparisonRepository()
+			comparison, err := comparisonuc.NewService(comparisons, snapshots, cycles, lineageStore, transactions, audit, clock, ids, verification, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			coordinator, err := assessmentlifecycle.NewShadowCoordinator(cycles, snapshots, finalizer, comparison, func(string) bool { return true })
+			if err != nil {
+				t.Fatal(err)
+			}
+			service.SetScanRunObserver(coordinator)
+			queue := memory.NewJobQueue(ids, clock.Now)
+			if mode == "durable-job" {
+				service.SetQueue(queue)
+			}
+			runScan := func() *ScanResult {
+				t.Helper()
+				if mode == "synchronous" {
+					result, err := service.Scan(ctx, "tester", assessment.ID, request)
+					if err != nil {
+						t.Fatalf("mixed native Scan failed: %v", err)
+					}
+					return result
+				}
+				job, err := service.StartScan(ctx, "tester", assessment.ID, request)
+				if err != nil {
+					t.Fatal(err)
+				}
+				queued, err := queue.Claim(ctx, time.Minute, ScanJobKind)
+				if err != nil || queued == nil {
+					t.Fatalf("claim scan job: %+v err=%v", queued, err)
+				}
+				if err := service.RunScanJob(ctx, queued.Payload); err != nil {
+					t.Fatal(err)
+				}
+				terminal, err := jobs.GetJob(ctx, job.ID)
+				if err != nil || terminal.Status != ports.ScanSucceeded || terminal.Progress != 100 || terminal.Error != "" {
+					t.Fatalf("mixed native job must succeed, not merely reach 100%%: %+v err=%v", terminal, err)
+				}
+				if err := queue.Complete(ctx, queued.ID, queued.Fence); err != nil {
+					t.Fatal(err)
+				}
+				data, err := results.LatestResult(ctx, assessment.ID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var result ScanResult
+				if err := json.Unmarshal(data, &result); err != nil {
+					t.Fatal(err)
+				}
+				return &result
+			}
+
+			result := runScan()
+			wantCount := len(rawIaC) + 1 // The unrelated SCA vulnerability must also survive.
+			if len(result.Findings) != wantCount || len(result.Vulnerabilities) != 1 {
+				t.Fatalf("pipeline lost derived findings: findings=%d want=%d vulnerabilities=%d", len(result.Findings), wantCount, len(result.Vulnerabilities))
+			}
+			storedFindings, err := findings.ListByEngagement(ctx, assessment.ID)
+			if err != nil || len(storedFindings) != wantCount {
+				t.Fatalf("persisted findings=%d want=%d err=%v", len(storedFindings), wantCount, err)
+			}
+			cached, err := results.LatestResult(ctx, assessment.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var cachedResult ScanResult
+			if err := json.Unmarshal(cached, &cachedResult); err != nil || len(cachedResult.Findings) != wantCount {
+				t.Fatalf("persisted scan result lost findings: count=%d err=%v", len(cachedResult.Findings), err)
+			}
+			baseline, _, err := snapshots.GetDefault(ctx, assessment.TenantID, assessment.ID)
+			if err != nil {
+				t.Fatalf("scan did not finalize its native snapshot: %v", err)
+			}
+			var runID string
+			for _, dimension := range baseline.Dimensions {
+				if dimension.Producer == "iac" {
+					if dimension.State != snapshotdom.CoveragePartial {
+						t.Fatalf("IaC positive findings incorrectly imply exhaustive coverage: %+v", dimension)
+					}
+					runID = dimension.RunID
+				}
+			}
+			if runID == "" {
+				t.Fatal("snapshot lost the IaC lane")
+			}
+			retainedRun, err := runs.GetScanRun(ctx, assessment.TenantID, runID)
+			if err != nil || retainedRun.Provenance != scanrun.ProvenanceNative || !retainedRun.IsSealed() {
+				t.Fatalf("native run is not sealed: %+v err=%v", retainedRun, err)
+			}
+			evidence, err := runs.GetScanRunEvidence(ctx, assessment.TenantID, runID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var native lineageuc.NativeEvidence
+			if err := json.Unmarshal(evidence.Payload, &native); err != nil || len(native.Records) != wantCount {
+				t.Fatalf("retained native records=%d want=%d err=%v", len(native.Records), wantCount, err)
+			}
+			families := []string{"dockerfile", "compose", "github_actions", "arm", "terraform", "cloudformation", "kubernetes"}
+			seenFamilies := make(map[string]bool)
+			for _, record := range native.Records {
+				if record.ProducerKind != "iac" {
+					continue
+				}
+				if !record.ProvisionalIdentity || record.ReviewReason != linedom.ReasonInsufficientAnchor {
+					t.Fatalf("unanchored IaC observation must remain provisional for review: %+v", record)
+				}
+				for _, family := range families {
+					if reflect.DeepEqual(record.FingerprintInput.IdentityFields["config_kind"], linedom.Text(family)) {
+						seenFamilies[family] = true
+					}
+				}
+			}
+			for _, family := range families {
+				if !seenFamilies[family] {
+					t.Errorf("real scanner family %q is missing from immutable native evidence", family)
+				}
+			}
+			observations, err := lineageStore.ListObservationsBySnapshot(ctx, assessment.TenantID, cycle.ID, baseline.ID)
+			if err != nil || len(observations) != wantCount {
+				t.Fatalf("snapshot observations=%d want=%d err=%v", len(observations), wantCount, err)
+			}
+			candidates, err := lineageStore.ListOpenCandidatesBySnapshot(ctx, assessment.TenantID, cycle.ID, baseline.ID)
+			if err != nil || len(candidates) < len(rawIaC) {
+				t.Fatalf("unanchored IaC findings lost their review candidates: count=%d want >=%d err=%v", len(candidates), len(rawIaC), err)
+			}
+
+			// Repeated positive scans must retain review in each Snapshot, even when
+			// the source Finding ID and provisional fingerprint match exactly.
+			for repeat := 0; repeat < 2; repeat++ {
+				clock.t = clock.t.Add(time.Minute)
+				runScan()
+				next, _, err := snapshots.GetDefault(ctx, assessment.TenantID, assessment.ID)
+				if err != nil || next.ID == baseline.ID {
+					t.Fatalf("repeat scan did not advance its snapshot: err=%v", err)
+				}
+				candidates, err := lineageStore.ListOpenCandidatesBySnapshot(ctx, assessment.TenantID, cycle.ID, next.ID)
+				if err != nil || len(candidates) < len(rawIaC) {
+					t.Fatalf("repeat scan lost provisional review: count=%d want >=%d err=%v", len(candidates), len(rawIaC), err)
+				}
+				queued, _, _, err := comparison.Queue(ctx, comparisonuc.QueueInput{
+					TenantID: assessment.TenantID, BaselineSnapshotID: baseline.ID, CurrentSnapshotID: next.ID,
+					Mode: cmpdom.ModeLifecycle, FingerprintVersion: 1, RiskModelVersion: comparisonuc.RiskModelVersionV1, Actor: "tester",
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				generated, err := comparison.Generate(ctx, comparisonuc.WorkInput{TenantID: assessment.TenantID, ComparisonID: queued.ID, Actor: "worker"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				iacItems := 0
+				for _, item := range generated.Items {
+					if item.ProducerKind != "iac" {
+						continue
+					}
+					iacItems++
+					if item.Presence != cmpdom.PresenceNeedsReview || item.ComparableBaseline || item.FixedBasis != "" {
+						t.Errorf("repeated provisional finding became definitive: %+v", item)
+					}
+				}
+				if iacItems != len(rawIaC) {
+					t.Fatalf("repeat comparison lost IaC observations: count=%d want=%d", iacItems, len(rawIaC))
+				}
+				baseline = next
+			}
+
+			// Removing config files establishes no exhaustive IaC coverage. The full
+			// comparison pipeline must never classify that absence as remediation.
+			clock.t = clock.t.Add(time.Minute)
+			acquirer.dir, acquirer.commit = t.TempDir(), strings.Repeat("b", 40)
+			current := runScan()
+			for _, item := range current.Findings {
+				if item.Kind == finding.KindMisconfig {
+					t.Fatalf("empty scan unexpectedly retained a removed IaC finding: %s", item.ID)
+				}
+			}
+			finalSnapshot, _, err := snapshots.GetDefault(ctx, assessment.TenantID, assessment.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			queued, created, _, err := comparison.Queue(ctx, comparisonuc.QueueInput{
+				TenantID: assessment.TenantID, BaselineSnapshotID: baseline.ID, CurrentSnapshotID: finalSnapshot.ID,
+				Mode: cmpdom.ModeLifecycle, FingerprintVersion: 1, RiskModelVersion: comparisonuc.RiskModelVersionV1, Actor: "tester",
+			})
+			if err != nil || created {
+				t.Fatalf("empty scan did not auto-queue its comparison: created=%t err=%v", created, err)
+			}
+			generated, err := comparison.Generate(ctx, comparisonuc.WorkInput{TenantID: assessment.TenantID, ComparisonID: queued.ID, Actor: "worker"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			iacItems := 0
+			for _, item := range generated.Items {
+				if item.ProducerKind != "iac" {
+					continue
+				}
+				iacItems++
+				if item.Presence != cmpdom.PresenceNeedsReview && item.Presence != cmpdom.PresenceNotEvaluated {
+					t.Errorf("IaC absence falsely resolved: presence=%s fixed_basis=%s", item.Presence, item.FixedBasis)
+				}
+				if item.FixedBasis != "" || item.ComparableBaseline {
+					t.Errorf("partial IaC evidence counted as Fixed: %+v", item)
+				}
+			}
+			if iacItems != len(rawIaC) {
+				t.Fatalf("comparison lost IaC observations: count=%d want=%d", iacItems, len(rawIaC))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context

Fixes a scan-finalization regression in #853. With native Assessment Snapshot capture enabled, an engagement scan could fail at 100% with:

```text
prepare redacted native observation: validation error: IaC config kind is unsupported
```

The real misconfiguration scanner supports seven config families, but the native lineage matcher accepted only Terraform, CloudFormation and Kubernetes. A Dockerfile, Compose, GitHub Actions or ARM finding therefore aborted native observation preparation before Scan/Findings/ScanResult persistence. An earlier immutable evidence-ledger append may already have succeeded; this is not a claim of full transactional rollback.

**Stacked PR:** base is `codex/assessment-cycle-rebuild`, because #853 is still open. Review this small fix independently; merge #853 first, then retarget this PR to `main` if GitHub does not do so automatically. Refs #694; this does not close the Assessment Cycle epic.

## Solution and changes

- Recognize all seven native IaC families, including the `gha-` prefix; Helm-derived findings retain their Kubernetes classification.
- Retain findings as redacted observations plus provisional identities / `needs_review` candidates when no approved resource identity adapter exists. Do not invent resource anchors or adapter-version metadata, silently skip findings, or weaken partial-coverage rules.
- Keep provisional review in every new Snapshot when a re-scan repeats the same source fingerprint. Reuse the identity, retain the new observation and create the snapshot-local candidate. Preserve explicit override/trusted producer/approved alias precedence and same-Snapshot replay/resolution behavior.
- Reject unsupported explicit config kinds and unsafe input. Reject URL locators before repository-path normalization can obscure embedded userinfo. Existing valid relative-path normalization and Terraform fingerprint golden bytes stay unchanged.
- Document upgrade/retry behavior and update the changelog.

## Regression coverage

- Matcher/native adapter: all seven families plus Helm normalization, rule aliases, line movement, legacy dedup fallback, missing anchors, untrusted raw fields, unknown kinds, URL/path redaction and unchanged golden fingerprints.
- Backfill: all four previously rejected families retain observations and review candidates, with no silent skips or duplicate replay records.
- Correlation: three Snapshots retain one provisional identity with per-Snapshot review; same-Snapshot replay is idempotent and does not reopen a dismissed candidate.
- Service end-to-end (in-memory repositories, **real IaC scanner**, inert fixtures, deterministic SCA source): synchronous `Scan` and `StartScan → queue claim → RunScanJob`, findings/results/sealed native evidence/Snapshots retained; three positive scans remain `needs_review`; a subsequent empty scan cannot imply Fixed. No Helm subprocess, external target, or network scan is used.
- PostgreSQL: all four additional families across three Snapshots, native evidence, lineage/backfill, Snapshot/comparison, tenant isolation, replay and immutable-evidence constraints in disposable test databases.

## Verification

Run the same checks locally:

```sh
TMPDIR=/private/tmp go test -p 4 ./...
TMPDIR=/private/tmp go test -race -count=1 ./internal/usecase/findinglineage ./internal/usecase/sca ./internal/usecase/assessmentcomparison ./internal/usecase/assessmentlifecycle ./internal/usecase/assessmentsnapshot
go vet ./...
go build ./...
golangci-lint run --new-from-rev=212c036ad63f1d19484d7270b874258d18c35ac1
pnpm --dir web run lint
pnpm --dir web run typecheck
pnpm --dir web run test
pnpm --dir web run build
```

For PostgreSQL, set `SYNAPSE_TEST_DB_DSN` to an isolated local test server whose role can create disposable databases, then run:

```sh
go test -count=1 -run '^Test(Postgres(ScanRunStore_|FindingLineage|IaCMatcher|AssessmentSnapshot|AssessmentComparison(Repository|Service))|Migration0151Evidence)' ./internal/infrastructure/persistence/postgres
```

Results:

- Full Go suite, focused race suite, `go vet`, and Go build: **PASS**.
- Opt-in PostgreSQL suite: **26 top-level tests + 24 subtests PASS**, 0 failures/skips, including the new four-family/three-Snapshot regression.
- Changed-code Go lint: **PASS, 0 issues**. Full-repository lint still reports the same **8 pre-existing issues** outside the changed files (2 gosec, 2 ineffassign, 4 unused); none are suppressed by this PR.
- Frontend: lint **0 errors / 10 existing warnings**, type-check **PASS**, **107 files / 616 tests PASS**, production build **PASS**. Existing large-chunk and Node localstorage warnings remain.
- GitHub Actions is disabled at repository level; no Actions run is claimed. Local verification was run explicitly.

## UI, migration, compatibility and rollout

- Backend-only behavior fix; no UI layout/components or API contract changed, so screenshots are not applicable. Frontend compatibility gates were rerun.
- No migration, schema rewrite or data backfill is required for this fix. Existing three-family canonical fingerprints and immutable evidence are preserved.
- Conservative limitation: the four additional families still have no approved semantic resource adapters. Their observations require review; incomplete IaC coverage must not count as Fixed.
- After deploying the updated API **and** worker, start a new scan in the same non-completed Engagement with available source and valid authorization. A new Re-test Engagement is not required solely to retry this error. Failed jobs/sealed evidence are not rewritten or deleted.
- This PR does **not** deploy/restart the existing environment, rerun user scans, or alter user data/stashes. Existing failed jobs remain unchanged until a new scan is explicitly run after upgrade.
