### PR TITLE
build(go): bump go directive to 1.27.0 to fix Windows GC crash

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/KKloudTarus/synapse-ce
 
-go 1.26.4
+go 1.27.0
 
 require (
 	cloud.google.com/go/auth v0.23.2

--- a/internal/infrastructure/acquire/git_private_auth_test.go
+++ b/internal/infrastructure/acquire/git_private_auth_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -65,15 +66,19 @@ func TestGitAuthInjectsTokenViaAskpassNotArgv(t *testing.T) {
 	if len(roPaths) != 1 {
 		t.Fatalf("roPaths must carry the credential dir for the sandbox bind: %v", roPaths)
 	}
-	// Running the helper with the token-file env (as git will) must emit exactly the token.
-	cmd := exec.Command(askpass, "Password: ")
-	cmd.Env = append(os.Environ(), tokenFileEnv)
-	got, err := cmd.Output()
-	if err != nil {
-		t.Fatalf("askpass with token-file env: %v", err)
-	}
-	if strings.TrimSpace(string(got)) != token {
-		t.Fatalf("askpass emitted %q, want the token", strings.TrimSpace(string(got)))
+	// Running the helper with the token-file env (as git will) must emit exactly the token. The
+	// helper is a POSIX /bin/sh script and the git-acquire pipeline runs only in the Linux sandbox,
+	// so exec the shebang directly on non-Windows only; Windows cannot run a shebang script via exec.
+	if runtime.GOOS != "windows" {
+		cmd := exec.Command(askpass, "Password: ")
+		cmd.Env = append(os.Environ(), tokenFileEnv)
+		got, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("askpass with token-file env: %v", err)
+		}
+		if strings.TrimSpace(string(got)) != token {
+			t.Fatalf("askpass emitted %q, want the token", strings.TrimSpace(string(got)))
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Fix the pre-existing `Backend (Go, Windows)` CI failure on `main`. It has two layers; the first masked the second.

### 1. Go 1.26.4 windows/amd64 GC crash

The Windows job aborted with a Go runtime fatal error in the `httpapi` test binary:

```
fatal error: found pointer to free object
runtime.(*mspan).reportZombies  (mgcsweep.go:893)
runtime.bgsweep
```

`httpapi` has no cgo, no `unsafe`, and no data race (`go test -race` is clean on Linux). A race-clean, pure-Go program hitting the sweeper's zombie check is a Go 1.26.4 windows/amd64 runtime GC bug. It reproduced on unrelated PRs, so it predates any feature work. Fix: bump the `go` directive to `1.27.0` (CI installs the toolchain from `go-version-file`). Confirmed on CI: the crash is gone.

### 2. POSIX askpass exec in a test

With the crash cleared, a genuine Windows test failure surfaced (previously masked):

```
--- FAIL: TestGitAuthInjectsTokenViaAskpassNotArgv
  exec: "...\synapse-gitcred-...\askpass": executable file not found in %PATH%
```

The test execs the generated askpass helper directly. The helper is a `#!/bin/sh` script and the git-acquire pipeline runs only in the Linux sandbox, so a direct exec of a shebang script has no meaning on Windows (the existing `sh`-in-PATH guard passes there because Git bash ships `sh`). Fix: gate the exec assertion on non-Windows; the URL, env, and roPaths assertions still run on every platform. Production is unchanged (the askpass is a POSIX helper by design).

## Verification

- Go 1.27.0 on Linux: `go build ./...`, `go vet`, and `go test -race ./internal/adapter/httpapi/` all pass.
- `go test ./internal/infrastructure/acquire/ -run TestGitAuth` passes; `golangci-lint run ./internal/infrastructure/acquire/...` reports 0 issues.
- Windows is verifiable only on CI; the `Backend (Go, Windows)` job on this PR is the confirmation.

One of the three pre-existing CI debts on `main` (lint in #857, Backend-Go integration in #858, and this); together they unblock #856 and every other open PR.
