### PR TITLE
feat(assessment): [2/10] define lifecycle contracts and ordered schema

### DIFF
--- a/internal/domain/assessmentclosure/closure.go
+++ b/internal/domain/assessmentclosure/closure.go
@@ -1,0 +1,633 @@
+package assessmentclosure
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	PolicyVersionV1           = "closure-policy-v1"
+	RendererContractVersionV1 = "assessment-cycle-report-v1"
+)
+
+type Lifecycle string
+
+const (
+	LifecycleBuilding   Lifecycle = "building"
+	LifecycleActive     Lifecycle = "active"
+	LifecycleSuperseded Lifecycle = "superseded"
+)
+
+type Blocker struct {
+	ID           string `json:"id"`
+	Code         string `json:"code"`
+	Message      string `json:"message"`
+	Overrideable bool   `json:"overrideable"`
+	Overridden   bool   `json:"overridden"`
+}
+
+type Warning struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type CoverageDecision struct {
+	SnapshotID  shared.ID                        `json:"snapshot_id"`
+	DimensionID string                           `json:"dimension_id"`
+	State       assessmentsnapshot.CoverageState `json:"state"`
+	ReasonCode  string                           `json:"reason_code"`
+	Waived      bool                             `json:"waived"`
+}
+
+type CoverageDecisions struct {
+	Initial []CoverageDecision `json:"initial"`
+	Final   []CoverageDecision `json:"final"`
+}
+
+type PathMember struct {
+	PathPosition        int                            `json:"path_position"`
+	AssessmentID        shared.ID                      `json:"assessment_id"`
+	AssessmentType      assessmentcycle.AssessmentType `json:"assessment_type"`
+	RetestNumber        int                            `json:"retest_number"`
+	RelationshipVersion int64                          `json:"relationship_version"`
+	SnapshotID          shared.ID                      `json:"snapshot_id,omitempty"`
+}
+
+type Reference struct {
+	Kind        string          `json:"kind"`
+	ID          shared.ID       `json:"id"`
+	Version     int64           `json:"version"`
+	ContentHash string          `json:"content_hash,omitempty"`
+	ExpiresAt   *time.Time      `json:"expires_at,omitempty"`
+	Metadata    json.RawMessage `json:"metadata,omitempty"`
+}
+
+type BranchState struct {
+	AssessmentID        shared.ID `json:"assessment_id"`
+	RelationshipVersion int64     `json:"relationship_version"`
+	Archived            bool      `json:"archived"`
+}
+
+type ScopeProfileChange struct {
+	AssessmentID shared.ID `json:"assessment_id"`
+	Kind         string    `json:"kind"`
+	Summary      string    `json:"summary"`
+}
+
+type Manifest struct {
+	TenantID                shared.ID
+	CycleID                 shared.ID
+	ID                      shared.ID
+	ManifestVersion         int64
+	Lifecycle               Lifecycle
+	CycleVersion            int64
+	RootAssessmentID        shared.ID
+	FinalAssessmentID       shared.ID
+	InitialSnapshotID       shared.ID
+	FinalSnapshotID         shared.ID
+	ComparisonID            shared.ID
+	InitialSnapshotHash     string
+	FinalSnapshotHash       string
+	ComparisonHash          string
+	CanonicalInputHash      string
+	ContentHash             string
+	PolicyVersion           string
+	AlgorithmVersion        string
+	FingerprintVersion      string
+	RiskVersion             string
+	RendererContractVersion string
+	CoverageDecisions       CoverageDecisions
+	ScopeProfileChanges     []ScopeProfileChange
+	OverrideBlockerIDs      []string
+	NonFinalBranches        []BranchState
+	Path                    []PathMember
+	References              []Reference
+	Reason                  string
+	OverrideReason          string
+	AsOfAt                  time.Time
+	CreatedAt               time.Time
+	CreatedBy               string
+	SealedAt                *time.Time
+	SealedBy                string
+	SupersededAt            *time.Time
+	SupersededByManifestID  shared.ID
+}
+
+type PolicyInput struct {
+	Cycle              *assessmentcycle.AssessmentCycle
+	FinalStatus        engagement.Status
+	InitialSnapshot    *assessmentsnapshot.Snapshot
+	FinalSnapshot      *assessmentsnapshot.Snapshot
+	Comparison         *assessmentcomparison.Comparison
+	References         []Reference
+	AsOfAt             time.Time
+	OverrideBlockerIDs []string
+	OverrideReason     string
+}
+
+type PolicyResult struct {
+	PolicyVersion     string            `json:"policy_version"`
+	Blockers          []Blocker         `json:"blockers"`
+	Warnings          []Warning         `json:"warnings"`
+	CoverageDecisions CoverageDecisions `json:"coverage_decisions"`
+	CommitAllowed     bool              `json:"commit_allowed"`
+}
+
+func Evaluate(input PolicyInput) PolicyResult {
+	result := PolicyResult{PolicyVersion: PolicyVersionV1, Blockers: []Blocker{}, Warnings: []Warning{}}
+	add := func(id, code, message string, overrideable bool) {
+		result.Blockers = append(result.Blockers, Blocker{ID: id, Code: code, Message: message, Overrideable: overrideable})
+	}
+	if input.Cycle == nil || input.Cycle.Status != assessmentcycle.StatusOpen {
+		add("cycle:not_open", "cycle_not_open", "Assessment Cycle must be open.", false)
+	}
+	if input.FinalStatus != engagement.StatusCompleted {
+		add("assessment:not_completed", "final_assessment_not_completed", "Selected final Assessment must be completed.", false)
+	}
+	if input.InitialSnapshot == nil {
+		add("snapshot:initial_missing", "initial_snapshot_missing", "Root Assessment has no default finalized Snapshot.", false)
+	}
+	if input.FinalSnapshot == nil {
+		add("snapshot:final_missing", "final_snapshot_missing", "Selected final Assessment has no default finalized Snapshot.", false)
+	}
+	if input.Comparison == nil {
+		add("comparison:missing", "comparison_missing", "No immutable root-to-final lifecycle Comparison exists.", false)
+	} else {
+		if input.Comparison.Status != assessmentcomparison.StatusComplete {
+			add("comparison:incomplete", "comparison_incomplete", "Lifecycle Comparison must be complete with no pending review.", false)
+		}
+		if input.InitialSnapshot != nil && input.FinalSnapshot != nil &&
+			(input.Comparison.BaselineSnapshotID != input.InitialSnapshot.ID || input.Comparison.CurrentSnapshotID != input.FinalSnapshot.ID || input.Comparison.Mode != assessmentcomparison.ModeLifecycle) {
+			add("comparison:pair_mismatch", "comparison_pair_mismatch", "Lifecycle Comparison does not bind the root and selected final Snapshots.", false)
+		}
+		if input.Comparison.Summary.ReviewCount > 0 {
+			add("comparison:review_pending", "identity_review_pending", "Comparison contains unresolved identity review.", false)
+		}
+		var incompleteVerifications, actionableFindings []string
+		for _, item := range input.Comparison.Items {
+			if !item.VerificationID.IsZero() && item.VerificationState != "remediated" {
+				incompleteVerifications = append(incompleteVerifications, item.VerificationID.String())
+			}
+			severity := item.CurrentObservation.Severity
+			if item.CurrentActionable && (severity == shared.SeverityCritical || severity == shared.SeverityHigh) {
+				actionableFindings = append(actionableFindings, item.ID.String())
+			}
+		}
+		addCohortBlockers(incompleteVerifications, "verification", "verification_incomplete", "Required Finding verification is not complete.", false, add)
+		addCohortBlockers(actionableFindings, "finding", "open_high_critical", "Critical/High finding remains actionable at closure.", true, add)
+	}
+	asOfAt := input.AsOfAt.UTC()
+	for _, reference := range input.References {
+		if !asOfAt.IsZero() && reference.ExpiresAt != nil && !asOfAt.Before(*reference.ExpiresAt) {
+			add("reference:expired:"+digestID(reference.Kind+"|"+reference.ID.String()), "decision_expired", "An effective closure decision expired before preview.", false)
+		}
+	}
+	result.CoverageDecisions.Initial = coverageDecisions(input.InitialSnapshot, "initial", add)
+	result.CoverageDecisions.Final = coverageDecisions(input.FinalSnapshot, "final", add)
+	applyOverrides(&result, input.OverrideBlockerIDs, input.OverrideReason)
+	result.CommitAllowed = true
+	for _, blocker := range result.Blockers {
+		if !blocker.Overridden {
+			result.CommitAllowed = false
+			break
+		}
+	}
+	return result
+}
+
+// A large policy cohort is one explicit, counted decision bound to all member
+// IDs. The signed preview still binds the full comparison; no blocker is omitted.
+func addCohortBlockers(ids []string, prefix, code, message string, overrideable bool, add func(string, string, string, bool)) {
+	ids = canonicalStrings(ids)
+	if len(ids) > 256 {
+		add(prefix+":set:"+digestID(strings.Join(ids, "\x00")), code, fmt.Sprintf("%d findings: %s This decision covers the entire listed comparison cohort.", len(ids), message), overrideable)
+		return
+	}
+	for _, id := range ids {
+		add(prefix+":"+id, code, message, overrideable)
+	}
+}
+
+func coverageDecisions(snapshot *assessmentsnapshot.Snapshot, label string, add func(string, string, string, bool)) []CoverageDecision {
+	if snapshot == nil {
+		return []CoverageDecision{}
+	}
+	decisions := make([]CoverageDecision, 0, len(snapshot.Dimensions))
+	for _, dimension := range snapshot.Dimensions {
+		id := strings.Join([]string{string(dimension.Target.Kind), dimension.Target.Canonical, dimension.Producer, dimension.FindingKind}, "|")
+		decision := CoverageDecision{SnapshotID: snapshot.ID, DimensionID: id, State: dimension.State, ReasonCode: dimension.ReasonCode}
+		if dimension.State != assessmentsnapshot.CoverageComplete {
+			add("coverage:"+label+":"+digestID(id), "coverage_incomplete", "Required coverage is partial or unknown.", true)
+		}
+		decisions = append(decisions, decision)
+	}
+	return decisions
+}
+
+func applyOverrides(result *PolicyResult, requested []string, reason string) {
+	requested = canonicalStrings(requested)
+	known := map[string]int{}
+	for index := range result.Blockers {
+		known[result.Blockers[index].ID] = index
+	}
+	for _, id := range requested {
+		index, exists := known[id]
+		switch {
+		case !exists:
+			result.Blockers = append(result.Blockers, Blocker{ID: "override:unknown:" + digestID(id), Code: "override_unknown", Message: "Requested override does not match a current blocker."})
+		case !result.Blockers[index].Overrideable:
+			result.Blockers = append(result.Blockers, Blocker{ID: "override:hard:" + digestID(id), Code: "override_hard_blocker", Message: "Integrity blocker cannot be overridden."})
+		case strings.TrimSpace(reason) == "":
+			result.Blockers = append(result.Blockers, Blocker{ID: "override:reason_required", Code: "override_reason_required", Message: "Override reason is required."})
+		default:
+			result.Blockers[index].Overridden = true
+		}
+	}
+	for index := range result.CoverageDecisions.Initial {
+		result.CoverageDecisions.Initial[index].Waived = coverageWaived(result.Blockers, "initial", result.CoverageDecisions.Initial[index].DimensionID)
+	}
+	for index := range result.CoverageDecisions.Final {
+		result.CoverageDecisions.Final[index].Waived = coverageWaived(result.Blockers, "final", result.CoverageDecisions.Final[index].DimensionID)
+	}
+}
+
+func coverageWaived(blockers []Blocker, label, dimensionID string) bool {
+	id := "coverage:" + label + ":" + digestID(dimensionID)
+	for _, blocker := range blockers {
+		if blocker.ID == id {
+			return blocker.Overridden
+		}
+	}
+	return false
+}
+
+type ManifestInput struct {
+	TenantID            shared.ID
+	CycleID             shared.ID
+	ManifestVersion     int64
+	CycleVersion        int64
+	RootAssessmentID    shared.ID
+	FinalAssessmentID   shared.ID
+	InitialSnapshot     *assessmentsnapshot.Snapshot
+	FinalSnapshot       *assessmentsnapshot.Snapshot
+	Comparison          *assessmentcomparison.Comparison
+	CoverageDecisions   CoverageDecisions
+	ScopeProfileChanges []ScopeProfileChange
+	OverrideBlockerIDs  []string
+	NonFinalBranches    []BranchState
+	Path                []PathMember
+	References          []Reference
+	Reason              string
+	OverrideReason      string
+	AsOfAt              time.Time
+	CreatedAt           time.Time
+	CreatedBy           string
+}
+
+func NewManifest(id shared.ID, input ManifestInput) (*Manifest, error) {
+	if input.InitialSnapshot == nil || input.FinalSnapshot == nil || input.Comparison == nil {
+		return nil, fmt.Errorf("%w: closure manifest immutable artifacts are required", shared.ErrValidation)
+	}
+	if input.InitialSnapshot.TenantID != input.TenantID || input.FinalSnapshot.TenantID != input.TenantID || input.Comparison.TenantID != input.TenantID ||
+		input.InitialSnapshot.CycleID != input.CycleID || input.FinalSnapshot.CycleID != input.CycleID || input.Comparison.CycleID != input.CycleID ||
+		input.InitialSnapshot.AssessmentID != input.RootAssessmentID || input.FinalSnapshot.AssessmentID != input.FinalAssessmentID ||
+		input.Comparison.BaselineSnapshotID != input.InitialSnapshot.ID || input.Comparison.CurrentSnapshotID != input.FinalSnapshot.ID ||
+		(input.InitialSnapshot.Lifecycle != assessmentsnapshot.LifecycleFinalized && input.InitialSnapshot.Lifecycle != assessmentsnapshot.LifecycleSuperseded) ||
+		(input.FinalSnapshot.Lifecycle != assessmentsnapshot.LifecycleFinalized && input.FinalSnapshot.Lifecycle != assessmentsnapshot.LifecycleSuperseded) ||
+		input.Comparison.Mode != assessmentcomparison.ModeLifecycle || input.Comparison.Status != assessmentcomparison.StatusComplete ||
+		input.Comparison.AlgorithmVersion < 1 || input.Comparison.FingerprintVersion < 1 || input.Comparison.RiskModelVersion < 1 {
+		return nil, fmt.Errorf("%w: closure manifest immutable artifacts do not match the final path", shared.ErrValidation)
+	}
+	references, err := canonicalReferences(input.References)
+	if err != nil {
+		return nil, err
+	}
+	manifest := &Manifest{
+		TenantID: input.TenantID, CycleID: input.CycleID, ID: id, ManifestVersion: input.ManifestVersion,
+		Lifecycle: LifecycleBuilding, CycleVersion: input.CycleVersion, RootAssessmentID: input.RootAssessmentID, FinalAssessmentID: input.FinalAssessmentID,
+		InitialSnapshotID: input.InitialSnapshot.ID, FinalSnapshotID: input.FinalSnapshot.ID, ComparisonID: input.Comparison.ID,
+		InitialSnapshotHash: input.InitialSnapshot.ContentHash, FinalSnapshotHash: input.FinalSnapshot.ContentHash, ComparisonHash: input.Comparison.ContentHash,
+		PolicyVersion: PolicyVersionV1, AlgorithmVersion: fmt.Sprintf("comparison-v%d", input.Comparison.AlgorithmVersion),
+		FingerprintVersion: fmt.Sprintf("fingerprint-v%d", input.Comparison.FingerprintVersion), RiskVersion: fmt.Sprintf("risk-v%d", input.Comparison.RiskModelVersion),
+		RendererContractVersion: RendererContractVersionV1, CoverageDecisions: canonicalCoverage(input.CoverageDecisions),
+		ScopeProfileChanges: canonicalScopeChanges(input.ScopeProfileChanges), OverrideBlockerIDs: canonicalStrings(input.OverrideBlockerIDs),
+		NonFinalBranches: canonicalBranches(input.NonFinalBranches), Path: canonicalPath(input.Path), References: references,
+		Reason: strings.TrimSpace(input.Reason), OverrideReason: strings.TrimSpace(input.OverrideReason), AsOfAt: canonicalTime(input.AsOfAt), CreatedAt: canonicalTime(input.CreatedAt), CreatedBy: strings.TrimSpace(input.CreatedBy),
+	}
+	hash, err := manifest.hashInput()
+	if err != nil {
+		return nil, err
+	}
+	manifest.CanonicalInputHash = hash
+	return manifest, manifest.Validate()
+}
+
+func (manifest *Manifest) Seal(at time.Time, actor string) error {
+	if manifest == nil || manifest.Lifecycle != LifecycleBuilding || at.IsZero() || strings.TrimSpace(actor) == "" {
+		return fmt.Errorf("%w: closure manifest cannot be sealed", shared.ErrValidation)
+	}
+	hash, err := manifest.hashContent()
+	if err != nil {
+		return err
+	}
+	sealedAt := canonicalTime(at)
+	manifest.Lifecycle, manifest.ContentHash, manifest.SealedAt, manifest.SealedBy = LifecycleActive, hash, &sealedAt, strings.TrimSpace(actor)
+	return manifest.Validate()
+}
+
+func (manifest *Manifest) Supersede(at time.Time, successor shared.ID) error {
+	if manifest == nil || manifest.Lifecycle != LifecycleActive || at.IsZero() {
+		return fmt.Errorf("%w: active closure manifest is required", shared.ErrValidation)
+	}
+	supersededAt := canonicalTime(at)
+	manifest.Lifecycle, manifest.SupersededAt, manifest.SupersededByManifestID = LifecycleSuperseded, &supersededAt, successor
+	return manifest.Validate()
+}
+
+func (manifest Manifest) Validate() error {
+	if manifest.TenantID.IsZero() || manifest.CycleID.IsZero() || manifest.ID.IsZero() || manifest.RootAssessmentID.IsZero() || manifest.FinalAssessmentID.IsZero() ||
+		manifest.InitialSnapshotID.IsZero() || manifest.FinalSnapshotID.IsZero() || manifest.ComparisonID.IsZero() || manifest.ManifestVersion < 1 || manifest.CycleVersion < 1 {
+		return fmt.Errorf("%w: closure manifest identity is invalid", shared.ErrValidation)
+	}
+	if !validHash(manifest.InitialSnapshotHash) || !validHash(manifest.FinalSnapshotHash) || !validHash(manifest.ComparisonHash) || !validHash(manifest.CanonicalInputHash) {
+		return fmt.Errorf("%w: closure manifest reference hash is invalid", shared.ErrValidation)
+	}
+	versions := []string{manifest.PolicyVersion, manifest.AlgorithmVersion, manifest.FingerprintVersion, manifest.RiskVersion, manifest.RendererContractVersion}
+	for _, version := range versions {
+		if version == "" || version != strings.TrimSpace(version) || len(version) > 128 {
+			return fmt.Errorf("%w: closure manifest policy metadata is invalid", shared.ErrValidation)
+		}
+	}
+	if manifest.AsOfAt.IsZero() || manifest.CreatedAt.IsZero() || manifest.AsOfAt.After(manifest.CreatedAt) || manifest.CreatedBy == "" ||
+		manifest.CreatedBy != strings.TrimSpace(manifest.CreatedBy) || len(manifest.CreatedBy) > 256 || manifest.SealedBy != strings.TrimSpace(manifest.SealedBy) || len(manifest.SealedBy) > 256 ||
+		len(manifest.Reason) > 4096 || len(manifest.OverrideReason) > 4096 {
+		return fmt.Errorf("%w: closure manifest policy metadata is invalid", shared.ErrValidation)
+	}
+	if err := validatePath(manifest); err != nil {
+		return err
+	}
+	if err := validateCoverage(manifest.CoverageDecisions, manifest.InitialSnapshotID, manifest.FinalSnapshotID); err != nil {
+		return err
+	}
+	for _, reference := range manifest.References {
+		if strings.TrimSpace(reference.Kind) == "" || reference.ID.IsZero() || reference.Version < 1 || reference.Kind != strings.TrimSpace(reference.Kind) ||
+			(reference.ContentHash != "" && !validHash(reference.ContentHash)) {
+			return fmt.Errorf("%w: closure manifest reference is invalid", shared.ErrValidation)
+		}
+		canonical, err := canonicalJSON(reference.Metadata)
+		if err != nil || !bytes.Equal(canonical, reference.Metadata) {
+			return fmt.Errorf("%w: closure manifest reference metadata is not canonical", shared.ErrValidation)
+		}
+	}
+	wantInputHash, err := manifest.hashInput()
+	if err != nil || wantInputHash != manifest.CanonicalInputHash {
+		return fmt.Errorf("%w: closure manifest canonical input hash mismatch", shared.ErrValidation)
+	}
+	switch manifest.Lifecycle {
+	case LifecycleBuilding:
+		if manifest.ContentHash != "" || manifest.SealedAt != nil || manifest.SealedBy != "" || manifest.SupersededAt != nil || !manifest.SupersededByManifestID.IsZero() {
+			return fmt.Errorf("%w: building closure manifest has terminal fields", shared.ErrValidation)
+		}
+	case LifecycleActive:
+		if !validHash(manifest.ContentHash) || manifest.SealedAt == nil || manifest.SealedBy == "" || manifest.SealedAt.Before(manifest.CreatedAt) || manifest.SupersededAt != nil || !manifest.SupersededByManifestID.IsZero() {
+			return fmt.Errorf("%w: active closure manifest is not sealed", shared.ErrValidation)
+		}
+	case LifecycleSuperseded:
+		if !validHash(manifest.ContentHash) || manifest.SealedAt == nil || manifest.SealedBy == "" || manifest.SealedAt.Before(manifest.CreatedAt) || manifest.SupersededAt == nil || manifest.SupersededAt.Before(*manifest.SealedAt) {
+			return fmt.Errorf("%w: superseded closure manifest is invalid", shared.ErrValidation)
+		}
+	default:
+		return fmt.Errorf("%w: closure manifest lifecycle is invalid", shared.ErrValidation)
+	}
+	if manifest.Lifecycle != LifecycleBuilding {
+		wantContentHash, err := manifest.hashContent()
+		if err != nil || wantContentHash != manifest.ContentHash {
+			return fmt.Errorf("%w: closure manifest content hash mismatch", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+func (manifest Manifest) hashInput() (string, error) {
+	return hashJSON(struct {
+		TenantID            shared.ID            `json:"tenant_id"`
+		CycleID             shared.ID            `json:"cycle_id"`
+		ManifestVersion     int64                `json:"manifest_version"`
+		CycleVersion        int64                `json:"cycle_version"`
+		RootAssessmentID    shared.ID            `json:"root_assessment_id"`
+		FinalAssessmentID   shared.ID            `json:"final_assessment_id"`
+		InitialSnapshotID   shared.ID            `json:"initial_snapshot_id"`
+		FinalSnapshotID     shared.ID            `json:"final_snapshot_id"`
+		ComparisonID        shared.ID            `json:"comparison_id"`
+		InitialSnapshotHash string               `json:"initial_snapshot_hash"`
+		FinalSnapshotHash   string               `json:"final_snapshot_hash"`
+		ComparisonHash      string               `json:"comparison_hash"`
+		PolicyVersion       string               `json:"policy_version"`
+		AlgorithmVersion    string               `json:"algorithm_version"`
+		FingerprintVersion  string               `json:"fingerprint_version"`
+		RiskVersion         string               `json:"risk_version"`
+		RendererVersion     string               `json:"renderer_contract_version"`
+		Coverage            CoverageDecisions    `json:"coverage_decisions"`
+		ScopeProfileChanges []ScopeProfileChange `json:"scope_profile_changes"`
+		OverrideBlockerIDs  []string             `json:"override_blocker_ids"`
+		NonFinalBranches    []BranchState        `json:"non_final_branches"`
+		Path                []PathMember         `json:"path"`
+		References          []Reference          `json:"references"`
+		AsOfAt              time.Time            `json:"as_of_at"`
+	}{manifest.TenantID, manifest.CycleID, manifest.ManifestVersion, manifest.CycleVersion, manifest.RootAssessmentID, manifest.FinalAssessmentID,
+		manifest.InitialSnapshotID, manifest.FinalSnapshotID, manifest.ComparisonID, manifest.InitialSnapshotHash, manifest.FinalSnapshotHash, manifest.ComparisonHash,
+		manifest.PolicyVersion, manifest.AlgorithmVersion, manifest.FingerprintVersion, manifest.RiskVersion, manifest.RendererContractVersion, manifest.CoverageDecisions,
+		manifest.ScopeProfileChanges, manifest.OverrideBlockerIDs, manifest.NonFinalBranches, manifest.Path, manifest.References, manifest.AsOfAt})
+}
+
+func (manifest Manifest) hashContent() (string, error) {
+	return hashJSON(struct {
+		CanonicalInputHash string    `json:"canonical_input_hash"`
+		Reason             string    `json:"reason"`
+		OverrideReason     string    `json:"override_reason"`
+		CreatedAt          time.Time `json:"created_at"`
+		CreatedBy          string    `json:"created_by"`
+	}{manifest.CanonicalInputHash, manifest.Reason, manifest.OverrideReason, manifest.CreatedAt, manifest.CreatedBy})
+}
+
+func hashJSON(value any) (string, error) {
+	// ponytail: these canonical structs contain no maps or floating-point values; switch to a full RFC 8785 encoder if either is added.
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return "", fmt.Errorf("marshal canonical closure manifest: %w", err)
+	}
+	digest := sha256.Sum256(bytes.TrimSuffix(buffer.Bytes(), []byte("\n")))
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func canonicalPath(values []PathMember) []PathMember {
+	result := append([]PathMember(nil), values...)
+	sort.Slice(result, func(i, j int) bool { return result[i].PathPosition < result[j].PathPosition })
+	return result
+}
+
+func canonicalCoverage(values CoverageDecisions) CoverageDecisions {
+	canonical := func(decisions []CoverageDecision) []CoverageDecision {
+		result := append([]CoverageDecision(nil), decisions...)
+		sort.Slice(result, func(i, j int) bool {
+			if result[i].SnapshotID == result[j].SnapshotID {
+				return result[i].DimensionID < result[j].DimensionID
+			}
+			return result[i].SnapshotID < result[j].SnapshotID
+		})
+		return result
+	}
+	return CoverageDecisions{Initial: canonical(values.Initial), Final: canonical(values.Final)}
+}
+
+func canonicalBranches(values []BranchState) []BranchState {
+	result := append([]BranchState(nil), values...)
+	sort.Slice(result, func(i, j int) bool { return result[i].AssessmentID < result[j].AssessmentID })
+	return result
+}
+
+func canonicalReferences(values []Reference) ([]Reference, error) {
+	result := append([]Reference(nil), values...)
+	for index := range result {
+		metadata, err := canonicalJSON(result[index].Metadata)
+		if err != nil {
+			return nil, fmt.Errorf("%w: closure reference metadata is invalid", shared.ErrValidation)
+		}
+		result[index].Metadata = metadata
+		if result[index].ExpiresAt != nil {
+			expiresAt := canonicalTime(*result[index].ExpiresAt)
+			result[index].ExpiresAt = &expiresAt
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Kind == result[j].Kind {
+			return result[i].ID < result[j].ID
+		}
+		return result[i].Kind < result[j].Kind
+	})
+	return result, nil
+}
+
+func canonicalJSON(value json.RawMessage) (json.RawMessage, error) {
+	if len(value) == 0 {
+		return json.RawMessage("{}"), nil
+	}
+	decoder := json.NewDecoder(bytes.NewReader(value))
+	decoder.UseNumber()
+	var decoded map[string]any
+	if err := decoder.Decode(&decoded); err != nil {
+		return nil, err
+	}
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("multiple JSON values")
+		}
+		return nil, err
+	}
+	canonical, err := json.Marshal(decoded)
+	if err != nil {
+		return nil, err
+	}
+	return canonical, nil
+}
+
+func validatePath(manifest Manifest) error {
+	if len(manifest.Path) == 0 || manifest.Path[0].AssessmentID != manifest.RootAssessmentID || manifest.Path[len(manifest.Path)-1].AssessmentID != manifest.FinalAssessmentID {
+		return fmt.Errorf("%w: closure manifest path endpoints are invalid", shared.ErrValidation)
+	}
+	seen := map[shared.ID]struct{}{}
+	for index, member := range manifest.Path {
+		if member.PathPosition != index || member.AssessmentID.IsZero() || !member.AssessmentType.Valid() || member.RelationshipVersion < 1 {
+			return fmt.Errorf("%w: closure manifest path member is invalid", shared.ErrValidation)
+		}
+		if member.AssessmentType == assessmentcycle.AssessmentTypeInitial && (index != 0 || member.RetestNumber != 0) ||
+			member.AssessmentType == assessmentcycle.AssessmentTypeRetest && member.RetestNumber < 1 {
+			return fmt.Errorf("%w: closure manifest path sequence is invalid", shared.ErrValidation)
+		}
+		if _, exists := seen[member.AssessmentID]; exists {
+			return fmt.Errorf("%w: closure manifest path member is duplicated", shared.ErrValidation)
+		}
+		seen[member.AssessmentID] = struct{}{}
+	}
+	return nil
+}
+
+func validateCoverage(coverage CoverageDecisions, initialSnapshotID, finalSnapshotID shared.ID) error {
+	validate := func(decisions []CoverageDecision, snapshotID shared.ID) error {
+		seen := map[string]struct{}{}
+		for _, decision := range decisions {
+			if decision.SnapshotID != snapshotID || strings.TrimSpace(decision.DimensionID) == "" ||
+				(decision.State != assessmentsnapshot.CoverageComplete && decision.State != assessmentsnapshot.CoveragePartial && decision.State != assessmentsnapshot.CoverageUnknown) {
+				return fmt.Errorf("%w: closure manifest coverage decision is invalid", shared.ErrValidation)
+			}
+			if _, exists := seen[decision.DimensionID]; exists {
+				return fmt.Errorf("%w: closure manifest coverage decision is duplicated", shared.ErrValidation)
+			}
+			seen[decision.DimensionID] = struct{}{}
+		}
+		return nil
+	}
+	if err := validate(coverage.Initial, initialSnapshotID); err != nil {
+		return err
+	}
+	return validate(coverage.Final, finalSnapshotID)
+}
+
+func canonicalScopeChanges(values []ScopeProfileChange) []ScopeProfileChange {
+	result := append([]ScopeProfileChange(nil), values...)
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].AssessmentID == result[j].AssessmentID {
+			return result[i].Kind < result[j].Kind
+		}
+		return result[i].AssessmentID < result[j].AssessmentID
+	})
+	return result
+}
+
+func canonicalStrings(values []string) []string {
+	unique := map[string]struct{}{}
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			unique[value] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(unique))
+	for value := range unique {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func digestID(value string) string {
+	digest := sha256.Sum256([]byte(value))
+	return hex.EncodeToString(digest[:8])
+}
+
+func validHash(value string) bool {
+	if len(value) != sha256.Size*2 || value != strings.ToLower(value) {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func canonicalTime(value time.Time) time.Time {
+	return value.UTC().Truncate(time.Microsecond)
+}

--- a/internal/domain/assessmentclosure/closure_test.go
+++ b/internal/domain/assessmentclosure/closure_test.go
@@ -1,0 +1,228 @@
+package assessmentclosure
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestEvaluateFailsClosedAndRequiresExactOverrides(t *testing.T) {
+	cycle, initial, final, comparison := closureFixtures()
+	initial.Dimensions = []assessmentsnapshot.Dimension{{
+		Target:   assessmentsnapshot.Target{Kind: scanrun.TargetRepository, Canonical: "repo"},
+		Producer: "sca", FindingKind: "vulnerability", State: assessmentsnapshot.CoveragePartial, ReasonCode: assessmentsnapshot.ReasonRunPartial,
+	}}
+	comparison.Items = []assessmentcomparison.Item{{
+		ID: "finding-high", CurrentActionable: true,
+		CurrentObservation: assessmentcomparison.ObservationView{Severity: shared.SeverityHigh},
+	}}
+
+	result := Evaluate(PolicyInput{Cycle: cycle, FinalStatus: engagement.StatusCompleted, InitialSnapshot: initial, FinalSnapshot: final, Comparison: comparison})
+	if result.CommitAllowed {
+		t.Fatal("closure with incomplete coverage and actionable High finding must fail closed")
+	}
+	overrides := overrideableIDs(result.Blockers)
+	if len(overrides) != 2 {
+		t.Fatalf("overrideable blockers=%v, want coverage and High finding", overrides)
+	}
+
+	result = Evaluate(PolicyInput{
+		Cycle: cycle, FinalStatus: engagement.StatusCompleted, InitialSnapshot: initial, FinalSnapshot: final, Comparison: comparison,
+		OverrideBlockerIDs: overrides, OverrideReason: "approved exception",
+	})
+	if !result.CommitAllowed || !result.CoverageDecisions.Initial[0].Waived {
+		t.Fatalf("valid exact overrides should allow commit and waive coverage: %+v", result)
+	}
+
+	cycle.Status = assessmentcycle.StatusCompleted
+	result = Evaluate(PolicyInput{
+		Cycle: cycle, FinalStatus: engagement.StatusCompleted, InitialSnapshot: initial, FinalSnapshot: final, Comparison: comparison,
+		OverrideBlockerIDs: []string{"cycle:not_open"}, OverrideReason: "must not bypass integrity",
+	})
+	if result.CommitAllowed || !hasBlockerCode(result.Blockers, "override_hard_blocker") {
+		t.Fatalf("hard blocker override must fail closed: %+v", result.Blockers)
+	}
+}
+
+func TestEvaluateMissingArtifactsAndUnknownOverrideFailClosed(t *testing.T) {
+	cycle, _, _, _ := closureFixtures()
+	result := Evaluate(PolicyInput{
+		Cycle: cycle, FinalStatus: engagement.StatusCompleted,
+		OverrideBlockerIDs: []string{"coverage:made-up"}, OverrideReason: "invalid",
+	})
+	for _, code := range []string{"initial_snapshot_missing", "final_snapshot_missing", "comparison_missing", "override_unknown"} {
+		if !hasBlockerCode(result.Blockers, code) {
+			t.Fatalf("missing blocker %q in %+v", code, result.Blockers)
+		}
+	}
+	if result.CommitAllowed {
+		t.Fatal("missing immutable artifacts must fail closed")
+	}
+}
+
+func TestEvaluateExpiredDecisionAndIncompleteVerificationFailClosed(t *testing.T) {
+	cycle, initial, final, comparison := closureFixtures()
+	comparison.Items = []assessmentcomparison.Item{{ID: "finding", VerificationID: "verification", VerificationState: "pending"}}
+	asOfAt := time.Date(2026, 9, 1, 4, 0, 0, 0, time.UTC)
+	expiresAt := asOfAt.Add(-time.Second)
+	result := Evaluate(PolicyInput{
+		Cycle: cycle, FinalStatus: engagement.StatusCompleted, InitialSnapshot: initial, FinalSnapshot: final, Comparison: comparison, AsOfAt: asOfAt,
+		References: []Reference{{Kind: "accepted_risk", ID: "risk", Version: 1, ExpiresAt: &expiresAt}},
+	})
+	for _, code := range []string{"verification_incomplete", "decision_expired"} {
+		if !hasBlockerCode(result.Blockers, code) {
+			t.Fatalf("missing blocker %q in %+v", code, result.Blockers)
+		}
+	}
+	if result.CommitAllowed {
+		t.Fatal("expired decision and incomplete verification must fail closed")
+	}
+}
+
+func TestManifestCanonicalHashAndTamperDetection(t *testing.T) {
+	cycle, initial, final, comparison := closureFixtures()
+	now := time.Date(2026, 9, 2, 4, 0, 0, 0, time.UTC)
+	base := ManifestInput{
+		TenantID: cycle.TenantID, CycleID: cycle.ID, ManifestVersion: 1, CycleVersion: cycle.Version + 1,
+		RootAssessmentID: cycle.RootAssessmentID, FinalAssessmentID: cycle.SelectedHeadAssessmentID,
+		InitialSnapshot: initial, FinalSnapshot: final, Comparison: comparison,
+		CoverageDecisions: CoverageDecisions{
+			Initial: []CoverageDecision{
+				{SnapshotID: initial.ID, DimensionID: "z", State: assessmentsnapshot.CoverageComplete},
+				{SnapshotID: initial.ID, DimensionID: "a", State: assessmentsnapshot.CoverageComplete},
+			},
+			Final: []CoverageDecision{{SnapshotID: final.ID, DimensionID: "final", State: assessmentsnapshot.CoverageComplete}},
+		},
+		ScopeProfileChanges: []ScopeProfileChange{{AssessmentID: "final", Kind: "scope", Summary: "changed"}, {AssessmentID: "root", Kind: "profile", Summary: "initial"}},
+		OverrideBlockerIDs:  []string{"finding:b", "finding:a", "finding:a"},
+		NonFinalBranches:    []BranchState{{AssessmentID: "branch-b", RelationshipVersion: 2}, {AssessmentID: "branch-a", RelationshipVersion: 1}},
+		Path: []PathMember{
+			{PathPosition: 1, AssessmentID: "final", AssessmentType: assessmentcycle.AssessmentTypeRetest, RetestNumber: 1, RelationshipVersion: 2, SnapshotID: final.ID},
+			{PathPosition: 0, AssessmentID: "root", AssessmentType: assessmentcycle.AssessmentTypeInitial, RelationshipVersion: 1, SnapshotID: initial.ID},
+		},
+		References: []Reference{
+			{Kind: "verification", ID: "verification-2", Version: 2, Metadata: json.RawMessage(`{"b":2,"a":1}`)},
+			{Kind: "accepted_risk", ID: "risk-1", Version: 1, Metadata: json.RawMessage(`{"state":"active"}`)},
+		},
+		Reason: "finalized", OverrideReason: "approved", AsOfAt: now.Add(-time.Minute), CreatedAt: now, CreatedBy: "reviewer",
+	}
+
+	first, err := NewManifest("manifest-1", base)
+	if err != nil {
+		t.Fatalf("new manifest: %v", err)
+	}
+	reordered := base
+	reordered.CoverageDecisions.Initial = reverseCoverage(base.CoverageDecisions.Initial)
+	reordered.ScopeProfileChanges = reverseScope(base.ScopeProfileChanges)
+	reordered.OverrideBlockerIDs = []string{"finding:a", "finding:b"}
+	reordered.NonFinalBranches = reverseBranches(base.NonFinalBranches)
+	reordered.Path = reversePath(base.Path)
+	reordered.References = []Reference{
+		{Kind: "accepted_risk", ID: "risk-1", Version: 1, Metadata: json.RawMessage(`{"state":"active"}`)},
+		{Kind: "verification", ID: "verification-2", Version: 2, Metadata: json.RawMessage(`{"a":1,"b":2}`)},
+	}
+	second, err := NewManifest("manifest-1", reordered)
+	if err != nil {
+		t.Fatalf("new reordered manifest: %v", err)
+	}
+	if first.CanonicalInputHash != second.CanonicalInputHash {
+		t.Fatalf("canonical input hash changed for equivalent input: %s != %s", first.CanonicalInputHash, second.CanonicalInputHash)
+	}
+	sealedAt := now.Add(time.Second)
+	if err := first.Seal(sealedAt, "reviewer"); err != nil {
+		t.Fatalf("seal manifest: %v", err)
+	}
+	if err := second.Seal(sealedAt, "reviewer"); err != nil {
+		t.Fatalf("seal reordered manifest: %v", err)
+	}
+	if first.ContentHash != second.ContentHash {
+		t.Fatalf("content hash changed for equivalent input: %s != %s", first.ContentHash, second.ContentHash)
+	}
+	first.Reason = "tampered"
+	if err := first.Validate(); err == nil || !strings.Contains(err.Error(), "content hash mismatch") {
+		t.Fatalf("tampered manifest must fail content hash validation, got %v", err)
+	}
+}
+
+func closureFixtures() (*assessmentcycle.AssessmentCycle, *assessmentsnapshot.Snapshot, *assessmentsnapshot.Snapshot, *assessmentcomparison.Comparison) {
+	const hashA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	const hashB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+	const hashC = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	cycle := &assessmentcycle.AssessmentCycle{
+		TenantID: "tenant", ID: "cycle", Status: assessmentcycle.StatusOpen, RootAssessmentID: "root", SelectedHeadAssessmentID: "final", Version: 7,
+	}
+	initial := &assessmentsnapshot.Snapshot{TenantID: "tenant", CycleID: "cycle", ID: "snapshot-root", AssessmentID: "root", Lifecycle: assessmentsnapshot.LifecycleFinalized, ContentHash: hashA}
+	final := &assessmentsnapshot.Snapshot{TenantID: "tenant", CycleID: "cycle", ID: "snapshot-final", AssessmentID: "final", Lifecycle: assessmentsnapshot.LifecycleFinalized, ContentHash: hashB}
+	comparison := &assessmentcomparison.Comparison{
+		TenantID: "tenant", CycleID: "cycle", ID: "comparison", BaselineSnapshotID: initial.ID, CurrentSnapshotID: final.ID,
+		Mode: assessmentcomparison.ModeLifecycle, Status: assessmentcomparison.StatusComplete, ContentHash: hashC,
+		AlgorithmVersion: 1, FingerprintVersion: 1, RiskModelVersion: 1,
+	}
+	return cycle, initial, final, comparison
+}
+
+func overrideableIDs(blockers []Blocker) []string {
+	var ids []string
+	for _, blocker := range blockers {
+		if blocker.Overrideable {
+			ids = append(ids, blocker.ID)
+		}
+	}
+	return ids
+}
+
+func hasBlockerCode(blockers []Blocker, code string) bool {
+	for _, blocker := range blockers {
+		if blocker.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func reverseCoverage(values []CoverageDecision) []CoverageDecision {
+	return []CoverageDecision{values[1], values[0]}
+}
+
+func reverseScope(values []ScopeProfileChange) []ScopeProfileChange {
+	return []ScopeProfileChange{values[1], values[0]}
+}
+
+func reverseBranches(values []BranchState) []BranchState {
+	return []BranchState{values[1], values[0]}
+}
+
+func reversePath(values []PathMember) []PathMember {
+	return []PathMember{values[1], values[0]}
+}
+
+func TestEvaluateLargeCohortIsBoundedAndOverrideBindsEveryFinding(t *testing.T) {
+	cycle, initial, final, comparison := closureFixtures()
+	comparison.Items = make([]assessmentcomparison.Item, 100_000)
+	for i := range comparison.Items {
+		comparison.Items[i] = assessmentcomparison.Item{ID: shared.ID(fmt.Sprintf("item-%06d", i)), CurrentActionable: true, CurrentObservation: assessmentcomparison.ObservationView{Severity: shared.SeverityHigh}}
+	}
+	input := PolicyInput{Cycle: cycle, FinalStatus: engagement.StatusCompleted, InitialSnapshot: initial, FinalSnapshot: final, Comparison: comparison}
+	result := Evaluate(input)
+	if result.CommitAllowed || len(result.Blockers) != 1 || !strings.Contains(result.Blockers[0].Message, "100000 findings") {
+		t.Fatalf("policy=%+v", result)
+	}
+	input.OverrideBlockerIDs = []string{result.Blockers[0].ID}
+	input.OverrideReason = "Explicit acceptance of the entire 100000-finding test cohort"
+	if result := Evaluate(input); !result.CommitAllowed {
+		t.Fatalf("exact cohort override failed: %+v", result)
+	}
+	comparison.Items[99999].ID = "different-finding"
+	if result := Evaluate(input); result.CommitAllowed || !hasBlockerCode(result.Blockers, "override_unknown") {
+		t.Fatal("stale cohort override accepted")
+	}
+}

--- a/internal/domain/assessmentcomparison/artifact.go
+++ b/internal/domain/assessmentcomparison/artifact.go
@@ -1,0 +1,409 @@
+package assessmentcomparison
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type Status string
+
+const (
+	StatusQueued      Status = "queued"
+	StatusGenerating  Status = "generating"
+	StatusComplete    Status = "complete"
+	StatusNeedsReview Status = "needs_review"
+	StatusFailed      Status = "failed"
+	StatusSuperseded  Status = "superseded"
+)
+
+func (status Status) Valid() bool {
+	switch status {
+	case StatusQueued, StatusGenerating, StatusComplete, StatusNeedsReview, StatusFailed, StatusSuperseded:
+		return true
+	}
+	return false
+}
+
+type Comparison struct {
+	TenantID              shared.ID
+	CycleID               shared.ID
+	ID                    shared.ID
+	BaselineSnapshotID    shared.ID
+	CurrentSnapshotID     shared.ID
+	Mode                  Mode
+	InputHash             string
+	InputPayload          []byte
+	AlgorithmVersion      int
+	FingerprintVersion    int
+	RiskModelVersion      int
+	CoveragePolicyVersion int
+	Status                Status
+	Version               int64
+	Attempts              int
+	FailureCode           string
+	ContentHash           string
+	Items                 []Item
+	Summary               Summary
+	CreatedAt             time.Time
+	UpdatedAt             time.Time
+	CompletedAt           *time.Time
+	SupersededAt          *time.Time
+	SupersededBy          shared.ID
+}
+
+func NewQueued(tenantID, cycleID, id shared.ID, input GenerationInput, payload []byte, inputHash string, now time.Time) (Comparison, error) {
+	comparison := Comparison{
+		TenantID: tenantID, CycleID: cycleID, ID: id,
+		BaselineSnapshotID: input.Baseline.ID, CurrentSnapshotID: input.Current.ID, Mode: input.Mode,
+		InputHash: inputHash, InputPayload: append([]byte(nil), payload...),
+		AlgorithmVersion: input.AlgorithmVersion, FingerprintVersion: input.FingerprintVersion,
+		RiskModelVersion: input.RiskModelVersion, CoveragePolicyVersion: input.CoveragePolicyVersion,
+		Status: StatusQueued, Version: 1, CreatedAt: now.UTC(), UpdatedAt: now.UTC(),
+	}
+	return comparison, comparison.Validate()
+}
+
+func (comparison Comparison) Validate() error {
+	if comparison.TenantID.IsZero() || comparison.CycleID.IsZero() || comparison.ID.IsZero() || comparison.BaselineSnapshotID.IsZero() || comparison.CurrentSnapshotID.IsZero() {
+		return fmt.Errorf("%w: comparison ownership and snapshots are required", shared.ErrValidation)
+	}
+	if comparison.BaselineSnapshotID == comparison.CurrentSnapshotID || !comparison.Mode.Valid() || !validDigest(comparison.InputHash) || len(comparison.InputPayload) == 0 || len(comparison.InputPayload) > 64*1024 {
+		return fmt.Errorf("%w: comparison input is invalid", shared.ErrValidation)
+	}
+	if comparison.AlgorithmVersion <= 0 || comparison.FingerprintVersion <= 0 || comparison.RiskModelVersion <= 0 || comparison.CoveragePolicyVersion <= 0 || !comparison.Status.Valid() || comparison.Version <= 0 || comparison.Attempts < 0 {
+		return fmt.Errorf("%w: comparison versions or lifecycle are invalid", shared.ErrValidation)
+	}
+	if comparison.CreatedAt.IsZero() || comparison.UpdatedAt.IsZero() {
+		return fmt.Errorf("%w: comparison timestamps are required", shared.ErrValidation)
+	}
+	switch comparison.Status {
+	case StatusQueued, StatusGenerating:
+		if comparison.ContentHash != "" || len(comparison.Items) != 0 || comparison.CompletedAt != nil || comparison.SupersededAt != nil || !comparison.SupersededBy.IsZero() {
+			return fmt.Errorf("%w: active comparison has terminal output", shared.ErrValidation)
+		}
+	case StatusComplete, StatusNeedsReview:
+		if !validDigest(comparison.ContentHash) || comparison.CompletedAt == nil || comparison.SupersededAt != nil || !comparison.SupersededBy.IsZero() {
+			return fmt.Errorf("%w: completed comparison metadata is invalid", shared.ErrValidation)
+		}
+	case StatusFailed:
+		if !validReason(comparison.FailureCode) || comparison.ContentHash != "" || comparison.CompletedAt != nil || comparison.SupersededAt != nil || !comparison.SupersededBy.IsZero() {
+			return fmt.Errorf("%w: failed comparison metadata is invalid", shared.ErrValidation)
+		}
+	case StatusSuperseded:
+		if !validDigest(comparison.ContentHash) || comparison.CompletedAt == nil || comparison.SupersededAt == nil || comparison.SupersededBy.IsZero() {
+			return fmt.Errorf("%w: superseded comparison metadata is invalid", shared.ErrValidation)
+		}
+	}
+	return validateItems(comparison.Mode, comparison.Items)
+}
+
+func (comparison *Comparison) Start(expectedVersion int64, now time.Time) error {
+	if comparison == nil || expectedVersion != comparison.Version {
+		return fmt.Errorf("%w: comparison version mismatch", shared.ErrConflict)
+	}
+	if comparison.Status != StatusQueued && comparison.Status != StatusFailed {
+		return fmt.Errorf("%w: comparison cannot start from %s", shared.ErrValidation, comparison.Status)
+	}
+	comparison.Status, comparison.FailureCode = StatusGenerating, ""
+	comparison.Attempts++
+	comparison.Version++
+	comparison.UpdatedAt = now.UTC()
+	return comparison.Validate()
+}
+
+func (comparison *Comparison) Complete(items []Item, expectedVersion int64, now time.Time) error {
+	if comparison == nil || expectedVersion != comparison.Version {
+		return fmt.Errorf("%w: comparison version mismatch", shared.ErrConflict)
+	}
+	if comparison.Status != StatusGenerating {
+		return fmt.Errorf("%w: comparison is not generating", shared.ErrValidation)
+	}
+	items = append([]Item(nil), items...)
+	sort.Slice(items, func(i, j int) bool { return items[i].IdentityID < items[j].IdentityID })
+	for index := range items {
+		items[index].Position = index
+		items[index].ID = comparisonItemID(comparison.ID, items[index].IdentityID)
+		items[index].ReviewCandidateIDs = canonicalItemIDs(items[index].ReviewCandidateIDs)
+		items[index].ReviewCandidates = canonicalReviewCandidates(items[index].ReviewCandidates)
+		items[index].MatchMethods = canonicalMatchMethods(items[index].MatchMethods)
+	}
+	if err := validateItems(comparison.Mode, items); err != nil {
+		return err
+	}
+	status := StatusComplete
+	for _, item := range items {
+		if item.Presence == PresenceNeedsReview || item.NeutralPresence == NeutralNeedsReview {
+			status = StatusNeedsReview
+			break
+		}
+	}
+	summary := Summarize(items)
+	summary.ComparisonID = comparison.ID
+	summary.BaselineSnapshotID = comparison.BaselineSnapshotID
+	summary.CurrentSnapshotID = comparison.CurrentSnapshotID
+	summary.RiskModelVersion = comparison.RiskModelVersion
+	hash, err := hashOutput(comparison, items, summary)
+	if err != nil {
+		return err
+	}
+	completedAt := now.UTC()
+	comparison.Status, comparison.Items, comparison.Summary, comparison.ContentHash = status, items, summary, hash
+	comparison.CompletedAt, comparison.UpdatedAt = &completedAt, completedAt
+	comparison.Version++
+	return comparison.Validate()
+}
+
+func (comparison *Comparison) Fail(code string, retryable bool, maxAttempts int, expectedVersion int64, now time.Time) error {
+	if comparison == nil || expectedVersion != comparison.Version {
+		return fmt.Errorf("%w: comparison version mismatch", shared.ErrConflict)
+	}
+	if comparison.Status != StatusGenerating || !validReason(code) || maxAttempts <= 0 {
+		return fmt.Errorf("%w: comparison failure transition is invalid", shared.ErrValidation)
+	}
+	comparison.Status = StatusFailed
+	if retryable && comparison.Attempts < maxAttempts {
+		comparison.Status = StatusQueued
+	}
+	comparison.FailureCode = code
+	comparison.Version++
+	comparison.UpdatedAt = now.UTC()
+	if comparison.Status == StatusQueued {
+		comparison.FailureCode = ""
+	}
+	return comparison.Validate()
+}
+
+func (comparison *Comparison) Supersede(successorID shared.ID, expectedVersion int64, now time.Time) error {
+	if comparison == nil || expectedVersion != comparison.Version {
+		return fmt.Errorf("%w: comparison version mismatch", shared.ErrConflict)
+	}
+	if comparison.Status != StatusComplete && comparison.Status != StatusNeedsReview || successorID.IsZero() || successorID == comparison.ID {
+		return fmt.Errorf("%w: comparison supersession is invalid", shared.ErrValidation)
+	}
+	supersededAt := now.UTC()
+	comparison.Status, comparison.SupersededAt, comparison.SupersededBy = StatusSuperseded, &supersededAt, successorID
+	comparison.Version++
+	comparison.UpdatedAt = supersededAt
+	return comparison.Validate()
+}
+
+func validateItems(mode Mode, items []Item) error {
+	seenItems := map[shared.ID]struct{}{}
+	seenIdentities := map[shared.ID]struct{}{}
+	for position, item := range items {
+		if item.ID.IsZero() || item.Position != position || item.IdentityID.IsZero() || item.BaselineRiskMilli < 0 || item.CurrentRiskMilli < 0 || item.BaselineObservationID.IsZero() && item.CurrentObservationID.IsZero() {
+			return fmt.Errorf("%w: comparison item is invalid", shared.ErrValidation)
+		}
+		if _, duplicate := seenItems[item.ID]; duplicate {
+			return fmt.Errorf("%w: comparison contains duplicate item %q", shared.ErrValidation, item.ID)
+		}
+		seenItems[item.ID] = struct{}{}
+		if _, duplicate := seenIdentities[item.IdentityID]; duplicate {
+			return fmt.Errorf("%w: comparison contains duplicate identity %q", shared.ErrValidation, item.IdentityID)
+		}
+		seenIdentities[item.IdentityID] = struct{}{}
+		if mode == ModeLifecycle && (!item.Presence.Valid() || item.NeutralPresence != "") ||
+			mode == ModeNeutral && (!item.NeutralPresence.Valid() || item.Presence != "" || item.FixedBasis != "") {
+			return fmt.Errorf("%w: comparison item presence does not match mode", shared.ErrValidation)
+		}
+		if item.FixedBasis != "" && !item.FixedBasis.Valid() || item.FixedBasis == FixedByComparableAbsence && item.Presence != PresenceNotDetected ||
+			item.FixedBasis == FixedByExplicitVerification && (item.VerificationID.IsZero() || item.VerificationState == "") {
+			return fmt.Errorf("%w: comparison item fixed basis is invalid", shared.ErrValidation)
+		}
+		if item.VerificationState != "" && !validReason(item.VerificationState) || (item.VerificationState == "") != item.VerificationID.IsZero() {
+			return fmt.Errorf("%w: comparison item verification is invalid", shared.ErrValidation)
+		}
+		if err := validateItemProjection(item); err != nil {
+			return err
+		}
+		seenFlags := map[ChangeFlag]struct{}{}
+		for _, flag := range item.ChangeFlags {
+			if !flag.Valid() {
+				return fmt.Errorf("%w: comparison change flag is invalid", shared.ErrValidation)
+			}
+			if _, duplicate := seenFlags[flag]; duplicate {
+				return fmt.Errorf("%w: comparison change flag is duplicated", shared.ErrValidation)
+			}
+			seenFlags[flag] = struct{}{}
+		}
+		if !equalItemIDs(item.ReviewCandidateIDs, canonicalItemIDs(item.ReviewCandidateIDs)) {
+			return fmt.Errorf("%w: comparison review candidate ids are invalid", shared.ErrValidation)
+		}
+		if !equalReviewCandidates(item.ReviewCandidates, canonicalReviewCandidates(item.ReviewCandidates)) {
+			return fmt.Errorf("%w: comparison review candidates are invalid", shared.ErrValidation)
+		}
+		for _, candidate := range item.ReviewCandidates {
+			if !containsItemID(item.ReviewCandidateIDs, candidate.ID) {
+				return fmt.Errorf("%w: comparison review candidate metadata is unreferenced", shared.ErrValidation)
+			}
+		}
+		if !equalMatchMethods(item.MatchMethods, canonicalMatchMethods(item.MatchMethods)) {
+			return fmt.Errorf("%w: comparison match methods are invalid", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+func validateItemProjection(item Item) error {
+	legacy := item.ProducerKind == "" && item.FindingKind == "" && item.TargetCanonical == ""
+	if legacy {
+		if item.CoverageDecision != "" && item.CoverageDecision != assessmentsnapshot.NotComparable {
+			return fmt.Errorf("%w: legacy comparison coverage is invalid", shared.ErrValidation)
+		}
+		return nil
+	}
+	if strings.TrimSpace(item.ProducerKind) != item.ProducerKind || strings.TrimSpace(item.FindingKind) != item.FindingKind || strings.TrimSpace(item.TargetCanonical) != item.TargetCanonical || item.ProducerKind == "" || item.FindingKind == "" || item.TargetCanonical == "" {
+		return fmt.Errorf("%w: comparison item identity projection is invalid", shared.ErrValidation)
+	}
+	if !validComparability(item.CoverageDecision) || !validObservationView(item.BaselineObservationID, item.BaselineObservation) || !validObservationView(item.CurrentObservationID, item.CurrentObservation) {
+		return fmt.Errorf("%w: comparison item observation projection is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validObservationView(observationID shared.ID, view ObservationView) bool {
+	if observationID.IsZero() {
+		return view == (ObservationView{})
+	}
+	return view.Severity.Valid() && !view.ObservedAt.IsZero() && view.Scanner.Validate() == nil
+}
+
+func validComparability(value assessmentsnapshot.Comparability) bool {
+	return value == assessmentsnapshot.Comparable || value == assessmentsnapshot.PartiallyComparable || value == assessmentsnapshot.NotComparable
+}
+
+func comparisonItemID(comparisonID, identityID shared.ID) shared.ID {
+	digest := sha256.Sum256([]byte("synapse:assessment-comparison-item:v1\x00" + comparisonID.String() + "\x00" + identityID.String()))
+	return shared.ID("comparison-item-" + hex.EncodeToString(digest[:16]))
+}
+
+func canonicalItemIDs(values []shared.ID) []shared.ID {
+	seen := map[shared.ID]struct{}{}
+	result := make([]shared.ID, 0, len(values))
+	for _, value := range values {
+		if value.IsZero() {
+			continue
+		}
+		if _, duplicate := seen[value]; duplicate {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Slice(result, func(left, right int) bool { return result[left] < result[right] })
+	return result
+}
+
+func equalItemIDs(left, right []shared.ID) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func canonicalReviewCandidates(values []ReviewCandidateView) []ReviewCandidateView {
+	byID := map[shared.ID][]shared.ID{}
+	for _, value := range values {
+		if value.ID.IsZero() {
+			continue
+		}
+		byID[value.ID] = append(byID[value.ID], value.SourceObservationIDs...)
+	}
+	result := make([]ReviewCandidateView, 0, len(byID))
+	for id, sourceIDs := range byID {
+		result = append(result, ReviewCandidateView{ID: id, SourceObservationIDs: canonicalItemIDs(sourceIDs)})
+	}
+	sort.Slice(result, func(left, right int) bool { return result[left].ID < result[right].ID })
+	return result
+}
+
+func equalReviewCandidates(left, right []ReviewCandidateView) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index].ID != right[index].ID || !equalItemIDs(left[index].SourceObservationIDs, right[index].SourceObservationIDs) {
+			return false
+		}
+	}
+	return true
+}
+
+func containsItemID(values []shared.ID, expected shared.ID) bool {
+	for _, value := range values {
+		if value == expected {
+			return true
+		}
+	}
+	return false
+}
+
+func canonicalMatchMethods(values []findinglineage.MatchMethod) []findinglineage.MatchMethod {
+	seen := map[findinglineage.MatchMethod]struct{}{}
+	result := make([]findinglineage.MatchMethod, 0, len(values))
+	for _, value := range values {
+		if !value.Valid() {
+			continue
+		}
+		if _, duplicate := seen[value]; duplicate {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	sort.Slice(result, func(left, right int) bool { return result[left] < result[right] })
+	return result
+}
+
+func equalMatchMethods(left, right []findinglineage.MatchMethod) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func hashOutput(comparison *Comparison, items []Item, summary Summary) (string, error) {
+	payload, err := json.Marshal(struct {
+		ComparisonID string  `json:"comparison_id"`
+		InputHash    string  `json:"input_hash"`
+		Items        []Item  `json:"items"`
+		Mode         Mode    `json:"mode"`
+		Summary      Summary `json:"summary"`
+	}{comparison.ID.String(), comparison.InputHash, items, comparison.Mode, summary})
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(append([]byte("synapse:assessment-comparison-output:v1\x00"), payload...))
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func validReason(value string) bool {
+	if len(value) == 0 || len(value) > 64 || strings.TrimSpace(value) != value {
+		return false
+	}
+	for _, char := range value {
+		if char != '_' && (char < 'a' || char > 'z') && (char < '0' || char > '9') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/domain/assessmentcomparison/artifact_test.go
+++ b/internal/domain/assessmentcomparison/artifact_test.go
@@ -1,0 +1,166 @@
+package assessmentcomparison
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestComparisonLifecycleCASRetryCompleteAndSupersede(t *testing.T) {
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	input := GenerationInput{
+		Mode:             ModeLifecycle,
+		Baseline:         SnapshotHashRef{ID: "baseline", ContentHash: strings.Repeat("a", 64)},
+		Current:          SnapshotHashRef{ID: "current", ContentHash: strings.Repeat("b", 64)},
+		AlgorithmVersion: 1, FingerprintVersion: 1, RiskModelVersion: 1, CoveragePolicyVersion: 1,
+	}
+	payload, inputHash, err := HashGenerationInput(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	comparison, err := NewQueued("tenant", "cycle", "comparison", input, payload, inputHash, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := comparison.Start(9, now); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale start error=%v", err)
+	}
+	if err := comparison.Start(1, now.Add(time.Second)); err != nil || comparison.Status != StatusGenerating || comparison.Attempts != 1 || comparison.Version != 2 {
+		t.Fatalf("started=%+v err=%v", comparison, err)
+	}
+	if err := comparison.Fail("worker_timeout", true, 3, 2, now.Add(2*time.Second)); err != nil || comparison.Status != StatusQueued || comparison.Version != 3 {
+		t.Fatalf("retried=%+v err=%v", comparison, err)
+	}
+	if err := comparison.Start(3, now.Add(3*time.Second)); err != nil || comparison.Attempts != 2 {
+		t.Fatalf("restart=%+v err=%v", comparison, err)
+	}
+	items := []Item{
+		{IdentityID: "review", CurrentObservationID: "review-current", Presence: PresenceNeedsReview},
+		{IdentityID: "fixed", BaselineObservationID: "fixed-baseline", Presence: PresenceNotDetected, FixedBasis: FixedByComparableAbsence, BaselineActionable: true, ComparableBaseline: true, BaselineRiskMilli: 5000},
+	}
+	if err := comparison.Complete(items, 4, now.Add(4*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if comparison.Status != StatusNeedsReview || comparison.ContentHash == "" || comparison.CompletedAt == nil || comparison.Summary.FixedCount != 1 {
+		t.Fatalf("completed=%+v", comparison)
+	}
+	if comparison.Summary.ComparisonID != comparison.ID || comparison.Summary.BaselineSnapshotID != comparison.BaselineSnapshotID ||
+		comparison.Summary.CurrentSnapshotID != comparison.CurrentSnapshotID || comparison.Summary.RiskModelVersion != comparison.RiskModelVersion {
+		t.Fatalf("summary projection identity=%+v", comparison.Summary)
+	}
+	if comparison.Items[0].IdentityID != "fixed" || comparison.Items[1].IdentityID != "review" {
+		t.Fatalf("items not sorted=%+v", comparison.Items)
+	}
+	if err := comparison.Supersede("successor", comparison.Version, now.Add(5*time.Second)); err != nil || comparison.Status != StatusSuperseded {
+		t.Fatalf("superseded=%+v err=%v", comparison, err)
+	}
+}
+
+func TestComparisonFailureDeadLettersAtAttemptLimit(t *testing.T) {
+	now := time.Date(2026, 8, 31, 13, 0, 0, 0, time.UTC)
+	input := GenerationInput{
+		Mode:             ModeNeutral,
+		Baseline:         SnapshotHashRef{ID: "a", ContentHash: strings.Repeat("a", 64)},
+		Current:          SnapshotHashRef{ID: "b", ContentHash: strings.Repeat("b", 64)},
+		AlgorithmVersion: 1, FingerprintVersion: 1, RiskModelVersion: 1, CoveragePolicyVersion: 1,
+	}
+	payload, inputHash, _ := HashGenerationInput(input)
+	comparison, err := NewQueued("tenant", "cycle", "comparison", input, payload, inputHash, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := comparison.Start(1, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := comparison.Fail("classification_failed", true, 1, 2, now); err != nil {
+		t.Fatal(err)
+	}
+	if comparison.Status != StatusFailed || comparison.FailureCode != "classification_failed" {
+		t.Fatalf("failed=%+v", comparison)
+	}
+}
+
+func TestComparisonOutputHashIsStable(t *testing.T) {
+	now := time.Date(2026, 8, 31, 14, 0, 0, 0, time.UTC)
+	input := GenerationInput{
+		Mode:             ModeLifecycle,
+		Baseline:         SnapshotHashRef{ID: "baseline", ContentHash: strings.Repeat("a", 64)},
+		Current:          SnapshotHashRef{ID: "current", ContentHash: strings.Repeat("b", 64)},
+		AlgorithmVersion: 1, FingerprintVersion: 2, RiskModelVersion: 3, CoveragePolicyVersion: 4,
+	}
+	payload, inputHash, err := HashGenerationInput(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	comparison, err := NewQueued("tenant", "cycle", "comparison-golden", input, payload, inputHash, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := comparison.Start(comparison.Version, now); err != nil {
+		t.Fatal(err)
+	}
+	items := []Item{
+		{
+			IdentityID: "still", BaselineObservationID: "baseline-still", CurrentObservationID: "current-still",
+			Presence: PresenceDetected, ChangeFlags: []ChangeFlag{SeverityDecreased, EvidenceChanged},
+			BaselineActionable: true, CurrentActionable: true, ComparableBaseline: true,
+			BaselineRiskMilli: 8000, CurrentRiskMilli: 5000,
+		},
+		{
+			IdentityID: "fixed", BaselineObservationID: "baseline-fixed", Presence: PresenceNotDetected,
+			FixedBasis: FixedByComparableAbsence, BaselineActionable: true, ComparableBaseline: true,
+			BaselineRiskMilli: 7000,
+		},
+	}
+	if err := comparison.Complete(items, comparison.Version, now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	const want = "040b1db08ccbaaf29b94bc095a6a4861cfa652d58cb67033a0cf907b393444e4"
+	if comparison.ContentHash != want {
+		t.Fatalf("content hash=%s want=%s", comparison.ContentHash, want)
+	}
+}
+
+func TestComparisonCompletesOneHundredThousandItemsWithinTarget(t *testing.T) {
+	now := time.Date(2026, 8, 31, 14, 0, 0, 0, time.UTC)
+	input := GenerationInput{
+		Mode:             ModeLifecycle,
+		Baseline:         SnapshotHashRef{ID: "baseline", ContentHash: strings.Repeat("a", 64)},
+		Current:          SnapshotHashRef{ID: "current", ContentHash: strings.Repeat("b", 64)},
+		AlgorithmVersion: 1, FingerprintVersion: 1, RiskModelVersion: 1, CoveragePolicyVersion: 1,
+	}
+	payload, inputHash, err := HashGenerationInput(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	comparison, err := NewQueued("tenant", "cycle", "comparison-scale", input, payload, inputHash, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := comparison.Start(comparison.Version, now); err != nil {
+		t.Fatal(err)
+	}
+	items := make([]Item, 100_000)
+	for index := range items {
+		id := shared.ID(fmt.Sprintf("identity-%06d", index))
+		items[index] = Item{
+			IdentityID: id, BaselineObservationID: shared.ID("baseline-" + id), CurrentObservationID: shared.ID("current-" + id),
+			Presence: PresenceDetected, ChangeFlags: []ChangeFlag{}, BaselineActionable: true, CurrentActionable: true,
+			ComparableBaseline: true, BaselineRiskMilli: 5000, CurrentRiskMilli: 5000,
+		}
+	}
+	started := time.Now()
+	if err := comparison.Complete(items, comparison.Version, now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if elapsed := time.Since(started); elapsed > 5*time.Minute {
+		t.Fatalf("100k comparison completion took %s", elapsed)
+	}
+	if len(comparison.Items) != 100_000 || comparison.Summary.BaselineCount != 100_000 || comparison.Summary.CurrentCount != 100_000 {
+		t.Fatalf("scale comparison summary=%+v items=%d", comparison.Summary, len(comparison.Items))
+	}
+}

--- a/internal/domain/assessmentcomparison/comparison.go
+++ b/internal/domain/assessmentcomparison/comparison.go
@@ -1,0 +1,689 @@
+package assessmentcomparison
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	AlgorithmVersionV1         = 1
+	CoveragePolicyVersionV1    = 1
+	maxInlineMatchCandidateIDs = 256
+)
+
+type Mode string
+
+const (
+	ModeLifecycle Mode = "lifecycle"
+	ModeNeutral   Mode = "neutral_diff"
+)
+
+func (mode Mode) Valid() bool { return mode == ModeLifecycle || mode == ModeNeutral }
+
+// Scope constrains a read-model summary without changing the immutable comparison artifact.
+// The persisted comparison remains the authoritative all-finding projection; scoped summaries
+// are deterministic views over its immutable items.
+type Scope string
+
+const (
+	ScopeAll           Scope = "all"
+	ScopeVulnerability Scope = "vulnerability"
+	ScopeSecurity      Scope = "security"
+)
+
+func (scope Scope) Valid() bool {
+	return scope == ScopeAll || scope == ScopeVulnerability || scope == ScopeSecurity
+}
+
+func (scope Scope) Matches(item Item) bool {
+	switch scope {
+	case ScopeAll:
+		return true
+	case ScopeVulnerability:
+		return item.FindingKind == "vulnerability"
+	case ScopeSecurity:
+		switch item.FindingKind {
+		case "vulnerability", "sast", "secret", "misconfig":
+			return true
+		}
+	}
+	return false
+}
+
+const (
+	ReasonDirected                    = "directed"
+	ReasonNeutralSibling              = "neutral_sibling"
+	ReasonNeutralReverse              = "neutral_reverse"
+	ReasonSameSnapshot                = "same_snapshot"
+	ReasonCrossCycle                  = "cross_cycle"
+	ReasonSnapshotNotFinalized        = "snapshot_not_finalized"
+	ReasonLifecycleReverse            = "lifecycle_reverse"
+	ReasonLifecycleSibling            = "lifecycle_sibling"
+	ReasonLifecycleDirectionAvailable = "lifecycle_direction_available"
+	ReasonMissingRelationship         = "missing_relationship"
+)
+
+type PairDecision struct {
+	Allowed    bool
+	ReasonCode string
+}
+
+func DecidePair(mode Mode, baseline, current *assessmentsnapshot.Snapshot, members []assessmentcycle.Member) (PairDecision, error) {
+	if !mode.Valid() || baseline == nil || current == nil {
+		return PairDecision{}, fmt.Errorf("%w: comparison mode and snapshots are required", shared.ErrValidation)
+	}
+	if baseline.ID == current.ID {
+		return PairDecision{ReasonCode: ReasonSameSnapshot}, nil
+	}
+	if baseline.TenantID != current.TenantID || baseline.CycleID != current.CycleID {
+		return PairDecision{ReasonCode: ReasonCrossCycle}, nil
+	}
+	if !immutableSnapshot(baseline) || !immutableSnapshot(current) {
+		return PairDecision{ReasonCode: ReasonSnapshotNotFinalized}, nil
+	}
+
+	direction, err := lifecycleDirection(baseline, current, members)
+	if err != nil {
+		if errors.Is(err, shared.ErrNotFound) {
+			return PairDecision{ReasonCode: ReasonMissingRelationship}, nil
+		}
+		return PairDecision{}, err
+	}
+	if mode == ModeLifecycle {
+		switch direction {
+		case 1:
+			return PairDecision{Allowed: true, ReasonCode: ReasonDirected}, nil
+		case -1:
+			return PairDecision{ReasonCode: ReasonLifecycleReverse}, nil
+		default:
+			return PairDecision{ReasonCode: ReasonLifecycleSibling}, nil
+		}
+	}
+	if direction == 1 {
+		return PairDecision{ReasonCode: ReasonLifecycleDirectionAvailable}, nil
+	}
+	if direction == -1 {
+		return PairDecision{Allowed: true, ReasonCode: ReasonNeutralReverse}, nil
+	}
+	return PairDecision{Allowed: true, ReasonCode: ReasonNeutralSibling}, nil
+}
+
+func lifecycleDirection(baseline, current *assessmentsnapshot.Snapshot, members []assessmentcycle.Member) (int, error) {
+	if baseline.AssessmentID == current.AssessmentID {
+		switch {
+		case baseline.SnapshotNumber < current.SnapshotNumber:
+			return 1, nil
+		case baseline.SnapshotNumber > current.SnapshotNumber:
+			return -1, nil
+		default:
+			return 0, fmt.Errorf("%w: snapshots in one assessment cannot share a number", shared.ErrValidation)
+		}
+	}
+	forward, forwardErr := assessmentcycle.IsAncestor(members, baseline.AssessmentID, current.AssessmentID)
+	if forwardErr != nil && !errors.Is(forwardErr, shared.ErrNotFound) {
+		return 0, forwardErr
+	}
+	if forward {
+		return 1, nil
+	}
+	reverse, reverseErr := assessmentcycle.IsAncestor(members, current.AssessmentID, baseline.AssessmentID)
+	if reverseErr != nil && !errors.Is(reverseErr, shared.ErrNotFound) {
+		return 0, reverseErr
+	}
+	if reverse {
+		return -1, nil
+	}
+	if forwardErr != nil || reverseErr != nil {
+		return 0, fmt.Errorf("%w: snapshot assessment is absent from cycle relationships", shared.ErrNotFound)
+	}
+	return 0, nil
+}
+
+func immutableSnapshot(snapshot *assessmentsnapshot.Snapshot) bool {
+	return snapshot.Lifecycle == assessmentsnapshot.LifecycleFinalized || snapshot.Lifecycle == assessmentsnapshot.LifecycleSuperseded
+}
+
+type Presence string
+
+const (
+	PresenceNew          Presence = "new"
+	PresenceDetected     Presence = "still_detected"
+	PresenceNotDetected  Presence = "not_detected_under_comparable_coverage"
+	PresenceNotEvaluated Presence = "not_evaluated"
+	PresenceReopened     Presence = "reopened"
+	PresenceNeedsReview  Presence = "needs_review"
+)
+
+type NeutralPresence string
+
+const (
+	NeutralOnlyA       NeutralPresence = "only_in_a"
+	NeutralBoth        NeutralPresence = "both"
+	NeutralOnlyB       NeutralPresence = "only_in_b"
+	NeutralNeedsReview NeutralPresence = "needs_review"
+)
+
+func (presence Presence) Valid() bool {
+	switch presence {
+	case PresenceNew, PresenceDetected, PresenceNotDetected, PresenceNotEvaluated, PresenceReopened, PresenceNeedsReview:
+		return true
+	}
+	return false
+}
+
+func (presence NeutralPresence) Valid() bool {
+	switch presence {
+	case NeutralOnlyA, NeutralBoth, NeutralOnlyB, NeutralNeedsReview:
+		return true
+	}
+	return false
+}
+
+type FixedBasis string
+
+const (
+	FixedByComparableAbsence    FixedBasis = "comparable_absence"
+	FixedByExplicitVerification FixedBasis = "explicit_verification"
+)
+
+func (basis FixedBasis) Valid() bool {
+	return basis == FixedByComparableAbsence || basis == FixedByExplicitVerification
+}
+
+type ChangeFlag string
+
+const (
+	SeverityIncreased       ChangeFlag = "severity_increased"
+	SeverityDecreased       ChangeFlag = "severity_decreased"
+	ComponentVersionChanged ChangeFlag = "component_version_changed"
+	LocationChanged         ChangeFlag = "location_changed"
+	ReachabilityChanged     ChangeFlag = "reachability_changed"
+	EvidenceChanged         ChangeFlag = "evidence_changed"
+	ScannerChanged          ChangeFlag = "scanner_changed"
+	RuleProfileChanged      ChangeFlag = "rule_profile_changed"
+	AdvisoryChanged         ChangeFlag = "advisory_changed"
+)
+
+func (flag ChangeFlag) Valid() bool {
+	switch flag {
+	case SeverityIncreased, SeverityDecreased, ComponentVersionChanged, LocationChanged, ReachabilityChanged,
+		EvidenceChanged, ScannerChanged, RuleProfileChanged, AdvisoryChanged:
+		return true
+	}
+	return false
+}
+
+type HistoryState struct {
+	Order                int64
+	Observed             bool
+	ComparableAbsence    bool
+	VerifiedRemediation  bool
+	Ambiguous            bool
+	VerificationDecision shared.ID
+}
+
+type ClassifyInput struct {
+	IdentityID             shared.ID
+	Baseline               *findinglineage.Observation
+	Current                *findinglineage.Observation
+	CurrentCoverage        assessmentsnapshot.Comparability
+	Ambiguous              bool
+	History                []HistoryState
+	VerificationID         shared.ID
+	VerificationState      string
+	VerificationRemediated bool
+	BaselineActionable     bool
+	CurrentActionable      bool
+	BaselineRiskMilli      int64
+	CurrentRiskMilli       int64
+}
+
+type Item struct {
+	ID                    shared.ID                        `json:"id"`
+	Position              int                              `json:"position"`
+	IdentityID            shared.ID                        `json:"identity_id"`
+	ProducerKind          string                           `json:"producer_kind"`
+	FindingKind           string                           `json:"finding_kind"`
+	TargetCanonical       string                           `json:"target_canonical"`
+	BaselineObservationID shared.ID                        `json:"baseline_observation_id,omitempty"`
+	CurrentObservationID  shared.ID                        `json:"current_observation_id,omitempty"`
+	BaselineObservation   ObservationView                  `json:"baseline_observation,omitempty"`
+	CurrentObservation    ObservationView                  `json:"current_observation,omitempty"`
+	Presence              Presence                         `json:"presence,omitempty"`
+	NeutralPresence       NeutralPresence                  `json:"neutral_presence,omitempty"`
+	ChangeFlags           []ChangeFlag                     `json:"change_flags"`
+	CoverageDecision      assessmentsnapshot.Comparability `json:"coverage_decision"`
+	MatchMethods          []findinglineage.MatchMethod     `json:"match_methods,omitempty"`
+	VerificationID        shared.ID                        `json:"verification_id,omitempty"`
+	VerificationState     string                           `json:"verification_state,omitempty"`
+	FixedBasis            FixedBasis                       `json:"fixed_basis,omitempty"`
+	BaselineActionable    bool                             `json:"baseline_actionable"`
+	CurrentActionable     bool                             `json:"current_actionable"`
+	ComparableBaseline    bool                             `json:"comparable_baseline"`
+	BaselineRiskMilli     int64                            `json:"baseline_risk_milli"`
+	CurrentRiskMilli      int64                            `json:"current_risk_milli"`
+	ReviewCandidateIDs    []shared.ID                      `json:"review_candidate_ids,omitempty"`
+	ReviewCandidates      []ReviewCandidateView            `json:"review_candidates,omitempty"`
+}
+
+type ReviewCandidateView struct {
+	ID                   shared.ID   `json:"id"`
+	SourceObservationIDs []shared.ID `json:"source_observation_ids"`
+}
+
+type ObservationView struct {
+	Severity         shared.Severity                  `json:"severity"`
+	ComponentVersion string                           `json:"component_version,omitempty"`
+	Location         string                           `json:"location,omitempty"`
+	Reachability     string                           `json:"reachability,omitempty"`
+	EvidenceDigest   string                           `json:"evidence_digest,omitempty"`
+	Scanner          findinglineage.ScannerProvenance `json:"scanner"`
+	ObservedAt       time.Time                        `json:"observed_at"`
+}
+
+func ClassifyLifecycle(input ClassifyInput) (Item, error) {
+	item, err := newItem(input)
+	if err != nil {
+		return Item{}, err
+	}
+	if input.Ambiguous {
+		item.Presence = PresenceNeedsReview
+		return item, nil
+	}
+	switch {
+	case input.Baseline != nil && input.Current != nil:
+		item.Presence = PresenceDetected
+		item.ComparableBaseline = true
+		item.ChangeFlags = changeFlags(*input.Baseline, *input.Current)
+	case input.Baseline != nil:
+		if input.CurrentCoverage == assessmentsnapshot.Comparable {
+			item.Presence, item.ComparableBaseline = PresenceNotDetected, true
+			item.FixedBasis = FixedByComparableAbsence
+		} else {
+			item.Presence = PresenceNotEvaluated
+			if input.VerificationRemediated {
+				item.FixedBasis = FixedByExplicitVerification
+			}
+		}
+	case input.Current != nil:
+		item.Presence = classifyReturn(input.History)
+	default:
+		return Item{}, fmt.Errorf("%w: comparison item requires baseline or current presence", shared.ErrValidation)
+	}
+	return item, nil
+}
+
+func ClassifyNeutral(input ClassifyInput) (Item, error) {
+	item, err := newItem(input)
+	if err != nil {
+		return Item{}, err
+	}
+	if input.Ambiguous {
+		item.NeutralPresence = NeutralNeedsReview
+		return item, nil
+	}
+	switch {
+	case input.Baseline != nil && input.Current != nil:
+		item.NeutralPresence = NeutralBoth
+		item.ChangeFlags = changeFlags(*input.Baseline, *input.Current)
+	case input.Baseline != nil:
+		item.NeutralPresence = NeutralOnlyA
+	case input.Current != nil:
+		item.NeutralPresence = NeutralOnlyB
+	default:
+		return Item{}, fmt.Errorf("%w: neutral item requires presence in either snapshot", shared.ErrValidation)
+	}
+	return item, nil
+}
+
+func newItem(input ClassifyInput) (Item, error) {
+	if input.IdentityID.IsZero() || input.BaselineRiskMilli < 0 || input.CurrentRiskMilli < 0 {
+		return Item{}, fmt.Errorf("%w: comparison item identity and risk are invalid", shared.ErrValidation)
+	}
+	item := Item{
+		IdentityID: input.IdentityID, VerificationID: input.VerificationID, VerificationState: input.VerificationState,
+		BaselineActionable: input.BaselineActionable, CurrentActionable: input.CurrentActionable,
+		BaselineRiskMilli: input.BaselineRiskMilli, CurrentRiskMilli: input.CurrentRiskMilli, ChangeFlags: []ChangeFlag{},
+		CoverageDecision: assessmentsnapshot.NotComparable,
+	}
+	if input.Baseline != nil {
+		item.BaselineObservationID = input.Baseline.ID
+		item.BaselineObservation = projectObservation(*input.Baseline)
+		item.ProducerKind, item.FindingKind, item.TargetCanonical = input.Baseline.ProducerKind, input.Baseline.FindingKind, input.Baseline.TargetCanonical
+	}
+	if input.Current != nil {
+		item.CurrentObservationID = input.Current.ID
+		item.CurrentObservation = projectObservation(*input.Current)
+		if item.ProducerKind == "" {
+			item.ProducerKind, item.FindingKind, item.TargetCanonical = input.Current.ProducerKind, input.Current.FindingKind, input.Current.TargetCanonical
+		} else if item.ProducerKind != input.Current.ProducerKind || item.FindingKind != input.Current.FindingKind || item.TargetCanonical != input.Current.TargetCanonical {
+			return Item{}, fmt.Errorf("%w: comparison observations disagree on immutable identity metadata", shared.ErrValidation)
+		}
+	}
+	return item, nil
+}
+
+func projectObservation(observation findinglineage.Observation) ObservationView {
+	return ObservationView{
+		Severity: observation.Severity, ComponentVersion: observation.ComponentVersion, Location: observation.Location,
+		Reachability: observation.Reachability, EvidenceDigest: observation.EvidenceDigest, Scanner: observation.ScannerProvenance,
+		ObservedAt: observation.ObservedAt,
+	}
+}
+
+func classifyReturn(history []HistoryState) Presence {
+	if len(history) == 0 {
+		return PresenceNew
+	}
+	ordered := append([]HistoryState(nil), history...)
+	sort.SliceStable(ordered, func(i, j int) bool { return ordered[i].Order < ordered[j].Order })
+	for _, state := range ordered {
+		if state.Ambiguous {
+			return PresenceNeedsReview
+		}
+	}
+	seen := false
+	for index := len(ordered) - 1; index >= 0; index-- {
+		state := ordered[index]
+		if state.ComparableAbsence || state.VerifiedRemediation {
+			return PresenceReopened
+		}
+		if state.Observed {
+			seen = true
+			break
+		}
+	}
+	if seen {
+		return PresenceDetected
+	}
+	return PresenceNew
+}
+
+func changeFlags(baseline, current findinglineage.Observation) []ChangeFlag {
+	flags := make([]ChangeFlag, 0, 9)
+	baselineRank, currentRank := shared.SeverityRank(baseline.Severity), shared.SeverityRank(current.Severity)
+	if currentRank > baselineRank {
+		flags = append(flags, SeverityIncreased)
+	} else if currentRank < baselineRank {
+		flags = append(flags, SeverityDecreased)
+	}
+	if baseline.ComponentVersion != current.ComponentVersion {
+		flags = append(flags, ComponentVersionChanged)
+	}
+	if baseline.Location != current.Location {
+		flags = append(flags, LocationChanged)
+	}
+	if baseline.Reachability != current.Reachability {
+		flags = append(flags, ReachabilityChanged)
+	}
+	if baseline.EvidenceDigest != current.EvidenceDigest {
+		flags = append(flags, EvidenceChanged)
+	}
+	if baseline.ScannerProvenance.ToolName != current.ScannerProvenance.ToolName || baseline.ScannerProvenance.ToolVersion != current.ScannerProvenance.ToolVersion {
+		flags = append(flags, ScannerChanged)
+	}
+	if baseline.ScannerProvenance.LaneKey != current.ScannerProvenance.LaneKey {
+		flags = append(flags, RuleProfileChanged)
+	}
+	if baseline.ScannerProvenance.RuleID != current.ScannerProvenance.RuleID {
+		flags = append(flags, AdvisoryChanged)
+	}
+	return flags
+}
+
+type Ratio struct {
+	Numerator   int64  `json:"numerator"`
+	Denominator int64  `json:"denominator"`
+	NAReason    string `json:"na_reason,omitempty"`
+}
+
+type Summary struct {
+	ComparisonID       shared.ID      `json:"comparison_id"`
+	BaselineSnapshotID shared.ID      `json:"baseline_snapshot_id"`
+	CurrentSnapshotID  shared.ID      `json:"current_snapshot_id"`
+	RiskModelVersion   int            `json:"risk_model_version"`
+	FixedRate          Ratio          `json:"fixed_rate"`
+	CountReduction     Ratio          `json:"count_reduction"`
+	RiskReduction      Ratio          `json:"risk_reduction"`
+	FixedCount         int64          `json:"fixed_count"`
+	BaselineCount      int64          `json:"baseline_count"`
+	CurrentCount       int64          `json:"current_count"`
+	BaselineRisk       int64          `json:"baseline_risk"`
+	CurrentRisk        int64          `json:"current_risk"`
+	NewCount           int64          `json:"new_count"`
+	ReopenedCount      int64          `json:"reopened_count"`
+	StillDetectedCount int64          `json:"still_detected_count"`
+	NotEvaluatedCount  int64          `json:"not_evaluated_count"`
+	ReviewCount        int64          `json:"review_count"`
+	NewRisk            int64          `json:"new_risk"`
+	ReopenedRisk       int64          `json:"reopened_risk"`
+	BaselineSeverity   SeverityCounts `json:"baseline_severity"`
+	CurrentSeverity    SeverityCounts `json:"current_severity"`
+}
+
+type SeverityCounts struct {
+	Critical int64 `json:"critical"`
+	High     int64 `json:"high"`
+	Medium   int64 `json:"medium"`
+	Low      int64 `json:"low"`
+	Info     int64 `json:"info"`
+	Unknown  int64 `json:"unknown"`
+}
+
+func Summarize(items []Item) Summary {
+	var summary Summary
+	for _, item := range items {
+		if item.BaselineActionable {
+			summary.BaselineCount++
+			summary.BaselineRisk += item.BaselineRiskMilli
+			summary.BaselineSeverity.add(item.BaselineObservation.Severity)
+			if item.ComparableBaseline {
+				summary.FixedRate.Denominator++
+			}
+		}
+		if item.CurrentActionable {
+			summary.CurrentCount++
+			summary.CurrentRisk += item.CurrentRiskMilli
+			summary.CurrentSeverity.add(item.CurrentObservation.Severity)
+		}
+		if item.Presence == PresenceNotDetected && item.BaselineActionable {
+			summary.FixedCount++
+			summary.FixedRate.Numerator++
+		}
+		switch item.Presence {
+		case PresenceNew:
+			summary.NewCount++
+			summary.NewRisk += item.CurrentRiskMilli
+		case PresenceReopened:
+			summary.ReopenedCount++
+			summary.ReopenedRisk += item.CurrentRiskMilli
+		case PresenceDetected:
+			summary.StillDetectedCount++
+		case PresenceNotEvaluated:
+			summary.NotEvaluatedCount++
+		case PresenceNeedsReview:
+			summary.ReviewCount++
+		}
+		if item.NeutralPresence == NeutralNeedsReview || len(item.ReviewCandidateIDs) > 0 && item.Presence != PresenceNeedsReview {
+			summary.ReviewCount++
+		}
+	}
+	summary.CountReduction = Ratio{Numerator: summary.BaselineCount - summary.CurrentCount, Denominator: summary.BaselineCount}
+	summary.RiskReduction = Ratio{Numerator: summary.BaselineRisk - summary.CurrentRisk, Denominator: summary.BaselineRisk}
+	if summary.FixedRate.Denominator == 0 {
+		summary.FixedRate.NAReason = "no_comparable_actionable_baseline"
+	}
+	if summary.CountReduction.Denominator == 0 {
+		summary.CountReduction.NAReason = "no_actionable_baseline"
+	}
+	if summary.RiskReduction.Denominator <= 0 {
+		summary.RiskReduction.NAReason = "non_positive_baseline_risk"
+	}
+	return summary
+}
+
+func (counts *SeverityCounts) add(severity shared.Severity) {
+	switch severity {
+	case shared.SeverityCritical:
+		counts.Critical++
+	case shared.SeverityHigh:
+		counts.High++
+	case shared.SeverityMedium:
+		counts.Medium++
+	case shared.SeverityLow:
+		counts.Low++
+	case shared.SeverityInfo:
+		counts.Info++
+	default:
+		counts.Unknown++
+	}
+}
+
+type SnapshotHashRef struct {
+	ID          shared.ID
+	ContentHash string
+}
+
+type RelationshipRef struct {
+	AssessmentID        shared.ID
+	PredecessorID       shared.ID
+	RelationshipVersion int64
+}
+
+type GenerationInput struct {
+	Mode                    Mode
+	Baseline                SnapshotHashRef
+	Current                 SnapshotHashRef
+	HistorySnapshots        []SnapshotHashRef
+	Relationships           []RelationshipRef
+	AlgorithmVersion        int
+	FingerprintVersion      int
+	RiskModelVersion        int
+	CoveragePolicyVersion   int
+	ActiveOverrideIDs       []shared.ID
+	MatchCandidateIDs       []shared.ID
+	VerificationDecisionIDs []shared.ID
+}
+
+func HashGenerationInput(input GenerationInput) ([]byte, string, error) {
+	if !input.Mode.Valid() || input.Baseline.ID.IsZero() || input.Current.ID.IsZero() || !validDigest(input.Baseline.ContentHash) || !validDigest(input.Current.ContentHash) {
+		return nil, "", fmt.Errorf("%w: comparison snapshots and mode are invalid", shared.ErrValidation)
+	}
+	if input.AlgorithmVersion <= 0 || input.FingerprintVersion <= 0 || input.RiskModelVersion <= 0 || input.CoveragePolicyVersion <= 0 {
+		return nil, "", fmt.Errorf("%w: comparison generation versions are required", shared.ErrValidation)
+	}
+	relationships := make([]findinglineage.CanonicalValue, len(input.Relationships))
+	for index, relationship := range input.Relationships {
+		if relationship.AssessmentID.IsZero() || relationship.RelationshipVersion <= 0 {
+			return nil, "", fmt.Errorf("%w: comparison relationship is invalid", shared.ErrValidation)
+		}
+		fields := map[string]findinglineage.CanonicalValue{
+			"assessment_id": findinglineage.Text(relationship.AssessmentID.String()),
+			"version":       findinglineage.Integer(relationship.RelationshipVersion),
+		}
+		if !relationship.PredecessorID.IsZero() {
+			fields["predecessor_id"] = findinglineage.Text(relationship.PredecessorID.String())
+		}
+		relationships[index] = findinglineage.Object(fields)
+	}
+	fields := map[string]findinglineage.CanonicalValue{
+		"algorithm_version":       findinglineage.Integer(int64(input.AlgorithmVersion)),
+		"baseline_snapshot_hash":  findinglineage.Text(input.Baseline.ContentHash),
+		"baseline_snapshot_id":    findinglineage.Text(input.Baseline.ID.String()),
+		"coverage_policy_version": findinglineage.Integer(int64(input.CoveragePolicyVersion)),
+		"current_snapshot_hash":   findinglineage.Text(input.Current.ContentHash),
+		"current_snapshot_id":     findinglineage.Text(input.Current.ID.String()),
+		"fingerprint_version":     findinglineage.Integer(int64(input.FingerprintVersion)),
+		"mode":                    findinglineage.Text(string(input.Mode)),
+		"risk_model_version":      findinglineage.Integer(int64(input.RiskModelVersion)),
+	}
+	if len(relationships) > 0 {
+		fields["relationships"] = findinglineage.OrderedArray(relationships...)
+	}
+	if len(input.HistorySnapshots) > 0 {
+		history := make([]findinglineage.CanonicalValue, len(input.HistorySnapshots))
+		for index, snapshot := range input.HistorySnapshots {
+			if snapshot.ID.IsZero() || !validDigest(snapshot.ContentHash) || snapshot.ID == input.Baseline.ID || snapshot.ID == input.Current.ID {
+				return nil, "", fmt.Errorf("%w: comparison history snapshot is invalid", shared.ErrValidation)
+			}
+			history[index] = findinglineage.Object(map[string]findinglineage.CanonicalValue{
+				"content_hash": findinglineage.Text(snapshot.ContentHash),
+				"id":           findinglineage.Text(snapshot.ID.String()),
+			})
+		}
+		fields["history_snapshots"] = findinglineage.OrderedArray(history...)
+	}
+	if values := canonicalIDs(input.ActiveOverrideIDs); len(values) > 0 {
+		fields["active_override_ids"] = findinglineage.StringSet(values...)
+	}
+	if values := canonicalIDs(input.MatchCandidateIDs); len(values) > 0 {
+		if len(values) <= maxInlineMatchCandidateIDs {
+			fields["match_candidate_ids"] = findinglineage.StringSet(values...)
+		} else {
+			// A comparison may legitimately span more than the canonical collection
+			// limit of unresolved candidates. Preserve the full, stable dependency in
+			// the input fingerprint without making lifecycle projection depend on the
+			// serialization limit for a single canonical value.
+			fields["match_candidate_count"] = findinglineage.Integer(int64(len(values)))
+			fields["match_candidate_ids_digest"] = findinglineage.Text(canonicalIDSetDigest(values))
+		}
+	}
+	if values := canonicalIDs(input.VerificationDecisionIDs); len(values) > 0 {
+		fields["verification_decision_ids"] = findinglineage.StringSet(values...)
+	}
+	canonical, err := findinglineage.CanonicalizeFingerprintV1(findinglineage.FingerprintCanonicalInputV1{
+		CanonicalizationVersion: findinglineage.CanonicalizationVersionV1,
+		ProducerKind:            "assessment_comparison", TargetIdentitySchemaVersion: 1,
+		TargetIdentityCanonical: "comparison-input", IdentityFields: fields,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+	digest := sha256.Sum256(append([]byte("synapse:assessment-comparison-input:v1\x00"), canonical.IdentityFields...))
+	return canonical.IdentityFields, hex.EncodeToString(digest[:]), nil
+}
+
+func canonicalIDs(values []shared.ID) []string {
+	unique := map[string]struct{}{}
+	for _, value := range values {
+		if !value.IsZero() {
+			unique[value.String()] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(unique))
+	for value := range unique {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func canonicalIDSetDigest(values []string) string {
+	digest := sha256.New()
+	_, _ = digest.Write([]byte("synapse:assessment-comparison:match-candidate-ids:v1\x00"))
+	for _, value := range values {
+		// Length-prefix each value so adjacent IDs cannot produce an ambiguous
+		// byte stream. values are already deduplicated and sorted by canonicalIDs.
+		_, _ = fmt.Fprintf(digest, "%d:", len(value))
+		_, _ = digest.Write([]byte(value))
+	}
+	return hex.EncodeToString(digest.Sum(nil))
+}
+
+func validDigest(value string) bool {
+	if len(value) != sha256.Size*2 || value != strings.ToLower(value) {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}

--- a/internal/domain/assessmentcomparison/comparison_test.go
+++ b/internal/domain/assessmentcomparison/comparison_test.go
@@ -1,0 +1,277 @@
+package assessmentcomparison
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestDecidePairPartialOrderAndModes(t *testing.T) {
+	members := []assessmentcycle.Member{
+		{TenantID: "tenant", CycleID: "cycle", AssessmentID: "root", AssessmentType: assessmentcycle.AssessmentTypeInitial, RelationshipVersion: 1},
+		{TenantID: "tenant", CycleID: "cycle", AssessmentID: "left", AssessmentType: assessmentcycle.AssessmentTypeRetest, PredecessorAssessmentID: "root", RetestNumber: 1, RelationshipVersion: 2},
+		{TenantID: "tenant", CycleID: "cycle", AssessmentID: "right", AssessmentType: assessmentcycle.AssessmentTypeRetest, PredecessorAssessmentID: "root", RetestNumber: 2, RelationshipVersion: 1},
+	}
+	rootOne := comparisonSnapshot("root-1", "cycle", "root", 1)
+	rootTwo := comparisonSnapshot("root-2", "cycle", "root", 2)
+	left := comparisonSnapshot("left-1", "cycle", "left", 1)
+	right := comparisonSnapshot("right-1", "cycle", "right", 1)
+
+	for _, testCase := range []struct {
+		name              string
+		mode              Mode
+		baseline, current *assessmentsnapshot.Snapshot
+		allowed           bool
+		reason            string
+	}{
+		{name: "same assessment forward", mode: ModeLifecycle, baseline: rootOne, current: rootTwo, allowed: true, reason: ReasonDirected},
+		{name: "same assessment reverse", mode: ModeLifecycle, baseline: rootTwo, current: rootOne, reason: ReasonLifecycleReverse},
+		{name: "same assessment reverse neutral", mode: ModeNeutral, baseline: rootTwo, current: rootOne, allowed: true, reason: ReasonNeutralReverse},
+		{name: "ancestor forward", mode: ModeLifecycle, baseline: rootTwo, current: left, allowed: true, reason: ReasonDirected},
+		{name: "ancestor reverse", mode: ModeLifecycle, baseline: left, current: rootTwo, reason: ReasonLifecycleReverse},
+		{name: "siblings lifecycle", mode: ModeLifecycle, baseline: left, current: right, reason: ReasonLifecycleSibling},
+		{name: "siblings neutral", mode: ModeNeutral, baseline: left, current: right, allowed: true, reason: ReasonNeutralSibling},
+		{name: "directed neutral rejected", mode: ModeNeutral, baseline: rootTwo, current: left, reason: ReasonLifecycleDirectionAvailable},
+		{name: "same snapshot", mode: ModeLifecycle, baseline: rootOne, current: rootOne, reason: ReasonSameSnapshot},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			decision, err := DecidePair(testCase.mode, testCase.baseline, testCase.current, members)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if decision.Allowed != testCase.allowed || decision.ReasonCode != testCase.reason {
+				t.Fatalf("decision=%+v", decision)
+			}
+		})
+	}
+
+	crossCycle := comparisonSnapshot("other", "other-cycle", "right", 1)
+	decision, err := DecidePair(ModeNeutral, left, crossCycle, members)
+	if err != nil || decision.ReasonCode != ReasonCrossCycle {
+		t.Fatalf("cross-cycle decision=%+v err=%v", decision, err)
+	}
+	missing := comparisonSnapshot("missing", "cycle", "missing-assessment", 1)
+	decision, err = DecidePair(ModeLifecycle, rootOne, missing, members)
+	if err != nil || decision.ReasonCode != ReasonMissingRelationship {
+		t.Fatalf("missing relationship decision=%+v err=%v", decision, err)
+	}
+}
+
+func TestLifecycleAndNeutralClassification(t *testing.T) {
+	baseline := comparisonObservation("baseline", shared.SeverityMedium)
+	current := comparisonObservation("current", shared.SeverityHigh)
+	current.ComponentVersion = "2.0.0"
+	current.Location = "src/b.go"
+	current.Reachability = "high"
+	current.EvidenceDigest = strings.Repeat("b", 64)
+	current.ScannerProvenance = findinglineage.ScannerProvenance{ToolName: "scanner-2", ToolVersion: "2", LaneKey: "profile-2", RuleID: "GHSA-2"}
+
+	item, err := ClassifyLifecycle(ClassifyInput{IdentityID: "identity", Baseline: &baseline, Current: &current})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.Presence != PresenceDetected || len(item.ChangeFlags) != 8 || item.ChangeFlags[0] != SeverityIncreased {
+		t.Fatalf("changed item=%+v", item)
+	}
+
+	fixed, err := ClassifyLifecycle(ClassifyInput{
+		IdentityID: "fixed", Baseline: &baseline, CurrentCoverage: assessmentsnapshot.Comparable,
+		BaselineActionable: true, BaselineRiskMilli: 9000,
+	})
+	if err != nil || fixed.Presence != PresenceNotDetected || !fixed.ComparableBaseline || fixed.FixedBasis != FixedByComparableAbsence {
+		t.Fatalf("fixed=%+v err=%v", fixed, err)
+	}
+	verified, err := ClassifyLifecycle(ClassifyInput{
+		IdentityID: "verified", Baseline: &baseline, CurrentCoverage: assessmentsnapshot.NotComparable,
+		VerificationID: "verification-1", VerificationState: "remediated", VerificationRemediated: true,
+	})
+	if err != nil || verified.Presence != PresenceNotEvaluated || verified.FixedBasis != FixedByExplicitVerification {
+		t.Fatalf("verified=%+v err=%v", verified, err)
+	}
+	notEvaluated, err := ClassifyLifecycle(ClassifyInput{IdentityID: "unknown", Baseline: &baseline, CurrentCoverage: assessmentsnapshot.PartiallyComparable})
+	if err != nil || notEvaluated.Presence != PresenceNotEvaluated {
+		t.Fatalf("not evaluated=%+v err=%v", notEvaluated, err)
+	}
+	newItem, err := ClassifyLifecycle(ClassifyInput{IdentityID: "new", Current: &current})
+	if err != nil || newItem.Presence != PresenceNew {
+		t.Fatalf("new=%+v err=%v", newItem, err)
+	}
+	reopened, err := ClassifyLifecycle(ClassifyInput{
+		IdentityID: "reopened", Current: &current,
+		History: []HistoryState{{Order: 1, Observed: true}, {Order: 2, ComparableAbsence: true, VerificationDecision: "verification-1"}},
+	})
+	if err != nil || reopened.Presence != PresenceReopened {
+		t.Fatalf("reopened=%+v err=%v", reopened, err)
+	}
+	reviewHistory, err := ClassifyLifecycle(ClassifyInput{
+		IdentityID: "history-review", Current: &current,
+		History: []HistoryState{{Order: 1, Ambiguous: true}, {Order: 2, Observed: true}},
+	})
+	if err != nil || reviewHistory.Presence != PresenceNeedsReview {
+		t.Fatalf("history review=%+v err=%v", reviewHistory, err)
+	}
+	ambiguous, err := ClassifyLifecycle(ClassifyInput{IdentityID: "ambiguous", Current: &current, Ambiguous: true})
+	if err != nil || ambiguous.Presence != PresenceNeedsReview {
+		t.Fatalf("ambiguous=%+v err=%v", ambiguous, err)
+	}
+
+	neutral, err := ClassifyNeutral(ClassifyInput{IdentityID: "neutral", Baseline: &baseline, Current: &current})
+	if err != nil || neutral.NeutralPresence != NeutralBoth || neutral.Presence != "" {
+		t.Fatalf("neutral=%+v err=%v", neutral, err)
+	}
+}
+
+func TestSummaryAndGenerationHashAreStable(t *testing.T) {
+	items := []Item{
+		{IdentityID: "fixed", Presence: PresenceNotDetected, BaselineActionable: true, ComparableBaseline: true, BaselineRiskMilli: 8000},
+		{IdentityID: "still", Presence: PresenceDetected, BaselineActionable: true, CurrentActionable: true, ComparableBaseline: true, BaselineRiskMilli: 7000, CurrentRiskMilli: 5000},
+		{IdentityID: "new", Presence: PresenceNew, CurrentActionable: true, CurrentRiskMilli: 2000},
+	}
+	summary := Summarize(items)
+	if summary.FixedRate != (Ratio{Numerator: 1, Denominator: 2}) || summary.CountReduction != (Ratio{Numerator: 0, Denominator: 2}) || summary.RiskReduction != (Ratio{Numerator: 8000, Denominator: 15000}) {
+		t.Fatalf("summary=%+v", summary)
+	}
+
+	input := GenerationInput{
+		Mode:     ModeLifecycle,
+		Baseline: SnapshotHashRef{ID: "baseline", ContentHash: strings.Repeat("a", 64)},
+		Current:  SnapshotHashRef{ID: "current", ContentHash: strings.Repeat("b", 64)},
+		Relationships: []RelationshipRef{
+			{AssessmentID: "root", RelationshipVersion: 1},
+			{AssessmentID: "retest", PredecessorID: "root", RelationshipVersion: 2},
+		},
+		AlgorithmVersion: 1, FingerprintVersion: 1, RiskModelVersion: 3, CoveragePolicyVersion: 1,
+		ActiveOverrideIDs: []shared.ID{"override-b", "override-a"}, VerificationDecisionIDs: []shared.ID{"verify-1"},
+	}
+	canonical, digest, err := HashGenerationInput(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const wantDigest = "028407bed04d1e8231001dfc29fc7c2ea0a5655a535624c50c936ec062086750"
+	if digest != wantDigest {
+		t.Fatalf("digest=%s want=%s canonical=%s", digest, wantDigest, canonical)
+	}
+	reordered := input
+	reordered.ActiveOverrideIDs = []shared.ID{"override-a", "override-b", "override-a"}
+	_, replayDigest, err := HashGenerationInput(reordered)
+	if err != nil || replayDigest != digest {
+		t.Fatalf("replay digest=%s err=%v", replayDigest, err)
+	}
+}
+
+func TestScopeMatchesSecurityFindingKinds(t *testing.T) {
+	items := []Item{
+		{FindingKind: "vulnerability"},
+		{FindingKind: "sast"},
+		{FindingKind: "secret"},
+		{FindingKind: "misconfig"},
+		{FindingKind: "quality"},
+		{FindingKind: "reliability"},
+	}
+	wantVulnerability := []bool{true, false, false, false, false, false}
+	wantSecurity := []bool{true, true, true, true, false, false}
+	for index, item := range items {
+		if got := ScopeVulnerability.Matches(item); got != wantVulnerability[index] {
+			t.Errorf("vulnerability scope for %q=%v, want %v", item.FindingKind, got, wantVulnerability[index])
+		}
+		if got := ScopeSecurity.Matches(item); got != wantSecurity[index] {
+			t.Errorf("security scope for %q=%v, want %v", item.FindingKind, got, wantSecurity[index])
+		}
+		if !ScopeAll.Matches(item) {
+			t.Errorf("all scope excluded %q", item.FindingKind)
+		}
+	}
+	if Scope("quality").Valid() {
+		t.Fatal("unexpected custom scope accepted")
+	}
+}
+
+func TestGenerationHashSupportsLargeMatchCandidateSets(t *testing.T) {
+	candidates := make([]shared.ID, 257)
+	for index := range candidates {
+		candidates[index] = shared.ID("candidate-" + strconv.Itoa(index))
+	}
+	input := GenerationInput{
+		Mode:                  ModeLifecycle,
+		Baseline:              SnapshotHashRef{ID: "baseline", ContentHash: strings.Repeat("a", 64)},
+		Current:               SnapshotHashRef{ID: "current", ContentHash: strings.Repeat("b", 64)},
+		AlgorithmVersion:      1,
+		FingerprintVersion:    1,
+		RiskModelVersion:      1,
+		CoveragePolicyVersion: 1,
+		MatchCandidateIDs:     candidates,
+	}
+
+	canonical, digest, err := HashGenerationInput(input)
+	if err != nil {
+		t.Fatalf("large candidate set must be supported: %v", err)
+	}
+	if !strings.Contains(string(canonical), `"match_candidate_count":257`) || !strings.Contains(string(canonical), `"match_candidate_ids_digest":"`) {
+		t.Fatalf("canonical payload must retain a bounded candidate-set summary: %s", canonical)
+	}
+	if strings.Contains(string(canonical), `"match_candidate_ids":`) {
+		t.Fatalf("canonical payload must not embed an unbounded candidate set: %s", canonical)
+	}
+
+	reordered := input
+	reordered.MatchCandidateIDs = append([]shared.ID(nil), candidates...)
+	for left, right := 0, len(reordered.MatchCandidateIDs)-1; left < right; left, right = left+1, right-1 {
+		reordered.MatchCandidateIDs[left], reordered.MatchCandidateIDs[right] = reordered.MatchCandidateIDs[right], reordered.MatchCandidateIDs[left]
+	}
+	_, replayDigest, err := HashGenerationInput(reordered)
+	if err != nil || replayDigest != digest {
+		t.Fatalf("candidate order must not affect fingerprint: digest=%s replay=%s err=%v", digest, replayDigest, err)
+	}
+
+	changed := input
+	changed.MatchCandidateIDs = append([]shared.ID(nil), candidates...)
+	changed.MatchCandidateIDs[len(changed.MatchCandidateIDs)-1] = "candidate-replaced"
+	_, changedDigest, err := HashGenerationInput(changed)
+	if err != nil || changedDigest == digest {
+		t.Fatalf("candidate-set change must affect fingerprint: digest=%s changed=%s err=%v", digest, changedDigest, err)
+	}
+}
+
+func TestGenerationHashKeepsBoundedMatchCandidateSetsInline(t *testing.T) {
+	input := GenerationInput{
+		Mode:                  ModeLifecycle,
+		Baseline:              SnapshotHashRef{ID: "baseline", ContentHash: strings.Repeat("a", 64)},
+		Current:               SnapshotHashRef{ID: "current", ContentHash: strings.Repeat("b", 64)},
+		AlgorithmVersion:      1,
+		FingerprintVersion:    1,
+		RiskModelVersion:      1,
+		CoveragePolicyVersion: 1,
+		MatchCandidateIDs:     []shared.ID{"candidate-1"},
+	}
+	canonical, _, err := HashGenerationInput(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(canonical), `"match_candidate_ids":["candidate-1"]`) {
+		t.Fatalf("bounded candidate set must retain the existing canonical representation: %s", canonical)
+	}
+	if strings.Contains(string(canonical), `"match_candidate_ids_digest":`) {
+		t.Fatalf("bounded candidate set must not change fingerprint representation: %s", canonical)
+	}
+}
+
+func comparisonSnapshot(id, cycleID, assessmentID string, number int) *assessmentsnapshot.Snapshot {
+	return &assessmentsnapshot.Snapshot{
+		TenantID: "tenant", ID: shared.ID(id), CycleID: shared.ID(cycleID), AssessmentID: shared.ID(assessmentID),
+		SnapshotNumber: number, Lifecycle: assessmentsnapshot.LifecycleFinalized,
+	}
+}
+
+func comparisonObservation(id string, severity shared.Severity) findinglineage.Observation {
+	return findinglineage.Observation{
+		ID: shared.ID(id), Severity: severity, ComponentVersion: "1.0.0", Location: "src/a.go", Reachability: "medium",
+		EvidenceDigest: strings.Repeat("a", 64), ScannerProvenance: findinglineage.ScannerProvenance{
+			ToolName: "scanner-1", ToolVersion: "1", LaneKey: "profile-1", RuleID: "CVE-1",
+		},
+	}
+}

--- a/internal/domain/assessmentcycle/boundary.go
+++ b/internal/domain/assessmentcycle/boundary.go
@@ -57,17 +57,17 @@ func ValidateBoundaryEnforcement(kind BoundaryKind, businessAssetID, projectID s
 	return nil
 }
 
-// BoundaryFor derives the frozen boundary kind from the visible associations
-// retained by an Assessment.
+// BoundaryFor derives the frozen key from visible Assessment associations.
+// Hidden execution contexts are rejected separately, never mapped as Projects.
 func BoundaryFor(assetID, projectID shared.ID) BoundaryKind {
-	switch {
-	case !assetID.IsZero() && !projectID.IsZero():
+	if !assetID.IsZero() && !projectID.IsZero() {
 		return BoundaryAssetProject
-	case !assetID.IsZero():
-		return BoundaryAsset
-	case !projectID.IsZero():
-		return BoundaryProject
-	default:
-		return BoundaryStandalone
 	}
+	if !assetID.IsZero() {
+		return BoundaryAsset
+	}
+	if !projectID.IsZero() {
+		return BoundaryProject
+	}
+	return BoundaryStandalone
 }

--- a/internal/domain/assessmentcycle/cycle.go
+++ b/internal/domain/assessmentcycle/cycle.go
@@ -45,21 +45,23 @@ func (s Status) CanTransitionTo(to Status) bool {
 // AssessmentCycle is the aggregate root representing a cohesive series of assessment
 // runs (root assessment + retests) with a frozen asset/project boundary.
 type AssessmentCycle struct {
-	TenantID                 shared.ID
-	ID                       shared.ID
-	Name                     string
-	BoundaryKind             BoundaryKind
-	BusinessAssetID          shared.ID
-	ProjectID                shared.ID
-	Status                   Status
-	RootAssessmentID         shared.ID
-	SelectedHeadAssessmentID shared.ID
-	NextRetestNumber         int
-	Version                  int64
-	CreatedAt                time.Time
-	UpdatedAt                time.Time
-	CreatedBy                string
-	UpdatedBy                string
+	TenantID                  shared.ID
+	ID                        shared.ID
+	Name                      string
+	BoundaryKind              BoundaryKind
+	BusinessAssetID           shared.ID
+	ProjectID                 shared.ID
+	Status                    Status
+	RootAssessmentID          shared.ID
+	SelectedHeadAssessmentID  shared.ID
+	ActiveClosureManifestID   shared.ID
+	ActiveClosureCycleVersion int64
+	NextRetestNumber          int
+	Version                   int64
+	CreatedAt                 time.Time
+	UpdatedAt                 time.Time
+	CreatedBy                 string
+	UpdatedBy                 string
 }
 
 // NewAssessmentCycle constructs and validates a new AssessmentCycle aggregate in open status.
@@ -93,11 +95,8 @@ func NewAssessmentCycle(
 	}
 
 	actor = strings.TrimSpace(actor)
-	if actor == "" || utf8.RuneCountInString(actor) > 256 {
-		return nil, fmt.Errorf("%w: cycle actor must contain between 1 and 256 characters", shared.ErrValidation)
-	}
-	if now.IsZero() {
-		return nil, fmt.Errorf("%w: cycle creation time is required", shared.ErrValidation)
+	if actor == "" || utf8.RuneCountInString(actor) > 256 || now.IsZero() {
+		return nil, fmt.Errorf("%w: actor and creation time are required", shared.ErrValidation)
 	}
 	now = now.UTC()
 
@@ -150,7 +149,45 @@ func (c *AssessmentCycle) Validate() error {
 		strings.TrimSpace(c.UpdatedBy) == "" || utf8.RuneCountInString(strings.TrimSpace(c.UpdatedBy)) > 256 {
 		return fmt.Errorf("%w: cycle actors must contain between 1 and 256 characters", shared.ErrValidation)
 	}
+	if c.ActiveClosureManifestID.IsZero() != (c.ActiveClosureCycleVersion == 0) ||
+		!c.ActiveClosureManifestID.IsZero() && (c.Status != StatusCompleted || c.ActiveClosureCycleVersion != c.Version) {
+		return fmt.Errorf("%w: active closure manifest must match the completed cycle version", shared.ErrValidation)
+	}
 	return nil
+}
+
+// CompleteWithManifest atomically models the aggregate half of a closure commit.
+func (c *AssessmentCycle) CompleteWithManifest(manifestID shared.ID, expectedVersion int64, actor string, now time.Time) error {
+	if c == nil || c.Status != StatusOpen || manifestID.IsZero() || now.IsZero() || strings.TrimSpace(actor) == "" {
+		return fmt.Errorf("%w: open cycle, manifest, actor, and time are required for closure", shared.ErrValidation)
+	}
+	if expectedVersion != c.Version {
+		return fmt.Errorf("%w: cycle version mismatch (expected %d, current %d)", shared.ErrConflict, expectedVersion, c.Version)
+	}
+	c.Status = StatusCompleted
+	c.Version++
+	c.ActiveClosureManifestID = manifestID
+	c.ActiveClosureCycleVersion = c.Version
+	c.UpdatedAt = now.UTC()
+	c.UpdatedBy = strings.TrimSpace(actor)
+	return c.Validate()
+}
+
+// ReopenFromManifest reopens a completed Cycle while preserving its immutable manifest history.
+func (c *AssessmentCycle) ReopenFromManifest(expectedVersion int64, actor string, now time.Time) error {
+	if c == nil || c.Status != StatusCompleted || c.ActiveClosureManifestID.IsZero() || now.IsZero() || strings.TrimSpace(actor) == "" {
+		return fmt.Errorf("%w: completed cycle with an active closure manifest is required", shared.ErrValidation)
+	}
+	if expectedVersion != c.Version {
+		return fmt.Errorf("%w: cycle version mismatch (expected %d, current %d)", shared.ErrConflict, expectedVersion, c.Version)
+	}
+	c.Status = StatusOpen
+	c.Version++
+	c.ActiveClosureManifestID = ""
+	c.ActiveClosureCycleVersion = 0
+	c.UpdatedAt = now.UTC()
+	c.UpdatedBy = strings.TrimSpace(actor)
+	return c.Validate()
 }
 
 // Transition advances the cycle status according to the lifecycle state machine with CAS checking.
@@ -164,17 +201,18 @@ func (c *AssessmentCycle) Transition(to Status, expectedVersion int64, actor str
 	if c.Status == to {
 		return nil
 	}
-	actor = strings.TrimSpace(actor)
-	if actor == "" || utf8.RuneCountInString(actor) > 256 || now.IsZero() {
-		return fmt.Errorf("%w: actor and transition time are required", shared.ErrValidation)
-	}
 	if !c.Status.CanTransitionTo(to) {
 		return fmt.Errorf("%w: cycle cannot transition from %s to %s", shared.ErrValidation, c.Status, to)
 	}
+	actor = strings.TrimSpace(actor)
+	if actor == "" || utf8.RuneCountInString(actor) > 256 || now.IsZero() {
+		return fmt.Errorf("%w: actor and mutation time are required", shared.ErrValidation)
+	}
+
 	c.Status = to
 	c.Version++
 	c.UpdatedAt = now.UTC()
-	c.UpdatedBy = actor
+	c.UpdatedBy = strings.TrimSpace(actor)
 	return nil
 }
 
@@ -194,12 +232,13 @@ func (c *AssessmentCycle) SelectHead(targetAssessmentID shared.ID, expectedVersi
 	}
 	actor = strings.TrimSpace(actor)
 	if actor == "" || utf8.RuneCountInString(actor) > 256 || now.IsZero() {
-		return fmt.Errorf("%w: actor and selection time are required", shared.ErrValidation)
+		return fmt.Errorf("%w: actor and mutation time are required", shared.ErrValidation)
 	}
+
 	c.SelectedHeadAssessmentID = targetAssessmentID
 	c.Version++
 	c.UpdatedAt = now.UTC()
-	c.UpdatedBy = actor
+	c.UpdatedBy = strings.TrimSpace(actor)
 	return nil
 }
 
@@ -214,9 +253,10 @@ func (c *AssessmentCycle) AdvanceRetest(newAssessmentID, predecessorID shared.ID
 	if newAssessmentID.IsZero() || predecessorID.IsZero() {
 		return 0, fmt.Errorf("%w: new assessment id and predecessor id are required", shared.ErrValidation)
 	}
+
 	actor = strings.TrimSpace(actor)
 	if actor == "" || utf8.RuneCountInString(actor) > 256 || now.IsZero() {
-		return 0, fmt.Errorf("%w: actor and retest time are required", shared.ErrValidation)
+		return 0, fmt.Errorf("%w: actor and mutation time are required", shared.ErrValidation)
 	}
 
 	allocatedRetestNumber := c.NextRetestNumber
@@ -227,7 +267,7 @@ func (c *AssessmentCycle) AdvanceRetest(newAssessmentID, predecessorID shared.ID
 	}
 	c.Version++
 	c.UpdatedAt = now.UTC()
-	c.UpdatedBy = actor
+	c.UpdatedBy = strings.TrimSpace(actor)
 
 	return allocatedRetestNumber, nil
 }

--- a/internal/domain/assessmentcycle/cycle_test.go
+++ b/internal/domain/assessmentcycle/cycle_test.go
@@ -62,7 +62,6 @@ func TestNewAssessmentCycle(t *testing.T) {
 		if !errors.Is(err, shared.ErrValidation) {
 			t.Errorf("expected ErrValidation for empty name, got %v", err)
 		}
-
 		_, err = assessmentcycle.NewAssessmentCycle(cycleID, tenantID, "Name", assessmentcycle.BoundaryStandalone, "", "", rootID, "", now)
 		if !errors.Is(err, shared.ErrValidation) {
 			t.Errorf("expected ErrValidation for empty actor, got %v", err)
@@ -131,6 +130,27 @@ func TestAssessmentCycleCASConflict(t *testing.T) {
 	err := c.Transition(assessmentcycle.StatusCompleted, 99, "alice", now)
 	if !errors.Is(err, shared.ErrConflict) {
 		t.Fatalf("expected ErrConflict, got %v", err)
+	}
+}
+
+func TestAssessmentCycleClosureAndReopenBindManifestVersion(t *testing.T) {
+	now := time.Now().UTC()
+	cycle, err := assessmentcycle.NewAssessmentCycle("c-1", "t-1", "Cycle", assessmentcycle.BoundaryStandalone, "", "", "root-1", "alice", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycle.CompleteWithManifest("manifest-1", cycle.Version, "reviewer", now.Add(time.Minute)); err != nil {
+		t.Fatalf("complete with manifest: %v", err)
+	}
+	if cycle.Status != assessmentcycle.StatusCompleted || cycle.ActiveClosureManifestID != "manifest-1" || cycle.ActiveClosureCycleVersion != cycle.Version {
+		t.Fatalf("completed cycle manifest binding=%+v", cycle)
+	}
+	completedVersion := cycle.Version
+	if err := cycle.ReopenFromManifest(completedVersion, "reviewer", now.Add(2*time.Minute)); err != nil {
+		t.Fatalf("reopen from manifest: %v", err)
+	}
+	if cycle.Status != assessmentcycle.StatusOpen || !cycle.ActiveClosureManifestID.IsZero() || cycle.ActiveClosureCycleVersion != 0 || cycle.Version != completedVersion+1 {
+		t.Fatalf("reopened cycle=%+v", cycle)
 	}
 }
 

--- a/internal/domain/assessmentcycle/errors.go
+++ b/internal/domain/assessmentcycle/errors.go
@@ -16,4 +16,6 @@ var (
 	ErrCannotArchiveSelectedHead = fmt.Errorf("%w: currently selected head cannot be archived", shared.ErrValidation)
 	ErrCycleBoundaryMismatch     = fmt.Errorf("%w: assessment does not match cycle boundary", shared.ErrValidation)
 	ErrHiddenProjectContext      = fmt.Errorf("%w: hidden project analysis context assessment cannot become cycle member", shared.ErrValidation)
+	ErrCycleReopenRequired       = fmt.Errorf("%w: cycle_reopen_required", shared.ErrConflict)
+	ErrCycleArchived             = fmt.Errorf("%w: cycle_archived", shared.ErrConflict)
 )

--- a/internal/domain/assessmentcycle/member.go
+++ b/internal/domain/assessmentcycle/member.go
@@ -36,10 +36,12 @@ type Member struct {
 	AssessmentType          AssessmentType
 	PredecessorAssessmentID shared.ID
 	RetestNumber            int
-	RelationshipVersion     int64
-	CreatedAt               time.Time
-	CreatedBy               string
-	ArchivedAt              *time.Time
+	// PlannedDate is a date-only planning hint, never an execution authorization.
+	PlannedDate         string
+	RelationshipVersion int64
+	CreatedAt           time.Time
+	CreatedBy           string
+	ArchivedAt          *time.Time
 }
 
 // NewInitialMember creates the root member for an AssessmentCycle.
@@ -59,8 +61,8 @@ func NewInitialMember(tenantID, cycleID, assessmentID shared.ID, actor string, n
 		PredecessorAssessmentID: "",
 		RetestNumber:            0,
 		RelationshipVersion:     1,
-		CreatedAt:               now.UTC(),
-		CreatedBy:               actor,
+		CreatedAt:               now,
+		CreatedBy:               strings.TrimSpace(actor),
 		ArchivedAt:              nil,
 	}
 	return m, m.Validate()
@@ -85,11 +87,11 @@ func NewRetestMember(
 	if retestNumber <= 0 {
 		return nil, fmt.Errorf("%w: retest number must be positive, got %d", shared.ErrValidation, retestNumber)
 	}
+
 	actor = strings.TrimSpace(actor)
 	if actor == "" || utf8.RuneCountInString(actor) > 256 || now.IsZero() {
 		return nil, fmt.Errorf("%w: member actor and creation time are required", shared.ErrValidation)
 	}
-
 	m := &Member{
 		TenantID:                tenantID,
 		CycleID:                 cycleID,
@@ -98,8 +100,8 @@ func NewRetestMember(
 		PredecessorAssessmentID: predecessorID,
 		RetestNumber:            retestNumber,
 		RelationshipVersion:     1,
-		CreatedAt:               now.UTC(),
-		CreatedBy:               actor,
+		CreatedAt:               now,
+		CreatedBy:               strings.TrimSpace(actor),
 		ArchivedAt:              nil,
 	}
 	return m, m.Validate()
@@ -113,11 +115,17 @@ func (m *Member) Validate() error {
 	if !m.AssessmentType.Valid() {
 		return fmt.Errorf("%w: unknown assessment type %q", shared.ErrValidation, m.AssessmentType)
 	}
-	if m.RelationshipVersion < 1 {
-		return fmt.Errorf("%w: member relationship version must be >= 1, got %d", shared.ErrValidation, m.RelationshipVersion)
+	if m.PlannedDate != "" {
+		date, err := time.Parse(time.DateOnly, m.PlannedDate)
+		if err != nil || date.Year() < 1 || date.Format(time.DateOnly) != m.PlannedDate {
+			return fmt.Errorf("%w: planned_date must be a valid YYYY-MM-DD date", shared.ErrValidation)
+		}
 	}
 	if m.CreatedAt.IsZero() || strings.TrimSpace(m.CreatedBy) == "" || utf8.RuneCountInString(strings.TrimSpace(m.CreatedBy)) > 256 {
 		return fmt.Errorf("%w: member actor and creation time are required", shared.ErrValidation)
+	}
+	if m.RelationshipVersion < 1 {
+		return fmt.Errorf("%w: member relationship version must be >= 1, got %d", shared.ErrValidation, m.RelationshipVersion)
 	}
 
 	if m.AssessmentType == AssessmentTypeInitial {

--- a/internal/domain/assessmentcycle/member_test.go
+++ b/internal/domain/assessmentcycle/member_test.go
@@ -69,7 +69,6 @@ func TestMemberConstructorsAndValidation(t *testing.T) {
 		if !errors.Is(err, shared.ErrValidation) {
 			t.Errorf("expected ErrValidation for empty predecessor, got %v", err)
 		}
-
 		_, err = assessmentcycle.NewRetestMember(tenantID, cycleID, retestID, rootID, 1, "", now)
 		if !errors.Is(err, shared.ErrValidation) {
 			t.Errorf("expected ErrValidation for empty actor, got %v", err)

--- a/internal/domain/assessmentrelationship/model.go
+++ b/internal/domain/assessmentrelationship/model.go
@@ -1,0 +1,305 @@
+package assessmentrelationship
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	SchemaVersion        = 1
+	minCandidateLifetime = 24 * time.Hour
+	maxCandidateLifetime = 90 * 24 * time.Hour
+)
+
+type Confidence string
+
+const (
+	ConfidenceMedium Confidence = "medium"
+	ConfidenceHigh   Confidence = "high"
+)
+
+func (confidence Confidence) Valid() bool {
+	return confidence == ConfidenceMedium || confidence == ConfidenceHigh
+}
+
+type SignalKind string
+
+const (
+	SignalExactBoundary        SignalKind = "exact_frozen_boundary"
+	SignalImportedReference    SignalKind = "explicit_imported_reference"
+	SignalTrustedManifest      SignalKind = "trusted_manifest_compatible"
+	SignalDeterministicOverlap SignalKind = "deterministic_finding_overlap"
+)
+
+func (kind SignalKind) Valid() bool {
+	switch kind {
+	case SignalExactBoundary, SignalImportedReference, SignalTrustedManifest, SignalDeterministicOverlap:
+		return true
+	default:
+		return false
+	}
+}
+
+type Signal struct {
+	Kind          SignalKind `json:"kind"`
+	EvidenceHash  string     `json:"evidence_hash"`
+	MatchCount    int        `json:"match_count,omitempty"`
+	ScoreMilli    int        `json:"score_milli,omitempty"`
+	SchemaVersion int        `json:"schema_version"`
+}
+
+func (signal Signal) Validate() error {
+	if !signal.Kind.Valid() || !validDigest(signal.EvidenceHash) || signal.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("%w: relationship candidate signal is invalid", shared.ErrValidation)
+	}
+	if signal.MatchCount < 0 || signal.ScoreMilli < 0 || signal.ScoreMilli > 1000 {
+		return fmt.Errorf("%w: relationship candidate signal score is invalid", shared.ErrValidation)
+	}
+	switch signal.Kind {
+	case SignalExactBoundary:
+		if signal.MatchCount != 0 || signal.ScoreMilli != 0 {
+			return fmt.Errorf("%w: exact boundary signal score is invalid", shared.ErrValidation)
+		}
+	case SignalImportedReference:
+		if signal.MatchCount != 1 || signal.ScoreMilli != 1000 {
+			return fmt.Errorf("%w: imported relationship signal is invalid", shared.ErrValidation)
+		}
+	case SignalTrustedManifest:
+		if signal.MatchCount < 1 || signal.ScoreMilli != 1000 {
+			return fmt.Errorf("%w: trusted manifest signal is invalid", shared.ErrValidation)
+		}
+	case SignalDeterministicOverlap:
+		if signal.MatchCount < 2 || signal.ScoreMilli < 800 {
+			return fmt.Errorf("%w: deterministic overlap signal is too weak", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+type Candidate struct {
+	TenantID                       shared.ID
+	ID                             shared.ID
+	PredecessorCycleID             shared.ID
+	PredecessorAssessmentID        shared.ID
+	PredecessorRelationshipVersion int64
+	PredecessorSnapshotID          shared.ID
+	PredecessorSnapshotHash        string
+	SuccessorCycleID               shared.ID
+	SuccessorAssessmentID          shared.ID
+	SuccessorRelationshipVersion   int64
+	SuccessorSnapshotID            shared.ID
+	SuccessorSnapshotHash          string
+	BoundaryKeyHash                string
+	Signals                        []Signal
+	InputHash                      string
+	Confidence                     Confidence
+	ExpiresAt                      time.Time
+	CreatedBy                      string
+	CreatedAt                      time.Time
+}
+
+func NewCandidate(candidate Candidate) (Candidate, error) {
+	candidate.CreatedBy = strings.TrimSpace(candidate.CreatedBy)
+	candidate.Signals = append([]Signal(nil), candidate.Signals...)
+	sort.Slice(candidate.Signals, func(left, right int) bool {
+		if candidate.Signals[left].Kind != candidate.Signals[right].Kind {
+			return candidate.Signals[left].Kind < candidate.Signals[right].Kind
+		}
+		return candidate.Signals[left].EvidenceHash < candidate.Signals[right].EvidenceHash
+	})
+	inputHash, err := candidate.ComputeInputHash()
+	if err != nil {
+		return Candidate{}, err
+	}
+	candidate.InputHash = inputHash
+	return candidate, candidate.Validate()
+}
+
+func (candidate Candidate) Validate() error {
+	if candidate.TenantID.IsZero() || candidate.ID.IsZero() || candidate.PredecessorCycleID.IsZero() || candidate.PredecessorAssessmentID.IsZero() || candidate.PredecessorSnapshotID.IsZero() || candidate.SuccessorCycleID.IsZero() || candidate.SuccessorAssessmentID.IsZero() || candidate.SuccessorSnapshotID.IsZero() {
+		return fmt.Errorf("%w: relationship candidate ownership is required", shared.ErrValidation)
+	}
+	if candidate.PredecessorCycleID == candidate.SuccessorCycleID || candidate.PredecessorAssessmentID == candidate.SuccessorAssessmentID {
+		return fmt.Errorf("%w: relationship candidate subjects must differ", shared.ErrValidation)
+	}
+	if candidate.PredecessorRelationshipVersion < 1 || candidate.SuccessorRelationshipVersion < 1 {
+		return fmt.Errorf("%w: relationship candidate versions are invalid", shared.ErrValidation)
+	}
+	if !validDigest(candidate.PredecessorSnapshotHash) || !validDigest(candidate.SuccessorSnapshotHash) || !validDigest(candidate.BoundaryKeyHash) || !validDigest(candidate.InputHash) {
+		return fmt.Errorf("%w: relationship candidate hashes are invalid", shared.ErrValidation)
+	}
+	if !candidate.Confidence.Valid() || len(candidate.Signals) < 2 || len(candidate.Signals) > 4 {
+		return fmt.Errorf("%w: relationship candidate confidence or signals are invalid", shared.ErrValidation)
+	}
+	seen := map[SignalKind]bool{}
+	qualified := false
+	for _, signal := range candidate.Signals {
+		if err := signal.Validate(); err != nil {
+			return err
+		}
+		if seen[signal.Kind] {
+			return fmt.Errorf("%w: relationship candidate signal is duplicated", shared.ErrValidation)
+		}
+		seen[signal.Kind] = true
+		if signal.Kind != SignalExactBoundary {
+			qualified = true
+		}
+	}
+	if !seen[SignalExactBoundary] || !qualified {
+		return fmt.Errorf("%w: exact boundary plus a deterministic relationship signal are required", shared.ErrValidation)
+	}
+	wantConfidence := ConfidenceMedium
+	if len(candidate.Signals) >= 3 {
+		wantConfidence = ConfidenceHigh
+	}
+	if candidate.Confidence != wantConfidence {
+		return fmt.Errorf("%w: relationship candidate confidence does not match its signals", shared.ErrValidation)
+	}
+	lifetime := candidate.ExpiresAt.Sub(candidate.CreatedAt)
+	if candidate.CreatedAt.IsZero() || lifetime < minCandidateLifetime || lifetime > maxCandidateLifetime || candidate.CreatedBy == "" || candidate.CreatedBy != strings.TrimSpace(candidate.CreatedBy) || utf8.RuneCountInString(candidate.CreatedBy) > 256 {
+		return fmt.Errorf("%w: relationship candidate lifecycle metadata is invalid", shared.ErrValidation)
+	}
+	want, err := candidate.ComputeInputHash()
+	if err != nil {
+		return err
+	}
+	if want != candidate.InputHash {
+		return fmt.Errorf("%w: relationship candidate input hash mismatch", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (candidate Candidate) ComputeInputHash() (string, error) {
+	payload := struct {
+		SchemaVersion                  int       `json:"schema_version"`
+		TenantID                       shared.ID `json:"tenant_id"`
+		PredecessorCycleID             shared.ID `json:"predecessor_cycle_id"`
+		PredecessorAssessmentID        shared.ID `json:"predecessor_assessment_id"`
+		PredecessorRelationshipVersion int64     `json:"predecessor_relationship_version"`
+		PredecessorSnapshotID          shared.ID `json:"predecessor_snapshot_id"`
+		PredecessorSnapshotHash        string    `json:"predecessor_snapshot_hash"`
+		SuccessorCycleID               shared.ID `json:"successor_cycle_id"`
+		SuccessorAssessmentID          shared.ID `json:"successor_assessment_id"`
+		SuccessorRelationshipVersion   int64     `json:"successor_relationship_version"`
+		SuccessorSnapshotID            shared.ID `json:"successor_snapshot_id"`
+		SuccessorSnapshotHash          string    `json:"successor_snapshot_hash"`
+		BoundaryKeyHash                string    `json:"boundary_key_hash"`
+		Signals                        []Signal  `json:"signals"`
+	}{
+		SchemaVersion: SchemaVersion, TenantID: candidate.TenantID,
+		PredecessorCycleID: candidate.PredecessorCycleID, PredecessorAssessmentID: candidate.PredecessorAssessmentID,
+		PredecessorRelationshipVersion: candidate.PredecessorRelationshipVersion, PredecessorSnapshotID: candidate.PredecessorSnapshotID,
+		PredecessorSnapshotHash: candidate.PredecessorSnapshotHash, SuccessorCycleID: candidate.SuccessorCycleID,
+		SuccessorAssessmentID: candidate.SuccessorAssessmentID, SuccessorRelationshipVersion: candidate.SuccessorRelationshipVersion,
+		SuccessorSnapshotID: candidate.SuccessorSnapshotID, SuccessorSnapshotHash: candidate.SuccessorSnapshotHash,
+		BoundaryKeyHash: candidate.BoundaryKeyHash, Signals: candidate.Signals,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal relationship candidate input: %w", err)
+	}
+	return digest(encoded), nil
+}
+
+type DecisionAction string
+
+const (
+	DecisionConfirm DecisionAction = "confirm"
+	DecisionReject  DecisionAction = "reject"
+	DecisionDismiss DecisionAction = "dismiss"
+)
+
+func (action DecisionAction) Valid() bool {
+	return action == DecisionConfirm || action == DecisionReject || action == DecisionDismiss
+}
+
+type Decision struct {
+	TenantID        shared.ID
+	ID              shared.ID
+	CandidateID     shared.ID
+	Action          DecisionAction
+	Actor           string
+	Reason          string
+	IdempotencyKey  string
+	RequestHash     string
+	ExpectedVersion int64
+	Version         int64
+	RepairPlanID    shared.ID
+	CreatedAt       time.Time
+}
+
+func (decision Decision) Validate() error {
+	if decision.TenantID.IsZero() || decision.ID.IsZero() || decision.CandidateID.IsZero() || !decision.Action.Valid() || decision.Actor == "" || decision.Actor != strings.TrimSpace(decision.Actor) || utf8.RuneCountInString(decision.Actor) > 256 || decision.Reason == "" || decision.Reason != strings.TrimSpace(decision.Reason) || utf8.RuneCountInString(decision.Reason) > 2000 || decision.IdempotencyKey == "" || decision.IdempotencyKey != strings.TrimSpace(decision.IdempotencyKey) || utf8.RuneCountInString(decision.IdempotencyKey) > 128 || !validDigest(decision.RequestHash) || decision.ExpectedVersion != 1 || decision.Version != 2 || decision.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: relationship candidate decision is invalid", shared.ErrValidation)
+	}
+	if (decision.Action == DecisionConfirm) != !decision.RepairPlanID.IsZero() {
+		return fmt.Errorf("%w: confirmed decision repair plan is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+type RepairPlan struct {
+	TenantID    shared.ID
+	ID          shared.ID
+	CandidateID shared.ID
+	InputHash   string
+	PlanHash    string
+	Body        []byte
+	CreatedBy   string
+	CreatedAt   time.Time
+}
+
+func NewRepairPlan(plan RepairPlan) (RepairPlan, error) {
+	plan.CreatedBy = strings.TrimSpace(plan.CreatedBy)
+	plan.Body = append([]byte(nil), plan.Body...)
+	plan.PlanHash = digest(plan.Body)
+	return plan, plan.Validate()
+}
+
+func (plan RepairPlan) Validate() error {
+	if plan.TenantID.IsZero() || plan.ID.IsZero() || plan.CandidateID.IsZero() || !validDigest(plan.InputHash) || !validDigest(plan.PlanHash) || len(plan.Body) == 0 || len(plan.Body) > 8192 || !json.Valid(plan.Body) || plan.CreatedBy == "" || plan.CreatedBy != strings.TrimSpace(plan.CreatedBy) || utf8.RuneCountInString(plan.CreatedBy) > 256 || plan.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: relationship repair plan is invalid", shared.ErrValidation)
+	}
+	if digest(plan.Body) != plan.PlanHash {
+		return fmt.Errorf("%w: relationship repair plan hash mismatch", shared.ErrValidation)
+	}
+	var body struct {
+		SchemaVersion int       `json:"schema_version"`
+		Command       string    `json:"command"`
+		Execution     string    `json:"execution"`
+		Requires      string    `json:"requires"`
+		CandidateID   shared.ID `json:"candidate_id"`
+		InputHash     string    `json:"input_hash"`
+	}
+	if err := json.Unmarshal(plan.Body, &body); err != nil || body.SchemaVersion != SchemaVersion || body.Command != "assessment_cycle.merge_legacy_relationship" || body.Execution != "blocked" || body.Requires != "separately_approved_move_merge_command" || body.CandidateID != plan.CandidateID || body.InputHash != plan.InputHash {
+		return fmt.Errorf("%w: relationship repair plan body is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+type Record struct {
+	Candidate Candidate
+	Decision  *Decision
+	Plan      *RepairPlan
+}
+
+func digest(value []byte) string {
+	sum := sha256.Sum256(value)
+	return hex.EncodeToString(sum[:])
+}
+
+func validDigest(value string) bool {
+	if len(value) != 64 || value != strings.ToLower(value) {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}

--- a/internal/domain/assessmentrelationship/model_test.go
+++ b/internal/domain/assessmentrelationship/model_test.go
@@ -1,0 +1,65 @@
+package assessmentrelationship
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestSignalValidateEnforcesStrongEvidence(t *testing.T) {
+	digest := strings.Repeat("a", 64)
+	valid := []Signal{
+		{Kind: SignalExactBoundary, EvidenceHash: digest, SchemaVersion: SchemaVersion},
+		{Kind: SignalImportedReference, EvidenceHash: digest, MatchCount: 1, ScoreMilli: 1000, SchemaVersion: SchemaVersion},
+		{Kind: SignalTrustedManifest, EvidenceHash: digest, MatchCount: 1, ScoreMilli: 1000, SchemaVersion: SchemaVersion},
+		{Kind: SignalDeterministicOverlap, EvidenceHash: digest, MatchCount: 2, ScoreMilli: 800, SchemaVersion: SchemaVersion},
+	}
+	for _, signal := range valid {
+		if err := signal.Validate(); err != nil {
+			t.Fatalf("valid %s signal: %v", signal.Kind, err)
+		}
+	}
+
+	invalid := []Signal{
+		{Kind: SignalExactBoundary, EvidenceHash: digest, MatchCount: 1, SchemaVersion: SchemaVersion},
+		{Kind: SignalImportedReference, EvidenceHash: digest, MatchCount: 1, ScoreMilli: 999, SchemaVersion: SchemaVersion},
+		{Kind: SignalTrustedManifest, EvidenceHash: digest, ScoreMilli: 1000, SchemaVersion: SchemaVersion},
+		{Kind: SignalDeterministicOverlap, EvidenceHash: digest, MatchCount: 1, ScoreMilli: 1000, SchemaVersion: SchemaVersion},
+		{Kind: SignalDeterministicOverlap, EvidenceHash: digest, MatchCount: 2, ScoreMilli: 799, SchemaVersion: SchemaVersion},
+	}
+	for _, signal := range invalid {
+		if err := signal.Validate(); err == nil {
+			t.Fatalf("invalid %s signal was accepted: %+v", signal.Kind, signal)
+		}
+	}
+}
+
+func TestCandidateAndRepairPlanValidateRepositoryParity(t *testing.T) {
+	now := time.Date(2026, 9, 2, 1, 0, 0, 0, time.UTC)
+	candidate, err := NewCandidate(Candidate{
+		TenantID: "tenant", ID: "candidate", PredecessorCycleID: "cycle-a", PredecessorAssessmentID: "assessment-a",
+		PredecessorRelationshipVersion: 1, PredecessorSnapshotID: "snapshot-a", PredecessorSnapshotHash: strings.Repeat("a", 64),
+		SuccessorCycleID: "cycle-b", SuccessorAssessmentID: "assessment-b", SuccessorRelationshipVersion: 1,
+		SuccessorSnapshotID: "snapshot-b", SuccessorSnapshotHash: strings.Repeat("b", 64), BoundaryKeyHash: strings.Repeat("c", 64),
+		Signals: []Signal{
+			{Kind: SignalExactBoundary, EvidenceHash: strings.Repeat("c", 64), SchemaVersion: SchemaVersion},
+			{Kind: SignalImportedReference, EvidenceHash: strings.Repeat("d", 64), MatchCount: 1, ScoreMilli: 1000, SchemaVersion: SchemaVersion},
+		},
+		Confidence: ConfidenceMedium, ExpiresAt: now.Add(24 * time.Hour), CreatedBy: "operator", CreatedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidate.ExpiresAt = now.Add(90*time.Hour*24 + time.Second)
+	if err := candidate.Validate(); err == nil {
+		t.Fatal("candidate lifetime above the PostgreSQL ceiling was accepted")
+	}
+
+	body := []byte(`{"schema_version":1,"command":"assessment_cycle.merge_legacy_relationship","execution":"ready","requires":"none","candidate_id":"candidate","input_hash":"` + candidate.InputHash + `"}`)
+	plan, err := NewRepairPlan(RepairPlan{TenantID: "tenant", ID: "plan", CandidateID: shared.ID("candidate"), InputHash: candidate.InputHash, Body: body, CreatedBy: "operator", CreatedAt: now})
+	if err == nil {
+		t.Fatalf("executable repair plan was accepted: plan=%+v", plan)
+	}
+}

--- a/internal/domain/assessmentsnapshot/comparison.go
+++ b/internal/domain/assessmentsnapshot/comparison.go
@@ -1,0 +1,132 @@
+package assessmentsnapshot
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type Comparability string
+
+const (
+	Comparable          Comparability = "comparable"
+	PartiallyComparable Comparability = "partially_comparable"
+	NotComparable       Comparability = "not_comparable"
+)
+
+const (
+	CompareCompleteReevaluation    = "complete_re_evaluation"
+	CompareBaselineIncomplete      = "baseline_coverage_incomplete"
+	CompareCurrentDimensionMissing = "current_dimension_missing"
+	CompareTargetMismatch          = "target_mismatch"
+	CompareCurrentPartial          = "current_coverage_partial"
+	CompareCurrentUnknown          = "current_coverage_unknown"
+	CompareScopeChanged            = "scope_changed"
+	CompareRuleOrProfileChanged    = "rule_or_profile_changed"
+	CompareAdvisoryDatabaseChanged = "advisory_database_changed"
+	CompareProducerVersionChanged  = "producer_version_changed"
+)
+
+type DimensionComparison struct {
+	Baseline      Dimension     `json:"baseline"`
+	Current       *Dimension    `json:"current,omitempty"`
+	Comparability Comparability `json:"comparability"`
+	ReasonCode    string        `json:"reason_code"`
+}
+
+func Compare(baseline, current *Snapshot) ([]DimensionComparison, error) {
+	if baseline == nil || current == nil {
+		return nil, fmt.Errorf("%w: baseline and current snapshots are required", shared.ErrValidation)
+	}
+	if baseline.Lifecycle == LifecycleBuilding || current.Lifecycle == LifecycleBuilding {
+		return nil, fmt.Errorf("%w: only finalized snapshots are comparable", shared.ErrValidation)
+	}
+	if baseline.TenantID != current.TenantID || baseline.CycleID != current.CycleID {
+		return nil, fmt.Errorf("%w: snapshots must belong to the same tenant and cycle", shared.ErrValidation)
+	}
+
+	currentByKey := make(map[string]Dimension, len(current.Dimensions))
+	currentByProducerKind := make(map[string][]Dimension, len(current.Dimensions))
+	for _, dimension := range current.Dimensions {
+		currentByKey[dimensionKey(dimension)] = dimension
+		key := dimension.Producer + "\x00" + dimension.FindingKind
+		currentByProducerKind[key] = append(currentByProducerKind[key], dimension)
+	}
+	comparisons := make([]DimensionComparison, 0, len(baseline.Dimensions))
+	for _, base := range baseline.Dimensions {
+		candidate, found := currentByKey[dimensionKey(base)]
+		if !found {
+			reason := CompareCurrentDimensionMissing
+			if len(currentByProducerKind[base.Producer+"\x00"+base.FindingKind]) > 0 {
+				reason = CompareTargetMismatch
+			}
+			comparisons = append(comparisons, DimensionComparison{Baseline: base, Comparability: NotComparable, ReasonCode: reason})
+			continue
+		}
+		state, reason := compareDimension(base, candidate)
+		copyCandidate := candidate
+		comparisons = append(comparisons, DimensionComparison{Baseline: base, Current: &copyCandidate, Comparability: state, ReasonCode: reason})
+	}
+	sort.Slice(comparisons, func(i, j int) bool {
+		return dimensionKey(comparisons[i].Baseline) < dimensionKey(comparisons[j].Baseline)
+	})
+	return comparisons, nil
+}
+
+func compareDimension(baseline, current Dimension) (Comparability, string) {
+	if current.State == CoverageUnknown {
+		return NotComparable, CompareCurrentUnknown
+	}
+	if current.State == CoveragePartial {
+		return PartiallyComparable, CompareCurrentPartial
+	}
+	if baseline.State != CoverageComplete {
+		return PartiallyComparable, CompareBaselineIncomplete
+	}
+	if !equalStrings(baseline.IncludedScope, current.IncludedScope) || !equalStrings(baseline.ExcludedScope, current.ExcludedScope) {
+		return PartiallyComparable, CompareScopeChanged
+	}
+	if !equalVersionKinds(baseline.Versions, current.Versions, scanrun.VersionRulePack, scanrun.VersionProfile) {
+		return NotComparable, CompareRuleOrProfileChanged
+	}
+	if !equalVersionKinds(baseline.Versions, current.Versions, scanrun.VersionAdvisoryDB) {
+		return PartiallyComparable, CompareAdvisoryDatabaseChanged
+	}
+	if !equalVersionKinds(baseline.Versions, current.Versions, scanrun.VersionTool, scanrun.VersionScanner, scanrun.VersionCorrelation, scanrun.VersionSchema) {
+		return PartiallyComparable, CompareProducerVersionChanged
+	}
+	return Comparable, CompareCompleteReevaluation
+}
+
+func equalVersionKinds(left, right []Version, kinds ...scanrun.VersionKind) bool {
+	allowed := make(map[scanrun.VersionKind]struct{}, len(kinds))
+	for _, kind := range kinds {
+		allowed[kind] = struct{}{}
+	}
+	project := func(values []Version) []string {
+		var out []string
+		for _, value := range values {
+			if _, ok := allowed[value.Kind]; ok {
+				out = append(out, strings.Join([]string{string(value.Kind), value.Name, value.Version, value.Digest}, "\x00"))
+			}
+		}
+		sort.Strings(out)
+		return out
+	}
+	return equalStrings(project(left), project(right))
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/domain/assessmentsnapshot/snapshot.go
+++ b/internal/domain/assessmentsnapshot/snapshot.go
@@ -1,0 +1,390 @@
+// Package assessmentsnapshot defines immutable, comparison-ready Assessment snapshots.
+package assessmentsnapshot
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const SchemaVersion = 1
+
+type Lifecycle string
+
+const (
+	LifecycleBuilding   Lifecycle = "building"
+	LifecycleFinalized  Lifecycle = "finalized"
+	LifecycleSuperseded Lifecycle = "superseded"
+)
+
+type Provenance string
+
+const (
+	ProvenanceNative Provenance = "native"
+	ProvenanceLegacy Provenance = "legacy"
+)
+
+type CoverageState string
+
+const (
+	CoverageComplete CoverageState = "complete"
+	CoveragePartial  CoverageState = "partial"
+	CoverageUnknown  CoverageState = "unknown"
+)
+
+const (
+	ReasonTrustedTerminalLane = "trusted_terminal_lane"
+	ReasonLegacyProvenance    = "legacy_provenance"
+	ReasonRunPartial          = "run_partial"
+	ReasonRunFailed           = "run_failed"
+	ReasonRunCancelled        = "run_cancelled"
+	ReasonLanePartial         = "lane_partial"
+	ReasonLaneFailed          = "lane_failed"
+	ReasonLaneCancelled       = "lane_cancelled"
+	ReasonStageFailed         = "stage_failed"
+	ReasonStageSkipped        = "stage_skipped"
+)
+
+type Boundary struct {
+	BusinessAssetID shared.ID                    `json:"business_asset_id,omitempty"`
+	Kind            assessmentcycle.BoundaryKind `json:"boundary_kind"`
+	ProjectID       shared.ID                    `json:"project_id,omitempty"`
+}
+
+type LaneReference struct {
+	LaneKey      string `json:"lane_key"`
+	ManifestHash string `json:"manifest_hash"`
+}
+
+type RunReference struct {
+	LaneReferences []LaneReference `json:"lane_refs"`
+	ManifestHash   string          `json:"manifest_hash"`
+	RunID          string          `json:"run_id"`
+}
+
+type Target struct {
+	Canonical         string             `json:"canonical"`
+	EvaluatedRevision string             `json:"evaluated_revision,omitempty"`
+	Kind              scanrun.TargetKind `json:"kind"`
+	SchemaVersion     int                `json:"schema_version"`
+}
+
+type Version struct {
+	Digest  string              `json:"digest,omitempty"`
+	Kind    scanrun.VersionKind `json:"kind"`
+	Name    string              `json:"name"`
+	Version string              `json:"version"`
+}
+
+type Dimension struct {
+	ExcludedScope    []string      `json:"excluded_scope"`
+	FindingKind      string        `json:"finding_kind"`
+	IncludedScope    []string      `json:"included_scope"`
+	LaneKey          string        `json:"lane_key"`
+	LaneManifestHash string        `json:"lane_manifest_hash"`
+	Producer         string        `json:"producer"`
+	ReasonCode       string        `json:"reason_code"`
+	RunID            string        `json:"run_id"`
+	State            CoverageState `json:"state"`
+	Target           Target        `json:"target"`
+	Versions         []Version     `json:"versions"`
+}
+
+type Snapshot struct {
+	TenantID       shared.ID
+	ID             shared.ID
+	CycleID        shared.ID
+	AssessmentID   shared.ID
+	SnapshotNumber int
+	DefaultVersion int64
+	Lifecycle      Lifecycle
+	Provenance     Provenance
+	Boundary       Boundary
+	RunReferences  []RunReference
+	Dimensions     []Dimension
+	SchemaVersion  int
+	ContentHash    string
+	RequestKey     string
+	RequestHash    string
+	CreatedAt      time.Time
+	CreatedBy      string
+	FinalizedAt    *time.Time
+	FinalizedBy    string
+	SupersededAt   *time.Time
+	SupersededBy   string
+}
+
+type SelectedRun struct {
+	ID             string
+	ManifestHash   string
+	Provenance     scanrun.ProvenanceKind
+	TerminalStatus scanrun.TerminalStatus
+	Trusted        bool
+	Lanes          []scanrun.Lane
+}
+
+func NewFinalized(tenantID, id, cycleID, assessmentID shared.ID, boundary Boundary, requestKey, actor string, now time.Time, runs []SelectedRun) (*Snapshot, error) {
+	if tenantID.IsZero() || id.IsZero() || cycleID.IsZero() || assessmentID.IsZero() {
+		return nil, fmt.Errorf("%w: snapshot tenant, id, cycle, and assessment are required", shared.ErrValidation)
+	}
+	if strings.TrimSpace(requestKey) == "" || strings.TrimSpace(actor) == "" || now.IsZero() {
+		return nil, fmt.Errorf("%w: snapshot request key, actor, and time are required", shared.ErrValidation)
+	}
+	if err := assessmentcycle.ValidateBoundaryEnforcement(boundary.Kind, boundary.BusinessAssetID, boundary.ProjectID); err != nil {
+		return nil, err
+	}
+	if len(runs) == 0 {
+		return nil, fmt.Errorf("%w: snapshot requires at least one selected run", shared.ErrValidation)
+	}
+
+	runReferences, dimensions, provenance, err := compileRuns(runs)
+	if err != nil {
+		return nil, err
+	}
+	now = now.UTC()
+	snapshot := &Snapshot{
+		TenantID: tenantID, ID: id, CycleID: cycleID, AssessmentID: assessmentID,
+		Lifecycle: LifecycleFinalized, Provenance: provenance, Boundary: boundary,
+		RunReferences: runReferences, Dimensions: dimensions, SchemaVersion: SchemaVersion,
+		RequestKey: strings.TrimSpace(requestKey), CreatedAt: now, CreatedBy: strings.TrimSpace(actor),
+		FinalizedAt: timePointer(now), FinalizedBy: strings.TrimSpace(actor),
+	}
+	contentHash, err := snapshot.computeContentHash()
+	if err != nil {
+		return nil, err
+	}
+	snapshot.ContentHash = contentHash
+	snapshot.RequestHash = contentHash
+	return snapshot, snapshot.Validate()
+}
+
+func (snapshot *Snapshot) Validate() error {
+	if snapshot == nil || snapshot.TenantID.IsZero() || snapshot.ID.IsZero() || snapshot.CycleID.IsZero() || snapshot.AssessmentID.IsZero() {
+		return fmt.Errorf("%w: snapshot identity is invalid", shared.ErrValidation)
+	}
+	if snapshot.SchemaVersion != SchemaVersion || !validSHA256(snapshot.ContentHash) || !validSHA256(snapshot.RequestHash) {
+		return fmt.Errorf("%w: snapshot schema or hash is invalid", shared.ErrValidation)
+	}
+	if snapshot.Lifecycle != LifecycleFinalized && snapshot.Lifecycle != LifecycleSuperseded {
+		return fmt.Errorf("%w: persisted snapshot must be finalized or superseded", shared.ErrValidation)
+	}
+	if snapshot.Provenance != ProvenanceNative && snapshot.Provenance != ProvenanceLegacy {
+		return fmt.Errorf("%w: snapshot provenance is invalid", shared.ErrValidation)
+	}
+	if snapshot.FinalizedAt == nil || snapshot.FinalizedAt.IsZero() || strings.TrimSpace(snapshot.FinalizedBy) == "" {
+		return fmt.Errorf("%w: snapshot finalization metadata is required", shared.ErrValidation)
+	}
+	if snapshot.Lifecycle == LifecycleSuperseded && (snapshot.SupersededAt == nil || strings.TrimSpace(snapshot.SupersededBy) == "") {
+		return fmt.Errorf("%w: superseded snapshot metadata is required", shared.ErrValidation)
+	}
+	want, err := snapshot.computeContentHash()
+	if err != nil {
+		return err
+	}
+	if want != snapshot.ContentHash {
+		return fmt.Errorf("%w: snapshot content hash mismatch", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (snapshot *Snapshot) Supersede(actor string, at time.Time) error {
+	if snapshot == nil || snapshot.Lifecycle != LifecycleFinalized || strings.TrimSpace(actor) == "" || at.IsZero() {
+		return fmt.Errorf("%w: only a finalized snapshot can be superseded", shared.ErrValidation)
+	}
+	snapshot.Lifecycle = LifecycleSuperseded
+	snapshot.SupersededAt = timePointer(at.UTC())
+	snapshot.SupersededBy = strings.TrimSpace(actor)
+	return snapshot.Validate()
+}
+
+func compileRuns(runs []SelectedRun) ([]RunReference, []Dimension, Provenance, error) {
+	ordered := append([]SelectedRun(nil), runs...)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].ID < ordered[j].ID })
+	provenance := ProvenanceNative
+	seenRuns := map[string]struct{}{}
+	seenDimensions := map[string]struct{}{}
+	runReferences := make([]RunReference, 0, len(ordered))
+	var dimensions []Dimension
+	for _, run := range ordered {
+		run.ID = strings.TrimSpace(run.ID)
+		if run.ID == "" || !validSHA256(run.ManifestHash) {
+			return nil, nil, "", fmt.Errorf("%w: selected run identity or manifest hash is invalid", shared.ErrValidation)
+		}
+		if _, exists := seenRuns[run.ID]; exists {
+			return nil, nil, "", fmt.Errorf("%w: selected run %q is duplicated", shared.ErrValidation, run.ID)
+		}
+		seenRuns[run.ID] = struct{}{}
+		if run.Provenance == scanrun.ProvenanceNative {
+			if !run.Trusted {
+				return nil, nil, "", fmt.Errorf("%w: selected native run %q is not trusted sealed provenance", shared.ErrValidation, run.ID)
+			}
+		} else if run.Provenance == scanrun.ProvenanceLegacy {
+			provenance = ProvenanceLegacy
+		} else {
+			return nil, nil, "", fmt.Errorf("%w: selected run provenance is invalid", shared.ErrValidation)
+		}
+
+		lanes := append([]scanrun.Lane(nil), run.Lanes...)
+		sort.Slice(lanes, func(i, j int) bool { return lanes[i].LaneKey < lanes[j].LaneKey })
+		reference := RunReference{RunID: run.ID, ManifestHash: run.ManifestHash}
+		for _, lane := range lanes {
+			if err := validateSealedLane(lane); err != nil {
+				return nil, nil, "", fmt.Errorf("validate selected lane %s/%s: %w", run.ID, lane.LaneKey, err)
+			}
+			reference.LaneReferences = append(reference.LaneReferences, LaneReference{LaneKey: lane.LaneKey, ManifestHash: lane.ManifestHash})
+			for _, findingKind := range sortedUnique(lane.AuthoritativeFindingKinds) {
+				dimension := dimensionFrom(run, lane, findingKind)
+				key := dimensionKey(dimension)
+				if _, exists := seenDimensions[key]; exists {
+					return nil, nil, "", fmt.Errorf("%w: duplicate snapshot coverage dimension %q", shared.ErrValidation, key)
+				}
+				seenDimensions[key] = struct{}{}
+				dimensions = append(dimensions, dimension)
+			}
+		}
+		runReferences = append(runReferences, reference)
+	}
+	sort.Slice(dimensions, func(i, j int) bool { return dimensionKey(dimensions[i]) < dimensionKey(dimensions[j]) })
+	return runReferences, dimensions, provenance, nil
+}
+
+func dimensionFrom(run SelectedRun, lane scanrun.Lane, findingKind string) Dimension {
+	state, reason := coverageDecision(run, lane)
+	versions := make([]Version, 0, len(lane.Versions))
+	for _, version := range lane.Versions {
+		versions = append(versions, Version{Digest: version.Digest, Kind: version.VersionKind, Name: version.Name, Version: version.Version})
+	}
+	sort.Slice(versions, func(i, j int) bool {
+		if versions[i].Kind != versions[j].Kind {
+			return versions[i].Kind < versions[j].Kind
+		}
+		return versions[i].Name < versions[j].Name
+	})
+	return Dimension{
+		ExcludedScope: sortedUnique(lane.ExcludedScope), FindingKind: findingKind,
+		IncludedScope: sortedUnique(lane.IncludedScope), LaneKey: lane.LaneKey, LaneManifestHash: lane.ManifestHash,
+		Producer: lane.Producer, ReasonCode: reason, RunID: run.ID, State: state,
+		Target: Target{
+			Canonical: lane.Target.TargetIdentityCanonical, EvaluatedRevision: lane.Target.EvaluatedRevision,
+			Kind: lane.Target.TargetKind, SchemaVersion: lane.Target.TargetIdentitySchemaVersion,
+		},
+		Versions: versions,
+	}
+}
+
+func validateSealedLane(lane scanrun.Lane) error {
+	if err := lane.Validate(); err != nil {
+		return err
+	}
+	if !lane.TerminalStatus.IsTerminal() || lane.SealedAt == nil || lane.SealedAt.IsZero() || !validSHA256(lane.ManifestHash) {
+		return fmt.Errorf("%w: lane must have terminal, sealed provenance", shared.ErrValidation)
+	}
+	want, err := scanrun.ComputeManifestHash(lane)
+	if err != nil {
+		return err
+	}
+	if want != lane.ManifestHash {
+		return fmt.Errorf("%w: lane manifest hash mismatch", shared.ErrValidation)
+	}
+	return nil
+}
+
+func coverageDecision(run SelectedRun, lane scanrun.Lane) (CoverageState, string) {
+	if run.Provenance == scanrun.ProvenanceLegacy {
+		return CoverageUnknown, ReasonLegacyProvenance
+	}
+	switch run.TerminalStatus {
+	case scanrun.StatusFailed:
+		return CoverageUnknown, ReasonRunFailed
+	case scanrun.StatusCancelled:
+		return CoverageUnknown, ReasonRunCancelled
+	case scanrun.StatusPartial:
+		return CoveragePartial, ReasonRunPartial
+	}
+	switch lane.TerminalStatus {
+	case scanrun.StatusFailed:
+		return CoverageUnknown, ReasonLaneFailed
+	case scanrun.StatusCancelled:
+		return CoverageUnknown, ReasonLaneCancelled
+	case scanrun.StatusPartial:
+		return CoveragePartial, ReasonLanePartial
+	}
+	for _, stage := range lane.Stages {
+		if stage.Status == scanrun.StageFailed {
+			return CoveragePartial, ReasonStageFailed
+		}
+		if stage.Status == scanrun.StageSkipped {
+			return CoveragePartial, ReasonStageSkipped
+		}
+	}
+	return CoverageComplete, ReasonTrustedTerminalLane
+}
+
+func (snapshot Snapshot) computeContentHash() (string, error) {
+	type canonicalSnapshot struct {
+		AssessmentID string         `json:"assessment_id"`
+		Boundary     Boundary       `json:"boundary"`
+		CycleID      string         `json:"cycle_id"`
+		Dimensions   []Dimension    `json:"dimensions"`
+		Provenance   Provenance     `json:"provenance"`
+		RunRefs      []RunReference `json:"run_refs"`
+		Schema       int            `json:"schema_version"`
+		TenantID     string         `json:"tenant_id"`
+	}
+	// ponytail: this schema intentionally contains no maps or floating-point values; use a full
+	// RFC 8785 encoder if future snapshot schemas add either.
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(canonicalSnapshot{
+		AssessmentID: snapshot.AssessmentID.String(), Boundary: snapshot.Boundary,
+		CycleID: snapshot.CycleID.String(), Dimensions: snapshot.Dimensions,
+		Provenance: snapshot.Provenance, RunRefs: snapshot.RunReferences, Schema: snapshot.SchemaVersion,
+		TenantID: snapshot.TenantID.String(),
+	}); err != nil {
+		return "", fmt.Errorf("marshal canonical assessment snapshot: %w", err)
+	}
+	sum := sha256.Sum256(bytes.TrimSuffix(buffer.Bytes(), []byte("\n")))
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func dimensionKey(dimension Dimension) string {
+	return strings.Join([]string{string(dimension.Target.Kind), fmt.Sprintf("%d", dimension.Target.SchemaVersion), dimension.Target.Canonical, dimension.Producer, dimension.FindingKind}, "\x00")
+}
+
+func sortedUnique(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func validSHA256(value string) bool {
+	if len(value) != 64 || strings.ToLower(value) != value {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}
+
+func timePointer(value time.Time) *time.Time { return &value }

--- a/internal/domain/assessmentsnapshot/snapshot_test.go
+++ b/internal/domain/assessmentsnapshot/snapshot_test.go
@@ -1,0 +1,192 @@
+package assessmentsnapshot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+)
+
+func TestSnapshotHashIsStableAcrossInputOrder(t *testing.T) {
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	left, err := NewFinalized("tenant", "snapshot-a", "cycle", "assessment", Boundary{Kind: assessmentcycle.BoundaryStandalone}, "request-a", "operator", now, []SelectedRun{
+		selectedRun("run-b", "producer-b", "secret", "sast"),
+		selectedRun("run-a", "producer-a", "vulnerability", "license"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	right, err := NewFinalized("tenant", "snapshot-b", "cycle", "assessment", Boundary{Kind: assessmentcycle.BoundaryStandalone}, "request-b", "operator", now.Add(time.Hour), []SelectedRun{
+		selectedRun("run-a", "producer-a", "license", "vulnerability"),
+		selectedRun("run-b", "producer-b", "sast", "secret"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if left.ContentHash != right.ContentHash {
+		t.Fatalf("canonical hash changed across order/time/id variation: %s != %s", left.ContentHash, right.ContentHash)
+	}
+}
+
+func TestCoverageAndDirectionalComparability(t *testing.T) {
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	baseline, err := NewFinalized("tenant", "baseline", "cycle", "assessment-a", Boundary{Kind: assessmentcycle.BoundaryStandalone}, "request-a", "operator", now, []SelectedRun{selectedRun("run-a", "sca", "vulnerability")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	current, err := NewFinalized("tenant", "current", "cycle", "assessment-b", Boundary{Kind: assessmentcycle.BoundaryStandalone}, "request-b", "operator", now, []SelectedRun{selectedRun("run-b", "sca", "vulnerability")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	comparisons, err := Compare(baseline, current)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(comparisons) != 1 || comparisons[0].Comparability != Comparable || comparisons[0].ReasonCode != CompareCompleteReevaluation {
+		t.Fatalf("comparison = %+v", comparisons)
+	}
+
+	current.Dimensions[0].State = CoverageUnknown
+	current.Dimensions[0].ReasonCode = ReasonRunFailed
+	comparisons, err = Compare(baseline, current)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if comparisons[0].Comparability != NotComparable || comparisons[0].ReasonCode != CompareCurrentUnknown {
+		t.Fatalf("unknown current coverage upgraded: %+v", comparisons[0])
+	}
+}
+
+func TestCoverageDecisionReasonTable(t *testing.T) {
+	base := selectedRun("run", "sca", "vulnerability")
+	baseLane := base.Lanes[0]
+	cases := []struct {
+		name   string
+		run    SelectedRun
+		lane   scanrun.Lane
+		state  CoverageState
+		reason string
+	}{
+		{"complete", base, baseLane, CoverageComplete, ReasonTrustedTerminalLane},
+		{"legacy", func() SelectedRun { item := base; item.Provenance = scanrun.ProvenanceLegacy; return item }(), baseLane, CoverageUnknown, ReasonLegacyProvenance},
+		{"run partial", func() SelectedRun { item := base; item.TerminalStatus = scanrun.StatusPartial; return item }(), baseLane, CoveragePartial, ReasonRunPartial},
+		{"run failed", func() SelectedRun { item := base; item.TerminalStatus = scanrun.StatusFailed; return item }(), baseLane, CoverageUnknown, ReasonRunFailed},
+		{"run cancelled", func() SelectedRun { item := base; item.TerminalStatus = scanrun.StatusCancelled; return item }(), baseLane, CoverageUnknown, ReasonRunCancelled},
+		{"lane partial", base, func() scanrun.Lane { item := baseLane; item.TerminalStatus = scanrun.StatusPartial; return item }(), CoveragePartial, ReasonLanePartial},
+		{"lane failed", base, func() scanrun.Lane { item := baseLane; item.TerminalStatus = scanrun.StatusFailed; return item }(), CoverageUnknown, ReasonLaneFailed},
+		{"lane cancelled", base, func() scanrun.Lane { item := baseLane; item.TerminalStatus = scanrun.StatusCancelled; return item }(), CoverageUnknown, ReasonLaneCancelled},
+		{"stage failed", base, func() scanrun.Lane {
+			item := baseLane
+			item.Stages = []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageFailed, StartedAt: item.StartedAt}}
+			return item
+		}(), CoveragePartial, ReasonStageFailed},
+		{"stage skipped", base, func() scanrun.Lane {
+			item := baseLane
+			item.Stages = []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSkipped, StartedAt: item.StartedAt}}
+			return item
+		}(), CoveragePartial, ReasonStageSkipped},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			state, reason := coverageDecision(testCase.run, testCase.lane)
+			if state != testCase.state || reason != testCase.reason {
+				t.Fatalf("coverage=(%s,%s), want (%s,%s)", state, reason, testCase.state, testCase.reason)
+			}
+		})
+	}
+}
+
+func TestComparabilityReasonTable(t *testing.T) {
+	base := Dimension{
+		ExcludedScope: []string{"vendor/**"}, FindingKind: "vulnerability", IncludedScope: []string{"src/**"},
+		Producer: "sca", State: CoverageComplete,
+		Target: Target{Kind: scanrun.TargetRepository, SchemaVersion: 1, Canonical: "https://example.com/repo"},
+		Versions: []Version{
+			{Kind: scanrun.VersionRulePack, Name: "rules", Version: "1"},
+			{Kind: scanrun.VersionProfile, Name: "profile", Version: "1"},
+			{Kind: scanrun.VersionAdvisoryDB, Name: "advisories", Version: "1"},
+			{Kind: scanrun.VersionScanner, Name: "scanner", Version: "1"},
+		},
+	}
+	clone := func(dimension Dimension) Dimension {
+		dimension.IncludedScope = append([]string(nil), dimension.IncludedScope...)
+		dimension.ExcludedScope = append([]string(nil), dimension.ExcludedScope...)
+		dimension.Versions = append([]Version(nil), dimension.Versions...)
+		return dimension
+	}
+	setVersion := func(dimension *Dimension, kind scanrun.VersionKind, version string) {
+		for index := range dimension.Versions {
+			if dimension.Versions[index].Kind == kind {
+				dimension.Versions[index].Version = version
+				return
+			}
+		}
+	}
+	cases := []struct {
+		name   string
+		mutate func(*Dimension, *[]Dimension)
+		state  Comparability
+		reason string
+	}{
+		{"complete", func(_ *Dimension, _ *[]Dimension) {}, Comparable, CompareCompleteReevaluation},
+		{"baseline incomplete", func(baseline *Dimension, _ *[]Dimension) { baseline.State = CoveragePartial }, PartiallyComparable, CompareBaselineIncomplete},
+		{"current partial", func(_ *Dimension, current *[]Dimension) { (*current)[0].State = CoveragePartial }, PartiallyComparable, CompareCurrentPartial},
+		{"current unknown", func(_ *Dimension, current *[]Dimension) { (*current)[0].State = CoverageUnknown }, NotComparable, CompareCurrentUnknown},
+		{"scope changed", func(_ *Dimension, current *[]Dimension) { (*current)[0].IncludedScope = []string{"cmd/**"} }, PartiallyComparable, CompareScopeChanged},
+		{"rule changed", func(_ *Dimension, current *[]Dimension) { setVersion(&(*current)[0], scanrun.VersionRulePack, "2") }, NotComparable, CompareRuleOrProfileChanged},
+		{"profile changed", func(_ *Dimension, current *[]Dimension) { setVersion(&(*current)[0], scanrun.VersionProfile, "2") }, NotComparable, CompareRuleOrProfileChanged},
+		{"advisory database changed", func(_ *Dimension, current *[]Dimension) {
+			setVersion(&(*current)[0], scanrun.VersionAdvisoryDB, "2")
+		}, PartiallyComparable, CompareAdvisoryDatabaseChanged},
+		{"scanner changed", func(_ *Dimension, current *[]Dimension) { setVersion(&(*current)[0], scanrun.VersionScanner, "2") }, PartiallyComparable, CompareProducerVersionChanged},
+		{"target mismatch", func(_ *Dimension, current *[]Dimension) { (*current)[0].Target.Canonical = "https://example.com/other" }, NotComparable, CompareTargetMismatch},
+		{"dimension missing", func(_ *Dimension, current *[]Dimension) { *current = nil }, NotComparable, CompareCurrentDimensionMissing},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			baselineDimension := clone(base)
+			currentDimensions := []Dimension{clone(base)}
+			testCase.mutate(&baselineDimension, &currentDimensions)
+			comparisons, err := Compare(
+				&Snapshot{TenantID: "tenant", CycleID: "cycle", Lifecycle: LifecycleFinalized, Dimensions: []Dimension{baselineDimension}},
+				&Snapshot{TenantID: "tenant", CycleID: "cycle", Lifecycle: LifecycleFinalized, Dimensions: currentDimensions},
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(comparisons) != 1 || comparisons[0].Comparability != testCase.state || comparisons[0].ReasonCode != testCase.reason {
+				t.Fatalf("comparison=%+v, want (%s,%s)", comparisons, testCase.state, testCase.reason)
+			}
+		})
+	}
+}
+
+func TestUntrustedNativeRunCannotFinalize(t *testing.T) {
+	run := selectedRun("run", "sca", "vulnerability")
+	run.Trusted = false
+	if _, err := NewFinalized("tenant", "snapshot", "cycle", "assessment", Boundary{Kind: assessmentcycle.BoundaryStandalone}, "request", "operator", time.Now().UTC(), []SelectedRun{run}); err == nil {
+		t.Fatal("untrusted native run produced a finalized snapshot")
+	}
+}
+
+func selectedRun(id, producer string, findingKinds ...string) SelectedRun {
+	finished := time.Date(2026, 8, 31, 11, 5, 0, 0, time.UTC)
+	lane := scanrun.Lane{
+		TenantID: "tenant", EngagementID: "assessment", ScanRunID: id,
+		LaneKey: id + "-lane", Producer: producer, TerminalStatus: scanrun.StatusSucceeded,
+		Target:                    scanrun.TargetIdentity{TargetKind: scanrun.TargetRepository, TargetIdentitySchemaVersion: 1, TargetIdentityCanonical: "https://example.com/repo", EvaluatedRevision: "0123456789abcdef0123456789abcdef01234567"},
+		AuthoritativeFindingKinds: findingKinds, IncludedScope: []string{"src/**"}, ExcludedScope: []string{"vendor/**"},
+		StartedAt: finished.Add(-time.Minute), FinishedAt: &finished, ResultRef: "result:" + id, EvidenceRef: "evidence:" + id,
+		ResultSHA256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ManifestSchemaVersion: 1,
+		Versions: []scanrun.LaneVersion{{VersionKind: scanrun.VersionScanner, Name: "sca", Version: "1"}, {VersionKind: scanrun.VersionRulePack, Name: "rules", Version: "1"}},
+		Stages:   []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSucceeded, StartedAt: finished.Add(-time.Minute), FinishedAt: &finished}},
+	}
+	lane.SealedAt = &finished
+	manifestHash, err := scanrun.ComputeManifestHash(lane)
+	if err != nil {
+		panic(err)
+	}
+	lane.ManifestHash = manifestHash
+	return SelectedRun{ID: id, ManifestHash: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", Provenance: scanrun.ProvenanceNative, TerminalStatus: scanrun.StatusSucceeded, Trusted: true, Lanes: []scanrun.Lane{lane}}
+}

--- a/internal/domain/engagement/engagement.go
+++ b/internal/domain/engagement/engagement.go
@@ -47,15 +47,16 @@ func (s Status) canTransitionTo(to Status) bool {
 
 // Engagement is the aggregate root for a pentest/security assessment.
 type Engagement struct {
-	ID              shared.ID
-	TenantID        shared.ID // multi-tenant-ready; zero value = default tenant in single-tenant mode
-	ProjectID       shared.ID // non-zero for an internal Project analysis context; hidden from engagement lists
-	HostAssetID     shared.ID // non-zero for an internal fleet host vulnerability context; hidden from engagement lists
-	BusinessAssetID shared.ID // optional primary business-level Asset; zero means Unassigned
-	Name            string
-	Client          string
-	Status          Status
-	Scope           Scope
+	ID                  shared.ID
+	TenantID            shared.ID // multi-tenant-ready; zero value = default tenant in single-tenant mode
+	ProjectID           shared.ID // non-zero for an internal Project analysis context; hidden from engagement lists
+	AssessmentProjectID shared.ID // optional visible Assessment association; never makes an Engagement internal
+	HostAssetID         shared.ID // non-zero for an internal fleet host vulnerability context; hidden from engagement lists
+	BusinessAssetID     shared.ID // optional primary business-level Asset; zero means Unassigned
+	Name                string
+	Client              string
+	Status              Status
+	Scope               Scope
 	// RoE holds the minimal rules of engagement (allowed tool classes + blackout
 	// windows) the execution gate enforces alongside scope + the auth window.
 	RoE RoE
@@ -72,6 +73,9 @@ type Engagement struct {
 	// sandbox + egress allowlist exist, active recon is lab-only and must be
 	// explicitly enabled per engagement. Default false (off).
 	LiveReconEnabled bool
+	// RequiresExplicitExecutionAuthorization is set on Assessment Re-tests so
+	// legacy open-window/empty-RoE defaults cannot authorize execution.
+	RequiresExplicitExecutionAuthorization bool
 
 	// Offensive rules of engagement. The offensive governance policy (adversary emulation, exploitation
 	// chains) refuses ANY offensive action until these are set, so they gate the whole offensive pillar,
@@ -184,7 +188,17 @@ func (e *Engagement) IsAuthorizedAt(t time.Time) bool {
 // no tool may run regardless of the authorization window. Draft + Active are both
 // permitted. Enforced by the execution guard before any tool starts.
 func (e *Engagement) AllowsExecution() bool {
-	return e.Status != StatusCompleted && e.Status != StatusArchived
+	if e.Status == StatusCompleted || e.Status == StatusArchived {
+		return false
+	}
+	if !e.RequiresExplicitExecutionAuthorization {
+		return true
+	}
+	// A Re-test must positively name at least one executable tool class. A
+	// blackout-only RoE is merely a negative constraint and, because an empty
+	// allowlist means "all" for legacy engagements, cannot serve as explicit
+	// execution authorization.
+	return e.AuthorizedFrom != nil && e.AuthorizedTo != nil && len(e.RoE.AllowedToolClasses) > 0
 }
 
 // Transition validates and applies a lifecycle status change, stamping UpdatedAt.

--- a/internal/domain/engagement/engagement_test.go
+++ b/internal/domain/engagement/engagement_test.go
@@ -54,6 +54,27 @@ func TestAllowsExecution(t *testing.T) {
 	}
 }
 
+func TestRetestRequiresExplicitExecutionAuthorization(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	engagement := &Engagement{Status: StatusDraft, RequiresExplicitExecutionAuthorization: true}
+	if engagement.AllowsExecution() {
+		t.Fatal("Re-test without explicit authorization and RoE must not execute")
+	}
+	from, to := now.Add(-time.Hour), now.Add(time.Hour)
+	engagement.AuthorizedFrom, engagement.AuthorizedTo = &from, &to
+	if engagement.AllowsExecution() {
+		t.Fatal("authorization window without explicit RoE must not execute")
+	}
+	engagement.RoE = RoE{Blackouts: []Blackout{{From: now.Add(2 * time.Hour), To: now.Add(3 * time.Hour)}}}
+	if engagement.AllowsExecution() {
+		t.Fatal("a blackout-only RoE must not authorize every tool class")
+	}
+	engagement.RoE = RoE{AllowedToolClasses: []ToolClass{"sca"}}
+	if !engagement.AllowsExecution() {
+		t.Fatal("Re-test with explicit authorization window and RoE should execute")
+	}
+}
+
 func TestTransition(t *testing.T) {
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 	cases := []struct {

--- a/internal/domain/findinglineage/canonical.go
+++ b/internal/domain/findinglineage/canonical.go
@@ -1,0 +1,525 @@
+package findinglineage
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode/utf16"
+	"unicode/utf8"
+
+	"golang.org/x/text/unicode/norm"
+)
+
+const (
+	CanonicalizationVersionV1 = 1
+	maxCanonicalDepth         = 8
+	maxCanonicalEntries       = 256
+	maxCanonicalKeyBytes      = 128
+	maxCanonicalTextBytes     = 2048
+	maxCanonicalBytes         = 32 * 1024
+)
+
+var (
+	ErrIncompleteIdentity = errors.New("incomplete finding identity")
+	ErrSensitiveInput     = errors.New("sensitive finding identity input")
+)
+
+type canonicalKind uint8
+
+const (
+	canonicalText canonicalKind = iota + 1
+	canonicalInteger
+	canonicalBoolean
+	canonicalObject
+	canonicalArray
+	canonicalStringSet
+)
+
+type CanonicalValue struct {
+	kind    canonicalKind
+	text    string
+	integer int64
+	boolean bool
+	object  map[string]CanonicalValue
+	array   []CanonicalValue
+	set     []string
+}
+
+func Text(value string) CanonicalValue {
+	return CanonicalValue{kind: canonicalText, text: value}
+}
+
+func Integer(value int64) CanonicalValue {
+	return CanonicalValue{kind: canonicalInteger, integer: value}
+}
+
+func Boolean(value bool) CanonicalValue {
+	return CanonicalValue{kind: canonicalBoolean, boolean: value}
+}
+
+func Object(value map[string]CanonicalValue) CanonicalValue {
+	return CanonicalValue{kind: canonicalObject, object: cloneCanonicalObject(value)}
+}
+
+func OrderedArray(value ...CanonicalValue) CanonicalValue {
+	return CanonicalValue{kind: canonicalArray, array: append([]CanonicalValue(nil), value...)}
+}
+
+func StringSet(value ...string) CanonicalValue {
+	return CanonicalValue{kind: canonicalStringSet, set: append([]string(nil), value...)}
+}
+
+type FingerprintCanonicalInputV1 struct {
+	CanonicalizationVersion     int
+	ProducerKind                string
+	TargetIdentitySchemaVersion int
+	TargetIdentityCanonical     string
+	IdentityFields              map[string]CanonicalValue
+}
+
+type CanonicalFingerprint struct {
+	Bytes          []byte
+	IdentityFields []byte
+	Fingerprint    string
+}
+
+// NormalizeIdentityNamespace returns the exact NFC-normalized values used by
+// fingerprint and source-reference hashing. Repository lookups and writes must
+// use these values as well so canonically equivalent text cannot split a
+// lineage namespace.
+func NormalizeIdentityNamespace(producerKind, findingKind, targetCanonical string) (string, string, string, error) {
+	producer, err := canonicalRequiredText("producer_kind", producerKind, 128)
+	if err != nil {
+		return "", "", "", err
+	}
+	kind, err := canonicalRequiredText("finding_kind", findingKind, 128)
+	if err != nil {
+		return "", "", "", err
+	}
+	target, err := canonicalRequiredText("target_identity_canonical", targetCanonical, maxCanonicalTextBytes)
+	if err != nil {
+		return "", "", "", err
+	}
+	return producer, kind, target, nil
+}
+
+func CanonicalizeFingerprintV1(input FingerprintCanonicalInputV1) (CanonicalFingerprint, error) {
+	if input.CanonicalizationVersion != CanonicalizationVersionV1 {
+		return CanonicalFingerprint{}, fmt.Errorf("%w: canonicalization version must be %d", ErrIncompleteIdentity, CanonicalizationVersionV1)
+	}
+	producer, err := canonicalRequiredText("producer_kind", input.ProducerKind, 128)
+	if err != nil {
+		return CanonicalFingerprint{}, err
+	}
+	if input.TargetIdentitySchemaVersion <= 0 {
+		return CanonicalFingerprint{}, fmt.Errorf("%w: target identity schema version is required", ErrIncompleteIdentity)
+	}
+	target, err := canonicalRequiredText("target_identity_canonical", input.TargetIdentityCanonical, maxCanonicalTextBytes)
+	if err != nil {
+		return CanonicalFingerprint{}, err
+	}
+	if len(input.IdentityFields) == 0 {
+		return CanonicalFingerprint{}, fmt.Errorf("%w: identity fields are required", ErrIncompleteIdentity)
+	}
+
+	fields := Object(input.IdentityFields)
+	fieldsBytes, err := serializeCanonical(fields)
+	if err != nil {
+		return CanonicalFingerprint{}, err
+	}
+	payload := Object(map[string]CanonicalValue{
+		"canonicalization_version":       Integer(CanonicalizationVersionV1),
+		"identity_fields":                fields,
+		"producer_kind":                  Text(producer),
+		"target_identity_canonical":      Text(target),
+		"target_identity_schema_version": Integer(int64(input.TargetIdentitySchemaVersion)),
+	})
+	canonical, err := serializeCanonical(payload)
+	if err != nil {
+		return CanonicalFingerprint{}, err
+	}
+	if len(canonical) > maxCanonicalBytes {
+		return CanonicalFingerprint{}, fmt.Errorf("%w: canonical identity exceeds %d bytes", ErrIncompleteIdentity, maxCanonicalBytes)
+	}
+	digest := sha256.Sum256(append([]byte("synapse:finding-lineage:v1\x00"), canonical...))
+	return CanonicalFingerprint{
+		Bytes:          append([]byte(nil), canonical...),
+		IdentityFields: append([]byte(nil), fieldsBytes...),
+		Fingerprint:    hex.EncodeToString(digest[:]),
+	}, nil
+}
+
+func HashAlias(producerKind, findingKind, targetCanonical string, schemaVersion int, value string) (string, error) {
+	producer, err := canonicalRequiredText("producer_kind", producerKind, 128)
+	if err != nil {
+		return "", err
+	}
+	kind, err := canonicalRequiredText("finding_kind", findingKind, 128)
+	if err != nil {
+		return "", err
+	}
+	target, err := canonicalRequiredText("target_identity_canonical", targetCanonical, maxCanonicalTextBytes)
+	if err != nil {
+		return "", err
+	}
+	alias, err := canonicalRequiredText("alias", value, maxCanonicalTextBytes)
+	if err != nil {
+		return "", err
+	}
+	if schemaVersion <= 0 {
+		return "", fmt.Errorf("%w: alias schema version is required", ErrIncompleteIdentity)
+	}
+	payload, err := serializeCanonical(Object(map[string]CanonicalValue{
+		"alias":            Text(alias),
+		"finding_kind":     Text(kind),
+		"producer_kind":    Text(producer),
+		"schema_version":   Integer(int64(schemaVersion)),
+		"target_canonical": Text(target),
+	}))
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(append([]byte("synapse:finding-alias:v1\x00"), payload...))
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func serializeCanonical(value CanonicalValue) ([]byte, error) {
+	var buffer bytes.Buffer
+	if err := appendCanonical(&buffer, value, 0); err != nil {
+		return nil, err
+	}
+	if buffer.Len() > maxCanonicalBytes {
+		return nil, fmt.Errorf("%w: canonical value exceeds %d bytes", ErrIncompleteIdentity, maxCanonicalBytes)
+	}
+	return buffer.Bytes(), nil
+}
+
+func validateCanonicalIdentityFields(encoded []byte) error {
+	if len(encoded) == 0 || len(encoded) > maxCanonicalBytes {
+		return fmt.Errorf("%w: canonical identity fields must contain 1-%d bytes", ErrIncompleteIdentity, maxCanonicalBytes)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.UseNumber()
+	var decoded any
+	if err := decoder.Decode(&decoded); err != nil {
+		return fmt.Errorf("%w: canonical identity fields are invalid JSON", ErrIncompleteIdentity)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); err != io.EOF {
+		return fmt.Errorf("%w: canonical identity fields contain trailing data", ErrIncompleteIdentity)
+	}
+	object, ok := decoded.(map[string]any)
+	if !ok {
+		return fmt.Errorf("%w: canonical identity fields must be an object", ErrIncompleteIdentity)
+	}
+	return validateCanonicalJSONValue(object, 0)
+}
+
+func validateCanonicalJSONValue(value any, depth int) error {
+	if depth > maxCanonicalDepth {
+		return fmt.Errorf("%w: canonical value exceeds maximum depth", ErrIncompleteIdentity)
+	}
+	switch typed := value.(type) {
+	case string:
+		_, err := canonicalRequiredText("identity value", typed, maxCanonicalTextBytes)
+		return err
+	case json.Number:
+		if _, err := strconv.ParseInt(string(typed), 10, 64); err != nil {
+			return fmt.Errorf("%w: canonical numbers must be signed 64-bit integers", ErrIncompleteIdentity)
+		}
+		return nil
+	case bool:
+		return nil
+	case []any:
+		if len(typed) == 0 || len(typed) > maxCanonicalEntries {
+			return fmt.Errorf("%w: canonical array must contain 1-%d values", ErrIncompleteIdentity, maxCanonicalEntries)
+		}
+		for _, child := range typed {
+			if err := validateCanonicalJSONValue(child, depth+1); err != nil {
+				return err
+			}
+		}
+		return nil
+	case map[string]any:
+		if len(typed) == 0 || len(typed) > maxCanonicalEntries {
+			return fmt.Errorf("%w: canonical object must contain 1-%d fields", ErrIncompleteIdentity, maxCanonicalEntries)
+		}
+		keys := make(map[string]struct{}, len(typed))
+		for rawKey, child := range typed {
+			key, err := canonicalKey(rawKey)
+			if err != nil {
+				return err
+			}
+			if _, exists := keys[key]; exists {
+				return fmt.Errorf("%w: canonical object has duplicate NFC key %q", ErrIncompleteIdentity, key)
+			}
+			keys[key] = struct{}{}
+			if err := validateCanonicalJSONValue(child, depth+1); err != nil {
+				return fmt.Errorf("canonical field %q: %w", key, err)
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("%w: canonical values cannot be null", ErrIncompleteIdentity)
+	}
+}
+
+func appendCanonical(buffer *bytes.Buffer, value CanonicalValue, depth int) error {
+	if depth > maxCanonicalDepth {
+		return fmt.Errorf("%w: canonical value exceeds maximum depth", ErrIncompleteIdentity)
+	}
+	switch value.kind {
+	case canonicalText:
+		text, err := canonicalRequiredText("identity value", value.text, maxCanonicalTextBytes)
+		if err != nil {
+			return err
+		}
+		appendJSONString(buffer, text)
+	case canonicalInteger:
+		fmt.Fprintf(buffer, "%d", value.integer)
+	case canonicalBoolean:
+		if value.boolean {
+			buffer.WriteString("true")
+		} else {
+			buffer.WriteString("false")
+		}
+	case canonicalObject:
+		if len(value.object) == 0 || len(value.object) > maxCanonicalEntries {
+			return fmt.Errorf("%w: canonical object must contain 1-%d fields", ErrIncompleteIdentity, maxCanonicalEntries)
+		}
+		normalized := make(map[string]CanonicalValue, len(value.object))
+		keys := make([]string, 0, len(value.object))
+		for rawKey, child := range value.object {
+			key, err := canonicalKey(rawKey)
+			if err != nil {
+				return err
+			}
+			if _, exists := normalized[key]; exists {
+				return fmt.Errorf("%w: canonical object has duplicate NFC key %q", ErrIncompleteIdentity, key)
+			}
+			normalized[key] = child
+			keys = append(keys, key)
+		}
+		sort.Slice(keys, func(left, right int) bool { return utf16Less(keys[left], keys[right]) })
+		buffer.WriteByte('{')
+		for index, key := range keys {
+			if index > 0 {
+				buffer.WriteByte(',')
+			}
+			appendJSONString(buffer, key)
+			buffer.WriteByte(':')
+			if err := appendCanonical(buffer, normalized[key], depth+1); err != nil {
+				return fmt.Errorf("canonical field %q: %w", key, err)
+			}
+		}
+		buffer.WriteByte('}')
+	case canonicalArray:
+		if len(value.array) == 0 || len(value.array) > maxCanonicalEntries {
+			return fmt.Errorf("%w: canonical array must contain 1-%d values", ErrIncompleteIdentity, maxCanonicalEntries)
+		}
+		buffer.WriteByte('[')
+		for index, child := range value.array {
+			if index > 0 {
+				buffer.WriteByte(',')
+			}
+			if err := appendCanonical(buffer, child, depth+1); err != nil {
+				return err
+			}
+		}
+		buffer.WriteByte(']')
+	case canonicalStringSet:
+		if len(value.set) == 0 || len(value.set) > maxCanonicalEntries {
+			return fmt.Errorf("%w: canonical string set must contain 1-%d values", ErrIncompleteIdentity, maxCanonicalEntries)
+		}
+		unique := make(map[string]struct{}, len(value.set))
+		values := make([]string, 0, len(value.set))
+		for _, raw := range value.set {
+			text, err := canonicalRequiredText("identity set value", raw, maxCanonicalTextBytes)
+			if err != nil {
+				return err
+			}
+			if _, exists := unique[text]; exists {
+				continue
+			}
+			unique[text] = struct{}{}
+			values = append(values, text)
+		}
+		sort.Slice(values, func(left, right int) bool { return utf16Less(values[left], values[right]) })
+		buffer.WriteByte('[')
+		for index, text := range values {
+			if index > 0 {
+				buffer.WriteByte(',')
+			}
+			appendJSONString(buffer, text)
+		}
+		buffer.WriteByte(']')
+	default:
+		return fmt.Errorf("%w: unsupported canonical value", ErrIncompleteIdentity)
+	}
+	return nil
+}
+
+func canonicalKey(value string) (string, error) {
+	key, err := canonicalRequiredText("identity field name", value, maxCanonicalKeyBytes)
+	if err != nil {
+		return "", err
+	}
+	normalized := strings.Map(func(char rune) rune {
+		if char >= 'a' && char <= 'z' || char >= '0' && char <= '9' {
+			return char
+		}
+		if char >= 'A' && char <= 'Z' {
+			return char + ('a' - 'A')
+		}
+		return -1
+	}, key)
+	if SensitiveIdentityKey(normalized) {
+		return "", fmt.Errorf("%w: field %q is not allowed", ErrSensitiveInput, key)
+	}
+	if timestampCanonicalKeys[normalized] {
+		return "", fmt.Errorf("%w: timestamp field %q is not semantic identity", ErrIncompleteIdentity, key)
+	}
+	return key, nil
+}
+
+func canonicalRequiredText(field, value string, maxBytes int) (string, error) {
+	if !utf8.ValidString(value) {
+		return "", fmt.Errorf("%w: %s must be valid UTF-8", ErrIncompleteIdentity, field)
+	}
+	value = norm.NFC.String(value)
+	if strings.TrimSpace(value) == "" {
+		return "", fmt.Errorf("%w: %s is required", ErrIncompleteIdentity, field)
+	}
+	if len(value) > maxBytes {
+		return "", fmt.Errorf("%w: %s exceeds %d bytes", ErrIncompleteIdentity, field, maxBytes)
+	}
+	return value, nil
+}
+
+func appendJSONString(buffer *bytes.Buffer, value string) {
+	const hexDigits = "0123456789abcdef"
+	buffer.WriteByte('"')
+	for _, char := range value {
+		switch char {
+		case '"':
+			buffer.WriteString(`\"`)
+		case '\\':
+			buffer.WriteString(`\\`)
+		case '\b':
+			buffer.WriteString(`\b`)
+		case '\t':
+			buffer.WriteString(`\t`)
+		case '\n':
+			buffer.WriteString(`\n`)
+		case '\f':
+			buffer.WriteString(`\f`)
+		case '\r':
+			buffer.WriteString(`\r`)
+		default:
+			if char < 0x20 {
+				buffer.WriteString(`\u00`)
+				buffer.WriteByte(hexDigits[byte(char)>>4])
+				buffer.WriteByte(hexDigits[byte(char)&0x0f])
+			} else {
+				buffer.WriteRune(char)
+			}
+		}
+	}
+	buffer.WriteByte('"')
+}
+
+func utf16Less(left, right string) bool {
+	leftUnits := utf16.Encode([]rune(left))
+	rightUnits := utf16.Encode([]rune(right))
+	limit := len(leftUnits)
+	if len(rightUnits) < limit {
+		limit = len(rightUnits)
+	}
+	for index := 0; index < limit; index++ {
+		if leftUnits[index] != rightUnits[index] {
+			return leftUnits[index] < rightUnits[index]
+		}
+	}
+	return len(leftUnits) < len(rightUnits)
+}
+
+func cloneCanonicalObject(input map[string]CanonicalValue) map[string]CanonicalValue {
+	if input == nil {
+		return nil
+	}
+	output := make(map[string]CanonicalValue, len(input))
+	for key, value := range input {
+		output[key] = value
+	}
+	return output
+}
+
+var sensitiveIdentityMarkers = []string{
+	"accesstoken", "apikey", "apitoken", "auth", "authorization", "clientsecret",
+	"credential", "credentials", "password", "passwd", "privatekey", "refreshtoken",
+	"secret", "sessionkey", "token",
+}
+
+// SensitiveIdentityKey is the shared denylist for canonical fields and producer
+// adapters. Callers should pass either a raw or already-normalized key.
+func SensitiveIdentityKey(value string) bool {
+	normalized := normalizeSensitiveKey(value)
+	for _, marker := range sensitiveIdentityMarkers {
+		if normalized == marker {
+			return true
+		}
+	}
+	return false
+}
+
+// SensitiveIdentityQualifier detects secret-bearing compound qualifier names.
+func SensitiveIdentityQualifier(value string) bool {
+	normalized := normalizeSensitiveKey(value)
+	for _, marker := range sensitiveIdentityMarkers {
+		if strings.Contains(normalized, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// ContainsSensitiveAssignment detects credential-shaped values without
+// persisting or echoing the secret material.
+func ContainsSensitiveAssignment(value string) bool {
+	lower := strings.ToLower(value)
+	for _, marker := range []string{
+		"access_token=", "accesstoken=", "api_key=", "apikey=", "api_token=", "apitoken=",
+		"client_secret=", "clientsecret=", "credential=", "credentials=", "password=", "passwd=",
+		"private_key=", "privatekey=", "refresh_token=", "refreshtoken=", "secret=", "session_key=",
+		"sessionkey=", "token=", "authorization:", "bearer ",
+	} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeSensitiveKey(value string) string {
+	return strings.Map(func(char rune) rune {
+		if char >= 'a' && char <= 'z' || char >= '0' && char <= '9' {
+			return char
+		}
+		if char >= 'A' && char <= 'Z' {
+			return char + ('a' - 'A')
+		}
+		return -1
+	}, value)
+}
+
+var timestampCanonicalKeys = map[string]bool{
+	"createdat": true, "discoveredat": true, "firstseenat": true, "lastseenat": true,
+	"observedat": true, "scannedat": true, "timestamp": true, "updatedat": true,
+}

--- a/internal/domain/findinglineage/canonical_json.go
+++ b/internal/domain/findinglineage/canonical_json.go
@@ -1,0 +1,54 @@
+package findinglineage
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// MarshalJSON preserves the canonical value when native producer inputs are
+// retained. The unexported representation must never silently encode as {}.
+func (value CanonicalValue) MarshalJSON() ([]byte, error) { return serializeCanonical(value) }
+
+func (value *CanonicalValue) UnmarshalJSON(data []byte) error {
+	if len(data) > maxCanonicalBytes {
+		return fmt.Errorf("%w: canonical value too large", ErrIncompleteIdentity)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var decoded any
+	if err := decoder.Decode(&decoded); err != nil {
+		return err
+	}
+	if err := validateCanonicalJSONValue(decoded, 0); err != nil {
+		return err
+	}
+	*value = canonicalFromJSON(decoded)
+	return nil
+}
+
+func canonicalFromJSON(value any) CanonicalValue {
+	switch typed := value.(type) {
+	case string:
+		return Text(typed)
+	case bool:
+		return Boolean(typed)
+	case json.Number:
+		n, _ := typed.Int64()
+		return Integer(n) // checked by validation
+	case []any:
+		items := make([]CanonicalValue, len(typed))
+		for index, child := range typed {
+			items[index] = canonicalFromJSON(child)
+		}
+		return OrderedArray(items...)
+	case map[string]any:
+		fields := make(map[string]CanonicalValue, len(typed))
+		for key, child := range typed {
+			fields[key] = canonicalFromJSON(child)
+		}
+		return Object(fields)
+	default:
+		return CanonicalValue{} // unreachable after validation
+	}
+}

--- a/internal/domain/findinglineage/canonical_json_test.go
+++ b/internal/domain/findinglineage/canonical_json_test.go
@@ -1,0 +1,48 @@
+package findinglineage
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestCanonicalValueRetainedRoundTrip(t *testing.T) {
+	input := FingerprintCanonicalInputV1{CanonicalizationVersion: 1, ProducerKind: "sca", TargetIdentitySchemaVersion: 1, TargetIdentityCanonical: "repo:example", IdentityFields: map[string]CanonicalValue{
+		"path": OrderedArray(Text("root"), Text("leaf")), "ids": StringSet("B", "A", "A"), "anchor": Object(map[string]CanonicalValue{"index": Integer(3), "direct": Boolean(true)}),
+	}}
+	before, err := CanonicalizeFingerprintV1(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var restored FingerprintCanonicalInputV1
+	if err := json.Unmarshal(encoded, &restored); err != nil {
+		t.Fatal(err)
+	}
+	after, err := CanonicalizeFingerprintV1(restored)
+	if err != nil || before.Fingerprint != after.Fingerprint {
+		t.Fatalf("retention changed identity: before=%s after=%s err=%v", before.Fingerprint, after.Fingerprint, err)
+	}
+}
+
+func TestCanonicalValueRejectsInvalidRetainedValues(t *testing.T) {
+	for _, raw := range []string{`null`, `[]`, `{}`, `1.5`} {
+		var value CanonicalValue
+		if err := json.Unmarshal([]byte(raw), &value); err == nil {
+			t.Fatalf("accepted invalid canonical value %s", raw)
+		}
+	}
+}
+
+func TestCanonicalValueRejectsSensitiveRetainedKey(t *testing.T) {
+	// A boolean is a valid canonical value, but the sensitive field name must
+	// still be rejected. No credential-shaped string is needed for this fixture.
+	var value CanonicalValue
+	err := json.Unmarshal([]byte(`{"password":true}`), &value)
+	if !errors.Is(err, ErrSensitiveInput) {
+		t.Fatalf("expected sensitive-key rejection, got %v", err)
+	}
+}

--- a/internal/domain/findinglineage/canonical_test.go
+++ b/internal/domain/findinglineage/canonical_test.go
@@ -1,0 +1,182 @@
+package findinglineage
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestCanonicalizeFingerprintV1GoldenVector(t *testing.T) {
+	input := FingerprintCanonicalInputV1{
+		CanonicalizationVersion:     CanonicalizationVersionV1,
+		ProducerKind:                "sca",
+		TargetIdentitySchemaVersion: 2,
+		TargetIdentityCanonical:     "pkg:golang/example.com/mod",
+		IdentityFields: map[string]CanonicalValue{
+			"rule_id": Text("GO-2026-0001"),
+			"symbols": StringSet("Zeta", "Alpha", "Alpha"),
+			"nested": Object(map[string]CanonicalValue{
+				"enabled": Boolean(true),
+				"count":   Integer(2),
+			}),
+			"unicode": Text("e\u0301"),
+		},
+	}
+	got, err := CanonicalizeFingerprintV1(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantCanonical := `{"canonicalization_version":1,"identity_fields":{"nested":{"count":2,"enabled":true},"rule_id":"GO-2026-0001","symbols":["Alpha","Zeta"],"unicode":"é"},"producer_kind":"sca","target_identity_canonical":"pkg:golang/example.com/mod","target_identity_schema_version":2}`
+	if string(got.Bytes) != wantCanonical {
+		t.Fatalf("canonical bytes\n got: %s\nwant: %s", got.Bytes, wantCanonical)
+	}
+	const wantFingerprint = "b05cad5e6b9c01a020e6e06ca81e311fc3a007c3d3207188c4300735bd89e274"
+	if got.Fingerprint != wantFingerprint {
+		t.Fatalf("fingerprint=%s want=%s", got.Fingerprint, wantFingerprint)
+	}
+
+	nfc := input
+	nfc.IdentityFields = cloneCanonicalObject(input.IdentityFields)
+	nfc.IdentityFields["unicode"] = Text("é")
+	second, err := CanonicalizeFingerprintV1(nfc)
+	if err != nil || second.Fingerprint != got.Fingerprint {
+		t.Fatalf("NFC fingerprint=%s err=%v", second.Fingerprint, err)
+	}
+}
+
+func TestCanonicalizeRejectsSensitiveTimestampAndEmptyValues(t *testing.T) {
+	base := FingerprintCanonicalInputV1{
+		CanonicalizationVersion:     CanonicalizationVersionV1,
+		ProducerKind:                "sast",
+		TargetIdentitySchemaVersion: 1,
+		TargetIdentityCanonical:     "repo:example",
+	}
+	for name, testCase := range map[string]struct {
+		fields map[string]CanonicalValue
+		target error
+	}{
+		"sensitive": {map[string]CanonicalValue{"api_token": Text("redacted")}, ErrSensitiveInput},
+		"timestamp": {map[string]CanonicalValue{"observed_at": Text("2026-08-31T00:00:00Z")}, ErrIncompleteIdentity},
+		"empty":     {map[string]CanonicalValue{"rule_id": Text(" ")}, ErrIncompleteIdentity},
+	} {
+		t.Run(name, func(t *testing.T) {
+			input := base
+			input.IdentityFields = testCase.fields
+			_, err := CanonicalizeFingerprintV1(input)
+			if !errors.Is(err, testCase.target) {
+				t.Fatalf("error=%v want=%v", err, testCase.target)
+			}
+		})
+	}
+}
+
+func TestIdentityValidateRejectsSensitiveCanonicalJSON(t *testing.T) {
+	identity := Identity{
+		TenantID: "tenant", CycleID: "cycle", ID: "identity", FirstSeenSnapshotID: "snapshot",
+		ProducerKind: "sca", FindingKind: "vulnerability", CanonicalizationVersion: 1,
+		FingerprintSchemaVersion: 1, LineageFingerprint: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		TargetIdentitySchemaVersion: 1, TargetIdentityCanonical: "repo:example",
+		CanonicalIdentityFields: []byte(`{"nested":{"api_token":"redacted"}}`), CreatedAt: time.Unix(1, 0).UTC(),
+	}
+	if err := identity.Validate(); !errors.Is(err, ErrSensitiveInput) {
+		t.Fatalf("error=%v want=%v", err, ErrSensitiveInput)
+	}
+}
+
+func TestIdentityAndObservationCannotCarryWorkflowState(t *testing.T) {
+	banned := map[string]bool{
+		"AcceptedRisk": true, "FalsePositive": true, "Remediation": true,
+		"Assignee": true, "SLA": true, "VerificationState": true,
+		"RawEvidence": true, "Password": true, "Token": true, "Credentials": true,
+	}
+	for _, value := range []any{Identity{}, Observation{}} {
+		typeOf := reflect.TypeOf(value)
+		for index := 0; index < typeOf.NumField(); index++ {
+			if banned[typeOf.Field(index).Name] {
+				t.Fatalf("%s exposes workflow field %s", typeOf.Name(), typeOf.Field(index).Name)
+			}
+		}
+	}
+}
+
+func TestVerifyConformanceRejectsMissingMetadataAndUnprefixedHash(t *testing.T) {
+	descriptor := MatcherDescriptor{
+		ProducerKind: "sca", FindingKind: "vulnerability", Method: MethodMatcher, MethodVersion: 1,
+		CanonicalizationVersion: 1, FingerprintSchemaVersion: 1, TargetIdentitySchemaVersion: 1,
+	}
+	input := FingerprintCanonicalInputV1{
+		CanonicalizationVersion: 1, ProducerKind: "sca", TargetIdentitySchemaVersion: 1,
+		TargetIdentityCanonical: "repo:example", IdentityFields: map[string]CanonicalValue{"rule_id": Text("GO-2026-0001")},
+	}
+	fingerprint, err := CanonicalizeFingerprintV1(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := VerifyConformance(descriptor, []ConformanceVector{{Name: "valid", Input: input, ExpectedFingerprint: fingerprint.Fingerprint}}); err != nil {
+		t.Fatal(err)
+	}
+	missing := input
+	missing.ProducerKind = ""
+	if err := VerifyConformance(descriptor, []ConformanceVector{{Name: "missing metadata", Input: missing, ExpectedFingerprint: fingerprint.Fingerprint}}); err == nil {
+		t.Fatal("conformance accepted missing producer metadata")
+	}
+	rawDigest := sha256.Sum256(fingerprint.Bytes)
+	if err := VerifyConformance(descriptor, []ConformanceVector{{Name: "unprefixed", Input: input, ExpectedFingerprint: hex.EncodeToString(rawDigest[:])}}); err == nil {
+		t.Fatal("conformance accepted a hash without the lineage domain prefix")
+	}
+	sensitive := input
+	sensitive.IdentityFields = map[string]CanonicalValue{"password": Text("redacted")}
+	if err := VerifyConformance(descriptor, []ConformanceVector{{Name: "redaction", Input: sensitive, ExpectedError: ErrSensitiveInput}}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSourceReferenceHashNormalizesUnicodeAndFramesFields(t *testing.T) {
+	composed, err := SourceReferenceHash("sast", "finding", "repo:Café", "finding-a", "occurrence-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	decomposed, err := SourceReferenceHash("sast", "finding", "repo:Cafe\u0301", "finding-a", "occurrence-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if composed != decomposed {
+		t.Fatalf("NFC-equivalent source references diverged: %s != %s", composed, decomposed)
+	}
+	first, err := SourceReferenceHash("sast", "finding", "repo:example", "a\x00b", "c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := SourceReferenceHash("sast", "finding", "repo:example", "a", "b\x00c")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatal("structured source-reference framing collapsed distinct embedded-delimiter tuples")
+	}
+}
+
+func TestContainsSensitiveAssignmentDistinguishesNamespacesFromCredentials(t *testing.T) {
+	for _, safe := range []string{
+		"secret:generic-secret:config/app.env:9",
+		"auth:rule:src/auth.go:12",
+		"token:rule:src/parser.go:5",
+	} {
+		if ContainsSensitiveAssignment(safe) {
+			t.Fatalf("namespace %q was classified as credential material", safe)
+		}
+	}
+	for _, sensitive := range []string{
+		"password=hunter2",
+		"api_key=redacted",
+		"Authorization: Bearer redacted",
+		"client_secret=redacted",
+	} {
+		if !ContainsSensitiveAssignment(sensitive) {
+			t.Fatalf("credential assignment %q was not rejected", sensitive)
+		}
+	}
+}

--- a/internal/domain/findinglineage/matcher.go
+++ b/internal/domain/findinglineage/matcher.go
@@ -1,0 +1,108 @@
+package findinglineage
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type MatcherDescriptor struct {
+	ProducerKind                string
+	FindingKind                 string
+	Method                      MatchMethod
+	MethodVersion               int
+	CanonicalizationVersion     int
+	FingerprintSchemaVersion    int
+	TargetIdentitySchemaVersion int
+}
+
+func (descriptor MatcherDescriptor) Validate() error {
+	if err := validateShort("matcher producer kind", descriptor.ProducerKind); err != nil {
+		return err
+	}
+	if err := validateShort("matcher finding kind", descriptor.FindingKind); err != nil {
+		return err
+	}
+	if !descriptor.Method.Valid() || descriptor.MethodVersion <= 0 || descriptor.CanonicalizationVersion != CanonicalizationVersionV1 || descriptor.FingerprintSchemaVersion <= 0 || descriptor.TargetIdentitySchemaVersion <= 0 {
+		return fmt.Errorf("%w: matcher descriptor versions are invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+type MatcherRequest struct {
+	Fingerprint         CanonicalFingerprint
+	SourceReferenceHash string
+}
+
+type MatcherResult struct {
+	Method     MatchMethod
+	Version    int
+	Reasons    []string
+	Candidates []CandidateRef
+}
+
+func (result MatcherResult) Validate(descriptor MatcherDescriptor) error {
+	if err := descriptor.Validate(); err != nil {
+		return err
+	}
+	if result.Method != descriptor.Method || result.Version != descriptor.MethodVersion {
+		return fmt.Errorf("%w: matcher result metadata does not match descriptor", shared.ErrValidation)
+	}
+	if len(result.Reasons) == 0 || len(result.Reasons) > maxReasonPayload {
+		return fmt.Errorf("%w: matcher reasons are required and bounded", shared.ErrValidation)
+	}
+	for _, reason := range result.Reasons {
+		if err := validateShort("matcher reason", reason); err != nil {
+			return err
+		}
+	}
+	if len(result.Candidates) > maxCandidateRefs {
+		return fmt.Errorf("%w: matcher returned too many candidates", shared.ErrValidation)
+	}
+	for _, candidate := range result.Candidates {
+		if err := candidate.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type ConformanceVector struct {
+	Name                string
+	Input               FingerprintCanonicalInputV1
+	ExpectedFingerprint string
+	ExpectedError       error
+}
+
+func VerifyConformance(descriptor MatcherDescriptor, vectors []ConformanceVector) error {
+	if err := descriptor.Validate(); err != nil {
+		return err
+	}
+	if len(vectors) == 0 {
+		return fmt.Errorf("%w: conformance vectors are required", shared.ErrValidation)
+	}
+	for _, vector := range vectors {
+		if strings.TrimSpace(vector.Name) == "" {
+			return fmt.Errorf("%w: conformance vector name is required", shared.ErrValidation)
+		}
+		if vector.Input.ProducerKind != descriptor.ProducerKind || vector.Input.CanonicalizationVersion != descriptor.CanonicalizationVersion || vector.Input.TargetIdentitySchemaVersion != descriptor.TargetIdentitySchemaVersion {
+			return fmt.Errorf("%w: conformance vector %q omits required matcher metadata", shared.ErrValidation, vector.Name)
+		}
+		fingerprint, err := CanonicalizeFingerprintV1(vector.Input)
+		if vector.ExpectedError != nil {
+			if !errors.Is(err, vector.ExpectedError) {
+				return fmt.Errorf("conformance vector %q error = %v, expected %v", vector.Name, err, vector.ExpectedError)
+			}
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("conformance vector %q: %w", vector.Name, err)
+		}
+		if !validDigest(vector.ExpectedFingerprint) || fingerprint.Fingerprint != vector.ExpectedFingerprint {
+			return fmt.Errorf("%w: conformance vector %q fingerprint mismatch", shared.ErrValidation, vector.Name)
+		}
+	}
+	return nil
+}

--- a/internal/domain/findinglineage/model.go
+++ b/internal/domain/findinglineage/model.go
@@ -1,0 +1,850 @@
+package findinglineage
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	maxShortTextBytes  = 256
+	maxReasonTextBytes = 2000
+	maxReasonPayload   = 16
+	maxCandidateRefs   = 64
+	maxProvenanceText  = 512
+)
+
+type Identity struct {
+	TenantID                    shared.ID
+	CycleID                     shared.ID
+	ID                          shared.ID
+	ProducerKind                string
+	FindingKind                 string
+	CanonicalizationVersion     int
+	FingerprintSchemaVersion    int
+	LineageFingerprint          string
+	TargetIdentitySchemaVersion int
+	TargetIdentityCanonical     string
+	CanonicalIdentityFields     []byte
+	FirstSeenSnapshotID         shared.ID
+	CreatedAt                   time.Time
+}
+
+func (identity Identity) Validate() error {
+	if identity.TenantID.IsZero() || identity.CycleID.IsZero() || identity.ID.IsZero() || identity.FirstSeenSnapshotID.IsZero() {
+		return fmt.Errorf("%w: finding identity ownership is required", shared.ErrValidation)
+	}
+	if err := validateShort("producer kind", identity.ProducerKind); err != nil {
+		return err
+	}
+	if err := validateShort("finding kind", identity.FindingKind); err != nil {
+		return err
+	}
+	if identity.CanonicalizationVersion != CanonicalizationVersionV1 || identity.FingerprintSchemaVersion <= 0 || identity.TargetIdentitySchemaVersion <= 0 {
+		return fmt.Errorf("%w: finding identity versions are invalid", shared.ErrValidation)
+	}
+	if !validDigest(identity.LineageFingerprint) {
+		return fmt.Errorf("%w: lineage fingerprint must be a SHA-256 digest", shared.ErrValidation)
+	}
+	if err := validateText("target identity", identity.TargetIdentityCanonical, maxCanonicalTextBytes); err != nil {
+		return err
+	}
+	if err := validateCanonicalIdentityFields(identity.CanonicalIdentityFields); err != nil {
+		return fmt.Errorf("validate canonical identity fields: %w", err)
+	}
+	if identity.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: finding identity creation time is required", shared.ErrValidation)
+	}
+	return nil
+}
+
+type Alias struct {
+	TenantID        shared.ID
+	CycleID         shared.ID
+	ID              shared.ID
+	IdentityID      shared.ID
+	ProducerKind    string
+	FindingKind     string
+	TargetCanonical string
+	SchemaVersion   int
+	Fingerprint     string
+	ApprovedBy      string
+	ApprovedAt      time.Time
+}
+
+func (alias Alias) Validate() error {
+	if alias.TenantID.IsZero() || alias.CycleID.IsZero() || alias.ID.IsZero() || alias.IdentityID.IsZero() {
+		return fmt.Errorf("%w: alias ownership is required", shared.ErrValidation)
+	}
+	if err := validateShort("alias producer kind", alias.ProducerKind); err != nil {
+		return err
+	}
+	if err := validateShort("alias finding kind", alias.FindingKind); err != nil {
+		return err
+	}
+	if err := validateText("alias target", alias.TargetCanonical, maxCanonicalTextBytes); err != nil {
+		return err
+	}
+	if alias.SchemaVersion <= 0 || !validDigest(alias.Fingerprint) {
+		return fmt.Errorf("%w: alias schema and fingerprint are required", shared.ErrValidation)
+	}
+	if err := validateShort("alias approver", alias.ApprovedBy); err != nil {
+		return err
+	}
+	if alias.ApprovedAt.IsZero() {
+		return fmt.Errorf("%w: alias approval time is required", shared.ErrValidation)
+	}
+	return nil
+}
+
+type ScannerProvenance struct {
+	ScanRunID   string `json:"scan_run_id,omitempty"`
+	LaneKey     string `json:"lane_key,omitempty"`
+	ToolName    string `json:"tool_name"`
+	ToolVersion string `json:"tool_version,omitempty"`
+	RuleID      string `json:"rule_id,omitempty"`
+}
+
+func (provenance ScannerProvenance) Validate() error {
+	if err := validateShort("scanner tool name", provenance.ToolName); err != nil {
+		return err
+	}
+	for label, value := range map[string]string{
+		"scan run id": provenance.ScanRunID, "lane key": provenance.LaneKey,
+		"tool version": provenance.ToolVersion, "rule id": provenance.RuleID,
+	} {
+		if value != "" {
+			if err := validateText(label, value, maxProvenanceText); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+type Observation struct {
+	TenantID           shared.ID
+	CycleID            shared.ID
+	ID                 shared.ID
+	SnapshotID         shared.ID
+	IdentityID         shared.ID
+	ProducerKind       string
+	FindingKind        string
+	TargetCanonical    string
+	SourceFindingID    string
+	SourceOccurrenceID string
+	Severity           shared.Severity
+	RiskScoreMilli     *int
+	ComponentVersion   string
+	Location           string
+	Reachability       string
+	EvidenceDigest     string
+	ScannerProvenance  ScannerProvenance
+	ObservedAt         time.Time
+}
+
+func (observation Observation) Validate() error {
+	if observation.TenantID.IsZero() || observation.CycleID.IsZero() || observation.ID.IsZero() || observation.SnapshotID.IsZero() || observation.IdentityID.IsZero() {
+		return fmt.Errorf("%w: finding observation ownership is required", shared.ErrValidation)
+	}
+	if err := validateShort("observation producer kind", observation.ProducerKind); err != nil {
+		return err
+	}
+	if err := validateShort("observation finding kind", observation.FindingKind); err != nil {
+		return err
+	}
+	if err := validateText("observation target", observation.TargetCanonical, maxCanonicalTextBytes); err != nil {
+		return err
+	}
+	if observation.SourceFindingID == "" && observation.SourceOccurrenceID == "" {
+		return fmt.Errorf("%w: source finding or occurrence id is required", shared.ErrValidation)
+	}
+	for label, value := range map[string]string{
+		"source finding id": observation.SourceFindingID, "source occurrence id": observation.SourceOccurrenceID,
+		"component version": observation.ComponentVersion, "location": observation.Location, "reachability": observation.Reachability,
+	} {
+		if value != "" {
+			if err := validateText(label, value, maxProvenanceText); err != nil {
+				return err
+			}
+		}
+	}
+	if !observation.Severity.Valid() {
+		return fmt.Errorf("%w: observation severity is invalid", shared.ErrValidation)
+	}
+	if observation.RiskScoreMilli != nil && (*observation.RiskScoreMilli < 0 || *observation.RiskScoreMilli > 10000) {
+		return fmt.Errorf("%w: risk score must be between 0 and 10000 milli-points", shared.ErrValidation)
+	}
+	if observation.EvidenceDigest != "" && !validDigest(observation.EvidenceDigest) {
+		return fmt.Errorf("%w: evidence digest must be a SHA-256 digest", shared.ErrValidation)
+	}
+	if err := observation.ScannerProvenance.Validate(); err != nil {
+		return err
+	}
+	if observation.ObservedAt.IsZero() {
+		return fmt.Errorf("%w: observation time is required", shared.ErrValidation)
+	}
+	return nil
+}
+
+type CandidateReason string
+
+const (
+	ReasonFingerprintCollision CandidateReason = "fingerprint_collision"
+	ReasonSplit                CandidateReason = "split"
+	ReasonMerge                CandidateReason = "merge"
+	ReasonInsufficientAnchor   CandidateReason = "insufficient_anchor"
+	ReasonLegacyAmbiguous      CandidateReason = "legacy_ambiguous"
+)
+
+func (reason CandidateReason) Valid() bool {
+	switch reason {
+	case ReasonFingerprintCollision, ReasonSplit, ReasonMerge, ReasonInsufficientAnchor, ReasonLegacyAmbiguous:
+		return true
+	}
+	return false
+}
+
+type CandidateStatus string
+
+const (
+	CandidateOpen       CandidateStatus = "open"
+	CandidateResolved   CandidateStatus = "resolved"
+	CandidateSuperseded CandidateStatus = "superseded"
+)
+
+func (status CandidateStatus) Valid() bool {
+	return status == CandidateOpen || status == CandidateResolved || status == CandidateSuperseded
+}
+
+type ReferenceRole string
+
+const (
+	RoleSource    ReferenceRole = "source"
+	RoleCandidate ReferenceRole = "candidate"
+	RoleSelected  ReferenceRole = "selected"
+	RoleExcluded  ReferenceRole = "excluded"
+)
+
+func (role ReferenceRole) Valid() bool {
+	return role == RoleSource || role == RoleCandidate || role == RoleSelected || role == RoleExcluded
+}
+
+type MatchMethod string
+
+const (
+	MethodOverride    MatchMethod = "override"
+	MethodProducerID  MatchMethod = "producer_id"
+	MethodFingerprint MatchMethod = "fingerprint"
+	MethodAlias       MatchMethod = "alias"
+	MethodMatcher     MatchMethod = "matcher"
+	MethodManual      MatchMethod = "manual"
+	MethodNewIdentity MatchMethod = "new_identity"
+)
+
+func (method MatchMethod) Valid() bool {
+	switch method {
+	case MethodOverride, MethodProducerID, MethodFingerprint, MethodAlias, MethodMatcher, MethodManual, MethodNewIdentity:
+		return true
+	}
+	return false
+}
+
+type Confidence string
+
+const (
+	ConfidenceUnknown Confidence = "unknown"
+	ConfidenceLow     Confidence = "low"
+	ConfidenceMedium  Confidence = "medium"
+	ConfidenceHigh    Confidence = "high"
+)
+
+func (confidence Confidence) Valid() bool {
+	return confidence == ConfidenceUnknown || confidence == ConfidenceLow || confidence == ConfidenceMedium || confidence == ConfidenceHigh
+}
+
+type CandidateRef struct {
+	Position              int               `json:"position"`
+	Role                  ReferenceRole     `json:"role"`
+	IdentityID            shared.ID         `json:"identity_id,omitempty"`
+	ObservationID         shared.ID         `json:"observation_id,omitempty"`
+	ExternalReferenceHash string            `json:"external_reference_hash,omitempty"`
+	Method                MatchMethod       `json:"method"`
+	ScoreMilli            int               `json:"score_milli"`
+	Confidence            Confidence        `json:"confidence"`
+	ReasonPayload         map[string]string `json:"reason_payload,omitempty"`
+}
+
+func (reference CandidateRef) Validate() error {
+	if reference.Position < 0 || !reference.Role.Valid() || !reference.Method.Valid() || !reference.Confidence.Valid() {
+		return fmt.Errorf("%w: candidate reference metadata is invalid", shared.ErrValidation)
+	}
+	count := 0
+	if !reference.IdentityID.IsZero() {
+		count++
+	}
+	if !reference.ObservationID.IsZero() {
+		count++
+	}
+	if reference.ExternalReferenceHash != "" {
+		count++
+		if !validDigest(reference.ExternalReferenceHash) {
+			return fmt.Errorf("%w: external reference hash is invalid", shared.ErrValidation)
+		}
+	}
+	if count != 1 {
+		return fmt.Errorf("%w: candidate reference must identify exactly one subject", shared.ErrValidation)
+	}
+	if reference.ScoreMilli < 0 || reference.ScoreMilli > 1000 {
+		return fmt.Errorf("%w: candidate reference score is invalid", shared.ErrValidation)
+	}
+	return validateReasonPayload(reference.ReasonPayload)
+}
+
+type MatchCandidate struct {
+	TenantID                 shared.ID
+	CycleID                  shared.ID
+	SnapshotID               shared.ID
+	ID                       shared.ID
+	ProducerKind             string
+	FindingKind              string
+	Reason                   CandidateReason
+	FingerprintSchemaVersion int
+	Fingerprint              string
+	SourceReferenceHash      string
+	CandidateSetHash         string
+	Status                   CandidateStatus
+	Version                  int64
+	Refs                     []CandidateRef
+	CreatedAt                time.Time
+	ResolvedAt               *time.Time
+	SupersededAt             *time.Time
+	SupersededByCandidateID  shared.ID
+}
+
+func NewMatchCandidate(candidate MatchCandidate) (MatchCandidate, error) {
+	candidate.Status = CandidateOpen
+	candidate.Version = 1
+	candidate.ResolvedAt = nil
+	candidate.SupersededAt = nil
+	candidate.SupersededByCandidateID = ""
+	refs, hash, err := normalizeCandidateRefs(candidate.Refs)
+	if err != nil {
+		return MatchCandidate{}, err
+	}
+	candidate.Refs, candidate.CandidateSetHash = refs, hash
+	if candidate.SourceReferenceHash == "" {
+		for _, reference := range refs {
+			if reference.Role == RoleSource && reference.ExternalReferenceHash != "" {
+				candidate.SourceReferenceHash = reference.ExternalReferenceHash
+				break
+			}
+		}
+	}
+	if err := candidate.Validate(); err != nil {
+		return MatchCandidate{}, err
+	}
+	return candidate, nil
+}
+
+func (candidate MatchCandidate) Validate() error {
+	if candidate.TenantID.IsZero() || candidate.CycleID.IsZero() || candidate.SnapshotID.IsZero() || candidate.ID.IsZero() {
+		return fmt.Errorf("%w: match candidate ownership is required", shared.ErrValidation)
+	}
+	if err := validateShort("candidate producer kind", candidate.ProducerKind); err != nil {
+		return err
+	}
+	if err := validateShort("candidate finding kind", candidate.FindingKind); err != nil {
+		return err
+	}
+	if !candidate.Reason.Valid() || !candidate.Status.Valid() || candidate.Version <= 0 {
+		return fmt.Errorf("%w: match candidate lifecycle is invalid", shared.ErrValidation)
+	}
+	if candidate.Fingerprint == "" {
+		if candidate.Reason != ReasonInsufficientAnchor || candidate.FingerprintSchemaVersion < 0 {
+			return fmt.Errorf("%w: candidate fingerprint is required", shared.ErrValidation)
+		}
+	} else if candidate.FingerprintSchemaVersion <= 0 || !validDigest(candidate.Fingerprint) {
+		return fmt.Errorf("%w: candidate fingerprint is invalid", shared.ErrValidation)
+	}
+	if !validDigest(candidate.CandidateSetHash) {
+		return fmt.Errorf("%w: candidate set hash is invalid", shared.ErrValidation)
+	}
+	if !validDigest(candidate.SourceReferenceHash) {
+		return fmt.Errorf("%w: candidate source reference hash is invalid", shared.ErrValidation)
+	}
+	if len(candidate.Refs) == 0 || len(candidate.Refs) > maxCandidateRefs {
+		return fmt.Errorf("%w: candidate must contain 1-%d references", shared.ErrValidation, maxCandidateRefs)
+	}
+	for position, reference := range candidate.Refs {
+		if reference.Position != position {
+			return fmt.Errorf("%w: candidate reference positions must be contiguous", shared.ErrValidation)
+		}
+		if err := reference.Validate(); err != nil {
+			return err
+		}
+	}
+	if candidate.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: candidate creation time is required", shared.ErrValidation)
+	}
+	switch candidate.Status {
+	case CandidateOpen:
+		if candidate.ResolvedAt != nil || candidate.SupersededAt != nil || !candidate.SupersededByCandidateID.IsZero() {
+			return fmt.Errorf("%w: open candidate has terminal metadata", shared.ErrValidation)
+		}
+	case CandidateResolved:
+		if candidate.ResolvedAt == nil || candidate.SupersededAt != nil || !candidate.SupersededByCandidateID.IsZero() {
+			return fmt.Errorf("%w: resolved candidate metadata is invalid", shared.ErrValidation)
+		}
+	case CandidateSuperseded:
+		if candidate.SupersededAt == nil || candidate.SupersededByCandidateID.IsZero() || candidate.ResolvedAt != nil {
+			return fmt.Errorf("%w: superseded candidate metadata is invalid", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+type ResolutionAction string
+
+const (
+	ResolutionConfirmExisting        ResolutionAction = "confirm_existing"
+	ResolutionCreateDistinctIdentity ResolutionAction = "create_distinct_identity"
+	ResolutionUnlink                 ResolutionAction = "unlink"
+	ResolutionDismiss                ResolutionAction = "dismiss"
+	ResolutionSupersede              ResolutionAction = "supersede"
+)
+
+func (action ResolutionAction) Valid() bool {
+	switch action {
+	case ResolutionConfirmExisting, ResolutionCreateDistinctIdentity, ResolutionUnlink, ResolutionDismiss, ResolutionSupersede:
+		return true
+	}
+	return false
+}
+
+type ResolutionEvent struct {
+	TenantID             shared.ID
+	CycleID              shared.ID
+	CandidateID          shared.ID
+	ID                   shared.ID
+	Action               ResolutionAction
+	Actor                string
+	Reason               string
+	BeforeRefs           []CandidateRef
+	AfterRefs            []CandidateRef
+	SuccessorCandidateID shared.ID
+	ExpectedVersion      int64
+	Version              int64
+	PriorEventID         shared.ID
+	ContentHash          string
+	CreatedAt            time.Time
+}
+
+func (event ResolutionEvent) Validate() error {
+	if event.TenantID.IsZero() || event.CycleID.IsZero() || event.CandidateID.IsZero() || event.ID.IsZero() || !event.Action.Valid() {
+		return fmt.Errorf("%w: resolution event ownership is invalid", shared.ErrValidation)
+	}
+	if err := validateShort("resolution actor", event.Actor); err != nil {
+		return err
+	}
+	if err := validateText("resolution reason", event.Reason, maxReasonTextBytes); err != nil {
+		return err
+	}
+	if event.ExpectedVersion <= 0 || event.Version != event.ExpectedVersion+1 || event.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: resolution event version is invalid", shared.ErrValidation)
+	}
+	if event.Action == ResolutionSupersede {
+		if event.SuccessorCandidateID.IsZero() {
+			return fmt.Errorf("%w: supersede resolution requires a successor candidate", shared.ErrValidation)
+		}
+	} else if !event.SuccessorCandidateID.IsZero() {
+		return fmt.Errorf("%w: successor candidate is only valid for supersede", shared.ErrValidation)
+	}
+	for _, refs := range [][]CandidateRef{event.BeforeRefs, event.AfterRefs} {
+		if len(refs) == 0 {
+			continue
+		}
+		if _, _, err := normalizeCandidateRefs(refs); err != nil {
+			return err
+		}
+	}
+	hash, err := hashResolutionEvent(event)
+	if err != nil {
+		return err
+	}
+	if event.ContentHash != hash {
+		return fmt.Errorf("%w: resolution event content hash is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func ResolveCandidate(candidate MatchCandidate, eventID shared.ID, action ResolutionAction, actor, reason string, afterRefs []CandidateRef, successorCandidateID shared.ID, expectedVersion int64, priorEventID shared.ID, now time.Time) (MatchCandidate, ResolutionEvent, error) {
+	if candidate.Status != CandidateOpen || candidate.Version != expectedVersion {
+		return MatchCandidate{}, ResolutionEvent{}, fmt.Errorf("%w: candidate version or status changed", shared.ErrConflict)
+	}
+	if eventID.IsZero() || !action.Valid() || now.IsZero() {
+		return MatchCandidate{}, ResolutionEvent{}, fmt.Errorf("%w: resolution event metadata is invalid", shared.ErrValidation)
+	}
+	if err := validateShort("resolution actor", actor); err != nil {
+		return MatchCandidate{}, ResolutionEvent{}, err
+	}
+	if err := validateText("resolution reason", reason, maxReasonTextBytes); err != nil {
+		return MatchCandidate{}, ResolutionEvent{}, err
+	}
+	normalizedAfter, _, err := normalizeCandidateRefs(afterRefs)
+	if err != nil && !(action == ResolutionDismiss && len(afterRefs) == 0) {
+		return MatchCandidate{}, ResolutionEvent{}, err
+	}
+	updated := candidate
+	updated.Version++
+	if action == ResolutionSupersede {
+		if successorCandidateID.IsZero() {
+			return MatchCandidate{}, ResolutionEvent{}, fmt.Errorf("%w: supersede resolution requires a successor candidate", shared.ErrValidation)
+		}
+		updated.Status = CandidateSuperseded
+		updated.SupersededAt = &now
+		updated.SupersededByCandidateID = successorCandidateID
+	} else {
+		if !successorCandidateID.IsZero() {
+			return MatchCandidate{}, ResolutionEvent{}, fmt.Errorf("%w: successor candidate is only valid for supersede", shared.ErrValidation)
+		}
+		updated.Status = CandidateResolved
+		updated.ResolvedAt = &now
+	}
+	event := ResolutionEvent{
+		TenantID: candidate.TenantID, CycleID: candidate.CycleID, CandidateID: candidate.ID, ID: eventID,
+		Action: action, Actor: strings.TrimSpace(actor), Reason: strings.TrimSpace(reason),
+		BeforeRefs: cloneCandidateRefs(candidate.Refs), AfterRefs: normalizedAfter,
+		SuccessorCandidateID: successorCandidateID, ExpectedVersion: expectedVersion,
+		Version: updated.Version, PriorEventID: priorEventID, CreatedAt: now,
+	}
+	event.ContentHash, err = hashResolutionEvent(event)
+	if err != nil {
+		return MatchCandidate{}, ResolutionEvent{}, err
+	}
+	return updated, event, nil
+}
+
+type OverrideAction string
+
+const (
+	OverrideConfirm   OverrideAction = "confirm"
+	OverrideUnlink    OverrideAction = "unlink"
+	OverrideSupersede OverrideAction = "supersede"
+)
+
+func (action OverrideAction) Valid() bool {
+	return action == OverrideConfirm || action == OverrideUnlink || action == OverrideSupersede
+}
+
+type OverrideEvent struct {
+	TenantID            shared.ID
+	CycleID             shared.ID
+	ID                  shared.ID
+	Action              OverrideAction
+	SourceObservationID shared.ID
+	SourceIdentityID    shared.ID
+	TargetObservationID shared.ID
+	TargetIdentityID    shared.ID
+	Actor               string
+	Reason              string
+	ExpectedVersion     int64
+	Version             int64
+	PriorEventID        shared.ID
+	ContentHash         string
+	CreatedAt           time.Time
+}
+
+func NewOverrideEvent(event OverrideEvent) (OverrideEvent, error) {
+	if event.TenantID.IsZero() || event.CycleID.IsZero() || event.ID.IsZero() || event.SourceObservationID.IsZero() || event.TargetIdentityID.IsZero() {
+		return OverrideEvent{}, fmt.Errorf("%w: override ownership and references are required", shared.ErrValidation)
+	}
+	if !event.Action.Valid() || event.ExpectedVersion < 0 || event.Version != event.ExpectedVersion+1 || event.CreatedAt.IsZero() {
+		return OverrideEvent{}, fmt.Errorf("%w: override lifecycle metadata is invalid", shared.ErrValidation)
+	}
+	if err := validateShort("override actor", event.Actor); err != nil {
+		return OverrideEvent{}, err
+	}
+	if err := validateText("override reason", event.Reason, maxReasonTextBytes); err != nil {
+		return OverrideEvent{}, err
+	}
+	event.Actor, event.Reason = strings.TrimSpace(event.Actor), strings.TrimSpace(event.Reason)
+	hash, err := hashOverrideEvent(event)
+	if err != nil {
+		return OverrideEvent{}, err
+	}
+	event.ContentHash = hash
+	return event, nil
+}
+
+func (event OverrideEvent) Validate() error {
+	validated, err := NewOverrideEvent(event)
+	if err != nil {
+		return err
+	}
+	if event.ContentHash != validated.ContentHash {
+		return fmt.Errorf("%w: override event content hash is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+type SkipReason string
+
+const (
+	SkipInvalidTrust      SkipReason = "invalid_trust"
+	SkipInvalidOwnership  SkipReason = "invalid_ownership"
+	SkipRedactionRequired SkipReason = "redaction_required"
+)
+
+func (reason SkipReason) Valid() bool {
+	return reason == SkipInvalidTrust || reason == SkipInvalidOwnership || reason == SkipRedactionRequired
+}
+
+type SkipRecord struct {
+	TenantID            shared.ID
+	CycleID             shared.ID
+	SnapshotID          shared.ID
+	ID                  shared.ID
+	ProducerKind        string
+	FindingKind         string
+	Reason              SkipReason
+	SourceReferenceHash string
+	DetailCode          string
+	CreatedAt           time.Time
+}
+
+func (record SkipRecord) Validate() error {
+	if record.TenantID.IsZero() || record.CycleID.IsZero() || record.SnapshotID.IsZero() || record.ID.IsZero() {
+		return fmt.Errorf("%w: skip record ownership is required", shared.ErrValidation)
+	}
+	if err := validateShort("skip producer kind", record.ProducerKind); err != nil {
+		return err
+	}
+	if err := validateShort("skip finding kind", record.FindingKind); err != nil {
+		return err
+	}
+	if !record.Reason.Valid() || !validDigest(record.SourceReferenceHash) {
+		return fmt.Errorf("%w: skip record reason or source hash is invalid", shared.ErrValidation)
+	}
+	if err := validateShort("skip detail code", record.DetailCode); err != nil {
+		return err
+	}
+	if record.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: skip record creation time is required", shared.ErrValidation)
+	}
+	return nil
+}
+
+func SourceReferenceHash(producerKind, findingKind, targetCanonical, sourceFindingID, sourceOccurrenceID string) (string, error) {
+	producer, err := canonicalRequiredText("source producer", producerKind, maxCanonicalTextBytes)
+	if err != nil {
+		return "", err
+	}
+	kind, err := canonicalRequiredText("source finding kind", findingKind, maxCanonicalTextBytes)
+	if err != nil {
+		return "", err
+	}
+	target, err := canonicalRequiredText("source target", targetCanonical, maxCanonicalTextBytes)
+	if err != nil {
+		return "", err
+	}
+	findingID, occurrenceID := "", ""
+	if sourceFindingID != "" {
+		findingID, err = canonicalRequiredText("source finding id", sourceFindingID, maxCanonicalTextBytes)
+		if err != nil {
+			return "", err
+		}
+	}
+	if sourceOccurrenceID != "" {
+		occurrenceID, err = canonicalRequiredText("source occurrence id", sourceOccurrenceID, maxCanonicalTextBytes)
+		if err != nil {
+			return "", err
+		}
+	}
+	if sourceFindingID == "" && sourceOccurrenceID == "" {
+		return "", fmt.Errorf("%w: source finding or occurrence id is required", shared.ErrValidation)
+	}
+	// Use the canonical structured encoder rather than a delimiter-separated
+	// tuple. This makes NFC-equivalent references identical and prevents embedded
+	// delimiters from creating ambiguous tuples.
+	fields := map[string]CanonicalValue{
+		"finding_kind": Text(kind), "producer_kind": Text(producer), "target_canonical": Text(target),
+	}
+	if findingID != "" {
+		fields["source_finding_id"] = Text(findingID)
+	}
+	if occurrenceID != "" {
+		fields["source_occurrence_id"] = Text(occurrenceID)
+	}
+	payload, err := serializeCanonical(Object(fields))
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(append([]byte("synapse:finding-source:v2\x00"), payload...))
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func normalizeCandidateRefs(input []CandidateRef) ([]CandidateRef, string, error) {
+	if len(input) == 0 || len(input) > maxCandidateRefs {
+		return nil, "", fmt.Errorf("%w: candidate must contain 1-%d references", shared.ErrValidation, maxCandidateRefs)
+	}
+	refs := cloneCandidateRefs(input)
+	sort.Slice(refs, func(left, right int) bool { return refs[left].Position < refs[right].Position })
+	for position := range refs {
+		if refs[position].ReasonPayload == nil {
+			refs[position].ReasonPayload = map[string]string{}
+		}
+		if refs[position].Position != position {
+			return nil, "", fmt.Errorf("%w: candidate reference positions must be contiguous", shared.ErrValidation)
+		}
+		if err := refs[position].Validate(); err != nil {
+			return nil, "", err
+		}
+	}
+	canonicalRefs := make([]CanonicalValue, 0, len(refs))
+	for _, reference := range refs {
+		fields := map[string]CanonicalValue{
+			"confidence":  Text(string(reference.Confidence)),
+			"method":      Text(string(reference.Method)),
+			"position":    Integer(int64(reference.Position)),
+			"role":        Text(string(reference.Role)),
+			"score_milli": Integer(int64(reference.ScoreMilli)),
+		}
+		if !reference.IdentityID.IsZero() {
+			fields["identity_id"] = Text(reference.IdentityID.String())
+		}
+		if !reference.ObservationID.IsZero() {
+			fields["observation_id"] = Text(reference.ObservationID.String())
+		}
+		if reference.ExternalReferenceHash != "" {
+			fields["external_reference_hash"] = Text(reference.ExternalReferenceHash)
+		}
+		if len(reference.ReasonPayload) > 0 {
+			payload := make(map[string]CanonicalValue, len(reference.ReasonPayload))
+			for key, value := range reference.ReasonPayload {
+				payload[key] = Text(value)
+			}
+			fields["reason_payload"] = Object(payload)
+		}
+		canonicalRefs = append(canonicalRefs, Object(fields))
+	}
+	serialized, err := serializeCanonical(OrderedArray(canonicalRefs...))
+	if err != nil {
+		return nil, "", err
+	}
+	digest := sha256.Sum256(append([]byte("synapse:finding-match-candidate:v1\x00"), serialized...))
+	return refs, hex.EncodeToString(digest[:]), nil
+}
+
+func validateReasonPayload(payload map[string]string) error {
+	if len(payload) > maxReasonPayload {
+		return fmt.Errorf("%w: candidate reason payload exceeds %d fields", shared.ErrValidation, maxReasonPayload)
+	}
+	for key, value := range payload {
+		if _, err := canonicalKey(key); err != nil {
+			if errors.Is(err, ErrSensitiveInput) {
+				return fmt.Errorf("%w: candidate reason payload contains a sensitive key", shared.ErrValidation)
+			}
+			return err
+		}
+		if err := validateText("candidate reason payload", value, maxShortTextBytes); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateShort(label, value string) error {
+	return validateText(label, value, maxShortTextBytes)
+}
+
+func validateText(label, value string, limit int) error {
+	value = strings.TrimSpace(value)
+	if value == "" || !utf8.ValidString(value) || len(value) > limit {
+		return fmt.Errorf("%w: %s is required, valid UTF-8, and at most %d bytes", shared.ErrValidation, label, limit)
+	}
+	for _, char := range value {
+		if char < 32 && char != '\n' && char != '\t' {
+			return fmt.Errorf("%w: %s contains invalid control characters", shared.ErrValidation, label)
+		}
+	}
+	return nil
+}
+
+func validDigest(value string) bool {
+	if len(value) != sha256.Size*2 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil && value == strings.ToLower(value)
+}
+
+func cloneCandidateRefs(input []CandidateRef) []CandidateRef {
+	output := make([]CandidateRef, len(input))
+	for index, reference := range input {
+		output[index] = reference
+		if reference.ReasonPayload != nil {
+			output[index].ReasonPayload = make(map[string]string, len(reference.ReasonPayload))
+			for key, value := range reference.ReasonPayload {
+				output[index].ReasonPayload[key] = value
+			}
+		}
+	}
+	return output
+}
+
+func hashResolutionEvent(event ResolutionEvent) (string, error) {
+	beforeRefs := event.BeforeRefs
+	if beforeRefs == nil {
+		beforeRefs = []CandidateRef{}
+	}
+	afterRefs := event.AfterRefs
+	if afterRefs == nil {
+		afterRefs = []CandidateRef{}
+	}
+	payload, err := json.Marshal(struct {
+		Action               ResolutionAction `json:"action"`
+		Actor                string           `json:"actor"`
+		AfterRefs            []CandidateRef   `json:"after_refs"`
+		BeforeRefs           []CandidateRef   `json:"before_refs"`
+		CandidateID          shared.ID        `json:"candidate_id"`
+		ExpectedVersion      int64            `json:"expected_version"`
+		PriorEventID         shared.ID        `json:"prior_event_id,omitempty"`
+		Reason               string           `json:"reason"`
+		SuccessorCandidateID shared.ID        `json:"successor_candidate_id,omitempty"`
+		Version              int64            `json:"version"`
+	}{event.Action, event.Actor, afterRefs, beforeRefs, event.CandidateID, event.ExpectedVersion, event.PriorEventID, event.Reason, event.SuccessorCandidateID, event.Version})
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(append([]byte("synapse:finding-resolution:v1\x00"), payload...))
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func hashOverrideEvent(event OverrideEvent) (string, error) {
+	payload, err := json.Marshal(struct {
+		Action              OverrideAction `json:"action"`
+		Actor               string         `json:"actor"`
+		ExpectedVersion     int64          `json:"expected_version"`
+		PriorEventID        shared.ID      `json:"prior_event_id,omitempty"`
+		Reason              string         `json:"reason"`
+		SourceIdentityID    shared.ID      `json:"source_identity_id,omitempty"`
+		SourceObservationID shared.ID      `json:"source_observation_id"`
+		TargetIdentityID    shared.ID      `json:"target_identity_id"`
+		TargetObservationID shared.ID      `json:"target_observation_id,omitempty"`
+		Version             int64          `json:"version"`
+	}{event.Action, event.Actor, event.ExpectedVersion, event.PriorEventID, event.Reason, event.SourceIdentityID, event.SourceObservationID, event.TargetIdentityID, event.TargetObservationID, event.Version})
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(append([]byte("synapse:finding-override:v1\x00"), payload...))
+	return hex.EncodeToString(digest[:]), nil
+}

--- a/internal/domain/sourcepackage/package.go
+++ b/internal/domain/sourcepackage/package.go
@@ -17,16 +17,22 @@ const (
 )
 
 var sha256Pattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
+var versionPattern = regexp.MustCompile(`^[0-9a-f]{32}$`)
 
 type Package struct {
-	TenantID     shared.ID `json:"tenant_id"`
-	EngagementID shared.ID `json:"engagement_id"`
-	Filename     string    `json:"filename"`
-	Size         int64     `json:"size"`
-	SHA256       string    `json:"sha256"`
-	CreatedBy    string    `json:"created_by"`
-	CreatedAt    time.Time `json:"created_at"`
-	Locator      string    `json:"-"`
+	VersionID           shared.ID `json:"version_id,omitempty"`
+	ReusedFromVersionID shared.ID `json:"reused_from_version_id,omitempty"`
+	AssociatedBy        string    `json:"associated_by,omitempty"`
+	AssociatedAt        time.Time `json:"associated_at,omitempty"`
+	TenantID            shared.ID `json:"tenant_id"`
+	EngagementID        shared.ID `json:"engagement_id"`
+	Filename            string    `json:"filename"`
+	Size                int64     `json:"size"`
+	SHA256              string    `json:"sha256"`
+	CreatedBy           string    `json:"created_by"`
+	CreatedAt           time.Time `json:"created_at"`
+	Locator             string    `json:"-"`
+	ObjectKey           string    `json:"-"`
 }
 
 func (p Package) Target() string { return TargetPrefix + p.SHA256 }
@@ -46,6 +52,25 @@ func (p Package) Validate() error {
 	}
 	if strings.TrimSpace(p.CreatedBy) == "" || p.CreatedAt.IsZero() {
 		return fmt.Errorf("%w: uploaded source attribution is required", shared.ErrValidation)
+	}
+	if !p.VersionID.IsZero() && (strings.TrimSpace(p.AssociatedBy) == "" || p.AssociatedAt.IsZero()) {
+		return fmt.Errorf("%w: source package version association is required", shared.ErrValidation)
+	}
+	if p.VersionID.IsZero() && !p.ReusedFromVersionID.IsZero() || p.VersionID == p.ReusedFromVersionID && !p.VersionID.IsZero() {
+		return fmt.Errorf("%w: source package reuse version is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (p Package) ValidateVersion() error {
+	if err := p.Validate(); err != nil {
+		return err
+	}
+	if !versionPattern.MatchString(p.VersionID.String()) || (!p.ReusedFromVersionID.IsZero() && !versionPattern.MatchString(p.ReusedFromVersionID.String())) {
+		return fmt.Errorf("%w: source package version is invalid", shared.ErrValidation)
+	}
+	if p.Filename != BaseFilename(p.Filename) || p.Locator == "" || p.ObjectKey == "" || len(p.Locator) > 1024 || len(p.ObjectKey) > 1024 || len(p.CreatedBy) > 512 || len(p.AssociatedBy) > 512 {
+		return fmt.Errorf("%w: source package storage metadata is invalid", shared.ErrValidation)
 	}
 	return nil
 }

--- a/internal/usecase/ports/assessment_closure.go
+++ b/internal/usecase/ports/assessment_closure.go
@@ -1,0 +1,71 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentclosure"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sla"
+)
+
+type AssessmentClosureReferenceQuery struct {
+	CycleID         shared.ID
+	SnapshotIDs     []shared.ID
+	VerificationIDs []shared.ID
+	AsOfAt          time.Time
+}
+
+// AssessmentClosureDecisionReader binds closure manifests to the exact
+// immutable Finding/SLA/retest artifacts used by the decision and resolves
+// those artifacts again before a historical report is rendered.
+type AssessmentClosureDecisionReader interface {
+	ListAssessmentClosureReferences(context.Context, shared.ID, AssessmentClosureReferenceQuery) ([]assessmentclosure.Reference, error)
+	ResolveAssessmentClosureReference(context.Context, shared.ID, AssessmentClosureReferenceQuery, assessmentclosure.Reference) error
+}
+
+// AssessmentClosureReferenceBatchResolver resolves a report's retained sources
+// in one pass, avoiding a complete history reload for each reference.
+type AssessmentClosureReferenceBatchResolver interface {
+	ResolveAssessmentClosureReferences(context.Context, shared.ID, AssessmentClosureReferenceQuery, []assessmentclosure.Reference) error
+}
+
+// Closure history batches preserve append-only artifacts, including superseded
+// decisions. Implementations accept at most 1,000 Finding IDs and must never
+// silently truncate histories: historical reports depend on exact source hashes.
+type RetestHistoryBatchReader interface {
+	RetestHistories(context.Context, shared.ID, []shared.ID) (map[shared.ID][]finding.Retest, error)
+}
+
+type SLAHistoryBatch struct {
+	Assessments map[shared.ID][]sla.Assessment
+	Events      map[shared.ID][]sla.LifecycleEvent
+}
+
+type SLAHistoryBatchReader interface {
+	SLAHistories(context.Context, shared.ID, shared.ID, []shared.ID) (SLAHistoryBatch, error)
+}
+
+type AssessmentClosureCommit struct {
+	Manifest             *assessmentclosure.Manifest
+	Cycle                *assessmentcycle.AssessmentCycle
+	ExpectedCycleVersion int64
+}
+
+type AssessmentClosureReopen struct {
+	Manifest             *assessmentclosure.Manifest
+	Cycle                *assessmentcycle.AssessmentCycle
+	ExpectedCycleVersion int64
+}
+
+// AssessmentClosureRepository persists immutable closure history and the matching Cycle transition atomically.
+type AssessmentClosureRepository interface {
+	NextManifestVersion(ctx context.Context, tenantID, cycleID shared.ID) (int64, error)
+	CommitClosure(ctx context.Context, commit AssessmentClosureCommit) error
+	ReopenClosure(ctx context.Context, reopen AssessmentClosureReopen) error
+	GetClosureManifest(ctx context.Context, tenantID, cycleID, manifestID shared.ID) (*assessmentclosure.Manifest, error)
+	GetActiveClosureManifest(ctx context.Context, tenantID, cycleID shared.ID) (*assessmentclosure.Manifest, error)
+	ListClosureManifests(ctx context.Context, tenantID, cycleID shared.ID) ([]assessmentclosure.Manifest, error)
+}

--- a/internal/usecase/ports/assessment_closure_report.go
+++ b/internal/usecase/ports/assessment_closure_report.go
@@ -1,0 +1,27 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type AssessmentClosureReportArtifact struct {
+	TenantID                shared.ID
+	CycleID                 shared.ID
+	ManifestID              shared.ID
+	RendererContractVersion string
+	ContentHash             string
+	Content                 []byte
+	GeneratedAt             time.Time
+}
+
+type AssessmentClosureReportStore interface {
+	SaveClosureReport(ctx context.Context, report AssessmentClosureReportArtifact) (AssessmentClosureReportArtifact, bool, error)
+	GetClosureReport(ctx context.Context, tenantID, cycleID, manifestID shared.ID, rendererVersion string) (AssessmentClosureReportArtifact, error)
+}
+
+type AssessmentClosureReportObserver interface {
+	ObserveAssessmentClosureReport(outcome, reason string)
+}

--- a/internal/usecase/ports/assessment_comparison.go
+++ b/internal/usecase/ports/assessment_comparison.go
@@ -1,0 +1,94 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type AssessmentComparisonVerification struct {
+	ID                  shared.ID
+	IdentityID          shared.ID
+	EffectiveSnapshotID shared.ID
+	State               string
+	Remediated          bool
+}
+
+type AssessmentComparisonVerificationReader interface {
+	ListEffectiveComparisonVerifications(context.Context, shared.ID, shared.ID, []shared.ID) ([]AssessmentComparisonVerification, error)
+}
+
+// RetestLatestReader avoids one query per observation during large comparisons.
+// Implementations return at most one decision per requested Finding, scoped to
+// the context tenant and engagement. Each request is bounded to 1000 IDs.
+type RetestLatestReader interface {
+	LatestByEngagementFindings(context.Context, shared.ID, []shared.ID) (map[shared.ID]finding.Retest, error)
+}
+
+type AssessmentComparisonObserver interface {
+	ObserveAssessmentComparison(status, mode, reason string)
+}
+
+type AssessmentComparisonBacklog struct {
+	Queued         int
+	Generating     int
+	Failed         int
+	DeadLettered   int
+	OldestActiveAt *time.Time
+}
+
+func (backlog AssessmentComparisonBacklog) Active() int {
+	return backlog.Queued + backlog.Generating
+}
+
+type AssessmentComparisonBacklogReader interface {
+	GetAssessmentComparisonBacklog(context.Context, shared.ID) (AssessmentComparisonBacklog, error)
+}
+
+type AssessmentComparisonBacklogObserver interface {
+	ObserveAssessmentComparisonBacklog(tenantID string, backlog AssessmentComparisonBacklog, observedAt time.Time)
+}
+
+type AssessmentComparisonGenerationObserver interface {
+	ObserveAssessmentComparisonGeneration(tenantID, mode, status string, fingerprintVersion, riskModelVersion, itemCount int, duration time.Duration)
+}
+
+type AssessmentComparisonRepairRepository interface {
+	AssessmentComparisonBacklogReader
+	GetMetadata(context.Context, shared.ID, shared.ID) (assessmentcomparison.Comparison, error)
+	ListFailedAssessmentComparisons(context.Context, shared.ID, int) ([]assessmentcomparison.Comparison, error)
+}
+
+type AssessmentComparisonItemFilter struct {
+	AfterPosition int
+	Limit         int
+	Scope         assessmentcomparison.Scope
+	Presence      string
+	ChangeFlag    assessmentcomparison.ChangeFlag
+	Severity      shared.Severity
+	ProducerKind  string
+	FindingKind   string
+	Disposition   string
+	ReviewState   string
+}
+
+type AssessmentComparisonItemPage struct {
+	Items        []assessmentcomparison.Item
+	NextPosition int
+	HasMore      bool
+}
+
+type AssessmentComparisonRepository interface {
+	CreateQueued(context.Context, assessmentcomparison.Comparison) (assessmentcomparison.Comparison, bool, error)
+	Get(context.Context, shared.ID, shared.ID) (assessmentcomparison.Comparison, error)
+	GetMetadata(context.Context, shared.ID, shared.ID) (assessmentcomparison.Comparison, error)
+	GetByInputHash(context.Context, shared.ID, string) (assessmentcomparison.Comparison, error)
+	ListMetadataByCycle(context.Context, shared.ID, shared.ID) ([]assessmentcomparison.Comparison, error)
+	GetItem(context.Context, shared.ID, shared.ID, shared.ID) (assessmentcomparison.Item, error)
+	SummarizeItems(context.Context, shared.ID, shared.ID, assessmentcomparison.Scope) (assessmentcomparison.Summary, error)
+	ListItems(context.Context, shared.ID, shared.ID, AssessmentComparisonItemFilter) (AssessmentComparisonItemPage, error)
+	UpdateCAS(context.Context, assessmentcomparison.Comparison, int64) error
+}

--- a/internal/usecase/ports/assessment_cycle.go
+++ b/internal/usecase/ports/assessment_cycle.go
@@ -2,10 +2,95 @@ package ports
 
 import (
 	"context"
+	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
+
+type AssessmentCycleListQuery struct {
+	TenantID         shared.ID
+	Status           assessmentcycle.Status
+	BoundaryKind     assessmentcycle.BoundaryKind
+	AssessmentStatus engagement.Status
+	SelectedHeadID   shared.ID
+	AssessmentType   assessmentcycle.AssessmentType
+	ProducerKind     string
+	FindingKind      string
+	ReviewState      string
+	ChangePresence   assessmentcomparison.Presence
+	ChangeSeverity   shared.Severity
+	ScanStaleness    string
+	ScanStaleBefore  time.Time
+	Search           string
+	AfterUpdatedAt   time.Time
+	AfterCycleID     shared.ID
+	Limit            int
+	MemberLimit      int
+}
+
+type AssessmentCycleListRecord struct {
+	Cycle              assessmentcycle.AssessmentCycle
+	MemberCount        int
+	ActiveBranchCount  int
+	LatestAssessmentID shared.ID
+	LatestRetestNumber int
+	Members            []assessmentcycle.Member
+	MemberStatuses     map[shared.ID]engagement.Status
+	MembersHaveMore    bool
+	RootSnapshotID     shared.ID
+	CurrentSnapshotID  shared.ID
+	ComparisonID       shared.ID
+	ComparisonStatus   assessmentcomparison.Status
+	ComparisonSummary  assessmentcomparison.Summary
+	ActiveManifestID   shared.ID
+	SelectedHeadScanAt *time.Time
+	ScanStaleness      string
+}
+
+type AssessmentCycleListRepository interface {
+	ListCycles(ctx context.Context, query AssessmentCycleListQuery) ([]AssessmentCycleListRecord, error)
+	ListMigrationPendingAssessments(ctx context.Context, query AssessmentCycleListQuery) ([]AssessmentCycleMigrationPendingRecord, int, error)
+}
+
+type AssessmentCycleMigrationPendingRecord struct {
+	AssessmentID    shared.ID
+	Name            string
+	Status          string
+	BoundaryKind    assessmentcycle.BoundaryKind
+	BusinessAssetID shared.ID
+	UpdatedAt       time.Time
+}
+
+type AssessmentCycleCompensationRepository interface {
+	DeleteCycle(ctx context.Context, tenantID, cycleID shared.ID) error
+	DeleteMember(ctx context.Context, tenantID, cycleID, assessmentID shared.ID) error
+}
+
+type AssessmentCycleRequestScope struct {
+	TenantID       shared.ID
+	Actor          string
+	Route          string
+	IdempotencyKey string
+}
+
+type AssessmentCycleRequest struct {
+	Scope        AssessmentCycleRequestScope
+	RequestHash  string
+	StatusCode   int
+	ResponseBody []byte
+	CreatedAt    time.Time
+	ExpiresAt    time.Time
+	CompletedAt  *time.Time
+}
+
+type AssessmentCycleRequestStore interface {
+	BeginAssessmentCycleRequest(ctx context.Context, request AssessmentCycleRequest) (stored AssessmentCycleRequest, created bool, err error)
+	CompleteAssessmentCycleRequest(ctx context.Context, scope AssessmentCycleRequestScope, requestHash string, statusCode int, responseBody []byte, completedAt time.Time) error
+	AbortAssessmentCycleRequest(ctx context.Context, scope AssessmentCycleRequestScope, requestHash string) error
+}
 
 // AssessmentCycleRepository persists tenant-scoped AssessmentCycle aggregates and their members.
 type AssessmentCycleRepository interface {
@@ -41,11 +126,4 @@ type AssessmentCycleRepository interface {
 	// LockCycleForUpdate acquires a row lock on the cycle aggregate within the active transaction
 	// to serialize retest number allocation and selected-head advancement.
 	LockCycleForUpdate(ctx context.Context, tenantID, cycleID shared.ID) (*assessmentcycle.AssessmentCycle, error)
-}
-
-// AssessmentCycleCompensationRepository removes an unpublished partial
-// aggregate when an adapter cannot provide real transactional rollback.
-type AssessmentCycleCompensationRepository interface {
-	DeleteCycle(ctx context.Context, tenantID, cycleID shared.ID) error
-	DeleteMember(ctx context.Context, tenantID, cycleID, assessmentID shared.ID) error
 }

--- a/internal/usecase/ports/assessment_cycle_integrity.go
+++ b/internal/usecase/ports/assessment_cycle_integrity.go
@@ -1,0 +1,105 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type AssessmentCycleIntegrityState string
+
+const (
+	AssessmentCycleIntegrityRunning   AssessmentCycleIntegrityState = "running"
+	AssessmentCycleIntegrityCompleted AssessmentCycleIntegrityState = "completed"
+	AssessmentCycleIntegrityCancelled AssessmentCycleIntegrityState = "cancelled"
+	AssessmentCycleIntegrityFailed    AssessmentCycleIntegrityState = "failed"
+)
+
+type AssessmentCycleIntegrityRun struct {
+	TenantID             shared.ID
+	ID                   shared.ID
+	BatchSize            int
+	SnapshotAt           time.Time
+	SourceGeneration     int64
+	CheckpointAssessment shared.ID
+	State                AssessmentCycleIntegrityState
+	LeaseOwner           string
+	LeaseToken           shared.ID
+	LeaseExpiresAt       time.Time
+	ScannedCount         int
+	CleanCount           int
+	FindingCount         int
+	CreatedBy            string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	CompletedAt          *time.Time
+}
+
+type AssessmentCycleIntegrityAcquireRequest struct {
+	Run           AssessmentCycleIntegrityRun
+	LeaseDuration time.Duration
+}
+
+type AssessmentCycleIntegrityMember struct {
+	Member              cycledom.Member
+	AssessmentExists    bool
+	AssessmentStatus    engdom.Status
+	BusinessAssetID     shared.ID
+	ProjectID           shared.ID
+	AssessmentProjectID shared.ID
+	HostAssetID         shared.ID
+}
+
+type AssessmentCycleIntegrityCycle struct {
+	Cycle                  cycledom.AssessmentCycle
+	CycleExists            bool
+	SubjectMembershipCount int
+	Members                []AssessmentCycleIntegrityMember
+}
+
+type AssessmentCycleIntegritySubject struct {
+	TenantID     shared.ID
+	AssessmentID shared.ID
+	Cycles       []AssessmentCycleIntegrityCycle
+}
+
+type AssessmentCycleIntegritySubjectResult struct {
+	TenantID     shared.ID
+	RunID        shared.ID
+	AssessmentID shared.ID
+	Clean        bool
+	FindingCount int
+	ProcessedAt  time.Time
+}
+
+type AssessmentCycleIntegrityFinding struct {
+	TenantID     shared.ID
+	RunID        shared.ID
+	OccurrenceID string
+	AssessmentID shared.ID
+	CycleID      shared.ID
+	MemberID     shared.ID
+	ReasonCode   string
+	Severity     string
+	RepairPlan   []byte
+	DetectedAt   time.Time
+}
+
+type AssessmentCycleIntegritySource interface {
+	AssessmentCycleIntegrityGeneration(ctx context.Context, tenantID shared.ID) (int64, error)
+	ListAssessmentCycleIntegritySubjects(ctx context.Context, tenantID, after shared.ID, snapshotAt time.Time, limit int) ([]AssessmentCycleIntegritySubject, error)
+	CountAssessmentCycleIntegritySubjects(ctx context.Context, tenantID shared.ID, snapshotAt time.Time) (eligible int, memberships int, err error)
+}
+
+type AssessmentCycleIntegrityStore interface {
+	AcquireAssessmentCycleIntegrityRun(ctx context.Context, request AssessmentCycleIntegrityAcquireRequest) (run AssessmentCycleIntegrityRun, resumed bool, err error)
+	GetAssessmentCycleIntegrityRun(ctx context.Context, tenantID, runID shared.ID) (AssessmentCycleIntegrityRun, error)
+	GetAssessmentCycleIntegritySubject(ctx context.Context, tenantID, runID, assessmentID shared.ID) (AssessmentCycleIntegritySubjectResult, error)
+	ListAssessmentCycleIntegrityFindings(ctx context.Context, tenantID, runID shared.ID) ([]AssessmentCycleIntegrityFinding, error)
+	SaveAssessmentCycleIntegritySubject(ctx context.Context, leaseToken shared.ID, now time.Time, result AssessmentCycleIntegritySubjectResult, findings []AssessmentCycleIntegrityFinding) (created bool, err error)
+	AdvanceAssessmentCycleIntegrityRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken, checkpoint shared.ID, now time.Time, leaseDuration time.Duration) (AssessmentCycleIntegrityRun, error)
+	FinishAssessmentCycleIntegrityRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken shared.ID, state AssessmentCycleIntegrityState, now time.Time) (AssessmentCycleIntegrityRun, error)
+}

--- a/internal/usecase/ports/assessment_relationship.go
+++ b/internal/usecase/ports/assessment_relationship.go
@@ -1,0 +1,25 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentrelationship"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type AssessmentRelationshipCandidateFilter struct {
+	Status string
+	Limit  int
+}
+
+type AssessmentRelationshipRepository interface {
+	CreateCandidate(context.Context, assessmentrelationship.Candidate) (assessmentrelationship.Record, bool, error)
+	GetCandidate(context.Context, shared.ID, shared.ID) (assessmentrelationship.Record, error)
+	ListCandidates(context.Context, shared.ID, AssessmentRelationshipCandidateFilter) ([]assessmentrelationship.Record, error)
+	DecideCandidateCAS(context.Context, assessmentrelationship.Decision, *assessmentrelationship.RepairPlan) (assessmentrelationship.Record, bool, error)
+}
+
+type AssessmentRelationshipObserver interface {
+	ObserveAssessmentRelationshipCandidate(outcome, confidence string)
+	ObserveAssessmentRelationshipDecision(action, outcome string)
+}

--- a/internal/usecase/ports/assessment_snapshot.go
+++ b/internal/usecase/ports/assessment_snapshot.go
@@ -1,0 +1,118 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type AssessmentSnapshotDefault struct {
+	TenantID     shared.ID
+	AssessmentID shared.ID
+	SnapshotID   shared.ID
+	Version      int64
+	UpdatedAt    time.Time
+	UpdatedBy    string
+}
+
+type AssessmentSnapshotListQuery struct {
+	TenantID            shared.ID
+	AssessmentID        shared.ID
+	AfterSnapshotNumber int
+	Limit               int
+}
+
+type AssessmentSnapshotPage struct {
+	Items   []assessmentsnapshot.Snapshot
+	HasMore bool
+}
+
+type AssessmentSnapshotRepository interface {
+	CreateFinalizedCAS(ctx context.Context, snapshot *assessmentsnapshot.Snapshot, expectedDefaultVersion int64) (*assessmentsnapshot.Snapshot, bool, error)
+	CreateLegacyProjection(ctx context.Context, snapshot *assessmentsnapshot.Snapshot) (*assessmentsnapshot.Snapshot, bool, error)
+	Get(ctx context.Context, tenantID, snapshotID shared.ID) (*assessmentsnapshot.Snapshot, error)
+	GetByRequestKey(ctx context.Context, tenantID, assessmentID shared.ID, requestKey string) (*assessmentsnapshot.Snapshot, error)
+	GetDefault(ctx context.Context, tenantID, assessmentID shared.ID) (*assessmentsnapshot.Snapshot, AssessmentSnapshotDefault, error)
+	ListAssessmentSnapshots(ctx context.Context, query AssessmentSnapshotListQuery) (AssessmentSnapshotPage, error)
+}
+
+type AssessmentSnapshotDefaultReader interface {
+	GetDefault(ctx context.Context, tenantID, assessmentID shared.ID) (*assessmentsnapshot.Snapshot, AssessmentSnapshotDefault, error)
+}
+
+// AssessmentSnapshotRunReader exposes the tenant-scoped provenance reads used by
+// snapshot finalization and backfill without coupling them to legacy scan-run writes.
+type AssessmentSnapshotRunReader interface {
+	GetScanRun(ctx context.Context, tenantID shared.ID, runID string) (scanrun.ScanRun, error)
+	ListScanRuns(ctx context.Context, tenantID, engagementID shared.ID) ([]scanrun.ScanRun, error)
+}
+
+type AssessmentSnapshotBackfillState string
+
+const (
+	AssessmentSnapshotBackfillRunning   AssessmentSnapshotBackfillState = "running"
+	AssessmentSnapshotBackfillCompleted AssessmentSnapshotBackfillState = "completed"
+	AssessmentSnapshotBackfillCancelled AssessmentSnapshotBackfillState = "cancelled"
+	AssessmentSnapshotBackfillFailed    AssessmentSnapshotBackfillState = "failed"
+)
+
+type AssessmentSnapshotBackfillRun struct {
+	TenantID             shared.ID
+	ID                   shared.ID
+	SchemaVersion        int
+	DryRun               bool
+	BatchSize            int
+	SnapshotAt           time.Time
+	CheckpointAssessment shared.ID
+	State                AssessmentSnapshotBackfillState
+	LeaseOwner           string
+	LeaseToken           shared.ID
+	LeaseExpiresAt       time.Time
+	ProcessedCount       int
+	CreatedCount         int
+	WouldCreateCount     int
+	SkippedCount         int
+	FailedCount          int
+	CreatedBy            string
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+	CompletedAt          *time.Time
+}
+
+type AssessmentSnapshotBackfillAcquireRequest struct {
+	Run               AssessmentSnapshotBackfillRun
+	InitialCheckpoint shared.ID
+	LeaseDuration     time.Duration
+}
+
+type AssessmentSnapshotBackfillItem struct {
+	TenantID       shared.ID
+	RunID          shared.ID
+	AssessmentID   shared.ID
+	SchemaVersion  int
+	IdempotencyKey string
+	SourceHash     string
+	SnapshotID     shared.ID
+	Outcome        string
+	ReasonCode     string
+	Retryable      bool
+	RepairGuidance string
+	ProcessedAt    time.Time
+}
+
+type AssessmentSnapshotBackfillSource interface {
+	ListAssessmentSnapshotBackfillEngagements(ctx context.Context, tenantID, after shared.ID, snapshotAt time.Time, limit int) ([]*engdom.Engagement, error)
+}
+
+type AssessmentSnapshotBackfillStore interface {
+	AcquireAssessmentSnapshotBackfillRun(ctx context.Context, request AssessmentSnapshotBackfillAcquireRequest) (run AssessmentSnapshotBackfillRun, resumed bool, err error)
+	GetAssessmentSnapshotBackfillRun(ctx context.Context, tenantID, runID shared.ID) (AssessmentSnapshotBackfillRun, error)
+	GetAssessmentSnapshotBackfillItem(ctx context.Context, tenantID, runID, assessmentID shared.ID) (AssessmentSnapshotBackfillItem, error)
+	CommitAssessmentSnapshotBackfillItem(ctx context.Context, tenantID, runID, leaseToken shared.ID, now time.Time, build func(context.Context) (AssessmentSnapshotBackfillItem, error)) (item AssessmentSnapshotBackfillItem, created bool, err error)
+	AdvanceAssessmentSnapshotBackfillRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken, checkpoint shared.ID, now time.Time, leaseDuration time.Duration) (AssessmentSnapshotBackfillRun, error)
+	FinishAssessmentSnapshotBackfillRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken shared.ID, state AssessmentSnapshotBackfillState, now time.Time) (AssessmentSnapshotBackfillRun, error)
+}

--- a/internal/usecase/ports/finding_lineage.go
+++ b/internal/usecase/ports/finding_lineage.go
@@ -1,0 +1,39 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type FindingLineageRepository interface {
+	// LockCorrelationNamespace serializes the first identity/observation decision
+	// for one canonical namespace for the surrounding tenant transaction.
+	LockCorrelationNamespace(context.Context, shared.ID, shared.ID, string, string, string, string) error
+	CreateIdentityWithObservation(context.Context, findinglineage.Identity, findinglineage.Observation) error
+	AppendObservation(context.Context, findinglineage.Observation) error
+	AppendAlias(context.Context, findinglineage.Alias) (bool, error)
+	GetIdentity(context.Context, shared.ID, shared.ID, shared.ID) (findinglineage.Identity, error)
+	GetObservation(context.Context, shared.ID, shared.ID, shared.ID) (findinglineage.Observation, error)
+	GetObservationBySource(context.Context, shared.ID, shared.ID, shared.ID, string, string, string, string, string) (findinglineage.Observation, error)
+	FindIdentitiesByProducerID(context.Context, shared.ID, shared.ID, string, string, string, string) ([]findinglineage.Identity, error)
+	FindIdentitiesByFingerprint(context.Context, shared.ID, shared.ID, string, string, int, string, string) ([]findinglineage.Identity, error)
+	FindIdentitiesByAlias(context.Context, shared.ID, shared.ID, string, string, int, string, string) ([]findinglineage.Identity, error)
+	ListObservationsBySnapshot(context.Context, shared.ID, shared.ID, shared.ID) ([]findinglineage.Observation, error)
+	ListOpenCandidatesBySnapshot(context.Context, shared.ID, shared.ID, shared.ID) ([]findinglineage.MatchCandidate, error)
+	ListActiveOverridesBySnapshot(context.Context, shared.ID, shared.ID, shared.ID) ([]findinglineage.OverrideEvent, error)
+	CreateCandidate(context.Context, findinglineage.MatchCandidate, shared.ID) (findinglineage.MatchCandidate, bool, error)
+	GetCandidate(context.Context, shared.ID, shared.ID, shared.ID) (findinglineage.MatchCandidate, error)
+	ResolveCandidateCAS(context.Context, findinglineage.MatchCandidate, findinglineage.ResolutionEvent) (findinglineage.MatchCandidate, findinglineage.ResolutionEvent, bool, error)
+	ListCandidateResolutions(context.Context, shared.ID, shared.ID, shared.ID) ([]findinglineage.ResolutionEvent, error)
+	GetActiveOverride(context.Context, shared.ID, shared.ID, shared.ID) (findinglineage.OverrideEvent, error)
+	AppendOverrideCAS(context.Context, findinglineage.OverrideEvent) (findinglineage.OverrideEvent, bool, error)
+	ListOverrideEvents(context.Context, shared.ID, shared.ID, shared.ID) ([]findinglineage.OverrideEvent, error)
+	AppendSkip(context.Context, findinglineage.SkipRecord) (findinglineage.SkipRecord, bool, error)
+	ListSkipsBySnapshot(context.Context, shared.ID, shared.ID, shared.ID) ([]findinglineage.SkipRecord, error)
+}
+
+type FindingLineageObserver interface {
+	ObserveFindingLineage(outcome, method, reason string)
+}

--- a/internal/usecase/ports/finding_lineage_backfill.go
+++ b/internal/usecase/ports/finding_lineage_backfill.go
@@ -1,0 +1,98 @@
+package ports
+
+import (
+	"context"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type FindingLineageBackfillState string
+
+const (
+	FindingLineageBackfillRunning   FindingLineageBackfillState = "running"
+	FindingLineageBackfillCompleted FindingLineageBackfillState = "completed"
+	FindingLineageBackfillCancelled FindingLineageBackfillState = "cancelled"
+	FindingLineageBackfillFailed    FindingLineageBackfillState = "failed"
+)
+
+type FindingLineageBackfillRun struct {
+	TenantID                  shared.ID
+	ID                        shared.ID
+	SchemaVersion             int
+	DryRun                    bool
+	BatchSize                 int
+	ProducerFilters           []string
+	SnapshotAt                time.Time
+	CheckpointFinding         shared.ID
+	State                     FindingLineageBackfillState
+	LeaseOwner                string
+	LeaseToken                shared.ID
+	LeaseExpiresAt            time.Time
+	ProcessedCount            int
+	ObservationCreatedCount   int
+	ProvisionalCandidateCount int
+	SkippedCount              int
+	CreatedBy                 string
+	CreatedAt                 time.Time
+	UpdatedAt                 time.Time
+	CompletedAt               *time.Time
+}
+
+type FindingLineageBackfillAcquireRequest struct {
+	Run               FindingLineageBackfillRun
+	InitialCheckpoint shared.ID
+	LeaseDuration     time.Duration
+}
+
+type FindingLineageBackfillItem struct {
+	TenantID        shared.ID
+	RunID           shared.ID
+	AssessmentID    shared.ID
+	CycleID         shared.ID
+	SnapshotID      shared.ID
+	SourceFindingID shared.ID
+	SchemaVersion   int
+	MatcherVersion  int
+	IdempotencyKey  string
+	SourceHash      string
+	Outcome         string
+	ReasonCode      string
+	ProcessedAt     time.Time
+}
+
+type FindingLineageBackfillSourceRow struct {
+	TenantID             shared.ID
+	AssessmentID         shared.ID
+	CycleID              shared.ID
+	SnapshotID           shared.ID
+	SnapshotContentHash  string
+	OwnershipValid       bool
+	FindingID            shared.ID
+	Kind                 finding.Kind
+	RuleKey              string
+	DedupKey             string
+	AdvisoryID           string
+	OccurrenceID         shared.ID
+	ComponentFingerprint string
+	Severity             shared.Severity
+	RiskScore            float64
+	Reachability         string
+	SourceLocation       *finding.SourceLocation
+	CreatedAt            time.Time
+	ObservedAt           time.Time
+}
+
+type FindingLineageBackfillSource interface {
+	ListFindingLineageBackfillSources(ctx context.Context, tenantID, after shared.ID, snapshotAt time.Time, producerFilters []string, limit int) ([]FindingLineageBackfillSourceRow, error)
+}
+
+type FindingLineageBackfillStore interface {
+	AcquireFindingLineageBackfillRun(ctx context.Context, request FindingLineageBackfillAcquireRequest) (run FindingLineageBackfillRun, resumed bool, err error)
+	GetFindingLineageBackfillRun(ctx context.Context, tenantID, runID shared.ID) (FindingLineageBackfillRun, error)
+	GetFindingLineageBackfillItem(ctx context.Context, tenantID, runID, sourceFindingID shared.ID) (FindingLineageBackfillItem, error)
+	CommitFindingLineageBackfillItem(ctx context.Context, tenantID, runID, leaseToken shared.ID, now time.Time, build func(context.Context) (FindingLineageBackfillItem, error)) (item FindingLineageBackfillItem, created bool, err error)
+	AdvanceFindingLineageBackfillRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken, checkpoint shared.ID, now time.Time, leaseDuration time.Duration) (FindingLineageBackfillRun, error)
+	FinishFindingLineageBackfillRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken shared.ID, state FindingLineageBackfillState, now time.Time) (FindingLineageBackfillRun, error)
+}

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -325,6 +325,32 @@ type EngagementSourceStore interface {
 	Materialize(ctx context.Context, locator string) (string, sourcepackage.Package, func() error, error)
 }
 
+type EngagementSourceReuser interface {
+	Reuse(ctx context.Context, tenantID, parentEngagementID, childEngagementID, expectedVersionID shared.ID, actor string, at time.Time) (sourcepackage.Package, error)
+}
+
+type EngagementSourceVersionReader interface {
+	GetByVersion(ctx context.Context, tenantID, engagementID, versionID shared.ID) (sourcepackage.Package, error)
+}
+
+// EngagementSourceCompensator releases a newly uploaded, unpublished object after
+// the enclosing metadata transaction has rolled back. Reused objects are retained.
+type EngagementSourceCompensator interface {
+	DiscardUnpublished(ctx context.Context, item sourcepackage.Package) error
+}
+
+// EngagementSourceRepository retains one immutable, versioned package binding per
+// engagement. Delete removes only an unreferenced binding; its boolean is true
+// only when no retained package references the returned object's storage key.
+type EngagementSourceRepository interface {
+	Create(ctx context.Context, item sourcepackage.Package) (sourcepackage.Package, bool, error)
+	Get(ctx context.Context, tenantID, engagementID shared.ID) (sourcepackage.Package, error)
+	GetByVersion(ctx context.Context, tenantID, engagementID, versionID shared.ID) (sourcepackage.Package, error)
+	GetByLocator(ctx context.Context, tenantID shared.ID, locator string) (sourcepackage.Package, error)
+	Delete(ctx context.Context, tenantID, engagementID shared.ID) (sourcepackage.Package, bool, error)
+	ObjectUnreferenced(ctx context.Context, tenantID shared.ID, objectKey string) (bool, error)
+}
+
 // EngagementRepository persists engagements. Returned aggregates are read-only –
 // callers must not mutate them (implementations may return shared instances).
 type EngagementRepository interface {
@@ -620,14 +646,17 @@ type ScanSnapshot struct {
 // ScanManifest captures everything needed to explain + replay a scan result
 // (reproducibility / chain-of-custody). Stored per run.
 type ScanManifest struct {
-	ToolVersions       map[string]string `json:"tool_versions"`       // syft/grype/enry/synapse + *-db
-	VulnDBSnapshot     string            `json:"vuln_db_snapshot"`    // osv.dev@<time> (live source marker)
-	GrypeDBVersion     string            `json:"grype_db_version"`    // pinned grype DB schema@built
-	CorrelationVersion int               `json:"correlation_version"` // bumped when merge logic changes
-	SBOMSHA256         string            `json:"sbom_sha256"`         // hash of the generator's raw SBOM
-	ReproScore         int               `json:"repro_score"`         // 0..100, fraction of pinned inputs
-	PinnedInputs       []string          `json:"pinned_inputs"`       // which inputs are version-pinned
-	UnpinnedInputs     []string          `json:"unpinned_inputs"`     // which are live (e.g. osv.dev)
+	// SourcePackage is frozen at scan admission, never resolved from current
+	// engagement state when rendering historical scan results.
+	SourcePackage      *sourcepackage.Package `json:"source_package,omitempty"`
+	ToolVersions       map[string]string      `json:"tool_versions"`       // syft/grype/enry/synapse + *-db
+	VulnDBSnapshot     string                 `json:"vuln_db_snapshot"`    // osv.dev@<time> (live source marker)
+	GrypeDBVersion     string                 `json:"grype_db_version"`    // pinned grype DB schema@built
+	CorrelationVersion int                    `json:"correlation_version"` // bumped when merge logic changes
+	SBOMSHA256         string                 `json:"sbom_sha256"`         // hash of the generator's raw SBOM
+	ReproScore         int                    `json:"repro_score"`         // 0..100, fraction of pinned inputs
+	PinnedInputs       []string               `json:"pinned_inputs"`       // which inputs are version-pinned
+	UnpinnedInputs     []string               `json:"unpinned_inputs"`     // which are live (e.g. osv.dev)
 }
 
 // ScanRun is one persisted scan execution: its manifest plus the finding identity
@@ -861,17 +890,18 @@ type ScanDebugEvent struct {
 // ScanJob tracks the progress of an asynchronous scan so the UI can show a
 // progress bar and survive a page reload (the pipeline runs server-side).
 type ScanJob struct {
-	ID           string           `json:"id"`
-	EngagementID string           `json:"engagement_id"`
-	Target       string           `json:"target"`
-	Kind         string           `json:"kind"`
-	Status       ScanStatus       `json:"status"`
-	Stage        string           `json:"stage"`
-	Progress     int              `json:"progress"` // 0..100
-	Error        string           `json:"error,omitempty"`
-	StartedAt    time.Time        `json:"started_at"`
-	FinishedAt   *time.Time       `json:"finished_at,omitempty"`
-	DebugEvents  []ScanDebugEvent `json:"debug_events"`
+	SourcePackage *sourcepackage.Package `json:"source_package,omitempty"`
+	ID            string                 `json:"id"`
+	EngagementID  string                 `json:"engagement_id"`
+	Target        string                 `json:"target"`
+	Kind          string                 `json:"kind"`
+	Status        ScanStatus             `json:"status"`
+	Stage         string                 `json:"stage"`
+	Progress      int                    `json:"progress"` // 0..100
+	Error         string                 `json:"error,omitempty"`
+	StartedAt     time.Time              `json:"started_at"`
+	FinishedAt    *time.Time             `json:"finished_at,omitempty"`
+	DebugEvents   []ScanDebugEvent       `json:"debug_events"`
 }
 
 // ScanJobStore persists scan-job status (upserted as the pipeline progresses).
@@ -1357,12 +1387,15 @@ const (
 
 // AcquireRequest identifies a scan target and how to obtain it.
 type AcquireRequest struct {
-	Kind       string // local | git | archive | upload | image (default: local)
-	Value      string // path, git URL, archive path, or image ref
-	Locator    string // internal locator for a server-owned uploaded source package
-	Ref        string // optional git branch/tag to clone (git kind only)
-	BaseRef    string // optional validated Git comparison base ref
-	BaseCommit string // optional immutable base commit from a previous analysis
+	// SourcePackage is server-resolved and pinned before an upload scan is queued.
+	// HTTP adapters must never accept caller-supplied package metadata or locators.
+	SourcePackage *sourcepackage.Package
+	Kind          string // local | git | archive | upload | image (default: local)
+	Value         string // path, git URL, archive path, or image ref
+	Locator       string // internal locator for a server-owned uploaded source package
+	Ref           string // optional git branch/tag to clone (git kind only)
+	BaseRef       string // optional validated Git comparison base ref
+	BaseCommit    string // optional immutable base commit from a previous analysis
 }
 
 // Workspace is an isolated directory holding a target to analyze (never execute).

--- a/internal/usecase/ports/scan_run_evidence.go
+++ b/internal/usecase/ports/scan_run_evidence.go
@@ -1,0 +1,38 @@
+package ports
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const MaxScanRunEvidenceBytes = 128 << 20
+
+// ScanRunEvidence retains redacted comparison inputs, never the mutable latest
+// result cache. ContentHash is included in the sealed lane manifest.
+type ScanRunEvidence struct {
+	TenantID    shared.ID
+	RunID       string
+	ContentHash string
+	Payload     []byte
+}
+
+func (e ScanRunEvidence) Validate() error {
+	if e.TenantID.IsZero() || e.RunID == "" || len(e.Payload) == 0 || len(e.Payload) > MaxScanRunEvidenceBytes || !json.Valid(e.Payload) {
+		return fmt.Errorf("%w: invalid immutable scan evidence", shared.ErrValidation)
+	}
+	digest := sha256.Sum256(e.Payload)
+	if hex.EncodeToString(digest[:]) != e.ContentHash {
+		return fmt.Errorf("%w: scan evidence content hash mismatch", shared.ErrValidation)
+	}
+	return nil
+}
+
+type ScanRunEvidenceStore interface {
+	SaveScanRunEvidence(context.Context, ScanRunEvidence) error
+	GetScanRunEvidence(context.Context, shared.ID, string) (ScanRunEvidence, error)
+}

--- a/migrations/0147_assessment_snapshots.sql
+++ b/migrations/0147_assessment_snapshots.sql
@@ -1,0 +1,256 @@
+-- +goose Up
+-- Assessment Snapshot schema follows the scan-run provenance foundation (0129).
+-- A2 (#696): immutable Assessment Snapshots and deterministic coverage comparability.
+
+CREATE TABLE assessment_snapshots (
+    tenant_id        TEXT NOT NULL,
+    id               TEXT NOT NULL,
+    cycle_id         TEXT NOT NULL,
+    assessment_id    TEXT NOT NULL,
+    snapshot_number  INTEGER NOT NULL CHECK (snapshot_number > 0),
+    default_version BIGINT NOT NULL DEFAULT 0 CHECK (default_version >= 0),
+    lifecycle        TEXT NOT NULL CHECK (lifecycle IN ('building','finalized','superseded')),
+    provenance       TEXT NOT NULL CHECK (provenance IN ('native','legacy')),
+    boundary_kind    TEXT NOT NULL CHECK (boundary_kind IN ('standalone','asset','project','asset_project')),
+    business_asset_id TEXT,
+    project_id       TEXT,
+    schema_version   INTEGER NOT NULL CHECK (schema_version = 1),
+    content_hash     TEXT NOT NULL CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+    request_key      TEXT NOT NULL CHECK (btrim(request_key) <> ''),
+    request_hash     TEXT NOT NULL CHECK (request_hash ~ '^[0-9a-f]{64}$'),
+    created_at       TIMESTAMPTZ NOT NULL,
+    created_by       TEXT NOT NULL,
+    finalized_at     TIMESTAMPTZ,
+    finalized_by     TEXT NOT NULL DEFAULT '',
+    superseded_at    TIMESTAMPTZ,
+    superseded_by    TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (tenant_id, id),
+	UNIQUE (tenant_id, assessment_id, id),
+    UNIQUE (tenant_id, assessment_id, snapshot_number),
+    UNIQUE (tenant_id, assessment_id, request_key),
+    FOREIGN KEY (tenant_id, cycle_id, assessment_id)
+        REFERENCES assessment_cycle_members(tenant_id, cycle_id, assessment_id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, assessment_id)
+        REFERENCES engagements(tenant_id, id) ON DELETE RESTRICT,
+    CONSTRAINT assessment_snapshots_boundary_check CHECK (
+        (boundary_kind = 'standalone' AND business_asset_id IS NULL AND project_id IS NULL) OR
+        (boundary_kind = 'asset' AND business_asset_id IS NOT NULL AND project_id IS NULL) OR
+        (boundary_kind = 'project' AND business_asset_id IS NULL AND project_id IS NOT NULL) OR
+        (boundary_kind = 'asset_project' AND business_asset_id IS NOT NULL AND project_id IS NOT NULL)
+    ),
+    CONSTRAINT assessment_snapshots_lifecycle_metadata_check CHECK (
+        (lifecycle = 'building' AND finalized_at IS NULL AND finalized_by = '' AND superseded_at IS NULL AND superseded_by = '') OR
+        (lifecycle = 'finalized' AND finalized_at IS NOT NULL AND finalized_by <> '' AND superseded_at IS NULL AND superseded_by = '') OR
+        (lifecycle = 'superseded' AND finalized_at IS NOT NULL AND finalized_by <> '' AND superseded_at IS NOT NULL AND superseded_by <> '')
+    )
+);
+
+CREATE TABLE assessment_snapshot_run_refs (
+    tenant_id       TEXT NOT NULL,
+    snapshot_id     TEXT NOT NULL,
+    position        INTEGER NOT NULL CHECK (position >= 0),
+    scan_run_id     TEXT NOT NULL,
+    manifest_hash   TEXT NOT NULL CHECK (manifest_hash ~ '^[0-9a-f]{64}$'),
+    PRIMARY KEY (tenant_id, snapshot_id, position),
+    UNIQUE (tenant_id, snapshot_id, scan_run_id),
+    UNIQUE (tenant_id, snapshot_id, position, scan_run_id),
+    FOREIGN KEY (tenant_id, snapshot_id) REFERENCES assessment_snapshots(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, scan_run_id) REFERENCES scan_runs(tenant_id, id) ON DELETE RESTRICT
+);
+
+CREATE TABLE assessment_snapshot_lane_refs (
+    tenant_id       TEXT NOT NULL,
+    snapshot_id     TEXT NOT NULL,
+    run_position    INTEGER NOT NULL,
+    scan_run_id     TEXT NOT NULL,
+    lane_key        TEXT NOT NULL,
+    manifest_hash   TEXT NOT NULL CHECK (manifest_hash ~ '^[0-9a-f]{64}$'),
+    PRIMARY KEY (tenant_id, snapshot_id, run_position, lane_key),
+    FOREIGN KEY (tenant_id, snapshot_id, run_position, scan_run_id)
+        REFERENCES assessment_snapshot_run_refs(tenant_id, snapshot_id, position, scan_run_id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, scan_run_id, lane_key)
+        REFERENCES scan_run_lanes(tenant_id, scan_run_id, lane_key) ON DELETE RESTRICT
+);
+
+CREATE TABLE assessment_snapshot_dimensions (
+    tenant_id          TEXT NOT NULL,
+    snapshot_id        TEXT NOT NULL,
+    position           INTEGER NOT NULL CHECK (position >= 0),
+    run_id             TEXT NOT NULL,
+    lane_key           TEXT NOT NULL,
+    lane_manifest_hash TEXT NOT NULL CHECK (lane_manifest_hash ~ '^[0-9a-f]{64}$'),
+    producer           TEXT NOT NULL CHECK (btrim(producer) <> ''),
+    finding_kind       TEXT NOT NULL CHECK (btrim(finding_kind) <> ''),
+    target_kind        TEXT NOT NULL,
+    target_schema_version INTEGER NOT NULL CHECK (target_schema_version > 0),
+    target_canonical   TEXT NOT NULL CHECK (btrim(target_canonical) <> ''),
+    evaluated_revision TEXT NOT NULL DEFAULT '',
+    coverage_state     TEXT NOT NULL CHECK (coverage_state IN ('complete','partial','unknown')),
+    reason_code        TEXT NOT NULL CHECK (btrim(reason_code) <> ''),
+    included_scope     JSONB NOT NULL CHECK (jsonb_typeof(included_scope) = 'array'),
+    excluded_scope     JSONB NOT NULL CHECK (jsonb_typeof(excluded_scope) = 'array'),
+    versions           JSONB NOT NULL CHECK (jsonb_typeof(versions) = 'array'),
+    PRIMARY KEY (tenant_id, snapshot_id, position),
+    UNIQUE (tenant_id, snapshot_id, target_kind, target_schema_version, target_canonical, producer, finding_kind),
+    FOREIGN KEY (tenant_id, snapshot_id) REFERENCES assessment_snapshots(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, snapshot_id, run_id) REFERENCES assessment_snapshot_run_refs(tenant_id, snapshot_id, scan_run_id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, run_id, lane_key) REFERENCES scan_run_lanes(tenant_id, scan_run_id, lane_key) ON DELETE RESTRICT
+);
+
+CREATE TABLE assessment_snapshot_counters (
+    tenant_id            TEXT NOT NULL,
+    assessment_id        TEXT NOT NULL,
+    next_snapshot_number INTEGER NOT NULL CHECK (next_snapshot_number >= 1),
+    PRIMARY KEY (tenant_id, assessment_id),
+    FOREIGN KEY (tenant_id, assessment_id) REFERENCES engagements(tenant_id, id) ON DELETE RESTRICT
+);
+
+CREATE TABLE assessment_snapshot_defaults (
+    tenant_id      TEXT NOT NULL,
+    assessment_id  TEXT NOT NULL,
+    snapshot_id    TEXT NOT NULL,
+    version        BIGINT NOT NULL CHECK (version >= 1),
+    updated_at     TIMESTAMPTZ NOT NULL,
+    updated_by     TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, assessment_id),
+    FOREIGN KEY (tenant_id, assessment_id) REFERENCES engagements(tenant_id, id) ON DELETE RESTRICT,
+	FOREIGN KEY (tenant_id, assessment_id, snapshot_id) REFERENCES assessment_snapshots(tenant_id, assessment_id, id) ON DELETE RESTRICT
+);
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION synapse_assessment_snapshot_guard() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE engagement_status TEXT;
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        SELECT status INTO engagement_status FROM engagements WHERE tenant_id = NEW.tenant_id AND id = NEW.assessment_id;
+		IF NEW.provenance = 'native' AND engagement_status NOT IN ('draft','active') THEN
+            RAISE EXCEPTION 'assessment snapshot requires draft/active engagement';
+        END IF;
+        RETURN NEW;
+    END IF;
+    IF OLD.lifecycle = 'building' AND NEW.lifecycle = 'finalized' AND
+	   (NEW.tenant_id,NEW.id,NEW.cycle_id,NEW.assessment_id,NEW.snapshot_number,NEW.default_version,NEW.provenance,NEW.boundary_kind,
+        NEW.business_asset_id,NEW.project_id,NEW.schema_version,NEW.content_hash,NEW.request_key,NEW.request_hash,
+        NEW.created_at,NEW.created_by,NEW.superseded_at,NEW.superseded_by)
+       IS NOT DISTINCT FROM
+	   (OLD.tenant_id,OLD.id,OLD.cycle_id,OLD.assessment_id,OLD.snapshot_number,OLD.default_version,OLD.provenance,OLD.boundary_kind,
+        OLD.business_asset_id,OLD.project_id,OLD.schema_version,OLD.content_hash,OLD.request_key,OLD.request_hash,
+        OLD.created_at,OLD.created_by,OLD.superseded_at,OLD.superseded_by) THEN
+        RETURN NEW;
+    END IF;
+    IF OLD.lifecycle = 'finalized' AND NEW.lifecycle = 'superseded' AND
+	   (NEW.tenant_id,NEW.id,NEW.cycle_id,NEW.assessment_id,NEW.snapshot_number,NEW.default_version,NEW.provenance,NEW.boundary_kind,
+        NEW.business_asset_id,NEW.project_id,NEW.schema_version,NEW.content_hash,NEW.request_key,NEW.request_hash,
+        NEW.created_at,NEW.created_by,NEW.finalized_at,NEW.finalized_by)
+       IS NOT DISTINCT FROM
+	   (OLD.tenant_id,OLD.id,OLD.cycle_id,OLD.assessment_id,OLD.snapshot_number,OLD.default_version,OLD.provenance,OLD.boundary_kind,
+        OLD.business_asset_id,OLD.project_id,OLD.schema_version,OLD.content_hash,OLD.request_key,OLD.request_hash,
+        OLD.created_at,OLD.created_by,OLD.finalized_at,OLD.finalized_by) THEN
+        RETURN NEW;
+    END IF;
+    RAISE EXCEPTION 'assessment snapshot is immutable';
+END $$;
+-- +goose StatementEnd
+
+CREATE TRIGGER assessment_snapshots_guard
+BEFORE INSERT OR UPDATE OR DELETE ON assessment_snapshots
+FOR EACH ROW EXECUTE FUNCTION synapse_assessment_snapshot_guard();
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION synapse_assessment_snapshot_child_guard() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE state TEXT;
+DECLARE sid TEXT;
+DECLARE tenant TEXT;
+BEGIN
+    sid := CASE WHEN TG_OP = 'DELETE' THEN OLD.snapshot_id ELSE NEW.snapshot_id END;
+    tenant := CASE WHEN TG_OP = 'DELETE' THEN OLD.tenant_id ELSE NEW.tenant_id END;
+    SELECT lifecycle INTO state FROM assessment_snapshots WHERE tenant_id = tenant AND id = sid;
+    IF state <> 'building' THEN
+        RAISE EXCEPTION 'finalized assessment snapshot child is immutable';
+    END IF;
+    RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END $$;
+-- +goose StatementEnd
+
+CREATE TRIGGER assessment_snapshot_run_refs_guard BEFORE INSERT OR UPDATE OR DELETE ON assessment_snapshot_run_refs FOR EACH ROW EXECUTE FUNCTION synapse_assessment_snapshot_child_guard();
+CREATE TRIGGER assessment_snapshot_lane_refs_guard BEFORE INSERT OR UPDATE OR DELETE ON assessment_snapshot_lane_refs FOR EACH ROW EXECUTE FUNCTION synapse_assessment_snapshot_child_guard();
+CREATE TRIGGER assessment_snapshot_dimensions_guard BEFORE INSERT OR UPDATE OR DELETE ON assessment_snapshot_dimensions FOR EACH ROW EXECUTE FUNCTION synapse_assessment_snapshot_child_guard();
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION synapse_assessment_snapshot_default_guard() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE engagement_status TEXT;
+DECLARE snapshot_state TEXT;
+BEGIN
+    SELECT status INTO engagement_status FROM engagements WHERE tenant_id = NEW.tenant_id AND id = NEW.assessment_id;
+    IF engagement_status NOT IN ('draft','active') THEN
+        RAISE EXCEPTION 'default assessment snapshot cannot change after engagement completion';
+    END IF;
+    SELECT lifecycle INTO snapshot_state FROM assessment_snapshots WHERE tenant_id = NEW.tenant_id AND id = NEW.snapshot_id;
+    IF snapshot_state <> 'finalized' THEN
+        RAISE EXCEPTION 'default assessment snapshot must be finalized';
+    END IF;
+    RETURN NEW;
+END $$;
+-- +goose StatementEnd
+
+CREATE TRIGGER assessment_snapshot_defaults_guard BEFORE INSERT OR UPDATE ON assessment_snapshot_defaults FOR EACH ROW EXECUTE FUNCTION synapse_assessment_snapshot_default_guard();
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION synapse_assessment_snapshot_pointer_delete_guard() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+	RAISE EXCEPTION 'assessment snapshot pointer and counter rows cannot be deleted';
+END $$;
+-- +goose StatementEnd
+
+CREATE TRIGGER assessment_snapshot_defaults_delete_guard BEFORE DELETE ON assessment_snapshot_defaults FOR EACH ROW EXECUTE FUNCTION synapse_assessment_snapshot_pointer_delete_guard();
+CREATE TRIGGER assessment_snapshot_counters_delete_guard BEFORE DELETE ON assessment_snapshot_counters FOR EACH ROW EXECUTE FUNCTION synapse_assessment_snapshot_pointer_delete_guard();
+
+-- Once an Assessment joins a Cycle its governed Business Asset boundary is
+-- immutable. This invariant lives in the first migration introduced by this
+-- slice so upgrades from an already-applied 0126 install it as well.
+-- +goose StatementBegin
+CREATE FUNCTION synapse_reject_assessment_cycle_boundary_change() RETURNS trigger AS $$
+BEGIN
+    IF NEW.business_asset_id IS DISTINCT FROM OLD.business_asset_id AND EXISTS (
+        SELECT 1 FROM assessment_cycle_members
+        WHERE tenant_id = OLD.tenant_id AND assessment_id = OLD.id
+    ) THEN
+        RAISE EXCEPTION 'Assessment Cycle membership freezes the Business Asset boundary'
+            USING ERRCODE = '23514', CONSTRAINT = 'assessment_cycle_frozen_business_asset';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER trg_assessment_cycle_frozen_business_asset
+    BEFORE UPDATE OF business_asset_id ON engagements
+    FOR EACH ROW EXECUTE FUNCTION synapse_reject_assessment_cycle_boundary_change();
+
+CALL synapse_enable_tenant_rls('assessment_snapshots');
+CALL synapse_enable_tenant_rls('assessment_snapshot_run_refs');
+CALL synapse_enable_tenant_rls('assessment_snapshot_lane_refs');
+CALL synapse_enable_tenant_rls('assessment_snapshot_dimensions');
+CALL synapse_enable_tenant_rls('assessment_snapshot_counters');
+CALL synapse_enable_tenant_rls('assessment_snapshot_defaults');
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM assessment_snapshots LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back assessment snapshots while snapshot rows exist';
+    END IF;
+END $$;
+-- +goose StatementEnd
+DROP TRIGGER IF EXISTS trg_assessment_cycle_frozen_business_asset ON engagements;
+DROP FUNCTION IF EXISTS synapse_reject_assessment_cycle_boundary_change();
+DROP TABLE IF EXISTS assessment_snapshot_defaults;
+DROP TABLE IF EXISTS assessment_snapshot_counters;
+DROP TABLE IF EXISTS assessment_snapshot_dimensions;
+DROP TABLE IF EXISTS assessment_snapshot_lane_refs;
+DROP TABLE IF EXISTS assessment_snapshot_run_refs;
+DROP TABLE IF EXISTS assessment_snapshots;
+DROP FUNCTION IF EXISTS synapse_assessment_snapshot_default_guard();
+DROP FUNCTION IF EXISTS synapse_assessment_snapshot_child_guard();
+DROP FUNCTION IF EXISTS synapse_assessment_snapshot_guard();
+DROP FUNCTION IF EXISTS synapse_assessment_snapshot_pointer_delete_guard();

--- a/migrations/0148_assessment_cycle_api.sql
+++ b/migrations/0148_assessment_cycle_api.sql
@@ -1,0 +1,92 @@
+-- +goose Up
+-- Assessment Cycle HTTP/idempotency schema.
+-- A5 (#699): tenant-scoped retained responses for Cycle/Re-test API idempotency.
+
+ALTER TABLE engagements
+    ADD COLUMN requires_explicit_execution_authorization BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- Date-only planning metadata is deliberately separate from authorization.
+ALTER TABLE assessment_cycle_members ADD COLUMN planned_date TEXT NOT NULL DEFAULT ''
+    CHECK (planned_date = '' OR (planned_date ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'
+        AND planned_date = to_char(planned_date::date, 'YYYY-MM-DD')));
+
+CREATE TABLE assessment_cycle_api_requests (
+    tenant_id       TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+    actor           TEXT NOT NULL,
+    route           TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    request_hash    TEXT NOT NULL,
+    status_code     INTEGER NULL,
+    response_body   BYTEA NULL,
+    created_at      TIMESTAMPTZ NOT NULL,
+	expires_at      TIMESTAMPTZ NOT NULL,
+    completed_at    TIMESTAMPTZ NULL,
+    PRIMARY KEY (tenant_id, actor, route, idempotency_key),
+    CONSTRAINT assessment_cycle_api_requests_actor_check CHECK (actor = btrim(actor) AND length(actor) BETWEEN 1 AND 256),
+    CONSTRAINT assessment_cycle_api_requests_route_check CHECK (route = btrim(route) AND length(route) BETWEEN 1 AND 256),
+    CONSTRAINT assessment_cycle_api_requests_key_check CHECK (idempotency_key = btrim(idempotency_key) AND length(idempotency_key) BETWEEN 1 AND 128),
+    CONSTRAINT assessment_cycle_api_requests_hash_check CHECK (request_hash ~ '^[0-9a-f]{64}$'),
+	CONSTRAINT assessment_cycle_api_requests_expiry_check CHECK (expires_at > created_at),
+    CONSTRAINT assessment_cycle_api_requests_response_check CHECK (
+        (status_code IS NULL AND response_body IS NULL AND completed_at IS NULL) OR
+        (status_code BETWEEN 200 AND 599 AND response_body IS NOT NULL AND completed_at IS NOT NULL AND octet_length(response_body) <= 2097152)
+    )
+);
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION synapse_guard_assessment_cycle_api_request()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.tenant_id <> NEW.tenant_id OR OLD.actor <> NEW.actor OR OLD.route <> NEW.route OR
+       OLD.idempotency_key <> NEW.idempotency_key OR OLD.request_hash <> NEW.request_hash OR
+	   OLD.created_at <> NEW.created_at OR OLD.expires_at <> NEW.expires_at THEN
+        RAISE EXCEPTION 'assessment cycle idempotency identity is immutable';
+    END IF;
+    IF OLD.completed_at IS NOT NULL THEN
+        RAISE EXCEPTION 'completed assessment cycle idempotency response is immutable';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE TRIGGER assessment_cycle_api_requests_guard
+BEFORE UPDATE ON assessment_cycle_api_requests
+FOR EACH ROW EXECUTE FUNCTION synapse_guard_assessment_cycle_api_request();
+
+CREATE INDEX idx_assessment_cycle_api_requests_expiry
+    ON assessment_cycle_api_requests (tenant_id, expires_at);
+
+CALL synapse_enable_tenant_rls('assessment_cycle_api_requests');
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM assessment_cycle_members WHERE planned_date <> '' LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back Assessment planning while planned dates exist';
+    END IF;
+    IF EXISTS (SELECT 1 FROM assessment_cycle_api_requests LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back assessment cycle API idempotency while retained responses exist';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+DROP TABLE IF EXISTS assessment_cycle_api_requests;
+DROP FUNCTION IF EXISTS synapse_guard_assessment_cycle_api_request();
+
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM engagements WHERE requires_explicit_execution_authorization LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back explicit Re-test execution authorization while guarded engagements exist';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+ALTER TABLE engagements DROP COLUMN requires_explicit_execution_authorization;
+ALTER TABLE assessment_cycle_members DROP COLUMN planned_date;

--- a/migrations/0149_assessment_cycle_integrity.sql
+++ b/migrations/0149_assessment_cycle_integrity.sql
@@ -1,0 +1,143 @@
+-- +goose Up
+-- Assessment Cycle integrity verification schema.
+-- A9b.2 (#731): resumable, read-only Assessment Cycle integrity verification and repair plans.
+
+CREATE TABLE assessment_cycle_integrity_generations (
+    tenant_id  TEXT PRIMARY KEY REFERENCES tenants(id) ON DELETE CASCADE,
+    generation BIGINT NOT NULL DEFAULT 0 CHECK (generation >= 0)
+);
+
+CREATE TABLE assessment_cycle_integrity_runs (
+    tenant_id                TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+    id                       TEXT NOT NULL,
+    batch_size               INTEGER NOT NULL,
+    snapshot_at              TIMESTAMPTZ NOT NULL,
+    source_generation        BIGINT NOT NULL,
+    checkpoint_assessment_id TEXT NOT NULL DEFAULT '',
+    state                    TEXT NOT NULL,
+    lease_owner              TEXT NOT NULL DEFAULT '',
+    lease_token              TEXT NOT NULL DEFAULT '',
+    lease_expires_at         TIMESTAMPTZ NULL,
+    scanned_count            INTEGER NOT NULL DEFAULT 0,
+    clean_count              INTEGER NOT NULL DEFAULT 0,
+    finding_count            INTEGER NOT NULL DEFAULT 0,
+    created_by               TEXT NOT NULL,
+    created_at               TIMESTAMPTZ NOT NULL,
+    updated_at               TIMESTAMPTZ NOT NULL,
+    completed_at             TIMESTAMPTZ NULL,
+    PRIMARY KEY (tenant_id, id),
+    CONSTRAINT assessment_cycle_integrity_runs_batch_check CHECK (batch_size BETWEEN 1 AND 2000),
+    CONSTRAINT assessment_cycle_integrity_runs_generation_check CHECK (source_generation >= 0),
+    CONSTRAINT assessment_cycle_integrity_runs_checkpoint_check CHECK (octet_length(checkpoint_assessment_id) <= 512),
+    CONSTRAINT assessment_cycle_integrity_runs_state_check CHECK (state IN ('running', 'completed', 'cancelled', 'failed')),
+    CONSTRAINT assessment_cycle_integrity_runs_lease_check CHECK (
+        (state = 'running' AND lease_owner = btrim(lease_owner) AND length(lease_owner) BETWEEN 1 AND 256 AND length(lease_token) BETWEEN 1 AND 512 AND lease_expires_at IS NOT NULL AND completed_at IS NULL) OR
+        (state <> 'running' AND lease_owner = '' AND lease_token = '' AND lease_expires_at IS NULL AND completed_at IS NOT NULL)
+    ),
+    CONSTRAINT assessment_cycle_integrity_runs_counts_check CHECK (
+        scanned_count >= 0 AND clean_count >= 0 AND finding_count >= 0 AND clean_count <= scanned_count AND
+        (finding_count > 0 OR clean_count = scanned_count)
+    ),
+    CONSTRAINT assessment_cycle_integrity_runs_actor_check CHECK (created_by = btrim(created_by) AND length(created_by) BETWEEN 1 AND 256),
+    CONSTRAINT assessment_cycle_integrity_runs_time_check CHECK (updated_at >= created_at AND snapshot_at <= created_at AND (completed_at IS NULL OR completed_at >= created_at))
+);
+
+CREATE UNIQUE INDEX uq_assessment_cycle_integrity_runs_active
+    ON assessment_cycle_integrity_runs (tenant_id)
+    WHERE state = 'running';
+CREATE INDEX idx_assessment_cycle_integrity_runs_history
+    ON assessment_cycle_integrity_runs (tenant_id, created_at DESC, id DESC);
+
+CREATE TABLE assessment_cycle_integrity_subjects (
+    tenant_id      TEXT NOT NULL,
+    run_id         TEXT NOT NULL,
+    assessment_id  TEXT NOT NULL,
+    clean           BOOLEAN NOT NULL,
+    finding_count   INTEGER NOT NULL,
+    processed_at    TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, assessment_id),
+    FOREIGN KEY (tenant_id, run_id) REFERENCES assessment_cycle_integrity_runs(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, assessment_id) REFERENCES engagements(tenant_id, id) ON DELETE RESTRICT,
+    CONSTRAINT assessment_cycle_integrity_subjects_counts_check CHECK (finding_count >= 0 AND clean = (finding_count = 0))
+);
+
+CREATE TABLE assessment_cycle_integrity_findings (
+    tenant_id       TEXT NOT NULL,
+    run_id          TEXT NOT NULL,
+    occurrence_id   TEXT NOT NULL,
+    assessment_id   TEXT NOT NULL,
+    cycle_id        TEXT NULL,
+    member_id       TEXT NULL,
+    reason_code     TEXT NOT NULL,
+    severity        TEXT NOT NULL,
+    repair_plan     JSONB NOT NULL,
+    detected_at     TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, occurrence_id),
+    FOREIGN KEY (tenant_id, run_id, assessment_id) REFERENCES assessment_cycle_integrity_subjects(tenant_id, run_id, assessment_id) ON DELETE RESTRICT,
+    CONSTRAINT assessment_cycle_integrity_findings_occurrence_check CHECK (occurrence_id ~ '^[0-9a-f]{32}$'),
+    CONSTRAINT assessment_cycle_integrity_findings_member_check CHECK ((cycle_id IS NULL AND member_id IS NULL) OR cycle_id IS NOT NULL),
+    CONSTRAINT assessment_cycle_integrity_findings_reason_check CHECK (reason_code ~ '^[a-z0-9_]{1,64}$'),
+    CONSTRAINT assessment_cycle_integrity_findings_severity_check CHECK (severity IN ('medium', 'high', 'critical')),
+    CONSTRAINT assessment_cycle_integrity_findings_repair_check CHECK (jsonb_typeof(repair_plan) = 'object' AND octet_length(repair_plan::text) <= 8192)
+);
+
+CREATE INDEX idx_assessment_cycle_integrity_findings_reason
+    ON assessment_cycle_integrity_findings (tenant_id, run_id, severity, reason_code, occurrence_id);
+
+CALL synapse_enable_tenant_rls('assessment_cycle_integrity_runs');
+CALL synapse_enable_tenant_rls('assessment_cycle_integrity_subjects');
+CALL synapse_enable_tenant_rls('assessment_cycle_integrity_findings');
+CALL synapse_enable_tenant_rls('assessment_cycle_integrity_generations');
+
+-- Serialize lifecycle source mutations with verifier completion and advance a
+-- tenant-local generation for every integrity-relevant change.
+-- +goose StatementBegin
+CREATE FUNCTION synapse_bump_assessment_cycle_integrity_generation() RETURNS trigger AS $$
+DECLARE
+    affected_tenant TEXT;
+BEGIN
+    affected_tenant := CASE WHEN TG_OP = 'DELETE' THEN OLD.tenant_id ELSE NEW.tenant_id END;
+    PERFORM pg_advisory_xact_lock(hashtextextended('assessment-cycle-integrity:' || affected_tenant, 0));
+    INSERT INTO assessment_cycle_integrity_generations(tenant_id,generation)
+    VALUES(affected_tenant,1)
+    ON CONFLICT (tenant_id) DO UPDATE SET generation=assessment_cycle_integrity_generations.generation+1;
+    IF TG_OP = 'DELETE' THEN
+        RETURN OLD;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER trg_engagement_integrity_generation
+    AFTER INSERT OR UPDATE OR DELETE ON engagements
+    FOR EACH ROW EXECUTE FUNCTION synapse_bump_assessment_cycle_integrity_generation();
+CREATE TRIGGER trg_assessment_cycle_integrity_generation
+    AFTER INSERT OR UPDATE OR DELETE ON assessment_cycles
+    FOR EACH ROW EXECUTE FUNCTION synapse_bump_assessment_cycle_integrity_generation();
+CREATE TRIGGER trg_assessment_cycle_member_integrity_generation
+    AFTER INSERT OR UPDATE OR DELETE ON assessment_cycle_members
+    FOR EACH ROW EXECUTE FUNCTION synapse_bump_assessment_cycle_integrity_generation();
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM assessment_cycle_integrity_findings LIMIT 1) OR
+       EXISTS (SELECT 1 FROM assessment_cycle_integrity_subjects LIMIT 1) OR
+       EXISTS (SELECT 1 FROM assessment_cycle_integrity_runs LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back assessment cycle integrity state while verification history exists';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+DROP TRIGGER IF EXISTS trg_assessment_cycle_member_integrity_generation ON assessment_cycle_members;
+DROP TRIGGER IF EXISTS trg_assessment_cycle_integrity_generation ON assessment_cycles;
+DROP TRIGGER IF EXISTS trg_engagement_integrity_generation ON engagements;
+DROP FUNCTION IF EXISTS synapse_bump_assessment_cycle_integrity_generation();
+
+DROP TABLE IF EXISTS assessment_cycle_integrity_findings;
+DROP TABLE IF EXISTS assessment_cycle_integrity_subjects;
+DROP TABLE IF EXISTS assessment_cycle_integrity_runs;
+DROP TABLE IF EXISTS assessment_cycle_integrity_generations;

--- a/migrations/0150_assessment_snapshot_backfill.sql
+++ b/migrations/0150_assessment_snapshot_backfill.sql
@@ -1,0 +1,104 @@
+-- +goose Up
+-- Assessment Snapshot legacy projection backfill schema.
+-- A9c (#718): resumable, append-only legacy Assessment Snapshot projection state.
+
+ALTER TABLE assessment_snapshots
+    ADD CONSTRAINT assessment_snapshots_tenant_assessment_id_unique UNIQUE (tenant_id, assessment_id, id);
+
+CREATE TABLE assessment_snapshot_backfill_runs (
+    tenant_id               TEXT NOT NULL REFERENCES tenants(id) ON DELETE RESTRICT,
+    id                      TEXT NOT NULL,
+    schema_version          INTEGER NOT NULL,
+    dry_run                 BOOLEAN NOT NULL,
+    batch_size              INTEGER NOT NULL,
+    snapshot_at             TIMESTAMPTZ NOT NULL,
+    checkpoint_assessment_id TEXT NOT NULL DEFAULT '',
+    state                   TEXT NOT NULL,
+    lease_owner             TEXT NOT NULL DEFAULT '',
+    lease_token             TEXT NOT NULL DEFAULT '',
+    lease_expires_at        TIMESTAMPTZ NULL,
+    processed_count         INTEGER NOT NULL DEFAULT 0,
+    created_count           INTEGER NOT NULL DEFAULT 0,
+    would_create_count      INTEGER NOT NULL DEFAULT 0,
+    skipped_count           INTEGER NOT NULL DEFAULT 0,
+    failed_count            INTEGER NOT NULL DEFAULT 0,
+    created_by              TEXT NOT NULL,
+    created_at              TIMESTAMPTZ NOT NULL,
+    updated_at              TIMESTAMPTZ NOT NULL,
+    completed_at            TIMESTAMPTZ NULL,
+    PRIMARY KEY (tenant_id, id),
+    CONSTRAINT assessment_snapshot_backfill_runs_schema_check CHECK (schema_version > 0),
+    CONSTRAINT assessment_snapshot_backfill_runs_batch_check CHECK (batch_size BETWEEN 1 AND 2000),
+    CONSTRAINT assessment_snapshot_backfill_runs_checkpoint_check CHECK (octet_length(checkpoint_assessment_id) <= 512),
+    CONSTRAINT assessment_snapshot_backfill_runs_state_check CHECK (state IN ('running', 'completed', 'cancelled', 'failed')),
+    CONSTRAINT assessment_snapshot_backfill_runs_lease_check CHECK (
+        (state = 'running' AND lease_owner = btrim(lease_owner) AND length(lease_owner) BETWEEN 1 AND 256 AND length(lease_token) BETWEEN 1 AND 512 AND lease_expires_at IS NOT NULL AND completed_at IS NULL) OR
+        (state <> 'running' AND lease_owner = '' AND lease_token = '' AND lease_expires_at IS NULL AND completed_at IS NOT NULL)
+    ),
+    CONSTRAINT assessment_snapshot_backfill_runs_counts_check CHECK (
+        processed_count >= 0 AND created_count >= 0 AND would_create_count >= 0 AND skipped_count >= 0 AND failed_count >= 0 AND
+        processed_count = created_count + would_create_count + skipped_count + failed_count
+    ),
+    CONSTRAINT assessment_snapshot_backfill_runs_actor_check CHECK (created_by = btrim(created_by) AND length(created_by) BETWEEN 1 AND 256),
+    CONSTRAINT assessment_snapshot_backfill_runs_time_check CHECK (updated_at >= created_at AND snapshot_at <= created_at AND (completed_at IS NULL OR completed_at >= created_at))
+);
+
+CREATE UNIQUE INDEX uq_assessment_snapshot_backfill_runs_active
+    ON assessment_snapshot_backfill_runs (tenant_id)
+    WHERE state = 'running';
+CREATE INDEX idx_assessment_snapshot_backfill_runs_history
+    ON assessment_snapshot_backfill_runs (tenant_id, created_at DESC, id DESC);
+
+CREATE TABLE assessment_snapshot_backfill_items (
+    tenant_id       TEXT NOT NULL,
+    run_id          TEXT NOT NULL,
+    assessment_id   TEXT NOT NULL,
+    schema_version  INTEGER NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    source_hash     TEXT NOT NULL,
+    snapshot_id     TEXT NULL,
+    outcome         TEXT NOT NULL,
+    reason_code     TEXT NOT NULL,
+    retryable       BOOLEAN NOT NULL DEFAULT FALSE,
+    repair_guidance TEXT NOT NULL DEFAULT '',
+    processed_at    TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, assessment_id),
+    FOREIGN KEY (tenant_id, run_id) REFERENCES assessment_snapshot_backfill_runs(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, assessment_id) REFERENCES engagements(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, assessment_id, snapshot_id)
+        REFERENCES assessment_snapshots(tenant_id, assessment_id, id) ON DELETE RESTRICT,
+    UNIQUE (tenant_id, run_id, idempotency_key),
+    CONSTRAINT assessment_snapshot_backfill_items_schema_check CHECK (schema_version > 0),
+    CONSTRAINT assessment_snapshot_backfill_items_key_check CHECK (idempotency_key = btrim(idempotency_key) AND length(idempotency_key) BETWEEN 1 AND 128),
+    CONSTRAINT assessment_snapshot_backfill_items_source_hash_check CHECK (source_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT assessment_snapshot_backfill_items_outcome_check CHECK (outcome IN ('created', 'would_create', 'skipped', 'failed')),
+    CONSTRAINT assessment_snapshot_backfill_items_reason_check CHECK (reason_code ~ '^[a-z0-9_]{1,64}$'),
+    CONSTRAINT assessment_snapshot_backfill_items_guidance_check CHECK (octet_length(repair_guidance) <= 1024),
+    CONSTRAINT assessment_snapshot_backfill_items_snapshot_check CHECK (
+        (outcome = 'created' AND snapshot_id IS NOT NULL) OR
+        (outcome IN ('would_create', 'failed') AND snapshot_id IS NULL) OR
+        outcome = 'skipped'
+    )
+);
+
+CREATE INDEX idx_assessment_snapshot_backfill_items_outcome
+    ON assessment_snapshot_backfill_items (tenant_id, run_id, outcome, assessment_id);
+
+CALL synapse_enable_tenant_rls('assessment_snapshot_backfill_runs');
+CALL synapse_enable_tenant_rls('assessment_snapshot_backfill_items');
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM assessment_snapshot_backfill_items LIMIT 1) OR
+       EXISTS (SELECT 1 FROM assessment_snapshot_backfill_runs LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back assessment snapshot backfill state while run history exists';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+DROP TABLE IF EXISTS assessment_snapshot_backfill_items;
+DROP TABLE IF EXISTS assessment_snapshot_backfill_runs;
+ALTER TABLE assessment_snapshots DROP CONSTRAINT IF EXISTS assessment_snapshots_tenant_assessment_id_unique;

--- a/migrations/0151_finding_lineage.sql
+++ b/migrations/0151_finding_lineage.sql
@@ -1,0 +1,319 @@
+-- +goose Up
+-- A3 (#697): common versioned Finding Identity and Observation lineage.
+
+ALTER TABLE assessment_snapshots
+    ADD CONSTRAINT assessment_snapshots_tenant_cycle_id_unique UNIQUE (tenant_id, cycle_id, id);
+
+CREATE TABLE finding_identities (
+    tenant_id                      TEXT NOT NULL,
+    cycle_id                       TEXT NOT NULL,
+    id                             TEXT NOT NULL,
+    producer_kind                  TEXT NOT NULL CHECK (btrim(producer_kind) <> '' AND octet_length(producer_kind) <= 256),
+    finding_kind                   TEXT NOT NULL CHECK (btrim(finding_kind) <> '' AND octet_length(finding_kind) <= 256),
+    canonicalization_version       INTEGER NOT NULL CHECK (canonicalization_version = 1),
+    fingerprint_schema_version     INTEGER NOT NULL CHECK (fingerprint_schema_version > 0),
+    lineage_fingerprint            TEXT NOT NULL CHECK (lineage_fingerprint ~ '^[0-9a-f]{64}$'),
+    target_identity_schema_version INTEGER NOT NULL CHECK (target_identity_schema_version > 0),
+    target_identity_canonical      TEXT NOT NULL CHECK (btrim(target_identity_canonical) <> '' AND octet_length(target_identity_canonical) <= 2048),
+    canonical_identity_fields      JSONB NOT NULL CHECK (jsonb_typeof(canonical_identity_fields) = 'object' AND octet_length(canonical_identity_fields::text) <= 32768),
+    first_seen_snapshot_id         TEXT NOT NULL,
+    created_at                     TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, cycle_id, id),
+	UNIQUE (tenant_id, cycle_id, id, producer_kind, finding_kind, target_identity_canonical),
+    FOREIGN KEY (tenant_id, cycle_id) REFERENCES assessment_cycles(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, first_seen_snapshot_id)
+        REFERENCES assessment_snapshots(tenant_id, cycle_id, id) ON DELETE RESTRICT
+);
+CREATE INDEX idx_finding_identities_fingerprint ON finding_identities
+    (tenant_id, cycle_id, producer_kind, finding_kind, target_identity_canonical, fingerprint_schema_version, lineage_fingerprint);
+
+CREATE TABLE finding_identity_aliases (
+    tenant_id        TEXT NOT NULL,
+    cycle_id         TEXT NOT NULL,
+    id               TEXT NOT NULL,
+    identity_id      TEXT NOT NULL,
+    producer_kind    TEXT NOT NULL CHECK (btrim(producer_kind) <> '' AND octet_length(producer_kind) <= 256),
+    finding_kind     TEXT NOT NULL CHECK (btrim(finding_kind) <> '' AND octet_length(finding_kind) <= 256),
+    target_canonical TEXT NOT NULL CHECK (btrim(target_canonical) <> '' AND octet_length(target_canonical) <= 2048),
+    schema_version   INTEGER NOT NULL CHECK (schema_version > 0),
+    fingerprint      TEXT NOT NULL CHECK (fingerprint ~ '^[0-9a-f]{64}$'),
+    approved_by      TEXT NOT NULL CHECK (btrim(approved_by) <> '' AND octet_length(approved_by) <= 256),
+    approved_at      TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, cycle_id, id),
+    UNIQUE (tenant_id, cycle_id, identity_id, producer_kind, finding_kind, target_canonical, schema_version, fingerprint),
+    FOREIGN KEY (tenant_id, cycle_id, identity_id, producer_kind, finding_kind, target_canonical)
+        REFERENCES finding_identities(tenant_id, cycle_id, id, producer_kind, finding_kind, target_identity_canonical) ON DELETE RESTRICT
+);
+CREATE INDEX idx_finding_identity_aliases_lookup ON finding_identity_aliases
+    (tenant_id, cycle_id, producer_kind, finding_kind, target_canonical, schema_version, fingerprint);
+
+CREATE TABLE finding_observations (
+    tenant_id           TEXT NOT NULL,
+    cycle_id            TEXT NOT NULL,
+    id                  TEXT NOT NULL,
+    snapshot_id         TEXT NOT NULL,
+    identity_id         TEXT NOT NULL,
+    producer_kind       TEXT NOT NULL CHECK (btrim(producer_kind) <> '' AND octet_length(producer_kind) <= 256),
+    finding_kind        TEXT NOT NULL CHECK (btrim(finding_kind) <> '' AND octet_length(finding_kind) <= 256),
+    target_canonical    TEXT NOT NULL CHECK (btrim(target_canonical) <> '' AND octet_length(target_canonical) <= 2048),
+    source_finding_id   TEXT NOT NULL DEFAULT '' CHECK (octet_length(source_finding_id) <= 512),
+    source_occurrence_id TEXT NOT NULL DEFAULT '' CHECK (octet_length(source_occurrence_id) <= 512),
+    severity            TEXT NOT NULL CHECK (severity IN ('critical','high','medium','low','info','unknown')),
+    risk_score_milli    INTEGER CHECK (risk_score_milli BETWEEN 0 AND 10000),
+    component_version   TEXT NOT NULL DEFAULT '' CHECK (octet_length(component_version) <= 512),
+    location            TEXT NOT NULL DEFAULT '' CHECK (octet_length(location) <= 512),
+    reachability        TEXT NOT NULL DEFAULT '' CHECK (octet_length(reachability) <= 512),
+    evidence_digest     TEXT NOT NULL DEFAULT '' CHECK (evidence_digest = '' OR evidence_digest ~ '^[0-9a-f]{64}$'),
+    scanner_provenance  JSONB NOT NULL CHECK (jsonb_typeof(scanner_provenance) = 'object' AND octet_length(scanner_provenance::text) <= 4096),
+    observed_at         TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, cycle_id, id),
+    UNIQUE (tenant_id, cycle_id, snapshot_id, producer_kind, finding_kind, target_canonical, source_finding_id, source_occurrence_id),
+    FOREIGN KEY (tenant_id, cycle_id, snapshot_id)
+        REFERENCES assessment_snapshots(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, identity_id, producer_kind, finding_kind, target_canonical)
+        REFERENCES finding_identities(tenant_id, cycle_id, id, producer_kind, finding_kind, target_identity_canonical) ON DELETE RESTRICT,
+    CONSTRAINT finding_observations_source_check CHECK (source_finding_id <> '' OR source_occurrence_id <> '')
+);
+CREATE INDEX idx_finding_observations_snapshot ON finding_observations (tenant_id, cycle_id, snapshot_id, producer_kind, finding_kind);
+CREATE INDEX idx_finding_observations_producer_id ON finding_observations
+    (tenant_id, cycle_id, producer_kind, finding_kind, target_canonical, source_finding_id, identity_id);
+
+CREATE TABLE finding_match_candidates (
+    tenant_id                 TEXT NOT NULL,
+    cycle_id                  TEXT NOT NULL,
+    snapshot_id               TEXT NOT NULL,
+    id                        TEXT NOT NULL,
+    producer_kind             TEXT NOT NULL CHECK (btrim(producer_kind) <> '' AND octet_length(producer_kind) <= 256),
+    finding_kind              TEXT NOT NULL CHECK (btrim(finding_kind) <> '' AND octet_length(finding_kind) <= 256),
+    reason                    TEXT NOT NULL CHECK (reason IN ('fingerprint_collision','split','merge','insufficient_anchor','legacy_ambiguous')),
+    fingerprint_schema_version INTEGER NOT NULL CHECK (fingerprint_schema_version >= 0),
+    fingerprint               TEXT NOT NULL DEFAULT '' CHECK (fingerprint = '' OR fingerprint ~ '^[0-9a-f]{64}$'),
+    source_reference_hash     TEXT NOT NULL CHECK (source_reference_hash ~ '^[0-9a-f]{64}$'),
+    candidate_set_hash        TEXT NOT NULL CHECK (candidate_set_hash ~ '^[0-9a-f]{64}$'),
+    status                    TEXT NOT NULL CHECK (status IN ('open','resolved','superseded')),
+    version                   BIGINT NOT NULL CHECK (version > 0),
+    created_at                TIMESTAMPTZ NOT NULL,
+    resolved_at               TIMESTAMPTZ,
+    superseded_at             TIMESTAMPTZ,
+    superseded_by_candidate_id TEXT,
+    PRIMARY KEY (tenant_id, cycle_id, id),
+    UNIQUE (tenant_id, cycle_id, snapshot_id, producer_kind, reason, candidate_set_hash),
+    FOREIGN KEY (tenant_id, cycle_id, snapshot_id)
+        REFERENCES assessment_snapshots(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, superseded_by_candidate_id)
+        REFERENCES finding_match_candidates(tenant_id, cycle_id, id) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT finding_match_candidates_fingerprint_shape_check CHECK (
+        (reason = 'insufficient_anchor' AND fingerprint_schema_version >= 0) OR
+        (reason <> 'insufficient_anchor' AND fingerprint_schema_version > 0 AND fingerprint <> '')
+    ),
+    CONSTRAINT finding_match_candidates_status_metadata_check CHECK (
+        (status = 'open' AND resolved_at IS NULL AND superseded_at IS NULL AND superseded_by_candidate_id IS NULL) OR
+        (status = 'resolved' AND resolved_at IS NOT NULL AND superseded_at IS NULL AND superseded_by_candidate_id IS NULL) OR
+        (status = 'superseded' AND resolved_at IS NULL AND superseded_at IS NOT NULL AND superseded_by_candidate_id IS NOT NULL)
+    )
+);
+CREATE UNIQUE INDEX uq_finding_match_candidates_open_subject ON finding_match_candidates
+    (tenant_id, cycle_id, snapshot_id, producer_kind, reason, source_reference_hash) WHERE status = 'open';
+CREATE INDEX idx_finding_match_candidates_open_fingerprint ON finding_match_candidates
+    (tenant_id, cycle_id, producer_kind, finding_kind, fingerprint_schema_version, fingerprint) WHERE status = 'open';
+
+CREATE TABLE finding_match_candidate_refs (
+    tenant_id               TEXT NOT NULL,
+    cycle_id                TEXT NOT NULL,
+    candidate_id            TEXT NOT NULL,
+    position                INTEGER NOT NULL CHECK (position >= 0 AND position < 64),
+    role                    TEXT NOT NULL CHECK (role IN ('source','candidate','selected','excluded')),
+    identity_id             TEXT,
+    observation_id          TEXT,
+    external_reference_hash TEXT,
+    match_method            TEXT NOT NULL CHECK (match_method IN ('override','producer_id','fingerprint','alias','matcher','manual','new_identity')),
+    score_milli             INTEGER NOT NULL CHECK (score_milli BETWEEN 0 AND 1000),
+    confidence              TEXT NOT NULL CHECK (confidence IN ('unknown','low','medium','high')),
+    reason_payload          JSONB NOT NULL CHECK (jsonb_typeof(reason_payload) = 'object' AND octet_length(reason_payload::text) <= 4096),
+    PRIMARY KEY (tenant_id, cycle_id, candidate_id, position),
+    FOREIGN KEY (tenant_id, cycle_id, candidate_id)
+        REFERENCES finding_match_candidates(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, identity_id)
+        REFERENCES finding_identities(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, observation_id)
+        REFERENCES finding_observations(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    CONSTRAINT finding_match_candidate_refs_subject_check CHECK (
+        num_nonnulls(identity_id, observation_id, external_reference_hash) = 1 AND
+        (external_reference_hash IS NULL OR external_reference_hash ~ '^[0-9a-f]{64}$')
+    )
+);
+
+CREATE TABLE finding_match_resolution_events (
+    tenant_id                  TEXT NOT NULL,
+    cycle_id                   TEXT NOT NULL,
+    candidate_id               TEXT NOT NULL,
+    id                         TEXT NOT NULL,
+    action                     TEXT NOT NULL CHECK (action IN ('confirm_existing','create_distinct_identity','unlink','dismiss','supersede')),
+    actor                      TEXT NOT NULL CHECK (btrim(actor) <> '' AND octet_length(actor) <= 256),
+    reason                     TEXT NOT NULL CHECK (btrim(reason) <> '' AND octet_length(reason) <= 2000),
+    before_refs                JSONB NOT NULL CHECK (jsonb_typeof(before_refs) = 'array' AND octet_length(before_refs::text) <= 32768),
+    after_refs                 JSONB NOT NULL CHECK (jsonb_typeof(after_refs) = 'array' AND octet_length(after_refs::text) <= 32768),
+    successor_candidate_id     TEXT,
+    expected_version           BIGINT NOT NULL CHECK (expected_version > 0),
+    version                    BIGINT NOT NULL CHECK (version = expected_version + 1),
+    prior_event_id             TEXT,
+    content_hash               TEXT NOT NULL CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+    created_at                 TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, cycle_id, id),
+    UNIQUE (tenant_id, cycle_id, candidate_id, id),
+    UNIQUE (tenant_id, cycle_id, candidate_id, version),
+    FOREIGN KEY (tenant_id, cycle_id, candidate_id)
+        REFERENCES finding_match_candidates(tenant_id, cycle_id, id) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (tenant_id, cycle_id, successor_candidate_id)
+        REFERENCES finding_match_candidates(tenant_id, cycle_id, id) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED,
+    FOREIGN KEY (tenant_id, cycle_id, candidate_id, prior_event_id)
+        REFERENCES finding_match_resolution_events(tenant_id, cycle_id, candidate_id, id) ON DELETE RESTRICT,
+    CONSTRAINT finding_match_resolution_events_prior_check CHECK (
+        (expected_version = 1 AND prior_event_id IS NULL) OR expected_version > 1
+    ),
+    CONSTRAINT finding_match_resolution_events_successor_check CHECK (
+        (action = 'supersede' AND successor_candidate_id IS NOT NULL) OR
+        (action <> 'supersede' AND successor_candidate_id IS NULL)
+    )
+);
+
+CREATE TABLE finding_match_override_events (
+    tenant_id             TEXT NOT NULL,
+    cycle_id              TEXT NOT NULL,
+    id                    TEXT NOT NULL,
+    action                TEXT NOT NULL CHECK (action IN ('confirm','unlink','supersede')),
+    source_observation_id TEXT NOT NULL,
+    source_identity_id    TEXT,
+    target_observation_id TEXT,
+    target_identity_id    TEXT NOT NULL,
+    actor                 TEXT NOT NULL CHECK (btrim(actor) <> '' AND octet_length(actor) <= 256),
+    reason                TEXT NOT NULL CHECK (btrim(reason) <> '' AND octet_length(reason) <= 2000),
+    expected_version      BIGINT NOT NULL CHECK (expected_version >= 0),
+    version               BIGINT NOT NULL CHECK (version = expected_version + 1),
+    prior_event_id        TEXT,
+    content_hash          TEXT NOT NULL CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+    created_at            TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, cycle_id, id),
+    UNIQUE (tenant_id, cycle_id, source_observation_id, id),
+    UNIQUE (tenant_id, cycle_id, source_observation_id, version),
+    FOREIGN KEY (tenant_id, cycle_id, source_observation_id)
+        REFERENCES finding_observations(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, source_identity_id)
+        REFERENCES finding_identities(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, target_observation_id)
+        REFERENCES finding_observations(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, target_identity_id)
+        REFERENCES finding_identities(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, source_observation_id, prior_event_id)
+        REFERENCES finding_match_override_events(tenant_id, cycle_id, source_observation_id, id) ON DELETE RESTRICT,
+    CONSTRAINT finding_match_override_events_prior_check CHECK (
+        (expected_version = 0 AND prior_event_id IS NULL) OR
+        (expected_version > 0 AND prior_event_id IS NOT NULL)
+    )
+);
+
+CREATE TABLE finding_lineage_skip_records (
+    tenant_id            TEXT NOT NULL,
+    cycle_id             TEXT NOT NULL,
+    snapshot_id          TEXT NOT NULL,
+    id                   TEXT NOT NULL,
+    producer_kind        TEXT NOT NULL CHECK (btrim(producer_kind) <> '' AND octet_length(producer_kind) <= 256),
+    finding_kind         TEXT NOT NULL CHECK (btrim(finding_kind) <> '' AND octet_length(finding_kind) <= 256),
+    reason               TEXT NOT NULL CHECK (reason IN ('invalid_trust','invalid_ownership','redaction_required')),
+    source_reference_hash TEXT NOT NULL CHECK (source_reference_hash ~ '^[0-9a-f]{64}$'),
+    detail_code          TEXT NOT NULL CHECK (btrim(detail_code) <> '' AND octet_length(detail_code) <= 256),
+    created_at           TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, cycle_id, id),
+    UNIQUE (tenant_id, cycle_id, snapshot_id, producer_kind, reason, source_reference_hash),
+    FOREIGN KEY (tenant_id, cycle_id, snapshot_id)
+        REFERENCES assessment_snapshots(tenant_id, cycle_id, id) ON DELETE RESTRICT
+);
+
+-- +goose StatementBegin
+CREATE FUNCTION synapse_guard_finding_match_candidate_update() RETURNS trigger AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'finding match candidates cannot be deleted';
+    END IF;
+    IF OLD.tenant_id IS DISTINCT FROM NEW.tenant_id
+        OR OLD.cycle_id IS DISTINCT FROM NEW.cycle_id
+        OR OLD.snapshot_id IS DISTINCT FROM NEW.snapshot_id
+        OR OLD.id IS DISTINCT FROM NEW.id
+        OR OLD.producer_kind IS DISTINCT FROM NEW.producer_kind
+        OR OLD.finding_kind IS DISTINCT FROM NEW.finding_kind
+        OR OLD.reason IS DISTINCT FROM NEW.reason
+        OR OLD.fingerprint_schema_version IS DISTINCT FROM NEW.fingerprint_schema_version
+        OR OLD.fingerprint IS DISTINCT FROM NEW.fingerprint
+        OR OLD.source_reference_hash IS DISTINCT FROM NEW.source_reference_hash
+        OR OLD.candidate_set_hash IS DISTINCT FROM NEW.candidate_set_hash
+        OR OLD.created_at IS DISTINCT FROM NEW.created_at THEN
+        RAISE EXCEPTION 'finding match candidate immutable fields cannot change';
+    END IF;
+    IF OLD.status <> 'open' OR NEW.status NOT IN ('resolved','superseded') OR NEW.version <> OLD.version + 1 THEN
+        RAISE EXCEPTION 'finding match candidate requires one open-to-terminal CAS transition';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+
+CREATE TRIGGER finding_match_candidates_guard
+    BEFORE UPDATE OR DELETE ON finding_match_candidates
+    FOR EACH ROW EXECUTE FUNCTION synapse_guard_finding_match_candidate_update();
+CREATE TRIGGER finding_match_candidates_no_truncate
+    BEFORE TRUNCATE ON finding_match_candidates
+    FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+
+CREATE TRIGGER finding_identities_append_only BEFORE UPDATE OR DELETE ON finding_identities FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER finding_identities_no_truncate BEFORE TRUNCATE ON finding_identities FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER finding_identity_aliases_append_only BEFORE UPDATE OR DELETE ON finding_identity_aliases FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER finding_identity_aliases_no_truncate BEFORE TRUNCATE ON finding_identity_aliases FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER finding_observations_append_only BEFORE UPDATE OR DELETE ON finding_observations FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER finding_observations_no_truncate BEFORE TRUNCATE ON finding_observations FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER finding_match_candidate_refs_append_only BEFORE UPDATE OR DELETE ON finding_match_candidate_refs FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER finding_match_candidate_refs_no_truncate BEFORE TRUNCATE ON finding_match_candidate_refs FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER finding_match_resolution_events_append_only BEFORE UPDATE OR DELETE ON finding_match_resolution_events FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER finding_match_resolution_events_no_truncate BEFORE TRUNCATE ON finding_match_resolution_events FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER finding_match_override_events_append_only BEFORE UPDATE OR DELETE ON finding_match_override_events FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER finding_match_override_events_no_truncate BEFORE TRUNCATE ON finding_match_override_events FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER finding_lineage_skip_records_append_only BEFORE UPDATE OR DELETE ON finding_lineage_skip_records FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER finding_lineage_skip_records_no_truncate BEFORE TRUNCATE ON finding_lineage_skip_records FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+
+CALL synapse_enable_tenant_rls('finding_identities');
+CALL synapse_enable_tenant_rls('finding_identity_aliases');
+CALL synapse_enable_tenant_rls('finding_observations');
+CALL synapse_enable_tenant_rls('finding_match_candidates');
+CALL synapse_enable_tenant_rls('finding_match_candidate_refs');
+CALL synapse_enable_tenant_rls('finding_match_resolution_events');
+CALL synapse_enable_tenant_rls('finding_match_override_events');
+CALL synapse_enable_tenant_rls('finding_lineage_skip_records');
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM finding_identities)
+        OR EXISTS (SELECT 1 FROM finding_identity_aliases)
+        OR EXISTS (SELECT 1 FROM finding_observations)
+        OR EXISTS (SELECT 1 FROM finding_match_candidates)
+        OR EXISTS (SELECT 1 FROM finding_match_candidate_refs)
+        OR EXISTS (SELECT 1 FROM finding_match_resolution_events)
+        OR EXISTS (SELECT 1 FROM finding_match_override_events)
+        OR EXISTS (SELECT 1 FROM finding_lineage_skip_records) THEN
+        RAISE EXCEPTION 'cannot roll back finding lineage while lineage rows exist';
+    END IF;
+END $$;
+-- +goose StatementEnd
+
+DROP TABLE finding_match_override_events;
+DROP TABLE finding_match_resolution_events;
+DROP TABLE finding_match_candidate_refs;
+DROP TRIGGER IF EXISTS finding_match_candidates_no_truncate ON finding_match_candidates;
+DROP TRIGGER IF EXISTS finding_match_candidates_guard ON finding_match_candidates;
+DROP FUNCTION IF EXISTS synapse_guard_finding_match_candidate_update();
+DROP TABLE finding_match_candidates;
+DROP TABLE finding_lineage_skip_records;
+DROP TABLE finding_observations;
+DROP TABLE finding_identity_aliases;
+DROP TABLE finding_identities;
+ALTER TABLE assessment_snapshots DROP CONSTRAINT assessment_snapshots_tenant_cycle_id_unique;

--- a/migrations/0152_finding_lineage_backfill.sql
+++ b/migrations/0152_finding_lineage_backfill.sql
@@ -1,0 +1,100 @@
+-- +goose Up
+-- A9d (#719): resumable Finding Identity and Observation backfill state.
+
+CREATE TABLE finding_lineage_backfill_runs (
+    tenant_id                   TEXT NOT NULL,
+    id                          TEXT NOT NULL,
+    schema_version              INTEGER NOT NULL,
+    dry_run                     BOOLEAN NOT NULL,
+    batch_size                  INTEGER NOT NULL,
+    producer_filters            TEXT[] NOT NULL DEFAULT '{}',
+    snapshot_at                 TIMESTAMPTZ NOT NULL,
+    checkpoint_finding_id       TEXT NOT NULL DEFAULT '',
+    state                       TEXT NOT NULL,
+    lease_owner                 TEXT NOT NULL DEFAULT '',
+    lease_token                 TEXT NOT NULL DEFAULT '',
+    lease_expires_at            TIMESTAMPTZ,
+    processed_count             INTEGER NOT NULL DEFAULT 0,
+    observation_created_count   INTEGER NOT NULL DEFAULT 0,
+    provisional_candidate_count INTEGER NOT NULL DEFAULT 0,
+    skipped_count               INTEGER NOT NULL DEFAULT 0,
+    created_by                  TEXT NOT NULL,
+    created_at                  TIMESTAMPTZ NOT NULL,
+    updated_at                  TIMESTAMPTZ NOT NULL,
+    completed_at                TIMESTAMPTZ,
+    PRIMARY KEY (tenant_id, id),
+    FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE RESTRICT,
+    CONSTRAINT finding_lineage_backfill_runs_schema_check CHECK (schema_version > 0),
+    CONSTRAINT finding_lineage_backfill_runs_batch_check CHECK (batch_size BETWEEN 1 AND 2000),
+    CONSTRAINT finding_lineage_backfill_runs_filter_check CHECK (
+        producer_filters <@ ARRAY['sca','recon','exploitation','manual','sast','secret','misconfig','cloud_posture','dast','threat','hypothesis','quality','reliability']::TEXT[]
+    ),
+    CONSTRAINT finding_lineage_backfill_runs_checkpoint_check CHECK (octet_length(checkpoint_finding_id) <= 512),
+    CONSTRAINT finding_lineage_backfill_runs_state_check CHECK (state IN ('running','completed','cancelled','failed')),
+    CONSTRAINT finding_lineage_backfill_runs_lease_check CHECK (
+        (state = 'running' AND lease_owner = btrim(lease_owner) AND length(lease_owner) BETWEEN 1 AND 256 AND length(lease_token) BETWEEN 1 AND 512 AND lease_expires_at IS NOT NULL AND completed_at IS NULL) OR
+        (state <> 'running' AND lease_owner = '' AND lease_token = '' AND lease_expires_at IS NULL AND completed_at IS NOT NULL)
+    ),
+    CONSTRAINT finding_lineage_backfill_runs_counts_check CHECK (
+        processed_count >= 0 AND observation_created_count >= 0 AND provisional_candidate_count >= 0 AND skipped_count >= 0 AND
+        processed_count = observation_created_count + provisional_candidate_count + skipped_count
+    ),
+    CONSTRAINT finding_lineage_backfill_runs_actor_check CHECK (created_by = btrim(created_by) AND length(created_by) BETWEEN 1 AND 256),
+    CONSTRAINT finding_lineage_backfill_runs_time_check CHECK (updated_at >= created_at AND snapshot_at <= created_at AND (completed_at IS NULL OR completed_at >= created_at))
+);
+
+CREATE UNIQUE INDEX uq_finding_lineage_backfill_runs_active
+    ON finding_lineage_backfill_runs (tenant_id) WHERE state = 'running';
+CREATE INDEX idx_finding_lineage_backfill_runs_history
+    ON finding_lineage_backfill_runs (tenant_id, created_at DESC, id DESC);
+
+CREATE TABLE finding_lineage_backfill_items (
+    tenant_id        TEXT NOT NULL,
+    run_id           TEXT NOT NULL,
+    assessment_id    TEXT NOT NULL,
+    cycle_id         TEXT,
+    snapshot_id      TEXT,
+    source_finding_id TEXT NOT NULL,
+    schema_version   INTEGER NOT NULL,
+    matcher_version  INTEGER NOT NULL,
+    idempotency_key  TEXT NOT NULL,
+    source_hash      TEXT NOT NULL,
+    outcome          TEXT NOT NULL,
+    reason_code      TEXT NOT NULL,
+    processed_at     TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, run_id, source_finding_id),
+    FOREIGN KEY (tenant_id, run_id) REFERENCES finding_lineage_backfill_runs(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, assessment_id, source_finding_id) REFERENCES findings(tenant_id, engagement_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, assessment_id) REFERENCES assessment_cycle_members(tenant_id, cycle_id, assessment_id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, assessment_id, snapshot_id) REFERENCES assessment_snapshots(tenant_id, assessment_id, id) ON DELETE RESTRICT,
+    UNIQUE (tenant_id, run_id, idempotency_key),
+    CONSTRAINT finding_lineage_backfill_items_schema_check CHECK (schema_version > 0 AND matcher_version > 0),
+    CONSTRAINT finding_lineage_backfill_items_key_check CHECK (idempotency_key = btrim(idempotency_key) AND length(idempotency_key) BETWEEN 1 AND 128),
+    CONSTRAINT finding_lineage_backfill_items_source_hash_check CHECK (source_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT finding_lineage_backfill_items_outcome_check CHECK (outcome IN ('observation_created','provisional_candidate_created','skipped')),
+    CONSTRAINT finding_lineage_backfill_items_reason_check CHECK (reason_code ~ '^[a-z0-9_]{1,64}$'),
+    CONSTRAINT finding_lineage_backfill_items_reference_check CHECK (
+        (outcome = 'skipped') OR (cycle_id IS NOT NULL AND snapshot_id IS NOT NULL)
+    )
+);
+
+CREATE INDEX idx_finding_lineage_backfill_items_outcome
+    ON finding_lineage_backfill_items (tenant_id, run_id, outcome, source_finding_id);
+
+CALL synapse_enable_tenant_rls('finding_lineage_backfill_runs');
+CALL synapse_enable_tenant_rls('finding_lineage_backfill_items');
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM finding_lineage_backfill_items LIMIT 1) OR
+       EXISTS (SELECT 1 FROM finding_lineage_backfill_runs LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back finding lineage backfill state while run history exists';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+DROP TABLE IF EXISTS finding_lineage_backfill_items;
+DROP TABLE IF EXISTS finding_lineage_backfill_runs;

--- a/migrations/0153_assessment_comparisons.sql
+++ b/migrations/0153_assessment_comparisons.sql
@@ -1,0 +1,161 @@
+-- +goose Up
+-- A4 (#698): durable immutable ancestry-aware Assessment Comparisons.
+
+CREATE TABLE assessment_comparisons (
+    tenant_id                TEXT NOT NULL,
+    cycle_id                 TEXT NOT NULL,
+    id                       TEXT NOT NULL,
+    baseline_snapshot_id     TEXT NOT NULL,
+    current_snapshot_id      TEXT NOT NULL,
+    mode                     TEXT NOT NULL CHECK (mode IN ('lifecycle','neutral_diff')),
+    input_hash               TEXT NOT NULL CHECK (input_hash ~ '^[0-9a-f]{64}$'),
+    input_payload            JSONB NOT NULL CHECK (jsonb_typeof(input_payload) = 'object' AND octet_length(input_payload::text) <= 65536),
+    algorithm_version        INTEGER NOT NULL CHECK (algorithm_version > 0),
+    fingerprint_version      INTEGER NOT NULL CHECK (fingerprint_version > 0),
+    risk_model_version       INTEGER NOT NULL CHECK (risk_model_version > 0),
+    coverage_policy_version  INTEGER NOT NULL CHECK (coverage_policy_version > 0),
+    status                   TEXT NOT NULL CHECK (status IN ('queued','generating','complete','needs_review','failed','superseded')),
+    version                  BIGINT NOT NULL CHECK (version > 0),
+    attempts                 INTEGER NOT NULL CHECK (attempts >= 0),
+    failure_code             TEXT NOT NULL DEFAULT '' CHECK (octet_length(failure_code) <= 64),
+    content_hash             TEXT NOT NULL DEFAULT '' CHECK (content_hash = '' OR content_hash ~ '^[0-9a-f]{64}$'),
+    summary                  JSONB NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(summary) = 'object'),
+    created_at               TIMESTAMPTZ NOT NULL,
+    updated_at               TIMESTAMPTZ NOT NULL,
+    completed_at             TIMESTAMPTZ,
+    superseded_at            TIMESTAMPTZ,
+    superseded_by            TEXT,
+    PRIMARY KEY (tenant_id, cycle_id, id),
+    UNIQUE (tenant_id, id),
+    UNIQUE (tenant_id, input_hash),
+    FOREIGN KEY (tenant_id, cycle_id) REFERENCES assessment_cycles(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, baseline_snapshot_id) REFERENCES assessment_snapshots(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, current_snapshot_id) REFERENCES assessment_snapshots(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, superseded_by) REFERENCES assessment_comparisons(tenant_id, cycle_id, id) ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT assessment_comparisons_distinct_snapshots CHECK (baseline_snapshot_id <> current_snapshot_id),
+    CONSTRAINT assessment_comparisons_state_metadata CHECK (
+        (status IN ('queued','generating') AND failure_code = '' AND content_hash = '' AND summary = '{}'::jsonb AND completed_at IS NULL AND superseded_at IS NULL AND superseded_by IS NULL) OR
+        (status IN ('complete','needs_review') AND failure_code = '' AND content_hash <> '' AND completed_at IS NOT NULL AND superseded_at IS NULL AND superseded_by IS NULL) OR
+        (status = 'failed' AND failure_code <> '' AND content_hash = '' AND summary = '{}'::jsonb AND completed_at IS NULL AND superseded_at IS NULL AND superseded_by IS NULL) OR
+        (status = 'superseded' AND failure_code = '' AND content_hash <> '' AND completed_at IS NOT NULL AND superseded_at IS NOT NULL AND superseded_by IS NOT NULL)
+    ),
+    CONSTRAINT assessment_comparisons_summary_identity CHECK (
+        status NOT IN ('complete','needs_review','superseded') OR
+        (summary->>'comparison_id' = id AND
+         summary->>'baseline_snapshot_id' = baseline_snapshot_id AND
+         summary->>'current_snapshot_id' = current_snapshot_id AND
+         (summary->>'risk_model_version')::INTEGER = risk_model_version)
+    )
+);
+CREATE INDEX idx_assessment_comparisons_pair ON assessment_comparisons (tenant_id, cycle_id, baseline_snapshot_id, current_snapshot_id, mode, created_at DESC);
+CREATE INDEX idx_assessment_comparisons_jobs ON assessment_comparisons (tenant_id, status, updated_at) WHERE status IN ('queued','generating','failed');
+
+CREATE TABLE assessment_comparison_items (
+    tenant_id                 TEXT NOT NULL,
+    cycle_id                  TEXT NOT NULL,
+    comparison_id            TEXT NOT NULL,
+    id                       TEXT NOT NULL,
+    position                  INTEGER NOT NULL CHECK (position >= 0),
+    identity_id               TEXT NOT NULL,
+    producer_kind             TEXT NOT NULL DEFAULT '',
+    finding_kind              TEXT NOT NULL DEFAULT '',
+    target_canonical          TEXT NOT NULL DEFAULT '',
+    baseline_observation_id   TEXT,
+    current_observation_id    TEXT,
+    baseline_observation      JSONB NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(baseline_observation) = 'object'),
+    current_observation       JSONB NOT NULL DEFAULT '{}'::jsonb CHECK (jsonb_typeof(current_observation) = 'object'),
+    presence                  TEXT NOT NULL DEFAULT '' CHECK (presence IN ('','new','still_detected','not_detected_under_comparable_coverage','not_evaluated','reopened','needs_review')),
+    neutral_presence          TEXT NOT NULL DEFAULT '' CHECK (neutral_presence IN ('','only_in_a','both','only_in_b','needs_review')),
+    change_flags              JSONB NOT NULL CHECK (jsonb_typeof(change_flags) = 'array'),
+    coverage_decision         TEXT NOT NULL DEFAULT '' CHECK (coverage_decision IN ('','comparable','partially_comparable','not_comparable')),
+    match_methods             JSONB NOT NULL DEFAULT '[]'::jsonb CHECK (jsonb_typeof(match_methods) = 'array'),
+    verification_id           TEXT,
+    verification_state        TEXT NOT NULL DEFAULT '' CHECK (octet_length(verification_state) <= 64),
+    fixed_basis               TEXT NOT NULL DEFAULT '' CHECK (fixed_basis IN ('','comparable_absence','explicit_verification')),
+    baseline_actionable       BOOLEAN NOT NULL,
+    current_actionable        BOOLEAN NOT NULL,
+    comparable_baseline       BOOLEAN NOT NULL,
+    baseline_risk_milli       BIGINT NOT NULL CHECK (baseline_risk_milli >= 0),
+    current_risk_milli        BIGINT NOT NULL CHECK (current_risk_milli >= 0),
+    review_candidate_ids      JSONB NOT NULL DEFAULT '[]'::jsonb CHECK (jsonb_typeof(review_candidate_ids) = 'array'),
+    review_candidates         JSONB NOT NULL DEFAULT '[]'::jsonb CHECK (jsonb_typeof(review_candidates) = 'array'),
+    PRIMARY KEY (tenant_id, cycle_id, comparison_id, position),
+    UNIQUE (tenant_id, comparison_id, id),
+    UNIQUE (tenant_id, cycle_id, comparison_id, identity_id),
+    FOREIGN KEY (tenant_id, cycle_id, comparison_id) REFERENCES assessment_comparisons(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, identity_id) REFERENCES finding_identities(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, baseline_observation_id) REFERENCES finding_observations(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, current_observation_id) REFERENCES finding_observations(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    CONSTRAINT assessment_comparison_items_mode_presence CHECK ((presence = '') <> (neutral_presence = '')),
+    CONSTRAINT assessment_comparison_items_fixed_basis CHECK (
+        (fixed_basis = '') OR
+        (fixed_basis = 'comparable_absence' AND presence = 'not_detected_under_comparable_coverage') OR
+        (fixed_basis = 'explicit_verification' AND presence <> '' AND verification_id IS NOT NULL AND verification_state <> '')
+    )
+);
+CREATE INDEX idx_assessment_comparison_items_explorer ON assessment_comparison_items (tenant_id, comparison_id, producer_kind, finding_kind, position);
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION synapse_assessment_comparison_guard() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN RAISE EXCEPTION 'assessment comparison is append-only'; END IF;
+    IF TG_OP = 'INSERT' THEN RETURN NEW; END IF;
+    IF (NEW.tenant_id,NEW.cycle_id,NEW.id,NEW.baseline_snapshot_id,NEW.current_snapshot_id,NEW.mode,NEW.input_hash,NEW.input_payload,
+        NEW.algorithm_version,NEW.fingerprint_version,NEW.risk_model_version,NEW.coverage_policy_version,NEW.created_at)
+       IS DISTINCT FROM
+       (OLD.tenant_id,OLD.cycle_id,OLD.id,OLD.baseline_snapshot_id,OLD.current_snapshot_id,OLD.mode,OLD.input_hash,OLD.input_payload,
+        OLD.algorithm_version,OLD.fingerprint_version,OLD.risk_model_version,OLD.coverage_policy_version,OLD.created_at) THEN
+        RAISE EXCEPTION 'assessment comparison input is immutable';
+    END IF;
+    IF NEW.version <> OLD.version + 1 THEN
+        RAISE EXCEPTION 'assessment comparison version must advance by one';
+    END IF;
+    IF NOT ((OLD.status = 'queued' AND NEW.status = 'generating') OR
+            (OLD.status = 'generating' AND NEW.status IN ('queued','complete','needs_review','failed')) OR
+            (OLD.status = 'failed' AND NEW.status = 'generating') OR
+            (OLD.status IN ('complete','needs_review') AND NEW.status = 'superseded')) THEN
+        RAISE EXCEPTION 'assessment comparison transition is invalid';
+    END IF;
+    IF NEW.attempts <> OLD.attempts + (CASE WHEN NEW.status = 'generating' THEN 1 ELSE 0 END) THEN
+        RAISE EXCEPTION 'assessment comparison attempt count is invalid';
+    END IF;
+    IF OLD.status <> 'generating' AND
+       (NEW.content_hash,NEW.summary,NEW.completed_at) IS DISTINCT FROM (OLD.content_hash,OLD.summary,OLD.completed_at) THEN
+        RAISE EXCEPTION 'completed assessment comparison output is immutable';
+    END IF;
+    RETURN NEW;
+END $$;
+-- +goose StatementEnd
+CREATE TRIGGER assessment_comparisons_guard BEFORE UPDATE OR DELETE ON assessment_comparisons FOR EACH ROW EXECUTE FUNCTION synapse_assessment_comparison_guard();
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION synapse_assessment_comparison_item_guard() RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE parent_status TEXT;
+BEGIN
+    IF TG_OP <> 'INSERT' THEN
+        RAISE EXCEPTION 'assessment comparison items are immutable';
+    END IF;
+    SELECT status INTO parent_status FROM assessment_comparisons
+    WHERE tenant_id = NEW.tenant_id AND cycle_id = NEW.cycle_id AND id = NEW.comparison_id
+    FOR KEY SHARE;
+    IF parent_status = 'generating' THEN RETURN NEW; END IF;
+    RAISE EXCEPTION 'assessment comparison items are immutable';
+END $$;
+-- +goose StatementEnd
+CREATE TRIGGER assessment_comparison_items_guard BEFORE INSERT OR UPDATE OR DELETE ON assessment_comparison_items FOR EACH ROW EXECUTE FUNCTION synapse_assessment_comparison_item_guard();
+
+CALL synapse_enable_tenant_rls('assessment_comparisons');
+CALL synapse_enable_tenant_rls('assessment_comparison_items');
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM assessment_comparisons LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back assessment comparisons while comparison rows exist';
+    END IF;
+END $$;
+-- +goose StatementEnd
+DROP TABLE IF EXISTS assessment_comparison_items;
+DROP TABLE IF EXISTS assessment_comparisons;
+DROP FUNCTION IF EXISTS synapse_assessment_comparison_item_guard();
+DROP FUNCTION IF EXISTS synapse_assessment_comparison_guard();

--- a/migrations/0154_assessment_closure_manifests.sql
+++ b/migrations/0154_assessment_closure_manifests.sql
@@ -1,0 +1,280 @@
+-- +goose Up
+-- A9a.1 (#703): feature-disabled persistence foundation for immutable Cycle closure manifests.
+
+CREATE INDEX idx_assessment_cycles_cursor
+    ON assessment_cycles (tenant_id, updated_at DESC, id DESC);
+CREATE INDEX idx_assessment_cycles_filtered_cursor
+    ON assessment_cycles (tenant_id, status, boundary_kind, updated_at DESC, id DESC);
+CREATE INDEX idx_assessment_cycle_members_active_tree
+    ON assessment_cycle_members (tenant_id, cycle_id, predecessor_assessment_id, retest_number DESC, assessment_id DESC)
+    WHERE archived_at IS NULL;
+CREATE INDEX idx_assessment_comparison_items_page
+    ON assessment_comparison_items (tenant_id, cycle_id, comparison_id, presence, neutral_presence, position);
+
+CREATE TABLE assessment_cycle_closure_manifests (
+    tenant_id                         TEXT NOT NULL,
+    cycle_id                          TEXT NOT NULL,
+    id                                TEXT NOT NULL,
+    manifest_version                  BIGINT NOT NULL,
+    lifecycle                         TEXT NOT NULL,
+    cycle_version                     BIGINT NOT NULL,
+    root_assessment_id                TEXT NOT NULL,
+    final_assessment_id               TEXT NOT NULL,
+    initial_snapshot_id               TEXT NOT NULL,
+    final_snapshot_id                 TEXT NOT NULL,
+    comparison_id                     TEXT NOT NULL,
+    initial_snapshot_hash             TEXT NOT NULL,
+    final_snapshot_hash               TEXT NOT NULL,
+    comparison_hash                   TEXT NOT NULL,
+    canonical_input_hash              TEXT NOT NULL,
+    content_hash                      TEXT NOT NULL DEFAULT '',
+    policy_version                    TEXT NOT NULL,
+    algorithm_version                 TEXT NOT NULL,
+    fingerprint_version               TEXT NOT NULL,
+    risk_version                      TEXT NOT NULL,
+    renderer_contract_version         TEXT NOT NULL,
+    coverage_decisions                JSONB NOT NULL DEFAULT '{}'::jsonb,
+    scope_profile_changes             JSONB NOT NULL DEFAULT '[]'::jsonb,
+    override_blocker_ids              JSONB NOT NULL DEFAULT '[]'::jsonb,
+    non_final_branches                JSONB NOT NULL DEFAULT '[]'::jsonb,
+    reason                            TEXT NOT NULL DEFAULT '',
+    override_reason                   TEXT NOT NULL DEFAULT '',
+    as_of_at                          TIMESTAMPTZ NOT NULL,
+    created_at                        TIMESTAMPTZ NOT NULL,
+    created_by                        TEXT NOT NULL,
+    sealed_at                         TIMESTAMPTZ NULL,
+    sealed_by                         TEXT NOT NULL DEFAULT '',
+    superseded_at                     TIMESTAMPTZ NULL,
+    superseded_by_manifest_id         TEXT NULL,
+    PRIMARY KEY (tenant_id, cycle_id, id),
+    UNIQUE (tenant_id, cycle_id, id, cycle_version),
+    UNIQUE (tenant_id, cycle_id, manifest_version),
+    UNIQUE (tenant_id, cycle_id, content_hash),
+    FOREIGN KEY (tenant_id, cycle_id) REFERENCES assessment_cycles(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, root_assessment_id)
+        REFERENCES assessment_cycle_members(tenant_id, cycle_id, assessment_id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, final_assessment_id)
+        REFERENCES assessment_cycle_members(tenant_id, cycle_id, assessment_id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, initial_snapshot_id)
+        REFERENCES assessment_snapshots(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, final_snapshot_id)
+        REFERENCES assessment_snapshots(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, comparison_id)
+        REFERENCES assessment_comparisons(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, superseded_by_manifest_id)
+        REFERENCES assessment_cycle_closure_manifests(tenant_id, cycle_id, id)
+        ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED,
+    CONSTRAINT assessment_cycle_closure_manifest_version_check CHECK (manifest_version >= 1 AND cycle_version >= 1),
+    CONSTRAINT assessment_cycle_closure_manifest_lifecycle_check CHECK (lifecycle IN ('building','active','superseded')),
+    CONSTRAINT assessment_cycle_closure_manifest_hash_check CHECK (
+        initial_snapshot_hash ~ '^[0-9a-f]{64}$' AND
+        final_snapshot_hash ~ '^[0-9a-f]{64}$' AND
+        comparison_hash ~ '^[0-9a-f]{64}$' AND
+        canonical_input_hash ~ '^[0-9a-f]{64}$' AND
+        (content_hash = '' OR content_hash ~ '^[0-9a-f]{64}$')
+    ),
+    CONSTRAINT assessment_cycle_closure_manifest_versions_check CHECK (
+        policy_version = btrim(policy_version) AND length(policy_version) BETWEEN 1 AND 128 AND
+        algorithm_version = btrim(algorithm_version) AND length(algorithm_version) BETWEEN 1 AND 128 AND
+        fingerprint_version = btrim(fingerprint_version) AND length(fingerprint_version) BETWEEN 1 AND 128 AND
+        risk_version = btrim(risk_version) AND length(risk_version) BETWEEN 1 AND 128 AND
+        renderer_contract_version = btrim(renderer_contract_version) AND length(renderer_contract_version) BETWEEN 1 AND 128
+    ),
+    CONSTRAINT assessment_cycle_closure_manifest_json_check CHECK (
+        jsonb_typeof(coverage_decisions) = 'object' AND pg_column_size(coverage_decisions) <= 262144 AND
+        jsonb_typeof(scope_profile_changes) = 'array' AND pg_column_size(scope_profile_changes) <= 262144 AND
+        jsonb_typeof(override_blocker_ids) = 'array' AND pg_column_size(override_blocker_ids) <= 65536 AND
+        jsonb_typeof(non_final_branches) = 'array' AND pg_column_size(non_final_branches) <= 262144
+    ),
+    CONSTRAINT assessment_cycle_closure_manifest_text_check CHECK (
+        created_by = btrim(created_by) AND length(created_by) BETWEEN 1 AND 256 AND
+        sealed_by = btrim(sealed_by) AND length(sealed_by) <= 256 AND
+        length(reason) <= 4096 AND length(override_reason) <= 4096
+    ),
+    CONSTRAINT assessment_cycle_closure_manifest_time_check CHECK (as_of_at <= created_at),
+    CONSTRAINT assessment_cycle_closure_manifest_state_check CHECK (
+        (lifecycle = 'building' AND content_hash = '' AND sealed_at IS NULL AND sealed_by = '' AND superseded_at IS NULL AND superseded_by_manifest_id IS NULL) OR
+        (lifecycle = 'active' AND content_hash <> '' AND sealed_at IS NOT NULL AND sealed_by <> '' AND superseded_at IS NULL AND superseded_by_manifest_id IS NULL) OR
+        (lifecycle = 'superseded' AND content_hash <> '' AND sealed_at IS NOT NULL AND sealed_by <> '' AND superseded_at IS NOT NULL)
+    )
+);
+
+CREATE UNIQUE INDEX uq_assessment_cycle_closure_active
+    ON assessment_cycle_closure_manifests (tenant_id, cycle_id)
+    WHERE lifecycle = 'active';
+CREATE INDEX idx_assessment_cycle_closure_history
+    ON assessment_cycle_closure_manifests (tenant_id, cycle_id, manifest_version DESC);
+CREATE INDEX idx_assessment_cycle_closure_hash
+    ON assessment_cycle_closure_manifests (tenant_id, content_hash)
+    WHERE content_hash <> '';
+
+CREATE TABLE assessment_cycle_closure_path_members (
+    tenant_id             TEXT NOT NULL,
+    cycle_id              TEXT NOT NULL,
+    manifest_id           TEXT NOT NULL,
+    path_position         INTEGER NOT NULL,
+    assessment_id         TEXT NOT NULL,
+    assessment_type       TEXT NOT NULL,
+    retest_number         INTEGER NOT NULL,
+    relationship_version  BIGINT NOT NULL,
+    snapshot_id           TEXT NULL,
+    PRIMARY KEY (tenant_id, cycle_id, manifest_id, path_position),
+    UNIQUE (tenant_id, cycle_id, manifest_id, assessment_id),
+    FOREIGN KEY (tenant_id, cycle_id, manifest_id)
+        REFERENCES assessment_cycle_closure_manifests(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, assessment_id)
+        REFERENCES assessment_cycle_members(tenant_id, cycle_id, assessment_id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, cycle_id, snapshot_id)
+        REFERENCES assessment_snapshots(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    CONSTRAINT assessment_cycle_closure_path_position_check CHECK (path_position >= 0),
+    CONSTRAINT assessment_cycle_closure_path_version_check CHECK (relationship_version >= 1),
+    CONSTRAINT assessment_cycle_closure_path_member_check CHECK (
+        (path_position = 0 AND assessment_type = 'initial' AND retest_number = 0) OR
+        (path_position > 0 AND assessment_type = 'retest' AND retest_number > 0)
+    )
+);
+
+CREATE INDEX idx_assessment_cycle_closure_path_assessment
+    ON assessment_cycle_closure_path_members (tenant_id, assessment_id, manifest_id);
+
+CREATE TABLE assessment_cycle_closure_references (
+    tenant_id          TEXT NOT NULL,
+    cycle_id           TEXT NOT NULL,
+    manifest_id        TEXT NOT NULL,
+    reference_kind     TEXT NOT NULL,
+    reference_id       TEXT NOT NULL,
+    reference_version  BIGINT NOT NULL,
+    content_hash       TEXT NOT NULL DEFAULT '',
+    expires_at         TIMESTAMPTZ NULL,
+    metadata           JSONB NOT NULL DEFAULT '{}'::jsonb,
+    PRIMARY KEY (tenant_id, cycle_id, manifest_id, reference_kind, reference_id),
+    FOREIGN KEY (tenant_id, cycle_id, manifest_id)
+        REFERENCES assessment_cycle_closure_manifests(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    CONSTRAINT assessment_cycle_closure_reference_kind_check CHECK (reference_kind ~ '^[a-z][a-z0-9_]{0,63}$'),
+    CONSTRAINT assessment_cycle_closure_reference_id_check CHECK (reference_id = btrim(reference_id) AND length(reference_id) BETWEEN 1 AND 512),
+    CONSTRAINT assessment_cycle_closure_reference_version_check CHECK (reference_version >= 1),
+    CONSTRAINT assessment_cycle_closure_reference_hash_check CHECK (content_hash = '' OR content_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT assessment_cycle_closure_reference_metadata_check CHECK (jsonb_typeof(metadata) = 'object' AND pg_column_size(metadata) <= 65536)
+);
+
+CREATE INDEX idx_assessment_cycle_closure_reference_lookup
+    ON assessment_cycle_closure_references (tenant_id, reference_kind, reference_id);
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION synapse_guard_assessment_cycle_closure_manifest()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'assessment cycle closure manifests are immutable';
+    END IF;
+    IF OLD.lifecycle = 'building' AND NEW.lifecycle = 'active' THEN
+        IF (to_jsonb(OLD) - 'lifecycle' - 'content_hash' - 'sealed_at' - 'sealed_by') IS DISTINCT FROM
+           (to_jsonb(NEW) - 'lifecycle' - 'content_hash' - 'sealed_at' - 'sealed_by') THEN
+            RAISE EXCEPTION 'only closure sealing fields may change while activating a manifest';
+        END IF;
+        RETURN NEW;
+    END IF;
+    IF OLD.lifecycle = 'active' AND NEW.lifecycle = 'superseded' THEN
+        IF (to_jsonb(OLD) - 'lifecycle' - 'superseded_at' - 'superseded_by_manifest_id') IS DISTINCT FROM
+           (to_jsonb(NEW) - 'lifecycle' - 'superseded_at' - 'superseded_by_manifest_id') THEN
+            RAISE EXCEPTION 'only closure supersession fields may change';
+        END IF;
+        RETURN NEW;
+    END IF;
+    RAISE EXCEPTION 'assessment cycle closure manifest transition is invalid';
+END;
+$$;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION synapse_guard_assessment_cycle_closure_child()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    parent_lifecycle TEXT;
+BEGIN
+    SELECT lifecycle INTO parent_lifecycle
+    FROM assessment_cycle_closure_manifests
+    WHERE tenant_id = NEW.tenant_id AND cycle_id = NEW.cycle_id AND id = NEW.manifest_id;
+    IF parent_lifecycle IS DISTINCT FROM 'building' THEN
+        RAISE EXCEPTION 'closure manifest children may only be added while building';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+-- +goose StatementEnd
+
+CREATE TRIGGER assessment_cycle_closure_manifests_guard
+BEFORE UPDATE OR DELETE ON assessment_cycle_closure_manifests
+FOR EACH ROW EXECUTE FUNCTION synapse_guard_assessment_cycle_closure_manifest();
+CREATE TRIGGER assessment_cycle_closure_manifests_no_truncate
+BEFORE TRUNCATE ON assessment_cycle_closure_manifests
+FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+
+CREATE TRIGGER assessment_cycle_closure_path_insert_guard
+BEFORE INSERT ON assessment_cycle_closure_path_members
+FOR EACH ROW EXECUTE FUNCTION synapse_guard_assessment_cycle_closure_child();
+CREATE TRIGGER assessment_cycle_closure_path_immutable
+BEFORE UPDATE OR DELETE ON assessment_cycle_closure_path_members
+FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER assessment_cycle_closure_path_no_truncate
+BEFORE TRUNCATE ON assessment_cycle_closure_path_members
+FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+
+CREATE TRIGGER assessment_cycle_closure_references_insert_guard
+BEFORE INSERT ON assessment_cycle_closure_references
+FOR EACH ROW EXECUTE FUNCTION synapse_guard_assessment_cycle_closure_child();
+CREATE TRIGGER assessment_cycle_closure_references_immutable
+BEFORE UPDATE OR DELETE ON assessment_cycle_closure_references
+FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER assessment_cycle_closure_references_no_truncate
+BEFORE TRUNCATE ON assessment_cycle_closure_references
+FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+
+ALTER TABLE assessment_cycles
+    ADD COLUMN active_closure_manifest_id TEXT NULL,
+    ADD COLUMN active_closure_cycle_version BIGINT NULL,
+    ADD CONSTRAINT assessment_cycles_active_closure_pair_check CHECK (
+        (active_closure_manifest_id IS NULL AND active_closure_cycle_version IS NULL) OR
+        (active_closure_manifest_id IS NOT NULL AND active_closure_cycle_version = version)
+    ),
+    ADD CONSTRAINT assessment_cycles_active_closure_fk FOREIGN KEY
+        (tenant_id, id, active_closure_manifest_id, active_closure_cycle_version)
+        REFERENCES assessment_cycle_closure_manifests(tenant_id, cycle_id, id, cycle_version)
+        ON DELETE RESTRICT DEFERRABLE INITIALLY DEFERRED;
+
+CALL synapse_enable_tenant_rls('assessment_cycle_closure_manifests');
+CALL synapse_enable_tenant_rls('assessment_cycle_closure_path_members');
+CALL synapse_enable_tenant_rls('assessment_cycle_closure_references');
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM assessment_cycle_closure_manifests LIMIT 1) OR
+       EXISTS (SELECT 1 FROM assessment_cycles WHERE active_closure_manifest_id IS NOT NULL LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back assessment closure manifests while closure rows exist';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+ALTER TABLE assessment_cycles
+    DROP CONSTRAINT IF EXISTS assessment_cycles_active_closure_fk,
+    DROP CONSTRAINT IF EXISTS assessment_cycles_active_closure_pair_check,
+    DROP COLUMN IF EXISTS active_closure_cycle_version,
+    DROP COLUMN IF EXISTS active_closure_manifest_id;
+
+DROP INDEX IF EXISTS idx_assessment_comparison_items_page;
+DROP INDEX IF EXISTS idx_assessment_cycle_members_active_tree;
+DROP INDEX IF EXISTS idx_assessment_cycles_filtered_cursor;
+DROP INDEX IF EXISTS idx_assessment_cycles_cursor;
+
+DROP TABLE IF EXISTS assessment_cycle_closure_references;
+DROP TABLE IF EXISTS assessment_cycle_closure_path_members;
+DROP TABLE IF EXISTS assessment_cycle_closure_manifests;
+DROP FUNCTION IF EXISTS synapse_guard_assessment_cycle_closure_child();
+DROP FUNCTION IF EXISTS synapse_guard_assessment_cycle_closure_manifest();

--- a/migrations/0155_assessment_relationship_candidates.sql
+++ b/migrations/0155_assessment_relationship_candidates.sql
@@ -1,0 +1,161 @@
+-- +goose Up
+-- A9e (#720): append-only historical Assessment relationship candidates, decisions, and blocked repair plans.
+
+ALTER TABLE assessment_snapshots
+    ADD CONSTRAINT assessment_snapshots_relationship_candidate_owner_unique
+    UNIQUE (tenant_id, cycle_id, assessment_id, id);
+
+CREATE TABLE assessment_relationship_candidates (
+    tenant_id                         TEXT NOT NULL,
+    id                                TEXT NOT NULL,
+    predecessor_cycle_id              TEXT NOT NULL,
+    predecessor_assessment_id         TEXT NOT NULL,
+    predecessor_relationship_version  BIGINT NOT NULL CHECK (predecessor_relationship_version >= 1),
+    predecessor_snapshot_id           TEXT NOT NULL,
+    predecessor_snapshot_hash         TEXT NOT NULL CHECK (predecessor_snapshot_hash ~ '^[0-9a-f]{64}$'),
+    successor_cycle_id                TEXT NOT NULL,
+    successor_assessment_id           TEXT NOT NULL,
+    successor_relationship_version    BIGINT NOT NULL CHECK (successor_relationship_version >= 1),
+    successor_snapshot_id             TEXT NOT NULL,
+    successor_snapshot_hash           TEXT NOT NULL CHECK (successor_snapshot_hash ~ '^[0-9a-f]{64}$'),
+    boundary_key_hash                 TEXT NOT NULL CHECK (boundary_key_hash ~ '^[0-9a-f]{64}$'),
+    signals                           JSONB NOT NULL,
+    input_hash                        TEXT NOT NULL CHECK (input_hash ~ '^[0-9a-f]{64}$'),
+    confidence                        TEXT NOT NULL CHECK (confidence IN ('medium','high')),
+    expires_at                        TIMESTAMPTZ NOT NULL,
+    created_by                        TEXT NOT NULL,
+    created_at                        TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, id),
+    UNIQUE (tenant_id, input_hash),
+    UNIQUE (tenant_id, id, input_hash),
+    FOREIGN KEY (tenant_id, predecessor_cycle_id, predecessor_assessment_id)
+        REFERENCES assessment_cycle_members(tenant_id, cycle_id, assessment_id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, successor_cycle_id, successor_assessment_id)
+        REFERENCES assessment_cycle_members(tenant_id, cycle_id, assessment_id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, predecessor_cycle_id, predecessor_assessment_id, predecessor_snapshot_id)
+        REFERENCES assessment_snapshots(tenant_id, cycle_id, assessment_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, successor_cycle_id, successor_assessment_id, successor_snapshot_id)
+        REFERENCES assessment_snapshots(tenant_id, cycle_id, assessment_id, id) ON DELETE RESTRICT,
+    CONSTRAINT assessment_relationship_candidates_subject_check CHECK (
+        predecessor_cycle_id <> successor_cycle_id AND predecessor_assessment_id <> successor_assessment_id
+    ),
+    CONSTRAINT assessment_relationship_candidates_signals_check CHECK (
+        jsonb_typeof(signals) = 'array' AND jsonb_array_length(signals) BETWEEN 2 AND 4 AND octet_length(signals::text) <= 4096
+    ),
+    CONSTRAINT assessment_relationship_candidates_actor_check CHECK (
+        created_by = btrim(created_by) AND length(created_by) BETWEEN 1 AND 256
+    ),
+    CONSTRAINT assessment_relationship_candidates_expiry_check CHECK (
+        expires_at >= created_at + INTERVAL '1 day' AND expires_at <= created_at + INTERVAL '90 days'
+    )
+);
+
+CREATE INDEX idx_assessment_relationship_candidates_review
+    ON assessment_relationship_candidates (tenant_id, created_at DESC, id DESC);
+CREATE INDEX idx_assessment_relationship_candidates_expiry
+    ON assessment_relationship_candidates (tenant_id, expires_at, id);
+
+CREATE TABLE assessment_relationship_repair_plans (
+    tenant_id     TEXT NOT NULL,
+    id            TEXT NOT NULL,
+    candidate_id  TEXT NOT NULL,
+    input_hash    TEXT NOT NULL CHECK (input_hash ~ '^[0-9a-f]{64}$'),
+    plan_hash     TEXT NOT NULL CHECK (plan_hash ~ '^[0-9a-f]{64}$'),
+    body          BYTEA NOT NULL,
+    created_by    TEXT NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, id),
+    UNIQUE (tenant_id, candidate_id),
+    UNIQUE (tenant_id, candidate_id, id),
+    FOREIGN KEY (tenant_id, candidate_id, input_hash)
+        REFERENCES assessment_relationship_candidates(tenant_id, id, input_hash) ON DELETE RESTRICT,
+    CONSTRAINT assessment_relationship_repair_plans_body_check CHECK (
+        octet_length(body) <= 8192 AND
+        jsonb_typeof(convert_from(body, 'UTF8')::jsonb) = 'object' AND
+        convert_from(body, 'UTF8')::jsonb->>'execution' = 'blocked' AND
+        convert_from(body, 'UTF8')::jsonb->>'requires' = 'separately_approved_move_merge_command'
+    ),
+    CONSTRAINT assessment_relationship_repair_plans_actor_check CHECK (
+        created_by = btrim(created_by) AND length(created_by) BETWEEN 1 AND 256
+    )
+);
+
+CREATE TABLE assessment_relationship_decisions (
+    tenant_id          TEXT NOT NULL,
+    id                 TEXT NOT NULL,
+    candidate_id       TEXT NOT NULL,
+    action             TEXT NOT NULL CHECK (action IN ('confirm','reject','dismiss')),
+    actor              TEXT NOT NULL,
+    reason             TEXT NOT NULL,
+    idempotency_key    TEXT NOT NULL,
+    request_hash       TEXT NOT NULL CHECK (request_hash ~ '^[0-9a-f]{64}$'),
+    expected_version   BIGINT NOT NULL CHECK (expected_version = 1),
+    version            BIGINT NOT NULL CHECK (version = 2),
+    repair_plan_id     TEXT,
+    created_at         TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, id),
+    UNIQUE (tenant_id, candidate_id),
+    UNIQUE (tenant_id, candidate_id, actor, idempotency_key),
+    FOREIGN KEY (tenant_id, candidate_id)
+        REFERENCES assessment_relationship_candidates(tenant_id, id) ON DELETE RESTRICT,
+    FOREIGN KEY (tenant_id, candidate_id, repair_plan_id)
+        REFERENCES assessment_relationship_repair_plans(tenant_id, candidate_id, id) ON DELETE RESTRICT,
+    CONSTRAINT assessment_relationship_decisions_actor_check CHECK (
+        actor = btrim(actor) AND length(actor) BETWEEN 1 AND 256
+    ),
+    CONSTRAINT assessment_relationship_decisions_reason_check CHECK (
+        reason = btrim(reason) AND length(reason) BETWEEN 1 AND 2000
+    ),
+    CONSTRAINT assessment_relationship_decisions_idempotency_check CHECK (
+        idempotency_key = btrim(idempotency_key) AND length(idempotency_key) BETWEEN 1 AND 128
+    ),
+    CONSTRAINT assessment_relationship_decisions_plan_check CHECK (
+        (action = 'confirm' AND repair_plan_id IS NOT NULL) OR
+        (action IN ('reject','dismiss') AND repair_plan_id IS NULL)
+    )
+);
+
+CREATE TRIGGER assessment_relationship_candidates_append_only
+BEFORE UPDATE OR DELETE ON assessment_relationship_candidates
+FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER assessment_relationship_candidates_no_truncate
+BEFORE TRUNCATE ON assessment_relationship_candidates
+FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+
+CREATE TRIGGER assessment_relationship_repair_plans_append_only
+BEFORE UPDATE OR DELETE ON assessment_relationship_repair_plans
+FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER assessment_relationship_repair_plans_no_truncate
+BEFORE TRUNCATE ON assessment_relationship_repair_plans
+FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+
+CREATE TRIGGER assessment_relationship_decisions_append_only
+BEFORE UPDATE OR DELETE ON assessment_relationship_decisions
+FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER assessment_relationship_decisions_no_truncate
+BEFORE TRUNCATE ON assessment_relationship_decisions
+FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+
+CALL synapse_enable_tenant_rls('assessment_relationship_candidates');
+CALL synapse_enable_tenant_rls('assessment_relationship_repair_plans');
+CALL synapse_enable_tenant_rls('assessment_relationship_decisions');
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM assessment_relationship_candidates LIMIT 1) OR
+       EXISTS (SELECT 1 FROM assessment_relationship_repair_plans LIMIT 1) OR
+       EXISTS (SELECT 1 FROM assessment_relationship_decisions LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back assessment relationship review while artifacts exist';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+DROP TABLE IF EXISTS assessment_relationship_decisions;
+DROP TABLE IF EXISTS assessment_relationship_repair_plans;
+DROP TABLE IF EXISTS assessment_relationship_candidates;
+
+ALTER TABLE assessment_snapshots
+    DROP CONSTRAINT IF EXISTS assessment_snapshots_relationship_candidate_owner_unique;

--- a/migrations/0156_assessment_closure_reports.sql
+++ b/migrations/0156_assessment_closure_reports.sql
@@ -1,0 +1,45 @@
+-- +goose Up
+-- A10b (#722): immutable deterministic report artifacts keyed by closure manifest + renderer contract.
+
+CREATE TABLE assessment_cycle_closure_reports (
+    tenant_id                  TEXT NOT NULL,
+    cycle_id                   TEXT NOT NULL,
+    manifest_id                TEXT NOT NULL,
+    renderer_contract_version  TEXT NOT NULL,
+    content_hash               TEXT NOT NULL,
+    content                    BYTEA NOT NULL,
+    generated_at               TIMESTAMPTZ NOT NULL,
+    PRIMARY KEY (tenant_id, cycle_id, manifest_id, renderer_contract_version),
+    FOREIGN KEY (tenant_id, cycle_id, manifest_id)
+        REFERENCES assessment_cycle_closure_manifests(tenant_id, cycle_id, id) ON DELETE RESTRICT,
+    CONSTRAINT assessment_cycle_closure_report_renderer_check CHECK (
+        renderer_contract_version = btrim(renderer_contract_version) AND length(renderer_contract_version) BETWEEN 1 AND 128
+    ),
+    CONSTRAINT assessment_cycle_closure_report_hash_check CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT assessment_cycle_closure_report_content_check CHECK (octet_length(content) BETWEEN 2 AND 16777216)
+);
+
+CREATE INDEX idx_assessment_cycle_closure_report_hash
+    ON assessment_cycle_closure_reports (tenant_id, content_hash);
+
+CREATE TRIGGER assessment_cycle_closure_reports_immutable
+BEFORE UPDATE OR DELETE ON assessment_cycle_closure_reports
+FOR EACH ROW EXECUTE FUNCTION synapse_forbid_mutation();
+CREATE TRIGGER assessment_cycle_closure_reports_no_truncate
+BEFORE TRUNCATE ON assessment_cycle_closure_reports
+FOR EACH STATEMENT EXECUTE FUNCTION synapse_forbid_mutation();
+
+CALL synapse_enable_tenant_rls('assessment_cycle_closure_reports');
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM assessment_cycle_closure_reports LIMIT 1) THEN
+        RAISE EXCEPTION 'cannot roll back assessment closure reports while report rows exist';
+    END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+DROP TABLE IF EXISTS assessment_cycle_closure_reports;

--- a/migrations/0157_visible_assessment_projects.sql
+++ b/migrations/0157_visible_assessment_projects.sql
@@ -1,0 +1,88 @@
+-- +goose Up
+-- A visible Assessment's optional Project is distinct from the hidden analysis
+-- context in engagements.project_id. Neither association can cross a tenant.
+ALTER TABLE engagements ADD COLUMN assessment_project_id TEXT;
+ALTER TABLE engagements ADD CONSTRAINT engagements_assessment_project_fk
+    FOREIGN KEY (tenant_id, assessment_project_id) REFERENCES projects(tenant_id,id) ON DELETE RESTRICT;
+ALTER TABLE engagements ADD CONSTRAINT engagements_visible_project_check
+    CHECK (assessment_project_id IS NULL OR (project_id IS NULL AND host_asset_id IS NULL));
+
+-- Recover the already-frozen association without changing Cycle ownership.
+UPDATE engagements e SET assessment_project_id=c.project_id
+FROM assessment_cycle_members m JOIN assessment_cycles c ON c.tenant_id=m.tenant_id AND c.id=m.cycle_id
+WHERE e.tenant_id=m.tenant_id AND e.id=m.assessment_id AND e.project_id IS NULL AND e.host_asset_id IS NULL AND c.project_id IS NOT NULL;
+
+-- +goose StatementBegin
+CREATE FUNCTION synapse_guard_visible_assessment_boundary() RETURNS trigger AS $$
+BEGIN
+    IF (NEW.assessment_project_id,NEW.project_id,NEW.host_asset_id,NEW.business_asset_id)
+        IS DISTINCT FROM (OLD.assessment_project_id,OLD.project_id,OLD.host_asset_id,OLD.business_asset_id)
+       AND EXISTS (SELECT 1 FROM assessment_cycle_members WHERE tenant_id=OLD.tenant_id AND assessment_id=OLD.id) THEN
+        IF NEW.business_asset_id IS DISTINCT FROM OLD.business_asset_id THEN
+            RAISE EXCEPTION 'Assessment Cycle membership freezes the Business Asset boundary'
+                USING ERRCODE='23514', CONSTRAINT='assessment_cycle_frozen_business_asset';
+        END IF;
+        RAISE EXCEPTION 'Assessment Cycle membership freezes the Project boundary'
+            USING ERRCODE='23514', CONSTRAINT='assessment_cycle_frozen_project';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+CREATE TRIGGER engagements_visible_assessment_boundary_guard
+    BEFORE UPDATE OF assessment_project_id,project_id,host_asset_id,business_asset_id ON engagements
+    FOR EACH ROW EXECUTE FUNCTION synapse_guard_visible_assessment_boundary();
+
+-- +goose StatementBegin
+CREATE FUNCTION synapse_guard_assessment_member_boundary() RETURNS trigger AS $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM engagements e JOIN assessment_cycles c ON c.tenant_id=e.tenant_id
+        WHERE e.tenant_id=NEW.tenant_id AND e.id=NEW.assessment_id AND c.id=NEW.cycle_id
+          AND e.project_id IS NULL AND e.host_asset_id IS NULL
+          AND e.business_asset_id IS NOT DISTINCT FROM c.business_asset_id
+          AND e.assessment_project_id IS NOT DISTINCT FROM c.project_id
+    ) THEN
+        RAISE EXCEPTION 'Assessment must match the exact frozen Cycle boundary' USING ERRCODE='23514';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+CREATE TRIGGER assessment_cycle_members_boundary_guard
+    BEFORE INSERT OR UPDATE OF tenant_id,cycle_id,assessment_id ON assessment_cycle_members
+    FOR EACH ROW EXECUTE FUNCTION synapse_guard_assessment_member_boundary();
+
+-- +goose StatementBegin
+CREATE FUNCTION synapse_guard_cycle_boundary() RETURNS trigger AS $$
+BEGIN
+    IF (NEW.tenant_id,NEW.id,NEW.boundary_kind,NEW.business_asset_id,NEW.project_id,NEW.root_assessment_id)
+        IS DISTINCT FROM (OLD.tenant_id,OLD.id,OLD.boundary_kind,OLD.business_asset_id,OLD.project_id,OLD.root_assessment_id) THEN
+        RAISE EXCEPTION 'Assessment Cycle identity, root and boundary are immutable'
+            USING ERRCODE='23514', CONSTRAINT='assessment_cycle_frozen_boundary';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+CREATE TRIGGER assessment_cycles_boundary_guard
+    BEFORE UPDATE ON assessment_cycles
+    FOR EACH ROW EXECUTE FUNCTION synapse_guard_cycle_boundary();
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM engagements WHERE assessment_project_id IS NOT NULL) THEN
+        RAISE EXCEPTION 'cannot roll back visible Assessment Projects while associations exist';
+    END IF;
+END $$;
+-- +goose StatementEnd
+DROP TRIGGER assessment_cycle_members_boundary_guard ON assessment_cycle_members;
+DROP TRIGGER assessment_cycles_boundary_guard ON assessment_cycles;
+DROP FUNCTION synapse_guard_cycle_boundary();
+DROP FUNCTION synapse_guard_assessment_member_boundary();
+DROP TRIGGER engagements_visible_assessment_boundary_guard ON engagements;
+DROP FUNCTION synapse_guard_visible_assessment_boundary();
+ALTER TABLE engagements DROP CONSTRAINT engagements_visible_project_check;
+ALTER TABLE engagements DROP CONSTRAINT engagements_assessment_project_fk;
+ALTER TABLE engagements DROP COLUMN assessment_project_id;

--- a/migrations/0158_scan_run_comparison_evidence.sql
+++ b/migrations/0158_scan_run_comparison_evidence.sql
@@ -1,0 +1,30 @@
+-- +goose Up
+CREATE TABLE scan_run_comparison_evidence (
+ tenant_id TEXT NOT NULL,
+ run_id TEXT NOT NULL,
+ content_hash TEXT NOT NULL CHECK (content_hash ~ '^[0-9a-f]{64}$'),
+ payload BYTEA NOT NULL CHECK (octet_length(payload) BETWEEN 1 AND 134217728),
+ PRIMARY KEY (tenant_id,run_id),
+ FOREIGN KEY (tenant_id,run_id) REFERENCES scan_runs(tenant_id,id) ON DELETE RESTRICT
+);
+CALL synapse_enable_tenant_rls('scan_run_comparison_evidence');
+-- +goose StatementBegin
+CREATE FUNCTION synapse_immutable_scan_comparison_evidence() RETURNS trigger AS $$
+BEGIN
+ RAISE EXCEPTION 'scan comparison evidence is immutable' USING ERRCODE='23514';
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+CREATE TRIGGER scan_comparison_evidence_immutable BEFORE UPDATE OR DELETE ON scan_run_comparison_evidence
+ FOR EACH ROW EXECUTE FUNCTION synapse_immutable_scan_comparison_evidence();
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$ BEGIN
+ IF EXISTS (SELECT 1 FROM scan_run_comparison_evidence) THEN
+  RAISE EXCEPTION 'cannot roll back scan comparison evidence while evidence exists';
+ END IF;
+END $$;
+-- +goose StatementEnd
+DROP TABLE scan_run_comparison_evidence;
+DROP FUNCTION synapse_immutable_scan_comparison_evidence();

--- a/migrations/0159_engagement_source_packages.sql
+++ b/migrations/0159_engagement_source_packages.sql
@@ -1,0 +1,64 @@
+-- +goose Up
+CREATE TABLE engagement_source_packages (
+ tenant_id TEXT NOT NULL,
+ engagement_id TEXT NOT NULL,
+ version_id TEXT NOT NULL CHECK (version_id ~ '^[0-9a-f]{32}$'),
+ filename TEXT NOT NULL CHECK (octet_length(filename) BETWEEN 1 AND 255),
+ size_bytes BIGINT NOT NULL CHECK (size_bytes BETWEEN 1 AND 536870912),
+ sha256 TEXT NOT NULL CHECK (sha256 ~ '^[0-9a-f]{64}$'),
+ locator TEXT NOT NULL CHECK (octet_length(locator) BETWEEN 1 AND 1024),
+ object_key TEXT NOT NULL CHECK (octet_length(object_key) BETWEEN 1 AND 1024),
+ created_by TEXT NOT NULL CHECK (octet_length(created_by) BETWEEN 1 AND 512),
+ created_at TIMESTAMPTZ NOT NULL,
+ associated_by TEXT NOT NULL CHECK (octet_length(associated_by) BETWEEN 1 AND 512),
+ associated_at TIMESTAMPTZ NOT NULL,
+ reused_from_version_id TEXT,
+ PRIMARY KEY (tenant_id,version_id),
+ UNIQUE (tenant_id,engagement_id),
+ UNIQUE (tenant_id,engagement_id,version_id),
+ UNIQUE (tenant_id,locator),
+ FOREIGN KEY (tenant_id,engagement_id) REFERENCES engagements(tenant_id,id) ON DELETE RESTRICT,
+ FOREIGN KEY (tenant_id,reused_from_version_id) REFERENCES engagement_source_packages(tenant_id,version_id) ON DELETE RESTRICT,
+ CHECK (reused_from_version_id IS NULL OR reused_from_version_id <> version_id)
+);
+CREATE INDEX engagement_source_packages_object_refs ON engagement_source_packages(tenant_id,object_key);
+CALL synapse_enable_tenant_rls('engagement_source_packages');
+-- +goose StatementBegin
+CREATE FUNCTION synapse_source_package_immutable() RETURNS trigger AS $$
+BEGIN
+ IF TG_OP = 'DELETE' THEN
+  IF EXISTS (SELECT 1 FROM scan_runs r WHERE r.tenant_id=OLD.tenant_id AND r.engagement_id=OLD.engagement_id)
+   OR EXISTS (SELECT 1 FROM scan_jobs j WHERE j.engagement_id=OLD.engagement_id) THEN
+   RAISE EXCEPTION 'uploaded source package is retained by scan history' USING ERRCODE='23503';
+  END IF;
+  RETURN OLD;
+ END IF;
+ IF TG_OP = 'UPDATE' THEN
+  RAISE EXCEPTION 'uploaded source package metadata is immutable' USING ERRCODE='23514';
+ END IF;
+ IF NEW.reused_from_version_id IS NOT NULL AND NOT EXISTS (
+  SELECT 1 FROM engagement_source_packages p
+  WHERE p.tenant_id=NEW.tenant_id AND p.version_id=NEW.reused_from_version_id
+   AND p.engagement_id<>NEW.engagement_id AND p.sha256=NEW.sha256
+   AND p.size_bytes=NEW.size_bytes AND p.filename=NEW.filename
+   AND p.object_key=NEW.object_key AND p.created_by=NEW.created_by AND p.created_at=NEW.created_at
+ ) THEN
+  RAISE EXCEPTION 'reused source package must preserve its original content and upload attribution' USING ERRCODE='23514';
+ END IF;
+ RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+-- +goose StatementEnd
+CREATE TRIGGER source_package_immutable BEFORE INSERT OR UPDATE OR DELETE ON engagement_source_packages
+ FOR EACH ROW EXECUTE FUNCTION synapse_source_package_immutable();
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$ BEGIN
+ IF EXISTS (SELECT 1 FROM engagement_source_packages) THEN
+  RAISE EXCEPTION 'cannot roll back uploaded source package metadata while packages exist';
+ END IF;
+END $$;
+-- +goose StatementEnd
+DROP TABLE engagement_source_packages;
+DROP FUNCTION synapse_source_package_immutable();

--- a/migrations/0160_scan_source_bindings.sql
+++ b/migrations/0160_scan_source_bindings.sql
@@ -1,0 +1,108 @@
+-- +goose Up
+-- Source metadata is frozen when a job is admitted, then copied into the
+-- immutable run manifest. Existing runs are deliberately not reconstructed.
+ALTER TABLE scan_jobs ADD COLUMN source_package JSONB;
+ALTER TABLE scan_jobs ADD COLUMN source_tenant_id TEXT
+ GENERATED ALWAYS AS (source_package->>'tenant_id') STORED;
+ALTER TABLE scan_jobs ADD COLUMN source_version_id TEXT
+ GENERATED ALWAYS AS (source_package->>'version_id') STORED;
+ALTER TABLE scan_jobs ADD CONSTRAINT scan_jobs_source_owner_fk
+ FOREIGN KEY (source_tenant_id, engagement_id, source_version_id)
+ REFERENCES engagement_source_packages(tenant_id, engagement_id, version_id) ON DELETE RESTRICT;
+CREATE INDEX scan_jobs_source_reference ON scan_jobs(source_tenant_id, engagement_id, source_version_id)
+ WHERE source_version_id IS NOT NULL;
+
+ALTER TABLE scan_runs ADD COLUMN source_version_id TEXT
+ GENERATED ALWAYS AS (manifest->'source_package'->>'version_id') STORED;
+ALTER TABLE scan_runs ADD CONSTRAINT scan_runs_source_owner_fk
+ FOREIGN KEY (tenant_id, engagement_id, source_version_id)
+ REFERENCES engagement_source_packages(tenant_id, engagement_id, version_id) ON DELETE RESTRICT;
+CREATE INDEX scan_runs_source_reference ON scan_runs(tenant_id, engagement_id, source_version_id)
+ WHERE source_version_id IS NOT NULL;
+
+-- +goose StatementBegin
+CREATE FUNCTION synapse_validate_scan_source(source JSONB, owner_tenant TEXT, owner_engagement TEXT)
+RETURNS VOID LANGUAGE plpgsql AS $$
+BEGIN
+ IF source IS NULL THEN RETURN; END IF;
+ IF jsonb_typeof(source) <> 'object' OR octet_length(source::text) > 16384
+    OR COALESCE(source->>'version_id','') = ''
+    OR source->>'tenant_id' IS DISTINCT FROM owner_tenant
+    OR source->>'engagement_id' IS DISTINCT FROM owner_engagement
+    OR source - ARRAY['tenant_id','engagement_id','version_id','reused_from_version_id',
+       'filename','size','sha256','created_by','created_at','associated_by','associated_at'] <> '{}'::jsonb THEN
+  RAISE EXCEPTION 'invalid scan source metadata' USING ERRCODE='23514';
+ END IF;
+ PERFORM 1 FROM engagement_source_packages p
+ WHERE p.tenant_id = owner_tenant AND p.engagement_id = owner_engagement
+   AND p.version_id = source->>'version_id' AND p.filename = source->>'filename'
+   AND p.size_bytes = (source->>'size')::bigint AND p.sha256 = source->>'sha256'
+   AND p.created_by = source->>'created_by' AND p.created_at = (source->>'created_at')::timestamptz
+   AND p.associated_by = source->>'associated_by' AND p.associated_at = (source->>'associated_at')::timestamptz
+   AND p.reused_from_version_id IS NOT DISTINCT FROM NULLIF(source->>'reused_from_version_id','');
+ IF NOT FOUND THEN
+  RAISE EXCEPTION 'scan source metadata does not match its owned version' USING ERRCODE='23514';
+ END IF;
+END;
+$$;
+-- +goose StatementEnd
+
+-- +goose StatementBegin
+CREATE FUNCTION synapse_guard_scan_job_source() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+ IF TG_OP = 'UPDATE' THEN
+  IF NEW.source_package IS DISTINCT FROM OLD.source_package
+     OR (OLD.source_package IS NOT NULL AND (NEW.engagement_id IS DISTINCT FROM OLD.engagement_id
+         OR NEW.target IS DISTINCT FROM OLD.target OR NEW.kind IS DISTINCT FROM OLD.kind)) THEN
+   RAISE EXCEPTION 'scan job source binding is immutable' USING ERRCODE='23514';
+  END IF;
+  RETURN NEW;
+ END IF;
+ IF NEW.source_package IS NOT NULL THEN
+  IF NEW.kind <> 'upload' OR NEW.target IS DISTINCT FROM ('uploaded-source/sha256/' || (NEW.source_package->>'sha256')) THEN
+   RAISE EXCEPTION 'scan job target does not match its source' USING ERRCODE='23514';
+  END IF;
+  PERFORM synapse_validate_scan_source(NEW.source_package, NEW.source_package->>'tenant_id', NEW.engagement_id);
+ END IF;
+ RETURN NEW;
+END;
+$$;
+-- +goose StatementEnd
+CREATE TRIGGER scan_jobs_immutable_source BEFORE INSERT OR UPDATE ON scan_jobs
+ FOR EACH ROW EXECUTE FUNCTION synapse_guard_scan_job_source();
+
+-- +goose StatementBegin
+CREATE FUNCTION synapse_guard_scan_run_source() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+ IF TG_OP = 'UPDATE' THEN
+  IF NEW.manifest->'source_package' IS DISTINCT FROM OLD.manifest->'source_package' THEN
+   RAISE EXCEPTION 'scan run source binding is immutable' USING ERRCODE='23514';
+  END IF;
+  RETURN NEW;
+ END IF;
+ PERFORM synapse_validate_scan_source(NEW.manifest->'source_package', NEW.tenant_id, NEW.engagement_id);
+ RETURN NEW;
+END;
+$$;
+-- +goose StatementEnd
+CREATE TRIGGER scan_runs_immutable_source BEFORE INSERT OR UPDATE ON scan_runs
+ FOR EACH ROW EXECUTE FUNCTION synapse_guard_scan_run_source();
+
+-- +goose Down
+-- +goose StatementBegin
+DO $$ BEGIN
+ IF EXISTS (SELECT 1 FROM scan_jobs WHERE source_package IS NOT NULL)
+    OR EXISTS (SELECT 1 FROM scan_runs WHERE source_version_id IS NOT NULL) THEN
+  RAISE EXCEPTION 'cannot roll back source bindings while scan history references uploaded source';
+ END IF;
+END $$;
+-- +goose StatementEnd
+DROP TRIGGER scan_runs_immutable_source ON scan_runs;
+DROP TRIGGER scan_jobs_immutable_source ON scan_jobs;
+DROP FUNCTION synapse_guard_scan_run_source();
+DROP FUNCTION synapse_guard_scan_job_source();
+DROP FUNCTION synapse_validate_scan_source(JSONB,TEXT,TEXT);
+ALTER TABLE scan_runs DROP COLUMN source_version_id;
+ALTER TABLE scan_jobs DROP COLUMN source_tenant_id;
+ALTER TABLE scan_jobs DROP COLUMN source_version_id;
+ALTER TABLE scan_jobs DROP COLUMN source_package;


### PR DESCRIPTION
Define the shared domain and persistence contracts for snapshots, lineage, comparison, closure and immutable sources. Add ordered migrations 0147–0160 so later capabilities can be introduced independently without missing schema or duplicate Goose versions. HTTP and worker wiring follows in phase 8.

Phase 2/10. Base: `codex/868-phase-02-cycle-core`. Keep #868 as tracking/reference only; do not merge it.

## Review follow-up: migration 0145 collision

Addressed the new review on #884 and the dependent holds on #885–#893. Main `9a7bae2d` includes #921's `0145_advisory_alias_index.sql`; the entire unmerged assessment block moves from 0145–0159 to **0146–0160**. #884 adds only 0146; #885 adds 0147–0160. All 15 assessment SQL bodies and their relative order are preserved. Existing main migrations (including 0145), core ScanRun and governed response/correlation code remain unchanged.

Updated migration test filenames and embedded-file references, Goose UpTo/DownTo targets, upgrade fixtures from main version 0145, diagnostics, and operational documentation. The complete payload is preserved through an explicit old/new filename map; runtime assessment code is unchanged by renumbering. Each PR still contains one capability commit against its immediate predecessor.

## Validation

Local validation after this update: all 10 phases passed scoped tests and repository-wide Go builds; the final stack passed repository-wide Go tests and vet. Isolated PostgreSQL 17 tests passed for duplicate migration inventory, authoritative main migrations, assessment upgrade/rollback paths, tenant isolation, immutable evidence and source bindings. Frontend typecheck, 116 test files / 694 tests, production build and lint passed (0 errors, 10 existing warnings); Helm lint/render assertions passed. CI is disabled, so these are explicitly local results. Final GitHub heads, bases and incremental file diffs are checked against the tested commits.

## Stack merge order

#884 → #885 → #886 → #887 → #888 → #889 → #890 → #891 → #892 → #893

Merge #884 first, then proceed in order. Prefer merge commits to retain ancestry; after each predecessor merges, retarget the next PR to `main` and inspect its remaining diff. Branch names remain stable. See the [preservation and migration audit](https://github.com/KKloudTarus/synapse-ce/blob/codex/868-phase-11-operations-docs/docs/architecture/assessment-stack-868-audit.md).
