### PR TITLE
style(lint): clear pre-existing golangci-lint debt on main

### DIFF
--- a/cmd/synapse-agent/detection_delivery.go
+++ b/cmd/synapse-agent/detection_delivery.go
@@ -65,7 +65,9 @@ func (r *runner) startDetectionDelivery(ctx context.Context, durable *spool.Spoo
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		if err := shipper.Run(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		// Run only returns on a terminal error (its loop never yields nil); a clean
+		// shutdown surfaces as context.Canceled and is not worth logging.
+		if err := shipper.Run(ctx); !errors.Is(err, context.Canceled) {
 			log.Printf("detection delivery stopped with P1 WAL retained: %v", err)
 		}
 	}()

--- a/cmd/synapse-agent/sweep.go
+++ b/cmd/synapse-agent/sweep.go
@@ -143,5 +143,5 @@ func sweepBootJitter(interval time.Duration) time.Duration {
 	if cap <= 0 {
 		return 0
 	}
-	return time.Duration(rand.Int63n(int64(cap)))
+	return time.Duration(rand.Int63n(int64(cap))) //nolint:gosec // Boot jitter is intentionally non-cryptographic.
 }

--- a/internal/adapter/httpapi/privacy_policy_handler_test.go
+++ b/internal/adapter/httpapi/privacy_policy_handler_test.go
@@ -178,12 +178,12 @@ func TestPrivacyPolicyHumanRoutesRequireServiceAndTenantContext(t *testing.T) {
 }
 
 func TestFleetPrivacyPolicyRouteAuthenticatesAndIsolatesTenant(t *testing.T) {
-	h, agentSvc, _ := setupFleet(t)
+	_, agentSvc, _ := setupFleet(t)
 	service, _ := newPrivacyPolicyHTTPService(t)
 	rt := &Router{log: discardLog()}
 	rt.SetFleet(agentSvc, nil, func() time.Time { return time.Now().UTC() }, "")
 	rt.SetFleetPrivacyPolicyReader(service)
-	h = rt.fleet.handler()
+	h := rt.fleet.handler()
 
 	if rec := fleetCall(h, http.MethodGet, "/api/v1/fleet/privacy-policy", "", nil, true); rec.Code != http.StatusUnauthorized {
 		t.Fatalf("unauthenticated policy read status = %d, want 401", rec.Code)
@@ -317,11 +317,11 @@ func TestPrivacyPolicyHashSaltNeverLeavesTheAgentPlane(t *testing.T) {
 
 	// Agent plane: the salt MUST still be delivered, or source-side hashing breaks.
 	t.Run("agent plane still receives the salt", func(t *testing.T) {
-		fleetHandler, agentSvc, _ := setupFleet(t)
+		_, agentSvc, _ := setupFleet(t)
 		agentRouter := &Router{log: discardLog()}
 		agentRouter.SetFleet(agentSvc, nil, func() time.Time { return time.Now().UTC() }, "")
 		agentRouter.SetFleetPrivacyPolicyReader(service)
-		fleetHandler = agentRouter.fleet.handler()
+		fleetHandler := agentRouter.fleet.handler()
 
 		token, err := agentSvc.MintEnrolToken(context.Background(), "operator", "tenant-a", time.Hour)
 		if err != nil {

--- a/internal/domain/judgment/claim.go
+++ b/internal/domain/judgment/claim.go
@@ -468,7 +468,7 @@ const (
 	TacticLateralMovement     InvestigationTactic = "lateral_movement"
 	TacticDataExfiltration    InvestigationTactic = "data_exfiltration"
 	TacticPrivilegeEscalation InvestigationTactic = "privilege_escalation"
-	TacticCredentialAccess    InvestigationTactic = "credential_access"
+	TacticCredentialAccess    InvestigationTactic = "credential_access" //nolint:gosec // G101 false positive: MITRE ATT&CK tactic name, not a credential.
 	TacticPersistence         InvestigationTactic = "persistence"
 	TacticCommandAndControl   InvestigationTactic = "command_and_control"
 	TacticDefenseEvasion      InvestigationTactic = "defense_evasion"

--- a/internal/infrastructure/tools/astwalk/cpp_quality_cgo.go
+++ b/internal/infrastructure/tools/astwalk/cpp_quality_cgo.go
@@ -20,11 +20,7 @@ const (
 	maxCPPCandidates = 2_000
 )
 
-var (
-	cppCommentedCodeRE   = regexp.MustCompile(`^\s*(?:class|struct|template|namespace|void|int|auto|for|if|while)\b`)
-	cppSQLPatternRE      = regexp.MustCompile(`(?i)(?:SELECT|INSERT|UPDATE|DELETE)\s+.*(?:FROM|INTO|SET|WHERE)`)
-	cppSensitiveSecretRE = regexp.MustCompile(`(?i)(?:password|secret|token|api[_-]?key|private[_-]?key)`)
-)
+var cppSQLPatternRE = regexp.MustCompile(`(?i)(?:SELECT|INSERT|UPDATE|DELETE)\s+.*(?:FROM|INTO|SET|WHERE)`)
 
 func cppFindings(root *sitter.Node, src []byte, rel string) []QualityFinding {
 	findings, _ := cppFindingsLimit(root, src, rel, maxCPPTotal)


### PR DESCRIPTION
## What

Clear the seven pre-existing golangci-lint findings on `main`. They predate every open PR, so each fresh PR inherits a red `Lint (Go)` job it did not introduce. This PR is independent: it touches only the five files that carry the findings and changes no behavior.

## Findings cleared

| File | Linter | Fix |
| --- | --- | --- |
| `cmd/synapse-agent/sweep.go` | gosec G404 | `//nolint` on the boot-jitter `math/rand`; jitter spaces a fleet's first sweep and needs no CSPRNG (same rationale as `agentspool/retry.go`). |
| `internal/domain/judgment/claim.go` | gosec G101 | `//nolint` on the `credential_access` MITRE ATT&CK tactic constant (hardcoded-credential false positive). |
| `cmd/synapse-agent/detection_delivery.go` | staticcheck SA4023 | Drop the redundant `err != nil`; `Service.Run` only returns on a terminal error, so the guard was provably always true. |
| `internal/adapter/httpapi/privacy_policy_handler_test.go` | ineffassign | Discard the unused `setupFleet` handler instead of assigning then overwriting it. |
| `internal/infrastructure/tools/astwalk/cpp_quality_cgo.go` | unused | Remove two dead regexp vars (`cppCommentedCodeRE`, `cppSensitiveSecretRE`) never referenced by `cppMatchNode`. |

## Verification

- `golangci-lint run ./...` reports `0 issues`
- `go build ./...` and `CGO_ENABLED=1 go build ./internal/infrastructure/tools/astwalk/` pass
- `go test` on the touched packages passes

No behavior change, so no new tests or CHANGELOG entry. Unblocks the `Lint (Go)` job for #856 and any other open PR, without depending on #855.
