### PR TITLE
test(postgres): fix pre-existing Backend (Go) integration failures

### DIFF
--- a/internal/infrastructure/persistence/postgres/leader_store_test.go
+++ b/internal/infrastructure/persistence/postgres/leader_store_test.go
@@ -93,6 +93,7 @@ func TestMigration0061(t *testing.T) {
 	if err := goose.SetDialect("postgres"); err != nil {
 		t.Fatalf("dialect: %v", err)
 	}
+	deleteV2AuditRowsForMigrationRollback(t, db)
 	if err := goose.DownTo(db, ".", 60); err != nil {
 		t.Fatalf("down to 60: %v", err)
 	}

--- a/internal/infrastructure/persistence/postgres/migration_0044_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0044_test.go
@@ -40,6 +40,7 @@ func TestMigration0044(t *testing.T) {
 		}
 	})
 
+	deleteV2AuditRowsForMigrationRollback(t, db)
 	if err := goose.DownTo(db, ".", 43); err != nil {
 		t.Fatalf("goose down to 43: %v", err)
 	}
@@ -118,6 +119,7 @@ func TestMigration0044(t *testing.T) {
 		}
 	}
 
+	deleteV2AuditRowsForMigrationRollback(t, db)
 	if err := goose.DownTo(db, ".", 43); err != nil {
 		t.Fatalf("goose down to 43: %v", err)
 	}

--- a/internal/infrastructure/persistence/postgres/migration_0056_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0056_test.go
@@ -34,6 +34,7 @@ func TestMigration0056BackfillsOnlyCanonicalRelativePaths(t *testing.T) {
 			t.Errorf("restore latest schema: %v", err)
 		}
 	})
+	deleteV2AuditRowsForMigrationRollback(t, db)
 	if err := goose.DownTo(db, ".", 55); err != nil {
 		t.Fatalf("goose down to 55: %v", err)
 	}
@@ -119,6 +120,7 @@ func TestMigration0056BackfillsOnlyCanonicalRelativePaths(t *testing.T) {
 			}
 		}
 	}
+	deleteV2AuditRowsForMigrationRollback(t, db)
 	if err := goose.DownTo(db, ".", 55); err != nil {
 		t.Fatalf("goose down to 55: %v", err)
 	}

--- a/internal/infrastructure/persistence/postgres/migration_0058_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0058_test.go
@@ -121,6 +121,7 @@ func TestMigration0058(t *testing.T) {
 		t.Fatalf("dialect: %v", err)
 	}
 
+	deleteV2AuditRowsForMigrationRollback(t, db)
 	if err := goose.DownTo(db, ".", 57); err != nil {
 		t.Fatalf("down to 57: %v", err)
 	}

--- a/internal/infrastructure/persistence/postgres/migration_0066_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0066_test.go
@@ -26,6 +26,7 @@ func TestMigration0066PreservesLegacyAssessmentGraph(t *testing.T) {
 	if err := goose.SetDialect("postgres"); err != nil {
 		t.Fatal(err)
 	}
+	deleteV2AuditRowsForMigrationRollback(t, db)
 	if err := goose.DownTo(db, ".", 65); err != nil {
 		t.Fatalf("down to 65: %v", err)
 	}

--- a/internal/infrastructure/persistence/postgres/migration_0068_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0068_test.go
@@ -27,6 +27,7 @@ func TestMigration0068EdgeConfidence(t *testing.T) {
 	}
 	// One below THIS migration (renumbered 0067 -> 0068 after #481 took 0067); going lower would
 	// also revert an unrelated feature and change what this test exercises.
+	deleteV2AuditRowsForMigrationRollback(t, db)
 	if err := goose.DownTo(db, ".", 67); err != nil {
 		t.Fatalf("down to 66: %v", err)
 	}

--- a/internal/infrastructure/persistence/postgres/migration_0136_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0136_test.go
@@ -2,6 +2,7 @@ package postgres
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -89,8 +90,14 @@ func TestMigration0136ProjectAnalysesBranch(t *testing.T) {
 
 	// LatestWithResult honors the branch filter.
 	latest, result, err := store.LatestWithResult(ctx, tenant, projectID, "main")
-	if err != nil || latest.ID != mainAnalysis.ID || string(result) != `{"r":"main"}` {
-		t.Fatalf("latest for main = %+v result=%q err=%v", latest, result, err)
+	if err != nil || latest.ID != mainAnalysis.ID {
+		t.Fatalf("latest for main = %+v err=%v", latest, err)
+	}
+	// result is a jsonb column, so Postgres returns canonical JSON (a space after the colon).
+	// Compare the decoded value, not the raw bytes.
+	var gotResult map[string]string
+	if uerr := json.Unmarshal(result, &gotResult); uerr != nil || gotResult["r"] != "main" {
+		t.Fatalf("latest result = %q (decode err %v), want JSON {\"r\":\"main\"}", result, uerr)
 	}
 
 	// Branches returns the distinct set, sorted.


### PR DESCRIPTION
## What

Clear the pre-existing `Backend (Go)` integration-test failures on `main`. Seven tests in the `postgres` package fail on every fresh PR run, unrelated to any feature branch. Two independent causes, both test-only.

### 1. Rollback past migration 0085 (6 tests)

`TestMigration0044/0056/0058/0061/0066/0068` roll the schema down past migration `0085_audit_log_tenant_idempotency`. Its down migration correctly refuses the rollback once `audit_log` holds v2 (tenant-local) chain rows. The integration tests share one database, so v2 rows written by sibling tests make every crossing rollback fail with `cannot roll back audit_log tenant chains after tenant genesis rows exist`, depending on test order.

Fix: call the existing `deleteV2AuditRowsForMigrationRollback` helper (already used by the 0088 test) before each `DownTo` that crosses 0085. It no-ops when the `hash_version` column is absent or no v2 rows exist. Migration 0085 itself is untouched; the guard stays.

### 2. jsonb result comparison (1 test)

`TestMigration0136ProjectAnalysesBranch` compared the stored analysis result byte-for-byte against `{"r":"main"}`, but `project_analyses.result` is `jsonb`, so Postgres returns the canonical form `{"r": "main"}` (a space after the colon) and the assertion always failed. Fix: decode the value and compare it.

## Verification

From a freshly created database (CI parity):

```
go test ./internal/infrastructure/persistence/postgres            -> ok (87.9s)
golangci-lint run ./internal/infrastructure/persistence/postgres/ -> 0 issues
```

Test-only, no production code or migration changed. One of the three pre-existing CI debts on `main` (lint in #857, this, and a Windows git-auth test next); together they unblock #856 and every other open PR.
