### PR TITLE
feat(assessment): [3/10] retain immutable snapshot history

### DIFF
--- a/cmd/synapse-assessment-snapshot-backfill/main.go
+++ b/cmd/synapse-assessment-snapshot-backfill/main.go
@@ -1,0 +1,164 @@
+// Command synapse-assessment-snapshot-backfill projects historical scan evidence into immutable legacy Assessment Snapshots.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/postgres"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/config"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/logging"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+)
+
+type snapshotBackfillOptions struct {
+	tenants       []shared.ID
+	actor         string
+	dryRun        bool
+	batchSize     int
+	resumeAfter   shared.ID
+	timeout       time.Duration
+	leaseDuration time.Duration
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stderr); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, output io.Writer) error {
+	options, err := parseSnapshotBackfillOptions(args, output)
+	if err != nil {
+		return err
+	}
+	cfg := config.Load()
+	log := logging.New(cfg.LogLevel)
+	if cfg.DBDSN == "" {
+		return errors.New("synapse-assessment-snapshot-backfill requires SYNAPSE_DB_DSN")
+	}
+	signalCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	ctx, cancel := context.WithTimeout(signalCtx, options.timeout)
+	defer cancel()
+	pool, err := postgres.Connect(ctx, cfg.DBDSN)
+	if err != nil {
+		return err
+	}
+	defer pool.Close()
+	if err := postgres.CheckRLSRuntimeRole(ctx, pool); err != nil {
+		return err
+	}
+
+	clock, ids := idgen.SystemClock{}, idgen.RandomID{}
+	engagements := postgres.NewEngagementRepository(pool)
+	cycles := postgres.NewAssessmentCycleRepository(pool)
+	snapshots := postgres.NewAssessmentSnapshotRepository(pool)
+	runs := postgres.NewScanRunStore(pool)
+	results := postgres.NewScanResultStore(pool)
+	audit := postgres.NewAuditLog(pool)
+	projector, err := snapshotuc.NewLegacyProjector(snapshots, cycles, postgres.NewTenantTransactionRunner(pool), ids, clock, audit)
+	if err != nil {
+		return err
+	}
+	runner, err := snapshotuc.NewBackfillRunner(projector, engagements, postgres.NewAssessmentSnapshotBackfillRepository(pool), runs, results, ids, clock, audit, nil)
+	if err != nil {
+		return err
+	}
+	hostname, _ := os.Hostname()
+	if len(hostname) > 160 {
+		hostname = hostname[:160]
+	}
+	ctx, cancelRuns := context.WithCancel(ctx)
+	defer cancelRuns()
+	errorsCh := make(chan error, len(options.tenants))
+	var wait sync.WaitGroup
+	for index, tenantID := range options.tenants {
+		wait.Add(1)
+		go func(index int, tenantID shared.ID) {
+			defer wait.Done()
+			leaseOwner := strings.Join([]string{hostname, strconv.Itoa(os.Getpid()), strconv.Itoa(index)}, "-")
+			log.Info("assessment snapshot backfill started", "tenant_id", tenantID, "dry_run", options.dryRun, "batch_size", options.batchSize)
+			run, err := runner.Run(ctx, snapshotuc.BackfillRequest{
+				TenantID: tenantID, Actor: options.actor, LeaseOwner: leaseOwner, DryRun: options.dryRun,
+				BatchSize: options.batchSize, ResumeAfter: options.resumeAfter, LeaseDuration: options.leaseDuration,
+			})
+			if err == nil && run.FailedCount > 0 {
+				err = fmt.Errorf("tenant %s snapshot backfill completed with %d stable failure records", tenantID, run.FailedCount)
+			}
+			if err != nil {
+				errorsCh <- fmt.Errorf("tenant %s: %w", tenantID, err)
+				cancelRuns()
+				return
+			}
+			log.Info("assessment snapshot backfill completed", "tenant_id", tenantID, "run_id", run.ID, "processed", run.ProcessedCount, "created", run.CreatedCount, "would_create", run.WouldCreateCount, "skipped", run.SkippedCount, "failed", run.FailedCount, "checkpoint", run.CheckpointAssessment)
+		}(index, tenantID)
+	}
+	wait.Wait()
+	close(errorsCh)
+	var combined error
+	for err := range errorsCh {
+		combined = errors.Join(combined, err)
+	}
+	return combined
+}
+
+func parseSnapshotBackfillOptions(args []string, output io.Writer) (snapshotBackfillOptions, error) {
+	flags := flag.NewFlagSet("synapse-assessment-snapshot-backfill", flag.ContinueOnError)
+	flags.SetOutput(output)
+	tenantsValue := flags.String("tenants", "", "comma-separated tenant IDs; maximum four")
+	actor := flags.String("actor", "assessment-snapshot-backfill", "audit actor")
+	dryRun := flags.Bool("dry-run", false, "plan without creating legacy Snapshots")
+	batchSize := flags.Int("batch-size", snapshotuc.DefaultAssessmentSnapshotBackfillBatch, "rows per committed batch")
+	resumeAfter := flags.String("resume-after", "", "initial Assessment ID checkpoint; single tenant only")
+	timeout := flags.Duration("timeout", 30*time.Minute, "overall command timeout")
+	leaseDuration := flags.Duration("lease-duration", 10*time.Minute, "per-tenant job lease")
+	if err := flags.Parse(args); err != nil {
+		return snapshotBackfillOptions{}, err
+	}
+	if flags.NArg() != 0 {
+		return snapshotBackfillOptions{}, fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	seen := map[shared.ID]bool{}
+	tenants := make([]shared.ID, 0, 4)
+	for _, value := range strings.Split(*tenantsValue, ",") {
+		tenantID := shared.ID(strings.TrimSpace(value))
+		if tenantID.IsZero() || seen[tenantID] {
+			continue
+		}
+		seen[tenantID] = true
+		tenants = append(tenants, tenantID)
+	}
+	if len(tenants) == 0 || len(tenants) > 4 {
+		return snapshotBackfillOptions{}, errors.New("--tenants requires between one and four unique tenant IDs")
+	}
+	if *batchSize < 1 || *batchSize > snapshotuc.MaxAssessmentSnapshotBackfillBatch {
+		return snapshotBackfillOptions{}, fmt.Errorf("--batch-size must be between 1 and %d", snapshotuc.MaxAssessmentSnapshotBackfillBatch)
+	}
+	if strings.TrimSpace(*actor) == "" || len(strings.TrimSpace(*actor)) > 256 {
+		return snapshotBackfillOptions{}, errors.New("--actor must contain between 1 and 256 characters")
+	}
+	if *timeout <= 0 || *leaseDuration <= 0 {
+		return snapshotBackfillOptions{}, errors.New("--timeout and --lease-duration must be positive")
+	}
+	if strings.TrimSpace(*resumeAfter) != "" && len(tenants) != 1 {
+		return snapshotBackfillOptions{}, errors.New("--resume-after requires exactly one tenant")
+	}
+	return snapshotBackfillOptions{
+		tenants: tenants, actor: strings.TrimSpace(*actor), dryRun: *dryRun, batchSize: *batchSize,
+		resumeAfter: shared.ID(strings.TrimSpace(*resumeAfter)), timeout: *timeout, leaseDuration: *leaseDuration,
+	}, nil
+}

--- a/cmd/synapse-assessment-snapshot-backfill/main_test.go
+++ b/cmd/synapse-assessment-snapshot-backfill/main_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/postgres"
+)
+
+func TestParseSnapshotBackfillOptions(t *testing.T) {
+	options, err := parseSnapshotBackfillOptions([]string{"--tenants", "tenant-a,tenant-b,tenant-a", "--dry-run", "--batch-size", "2000", "--timeout", "1h"}, io.Discard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(options.tenants) != 2 || !options.dryRun || options.batchSize != 2000 || options.timeout != time.Hour {
+		t.Fatalf("options=%+v", options)
+	}
+	for _, args := range [][]string{
+		{},
+		{"--tenants", "a,b,c,d,e"},
+		{"--tenants", "a", "--batch-size", "2001"},
+		{"--tenants", "a,b", "--resume-after", "assessment-1"},
+	} {
+		if _, err := parseSnapshotBackfillOptions(args, io.Discard); err == nil {
+			t.Fatalf("expected invalid options for %v", args)
+		}
+	}
+}
+
+func TestRunRejectsRLSBypassingRole(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN for the PostgreSQL startup guard test")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pool, err := postgres.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	guardErr := postgres.CheckRLSRuntimeRole(ctx, pool)
+	pool.Close()
+	if guardErr == nil {
+		t.Skip("test requires a privileged database fixture role")
+	}
+	if !strings.Contains(guardErr.Error(), "cannot enforce isolation") {
+		t.Fatal(guardErr)
+	}
+	t.Setenv("SYNAPSE_DB_DSN", dsn)
+	err = run([]string{"--tenants", "assessment-cycle-role-guard-test", "--dry-run", "--timeout", "10s"}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "cannot enforce isolation") {
+		t.Fatalf("expected startup rejection before backfill writes, got %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/memory/assessment_snapshot_backfill_repo.go
+++ b/internal/infrastructure/persistence/memory/assessment_snapshot_backfill_repo.go
@@ -1,0 +1,208 @@
+package memory
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AssessmentSnapshotBackfillRepository struct {
+	mu    sync.Mutex
+	runs  map[shared.ID]map[shared.ID]ports.AssessmentSnapshotBackfillRun
+	items map[shared.ID]map[shared.ID]map[shared.ID]ports.AssessmentSnapshotBackfillItem
+}
+
+func NewAssessmentSnapshotBackfillRepository() *AssessmentSnapshotBackfillRepository {
+	return &AssessmentSnapshotBackfillRepository{
+		runs:  map[shared.ID]map[shared.ID]ports.AssessmentSnapshotBackfillRun{},
+		items: map[shared.ID]map[shared.ID]map[shared.ID]ports.AssessmentSnapshotBackfillItem{},
+	}
+}
+
+var _ ports.AssessmentSnapshotBackfillStore = (*AssessmentSnapshotBackfillRepository)(nil)
+
+func (repository *AssessmentSnapshotBackfillRepository) AcquireAssessmentSnapshotBackfillRun(_ context.Context, request ports.AssessmentSnapshotBackfillAcquireRequest) (ports.AssessmentSnapshotBackfillRun, bool, error) {
+	if err := validateAssessmentSnapshotBackfillAcquire(request); err != nil {
+		return ports.AssessmentSnapshotBackfillRun{}, false, err
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantRuns := repository.runs[request.Run.TenantID]
+	if tenantRuns == nil {
+		tenantRuns = map[shared.ID]ports.AssessmentSnapshotBackfillRun{}
+		repository.runs[request.Run.TenantID] = tenantRuns
+	}
+	for id, run := range tenantRuns {
+		if run.State != ports.AssessmentSnapshotBackfillRunning {
+			continue
+		}
+		if run.LeaseOwner != request.Run.LeaseOwner && run.LeaseExpiresAt.After(request.Run.CreatedAt) {
+			return ports.AssessmentSnapshotBackfillRun{}, false, fmt.Errorf("%w: assessment snapshot backfill already running for tenant", shared.ErrConflict)
+		}
+		if run.SchemaVersion != request.Run.SchemaVersion || run.DryRun != request.Run.DryRun || run.BatchSize != request.Run.BatchSize {
+			return ports.AssessmentSnapshotBackfillRun{}, false, fmt.Errorf("%w: requested assessment snapshot backfill config (schema=%d dry_run=%t batch_size=%d) differs from persisted config (schema=%d dry_run=%t batch_size=%d)", shared.ErrConflict,
+				request.Run.SchemaVersion, request.Run.DryRun, request.Run.BatchSize, run.SchemaVersion, run.DryRun, run.BatchSize)
+		}
+		run.LeaseOwner = request.Run.LeaseOwner
+		run.LeaseToken = request.Run.LeaseToken
+		run.LeaseExpiresAt = request.Run.CreatedAt.Add(request.LeaseDuration)
+		run.UpdatedAt = request.Run.CreatedAt
+		tenantRuns[id] = run
+		return cloneAssessmentSnapshotBackfillRun(run), true, nil
+	}
+	run := request.Run
+	run.CheckpointAssessment = request.InitialCheckpoint
+	run.LeaseExpiresAt = run.CreatedAt.Add(request.LeaseDuration)
+	tenantRuns[run.ID] = run
+	return cloneAssessmentSnapshotBackfillRun(run), false, nil
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) GetAssessmentSnapshotBackfillRun(_ context.Context, tenantID, runID shared.ID) (ports.AssessmentSnapshotBackfillRun, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	run, ok := repository.runs[tenantID][runID]
+	if !ok {
+		return ports.AssessmentSnapshotBackfillRun{}, shared.ErrNotFound
+	}
+	return cloneAssessmentSnapshotBackfillRun(run), nil
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) GetAssessmentSnapshotBackfillItem(_ context.Context, tenantID, runID, assessmentID shared.ID) (ports.AssessmentSnapshotBackfillItem, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	item, ok := repository.items[tenantID][runID][assessmentID]
+	if !ok {
+		return ports.AssessmentSnapshotBackfillItem{}, shared.ErrNotFound
+	}
+	return item, nil
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) CommitAssessmentSnapshotBackfillItem(ctx context.Context, tenantID, runID, leaseToken shared.ID, now time.Time, build func(context.Context) (ports.AssessmentSnapshotBackfillItem, error)) (ports.AssessmentSnapshotBackfillItem, bool, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID, now = shared.TenantOrDefault(tenantID), now.UTC()
+	run, ok := repository.runs[tenantID][runID]
+	if !ok {
+		return ports.AssessmentSnapshotBackfillItem{}, false, shared.ErrNotFound
+	}
+	if run.State != ports.AssessmentSnapshotBackfillRunning || run.LeaseToken != leaseToken || !run.LeaseExpiresAt.After(now) {
+		return ports.AssessmentSnapshotBackfillItem{}, false, fmt.Errorf("%w: assessment snapshot backfill lease is stale", shared.ErrConflict)
+	}
+	item, err := build(shared.WithTenant(ctx, tenantID))
+	if err != nil {
+		return ports.AssessmentSnapshotBackfillItem{}, false, err
+	}
+	if item.TenantID != tenantID || item.RunID != runID {
+		return ports.AssessmentSnapshotBackfillItem{}, false, fmt.Errorf("%w: assessment snapshot backfill item ownership differs from lease", shared.ErrValidation)
+	}
+	if err := validateAssessmentSnapshotBackfillItem(item); err != nil {
+		return ports.AssessmentSnapshotBackfillItem{}, false, err
+	}
+	tenantItems := repository.items[item.TenantID]
+	if tenantItems == nil {
+		tenantItems = map[shared.ID]map[shared.ID]ports.AssessmentSnapshotBackfillItem{}
+		repository.items[item.TenantID] = tenantItems
+	}
+	runItems := tenantItems[item.RunID]
+	if runItems == nil {
+		runItems = map[shared.ID]ports.AssessmentSnapshotBackfillItem{}
+		tenantItems[item.RunID] = runItems
+	}
+	if _, exists := runItems[item.AssessmentID]; exists {
+		return item, false, nil
+	}
+	runItems[item.AssessmentID] = item
+	return item, true, nil
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) AdvanceAssessmentSnapshotBackfillRun(_ context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken, checkpoint shared.ID, now time.Time, leaseDuration time.Duration) (ports.AssessmentSnapshotBackfillRun, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	run, ok := repository.runs[tenantID][runID]
+	if !ok {
+		return ports.AssessmentSnapshotBackfillRun{}, shared.ErrNotFound
+	}
+	if run.State != ports.AssessmentSnapshotBackfillRunning || run.LeaseOwner != strings.TrimSpace(leaseOwner) || run.LeaseToken != leaseToken || !run.LeaseExpiresAt.After(now.UTC()) || checkpoint < run.CheckpointAssessment || leaseDuration <= 0 {
+		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: assessment snapshot backfill checkpoint rejected", shared.ErrConflict)
+	}
+	run.CheckpointAssessment, run.UpdatedAt, run.LeaseExpiresAt = checkpoint, now.UTC(), now.UTC().Add(leaseDuration)
+	recomputeAssessmentSnapshotBackfillCounts(&run, repository.items[tenantID][runID])
+	repository.runs[tenantID][runID] = run
+	return cloneAssessmentSnapshotBackfillRun(run), nil
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) FinishAssessmentSnapshotBackfillRun(_ context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken shared.ID, state ports.AssessmentSnapshotBackfillState, now time.Time) (ports.AssessmentSnapshotBackfillRun, error) {
+	if state != ports.AssessmentSnapshotBackfillCompleted && state != ports.AssessmentSnapshotBackfillCancelled && state != ports.AssessmentSnapshotBackfillFailed {
+		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: invalid assessment snapshot backfill terminal state", shared.ErrValidation)
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	run, ok := repository.runs[tenantID][runID]
+	if !ok {
+		return ports.AssessmentSnapshotBackfillRun{}, shared.ErrNotFound
+	}
+	if run.State != ports.AssessmentSnapshotBackfillRunning || run.LeaseOwner != strings.TrimSpace(leaseOwner) || run.LeaseToken != leaseToken || !run.LeaseExpiresAt.After(now.UTC()) {
+		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: assessment snapshot backfill completion rejected", shared.ErrConflict)
+	}
+	completedAt := now.UTC()
+	run.State, run.UpdatedAt, run.CompletedAt = state, completedAt, &completedAt
+	run.LeaseOwner, run.LeaseToken, run.LeaseExpiresAt = "", "", time.Time{}
+	recomputeAssessmentSnapshotBackfillCounts(&run, repository.items[tenantID][runID])
+	repository.runs[tenantID][runID] = run
+	return cloneAssessmentSnapshotBackfillRun(run), nil
+}
+
+func validateAssessmentSnapshotBackfillAcquire(request ports.AssessmentSnapshotBackfillAcquireRequest) error {
+	run := request.Run
+	if run.TenantID.IsZero() || run.ID.IsZero() || run.LeaseToken.IsZero() || run.SchemaVersion <= 0 || run.BatchSize < 1 || run.BatchSize > 2000 || run.SnapshotAt.IsZero() || run.State != ports.AssessmentSnapshotBackfillRunning || strings.TrimSpace(run.LeaseOwner) == "" || len(run.LeaseOwner) > 256 || run.LeaseExpiresAt.IsZero() || strings.TrimSpace(run.CreatedBy) == "" || len(run.CreatedBy) > 256 || run.CreatedAt.IsZero() || request.LeaseDuration <= 0 {
+		return fmt.Errorf("%w: assessment snapshot backfill run is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validateAssessmentSnapshotBackfillItem(item ports.AssessmentSnapshotBackfillItem) error {
+	validOutcome := item.Outcome == "created" || item.Outcome == "would_create" || item.Outcome == "skipped" || item.Outcome == "failed"
+	_, hashErr := hex.DecodeString(item.SourceHash)
+	if item.TenantID.IsZero() || item.RunID.IsZero() || item.AssessmentID.IsZero() || item.SchemaVersion <= 0 || strings.TrimSpace(item.IdempotencyKey) == "" || len(item.IdempotencyKey) > 128 || len(item.SourceHash) != 64 || strings.ToLower(item.SourceHash) != item.SourceHash || hashErr != nil || !validOutcome || strings.TrimSpace(item.ReasonCode) == "" || len(item.ReasonCode) > 64 || len(item.RepairGuidance) > 1024 || item.ProcessedAt.IsZero() {
+		return fmt.Errorf("%w: assessment snapshot backfill item is invalid", shared.ErrValidation)
+	}
+	if item.Outcome == "created" && item.SnapshotID.IsZero() {
+		return fmt.Errorf("%w: created assessment snapshot backfill item requires a snapshot", shared.ErrValidation)
+	}
+	return nil
+}
+
+func recomputeAssessmentSnapshotBackfillCounts(run *ports.AssessmentSnapshotBackfillRun, items map[shared.ID]ports.AssessmentSnapshotBackfillItem) {
+	run.ProcessedCount, run.CreatedCount, run.WouldCreateCount, run.SkippedCount, run.FailedCount = 0, 0, 0, 0, 0
+	for _, item := range items {
+		run.ProcessedCount++
+		switch item.Outcome {
+		case "created":
+			run.CreatedCount++
+		case "would_create":
+			run.WouldCreateCount++
+		case "skipped":
+			run.SkippedCount++
+		case "failed":
+			run.FailedCount++
+		}
+	}
+}
+
+func cloneAssessmentSnapshotBackfillRun(run ports.AssessmentSnapshotBackfillRun) ports.AssessmentSnapshotBackfillRun {
+	if run.CompletedAt != nil {
+		completedAt := *run.CompletedAt
+		run.CompletedAt = &completedAt
+	}
+	return run
+}

--- a/internal/infrastructure/persistence/memory/assessment_snapshot_repo.go
+++ b/internal/infrastructure/persistence/memory/assessment_snapshot_repo.go
@@ -1,0 +1,269 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AssessmentSnapshotRepository struct {
+	mu       sync.RWMutex
+	byID     map[shared.ID]map[shared.ID]*assessmentsnapshot.Snapshot
+	requests map[shared.ID]map[shared.ID]map[string]shared.ID
+	defaults map[shared.ID]map[shared.ID]ports.AssessmentSnapshotDefault
+	counters map[shared.ID]map[shared.ID]int
+}
+
+func NewAssessmentSnapshotRepository() *AssessmentSnapshotRepository {
+	return &AssessmentSnapshotRepository{
+		byID:     map[shared.ID]map[shared.ID]*assessmentsnapshot.Snapshot{},
+		requests: map[shared.ID]map[shared.ID]map[string]shared.ID{},
+		defaults: map[shared.ID]map[shared.ID]ports.AssessmentSnapshotDefault{},
+		counters: map[shared.ID]map[shared.ID]int{},
+	}
+}
+
+var _ ports.AssessmentSnapshotRepository = (*AssessmentSnapshotRepository)(nil)
+
+func (repository *AssessmentSnapshotRepository) CreateFinalizedCAS(ctx context.Context, snapshot *assessmentsnapshot.Snapshot, expectedDefaultVersion int64) (*assessmentsnapshot.Snapshot, bool, error) {
+	if snapshot == nil {
+		return nil, false, fmt.Errorf("%w: assessment snapshot is required", shared.ErrValidation)
+	}
+	if err := snapshot.Validate(); err != nil {
+		return nil, false, err
+	}
+	tenantID := shared.TenantOrDefault(snapshot.TenantID)
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+
+	if tenantRequests := repository.requests[tenantID]; tenantRequests != nil {
+		if assessmentRequests := tenantRequests[snapshot.AssessmentID]; assessmentRequests != nil {
+			if existingID, ok := assessmentRequests[snapshot.RequestKey]; ok {
+				existing := repository.byID[tenantID][existingID]
+				if existing.RequestHash != snapshot.RequestHash {
+					return nil, false, fmt.Errorf("%w: snapshot request key was reused with different content", shared.ErrConflict)
+				}
+				return cloneAssessmentSnapshot(existing), false, nil
+			}
+		}
+	}
+
+	current, hasDefault := repository.defaults[tenantID][snapshot.AssessmentID]
+	if (!hasDefault && expectedDefaultVersion != 0) || (hasDefault && current.Version != expectedDefaultVersion) {
+		return nil, false, fmt.Errorf("%w: assessment snapshot default version mismatch", shared.ErrConflict)
+	}
+	if repository.byID[tenantID] != nil {
+		if _, exists := repository.byID[tenantID][snapshot.ID]; exists {
+			return nil, false, fmt.Errorf("%w: assessment snapshot %q already exists", shared.ErrConflict, snapshot.ID)
+		}
+	}
+	repository.registerRollback(ctx)
+
+	if repository.counters[tenantID] == nil {
+		repository.counters[tenantID] = map[shared.ID]int{}
+	}
+	next := repository.counters[tenantID][snapshot.AssessmentID] + 1
+	repository.counters[tenantID][snapshot.AssessmentID] = next
+	stored := cloneAssessmentSnapshot(snapshot)
+	stored.SnapshotNumber = next
+
+	if repository.byID[tenantID] == nil {
+		repository.byID[tenantID] = map[shared.ID]*assessmentsnapshot.Snapshot{}
+	}
+	if hasDefault {
+		previous := repository.byID[tenantID][current.SnapshotID]
+		if previous == nil {
+			return nil, false, fmt.Errorf("%w: current default snapshot is missing", shared.ErrConflict)
+		}
+		if err := previous.Supersede(stored.FinalizedBy, *stored.FinalizedAt); err != nil {
+			return nil, false, err
+		}
+	}
+	repository.byID[tenantID][stored.ID] = stored
+	if repository.requests[tenantID] == nil {
+		repository.requests[tenantID] = map[shared.ID]map[string]shared.ID{}
+	}
+	if repository.requests[tenantID][stored.AssessmentID] == nil {
+		repository.requests[tenantID][stored.AssessmentID] = map[string]shared.ID{}
+	}
+	repository.requests[tenantID][stored.AssessmentID][stored.RequestKey] = stored.ID
+	if repository.defaults[tenantID] == nil {
+		repository.defaults[tenantID] = map[shared.ID]ports.AssessmentSnapshotDefault{}
+	}
+	pointer := ports.AssessmentSnapshotDefault{
+		TenantID: tenantID, AssessmentID: stored.AssessmentID, SnapshotID: stored.ID,
+		Version: current.Version + 1, UpdatedAt: *stored.FinalizedAt, UpdatedBy: stored.FinalizedBy,
+	}
+	stored.DefaultVersion = pointer.Version
+	repository.defaults[tenantID][stored.AssessmentID] = pointer
+	return cloneAssessmentSnapshot(stored), true, nil
+}
+
+func (repository *AssessmentSnapshotRepository) CreateLegacyProjection(ctx context.Context, snapshot *assessmentsnapshot.Snapshot) (*assessmentsnapshot.Snapshot, bool, error) {
+	if snapshot == nil || snapshot.Provenance != assessmentsnapshot.ProvenanceLegacy {
+		return nil, false, fmt.Errorf("%w: legacy assessment snapshot is required", shared.ErrValidation)
+	}
+	if err := snapshot.Validate(); err != nil {
+		return nil, false, err
+	}
+	tenantID := shared.TenantOrDefault(snapshot.TenantID)
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+
+	if tenantRequests := repository.requests[tenantID]; tenantRequests != nil {
+		if assessmentRequests := tenantRequests[snapshot.AssessmentID]; assessmentRequests != nil {
+			if existingID, ok := assessmentRequests[snapshot.RequestKey]; ok {
+				existing := repository.byID[tenantID][existingID]
+				if existing.RequestHash != snapshot.RequestHash {
+					return nil, false, fmt.Errorf("%w: snapshot request key was reused with different content", shared.ErrConflict)
+				}
+				return cloneAssessmentSnapshot(existing), false, nil
+			}
+		}
+	}
+	if repository.byID[tenantID] != nil {
+		if _, exists := repository.byID[tenantID][snapshot.ID]; exists {
+			return nil, false, fmt.Errorf("%w: assessment snapshot %q already exists", shared.ErrConflict, snapshot.ID)
+		}
+	}
+	repository.registerRollback(ctx)
+	if repository.counters[tenantID] == nil {
+		repository.counters[tenantID] = map[shared.ID]int{}
+	}
+	next := repository.counters[tenantID][snapshot.AssessmentID] + 1
+	repository.counters[tenantID][snapshot.AssessmentID] = next
+	stored := cloneAssessmentSnapshot(snapshot)
+	stored.SnapshotNumber = next
+	if repository.byID[tenantID] == nil {
+		repository.byID[tenantID] = map[shared.ID]*assessmentsnapshot.Snapshot{}
+	}
+	repository.byID[tenantID][stored.ID] = stored
+	if repository.requests[tenantID] == nil {
+		repository.requests[tenantID] = map[shared.ID]map[string]shared.ID{}
+	}
+	if repository.requests[tenantID][stored.AssessmentID] == nil {
+		repository.requests[tenantID][stored.AssessmentID] = map[string]shared.ID{}
+	}
+	repository.requests[tenantID][stored.AssessmentID][stored.RequestKey] = stored.ID
+	return cloneAssessmentSnapshot(stored), true, nil
+}
+
+func (repository *AssessmentSnapshotRepository) Get(_ context.Context, tenantID, snapshotID shared.ID) (*assessmentsnapshot.Snapshot, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	snapshot := repository.byID[tenantID][snapshotID]
+	if snapshot == nil {
+		return nil, fmt.Errorf("assessment snapshot %s: %w", snapshotID, shared.ErrNotFound)
+	}
+	return cloneAssessmentSnapshot(snapshot), nil
+}
+
+func (repository *AssessmentSnapshotRepository) GetByRequestKey(_ context.Context, tenantID, assessmentID shared.ID, requestKey string) (*assessmentsnapshot.Snapshot, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	id, ok := repository.requests[tenantID][assessmentID][strings.TrimSpace(requestKey)]
+	if !ok {
+		return nil, shared.ErrNotFound
+	}
+	return cloneAssessmentSnapshot(repository.byID[tenantID][id]), nil
+}
+
+func (repository *AssessmentSnapshotRepository) GetDefault(_ context.Context, tenantID, assessmentID shared.ID) (*assessmentsnapshot.Snapshot, ports.AssessmentSnapshotDefault, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	pointer, ok := repository.defaults[tenantID][assessmentID]
+	if !ok {
+		return nil, ports.AssessmentSnapshotDefault{}, shared.ErrNotFound
+	}
+	snapshot := repository.byID[tenantID][pointer.SnapshotID]
+	if snapshot == nil {
+		return nil, ports.AssessmentSnapshotDefault{}, fmt.Errorf("default assessment snapshot: %w", shared.ErrNotFound)
+	}
+	return cloneAssessmentSnapshot(snapshot), pointer, nil
+}
+
+func (repository *AssessmentSnapshotRepository) ListByAssessment(_ context.Context, tenantID, assessmentID shared.ID) ([]assessmentsnapshot.Snapshot, error) {
+	page, err := repository.ListAssessmentSnapshots(context.Background(), ports.AssessmentSnapshotListQuery{TenantID: tenantID, AssessmentID: assessmentID, Limit: 100})
+	return page.Items, err
+}
+
+func (repository *AssessmentSnapshotRepository) ListAssessmentSnapshots(_ context.Context, query ports.AssessmentSnapshotListQuery) (ports.AssessmentSnapshotPage, error) {
+	if query.Limit < 1 || query.Limit > 100 || query.AfterSnapshotNumber < 0 {
+		return ports.AssessmentSnapshotPage{}, fmt.Errorf("%w: assessment snapshot page is invalid", shared.ErrValidation)
+	}
+	tenantID, assessmentID := shared.TenantOrDefault(query.TenantID), query.AssessmentID
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	var out []assessmentsnapshot.Snapshot
+	for _, snapshot := range repository.byID[tenantID] {
+		if snapshot.AssessmentID == assessmentID && snapshot.SnapshotNumber > query.AfterSnapshotNumber {
+			out = append(out, *cloneAssessmentSnapshot(snapshot))
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].SnapshotNumber < out[j].SnapshotNumber })
+	page := ports.AssessmentSnapshotPage{Items: out}
+	if len(page.Items) > query.Limit {
+		page.Items, page.HasMore = page.Items[:query.Limit], true
+	}
+	return page, nil
+}
+
+func cloneAssessmentSnapshot(snapshot *assessmentsnapshot.Snapshot) *assessmentsnapshot.Snapshot {
+	if snapshot == nil {
+		return nil
+	}
+	copySnapshot := *snapshot
+	copySnapshot.RunReferences = append([]assessmentsnapshot.RunReference(nil), snapshot.RunReferences...)
+	for index := range copySnapshot.RunReferences {
+		copySnapshot.RunReferences[index].LaneReferences = append([]assessmentsnapshot.LaneReference(nil), snapshot.RunReferences[index].LaneReferences...)
+	}
+	copySnapshot.Dimensions = append([]assessmentsnapshot.Dimension(nil), snapshot.Dimensions...)
+	for index := range copySnapshot.Dimensions {
+		copySnapshot.Dimensions[index].IncludedScope = cloneSnapshotStrings(snapshot.Dimensions[index].IncludedScope)
+		copySnapshot.Dimensions[index].ExcludedScope = cloneSnapshotStrings(snapshot.Dimensions[index].ExcludedScope)
+		copySnapshot.Dimensions[index].Versions = append([]assessmentsnapshot.Version(nil), snapshot.Dimensions[index].Versions...)
+	}
+	if snapshot.FinalizedAt != nil {
+		value := *snapshot.FinalizedAt
+		copySnapshot.FinalizedAt = &value
+	}
+	if snapshot.SupersededAt != nil {
+		value := *snapshot.SupersededAt
+		copySnapshot.SupersededAt = &value
+	}
+	return &copySnapshot
+}
+
+func cloneSnapshotStrings(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	cloned := make([]string, len(values))
+	copy(cloned, values)
+	return cloned
+}
+
+func (repository *AssessmentSnapshotRepository) registerRollback(ctx context.Context) {
+	registerTenantCheckpoint(ctx, repository, func(tenantID shared.ID) func() {
+		snapshots := cloneMapValues(repository.byID[tenantID], cloneAssessmentSnapshot)
+		requests := cloneMapValues(repository.requests[tenantID], func(items map[string]shared.ID) map[string]shared.ID {
+			return cloneMapValues(items, func(id shared.ID) shared.ID { return id })
+		})
+		defaults := cloneMapValues(repository.defaults[tenantID], func(pointer ports.AssessmentSnapshotDefault) ports.AssessmentSnapshotDefault { return pointer })
+		counters := cloneMapValues(repository.counters[tenantID], func(count int) int { return count })
+		return func() {
+			repository.mu.Lock()
+			defer repository.mu.Unlock()
+			repository.byID[tenantID], repository.requests[tenantID], repository.defaults[tenantID], repository.counters[tenantID] = snapshots, requests, defaults, counters
+		}
+	})
+}

--- a/internal/infrastructure/persistence/memory/engagement_repo.go
+++ b/internal/infrastructure/persistence/memory/engagement_repo.go
@@ -32,12 +32,24 @@ var _ ports.VulnerabilityReconciliationTenantStore = (*EngagementRepository)(nil
 var _ ports.DetectionReconciliationTenantStore = (*EngagementRepository)(nil)
 var _ ports.VulnerabilityReconciliationEngagementStore = (*EngagementRepository)(nil)
 var _ ports.HostEngagementLister = (*EngagementRepository)(nil)
+var _ ports.AssessmentCycleBackfillSource = (*EngagementRepository)(nil)
 
-func (r *EngagementRepository) Create(_ context.Context, e *engagement.Engagement) error {
+func (r *EngagementRepository) Create(ctx context.Context, e *engagement.Engagement) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	e.TenantID = shared.TenantOrDefault(e.TenantID)
-	r.data[e.ID] = e
+	previous, existed := r.data[e.ID]
+	previous = cloneMemoryEngagement(previous)
+	registerTenantRollback(ctx, func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		if existed {
+			r.data[e.ID] = previous
+		} else {
+			delete(r.data, e.ID)
+		}
+	})
+	r.data[e.ID] = cloneMemoryEngagement(e)
 	return nil
 }
 
@@ -48,7 +60,7 @@ func (r *EngagementRepository) GetByID(_ context.Context, id shared.ID) (*engage
 	if !ok {
 		return nil, shared.ErrNotFound
 	}
-	return e, nil
+	return cloneMemoryEngagement(e), nil
 }
 
 // GetByIDInTenant loads an engagement scoped to tenantID. Empty input normalizes to the non-empty
@@ -64,7 +76,7 @@ func (r *EngagementRepository) GetByIDInTenant(_ context.Context, tenantID, id s
 	if e.Internal() || e.TenantID != tenantID {
 		return nil, shared.ErrNotFound // cross-tenant/internal access – do not reveal existence
 	}
-	return e, nil
+	return cloneMemoryEngagement(e), nil
 }
 
 func (r *EngagementRepository) GetByHostAssetID(_ context.Context, tenantID, assetID shared.ID) (*engagement.Engagement, error) {
@@ -76,7 +88,7 @@ func (r *EngagementRepository) GetByHostAssetID(_ context.Context, tenantID, ass
 	}
 	for _, e := range r.data {
 		if e.HostAssetID == assetID && e.TenantID == tenantID {
-			return e, nil
+			return cloneMemoryEngagement(e), nil
 		}
 	}
 	return nil, shared.ErrNotFound
@@ -88,7 +100,7 @@ func (r *EngagementRepository) GetByProjectID(_ context.Context, tenantID, proje
 	tenantID = shared.TenantOrDefault(tenantID)
 	for _, e := range r.data {
 		if e.ProjectID == projectID && e.TenantID == tenantID {
-			return e, nil
+			return cloneMemoryEngagement(e), nil
 		}
 	}
 	return nil, shared.ErrNotFound
@@ -105,31 +117,68 @@ func (r *EngagementRepository) ProjectContexts(_ context.Context, tenantID share
 	out := map[shared.ID]*engagement.Engagement{}
 	for _, e := range r.data {
 		if wanted[e.ProjectID] && e.TenantID == tenantID {
-			out[e.ProjectID] = e
+			out[e.ProjectID] = cloneMemoryEngagement(e)
 		}
 	}
 	return out, nil
 }
 
-func (r *EngagementRepository) Update(_ context.Context, e *engagement.Engagement) error {
+func (r *EngagementRepository) Update(ctx context.Context, e *engagement.Engagement) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if _, ok := r.data[e.ID]; !ok {
+	previous, ok := r.data[e.ID]
+	if !ok {
 		return shared.ErrNotFound
 	}
+	previous = cloneMemoryEngagement(previous)
+	registerTenantRollback(ctx, func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.data[e.ID] = previous
+	})
 	e.TenantID = shared.TenantOrDefault(e.TenantID)
-	r.data[e.ID] = e
+	r.data[e.ID] = cloneMemoryEngagement(e)
 	return nil
 }
 
 // Delete removes an engagement (idempotent). In Postgres the FK cascade removes
 // children; in memory other stores are independent, but import rollback only needs
 // the engagement gone so a re-import isn't blocked.
-func (r *EngagementRepository) Delete(_ context.Context, id shared.ID) error {
+func (r *EngagementRepository) Delete(ctx context.Context, id shared.ID) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+	previous, existed := r.data[id]
+	previous = cloneMemoryEngagement(previous)
+	registerTenantRollback(ctx, func() {
+		if !existed {
+			return
+		}
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		r.data[id] = previous
+	})
 	delete(r.data, id)
 	return nil
+}
+
+func cloneMemoryEngagement(item *engagement.Engagement) *engagement.Engagement {
+	if item == nil {
+		return nil
+	}
+	cloned := *item
+	cloned.Scope.InScope = append([]engagement.Target(nil), item.Scope.InScope...)
+	cloned.Scope.OutOfScope = append([]engagement.Target(nil), item.Scope.OutOfScope...)
+	cloned.RoE.AllowedToolClasses = append([]engagement.ToolClass(nil), item.RoE.AllowedToolClasses...)
+	cloned.RoE.Blackouts = append([]engagement.Blackout(nil), item.RoE.Blackouts...)
+	if item.AuthorizedFrom != nil {
+		value := *item.AuthorizedFrom
+		cloned.AuthorizedFrom = &value
+	}
+	if item.AuthorizedTo != nil {
+		value := *item.AuthorizedTo
+		cloned.AuthorizedTo = &value
+	}
+	return &cloned
 }
 
 // ListPromotionReconciliationScopes returns every non-project engagement for
@@ -160,7 +209,7 @@ func (r *EngagementRepository) List(_ context.Context, tenantID shared.ID) ([]*e
 	out := make([]*engagement.Engagement, 0, len(r.data))
 	for _, e := range r.data {
 		if !e.Internal() && e.TenantID == tenantID {
-			out = append(out, e)
+			out = append(out, cloneMemoryEngagement(e))
 		}
 	}
 	return out, nil
@@ -191,6 +240,10 @@ func (r *EngagementRepository) ListAssessmentCycleBackfillEngagements(_ context.
 	return items, nil
 }
 
+func (r *EngagementRepository) ListAssessmentSnapshotBackfillEngagements(ctx context.Context, tenantID, after shared.ID, snapshotAt time.Time, limit int) ([]*engagement.Engagement, error) {
+	return r.ListAssessmentCycleBackfillEngagements(ctx, tenantID, after, snapshotAt, limit)
+}
+
 func (r *EngagementRepository) ListProjectEngagements(_ context.Context, tenantID shared.ID) ([]*engagement.Engagement, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -198,7 +251,7 @@ func (r *EngagementRepository) ListProjectEngagements(_ context.Context, tenantI
 	out := make([]*engagement.Engagement, 0)
 	for _, e := range r.data {
 		if !e.ProjectID.IsZero() && e.TenantID == tenantID {
-			out = append(out, e)
+			out = append(out, cloneMemoryEngagement(e))
 		}
 	}
 	return out, nil
@@ -212,7 +265,7 @@ func (r *EngagementRepository) ListHostEngagements(_ context.Context, tenantID s
 	out := make([]*engagement.Engagement, 0)
 	for _, e := range r.data {
 		if !e.HostAssetID.IsZero() && e.TenantID == tenantID {
-			out = append(out, e)
+			out = append(out, cloneMemoryEngagement(e))
 		}
 	}
 	return out, nil

--- a/internal/infrastructure/persistence/memory/tenant_tx.go
+++ b/internal/infrastructure/persistence/memory/tenant_tx.go
@@ -10,8 +10,20 @@ import (
 )
 
 // TenantTransactionRunner provides an in-memory implementation of ports.TenantTransactionRunner.
-type TenantTransactionRunner struct {
-	mu sync.Mutex
+type TenantTransactionRunner struct{}
+
+// All runners may share repositories in the same process. Serialize their
+// transactions together so one runner cannot roll back another runner's commit.
+// The memory adapter is a development/test fallback, not a throughput backend.
+var memoryTenantTransactions sync.Mutex
+
+type tenantTransactionKey struct{}
+
+type tenantTransaction struct {
+	tenantID    shared.ID
+	rollbacks   []func()
+	checkpoints map[any]bool
+	afterCommit []func()
 }
 
 // NewTenantTransactionRunner constructs an in-memory TenantTransactionRunner.
@@ -23,10 +35,103 @@ var _ ports.TenantTransactionRunner = (*TenantTransactionRunner)(nil)
 
 // Run runs the given function within a simulated thread-safe tenant context.
 func (r *TenantTransactionRunner) Run(ctx context.Context, tenantID shared.ID, fn func(context.Context) error) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if tenantID.IsZero() || fn == nil {
 		return fmt.Errorf("%w: tenant transaction identity is required", shared.ErrValidation)
 	}
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return fn(shared.WithTenant(ctx, tenantID))
+	if transaction, ok := ctx.Value(tenantTransactionKey{}).(*tenantTransaction); ok {
+		if transaction.tenantID != tenantID {
+			return fmt.Errorf("%w: nested tenant transaction mismatch", shared.ErrValidation)
+		}
+		return fn(ctx)
+	}
+	memoryTenantTransactions.Lock()
+	defer memoryTenantTransactions.Unlock()
+	transaction := &tenantTransaction{tenantID: tenantID, checkpoints: make(map[any]bool)}
+	txCtx := shared.WithTenant(context.WithValue(ctx, tenantTransactionKey{}, transaction), tenantID)
+	committed := false
+	defer func() {
+		if !committed {
+			for index := len(transaction.rollbacks) - 1; index >= 0; index-- {
+				transaction.rollbacks[index]()
+			}
+		}
+	}()
+	if err := fn(txCtx); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	committed = true
+	for _, publish := range transaction.afterCommit {
+		publish()
+	}
+	return nil
+}
+
+// registerTenantCommit defers publishing process-local work until the enclosing
+// transaction (including its audit) succeeds. Failed transactions publish nothing.
+func registerTenantCommit(ctx context.Context, publish func()) bool {
+	transaction, ok := ctx.Value(tenantTransactionKey{}).(*tenantTransaction)
+	if !ok {
+		return false
+	}
+	transaction.afterCommit = append(transaction.afterCommit, publish)
+	return true
+}
+
+// registerTenantCheckpoint captures each repository once per transaction. This
+// avoids quadratic copying when a snapshot appends thousands of observations.
+// Callers hold their repository mutex while capturing and lock it on rollback.
+func registerTenantCheckpoint(ctx context.Context, repository any, capture func(shared.ID) func()) {
+	transaction, ok := ctx.Value(tenantTransactionKey{}).(*tenantTransaction)
+	if !ok || transaction.checkpoints[repository] {
+		return
+	}
+	transaction.checkpoints[repository] = true
+	transaction.rollbacks = append(transaction.rollbacks, capture(transaction.tenantID))
+}
+
+func cloneMapValues[K comparable, V any](source map[K]V, clone func(V) V) map[K]V {
+	result := make(map[K]V, len(source))
+	for key, value := range source {
+		result[key] = clone(value)
+	}
+	return result
+}
+
+// captureTenantEntries is for copy-on-write records; it restores only the
+// transaction tenant, preserving unrelated tenants' concurrent writes.
+func captureTenantEntries[K comparable, V any](entries map[K]V, belongs func(K, V) bool) func() {
+	previous := make(map[K]V)
+	for key, value := range entries {
+		if belongs(key, value) {
+			previous[key] = value
+		}
+	}
+	return func() {
+		for key, value := range entries {
+			if belongs(key, value) {
+				delete(entries, key)
+			}
+		}
+		for key, value := range previous {
+			entries[key] = value
+		}
+	}
+}
+
+// registerTenantRollback adds a repository-local compensation to the current
+// in-memory transaction. Repositories call it while holding their own mutex and
+// restore the captured state only after the mutation has returned and unlocked.
+func registerTenantRollback(ctx context.Context, rollback func()) bool {
+	transaction, ok := ctx.Value(tenantTransactionKey{}).(*tenantTransaction)
+	if !ok || rollback == nil {
+		return false
+	}
+	transaction.rollbacks = append(transaction.rollbacks, rollback)
+	return true
 }

--- a/internal/infrastructure/persistence/postgres/assessment_snapshot_backfill_repo.go
+++ b/internal/infrastructure/persistence/postgres/assessment_snapshot_backfill_repo.go
@@ -1,0 +1,247 @@
+package postgres
+
+import (
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const assessmentSnapshotBackfillRunColumns = `tenant_id,id,schema_version,dry_run,batch_size,snapshot_at,checkpoint_assessment_id,state,lease_owner,lease_token,lease_expires_at,processed_count,created_count,would_create_count,skipped_count,failed_count,created_by,created_at,updated_at,completed_at`
+
+type AssessmentSnapshotBackfillRepository struct{ pool *pgxpool.Pool }
+
+func NewAssessmentSnapshotBackfillRepository(pool *pgxpool.Pool) *AssessmentSnapshotBackfillRepository {
+	return &AssessmentSnapshotBackfillRepository{pool: pool}
+}
+
+var _ ports.AssessmentSnapshotBackfillStore = (*AssessmentSnapshotBackfillRepository)(nil)
+
+func (repository *AssessmentSnapshotBackfillRepository) AcquireAssessmentSnapshotBackfillRun(ctx context.Context, request ports.AssessmentSnapshotBackfillAcquireRequest) (run ports.AssessmentSnapshotBackfillRun, resumed bool, err error) {
+	if err := validatePostgresAssessmentSnapshotBackfillAcquire(request); err != nil {
+		return ports.AssessmentSnapshotBackfillRun{}, false, err
+	}
+	err = WithTenant(ctx, repository.pool, request.Run.TenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `SELECT id FROM tenants WHERE id=$1 FOR UPDATE`, request.Run.TenantID.String()); err != nil {
+			return fmt.Errorf("lock assessment snapshot backfill tenant: %w", err)
+		}
+		row := tx.QueryRow(ctx, `SELECT `+assessmentSnapshotBackfillRunColumns+` FROM assessment_snapshot_backfill_runs WHERE tenant_id=$1 AND state='running' FOR UPDATE`, request.Run.TenantID.String())
+		existing, scanErr := scanAssessmentSnapshotBackfillRun(row)
+		if scanErr == nil {
+			if existing.SchemaVersion != request.Run.SchemaVersion || existing.DryRun != request.Run.DryRun || existing.BatchSize != request.Run.BatchSize {
+				return fmt.Errorf("%w: requested assessment snapshot backfill config (schema=%d dry_run=%t batch_size=%d) differs from persisted config (schema=%d dry_run=%t batch_size=%d)", shared.ErrConflict,
+					request.Run.SchemaVersion, request.Run.DryRun, request.Run.BatchSize, existing.SchemaVersion, existing.DryRun, existing.BatchSize)
+			}
+			updated, err := scanAssessmentSnapshotBackfillRun(tx.QueryRow(ctx, `UPDATE assessment_snapshot_backfill_runs
+				SET lease_owner=$3,lease_token=$4,lease_expires_at=now()+($5 * interval '1 microsecond'),updated_at=$6
+				WHERE tenant_id=$1 AND id=$2 AND state='running' AND (lease_owner=$3 OR lease_expires_at <= now())
+				RETURNING `+assessmentSnapshotBackfillRunColumns,
+				request.Run.TenantID.String(), existing.ID.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.LeaseDuration.Microseconds(), request.Run.CreatedAt))
+			if errors.Is(err, pgx.ErrNoRows) {
+				return fmt.Errorf("%w: assessment snapshot backfill already running for tenant", shared.ErrConflict)
+			}
+			if err != nil {
+				return fmt.Errorf("resume assessment snapshot backfill run: %w", err)
+			}
+			run, resumed = updated, true
+			return nil
+		}
+		if !errors.Is(scanErr, pgx.ErrNoRows) {
+			return fmt.Errorf("find active assessment snapshot backfill run: %w", scanErr)
+		}
+		created, err := scanAssessmentSnapshotBackfillRun(tx.QueryRow(ctx, `INSERT INTO assessment_snapshot_backfill_runs (`+assessmentSnapshotBackfillRunColumns+`) VALUES ($1,$2,$3,$4,$5,$6,$7,'running',$8,$9,now()+($10 * interval '1 microsecond'),0,0,0,0,0,$11,$12,$12,NULL) RETURNING `+assessmentSnapshotBackfillRunColumns,
+			request.Run.TenantID.String(), request.Run.ID.String(), request.Run.SchemaVersion, request.Run.DryRun, request.Run.BatchSize, request.Run.SnapshotAt,
+			request.InitialCheckpoint.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.LeaseDuration.Microseconds(), request.Run.CreatedBy, request.Run.CreatedAt))
+		if err != nil {
+			return fmt.Errorf("create assessment snapshot backfill run: %w", err)
+		}
+		run = created
+		return nil
+	})
+	return run, resumed, err
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) GetAssessmentSnapshotBackfillRun(ctx context.Context, tenantID, runID shared.ID) (run ports.AssessmentSnapshotBackfillRun, err error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		item, err := scanAssessmentSnapshotBackfillRun(tx.QueryRow(ctx, `SELECT `+assessmentSnapshotBackfillRunColumns+` FROM assessment_snapshot_backfill_runs WHERE tenant_id=$1 AND id=$2`, tenantID.String(), runID.String()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("get assessment snapshot backfill run: %w", err)
+		}
+		run = item
+		return nil
+	})
+	return run, err
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) GetAssessmentSnapshotBackfillItem(ctx context.Context, tenantID, runID, assessmentID shared.ID) (item ports.AssessmentSnapshotBackfillItem, err error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		row := tx.QueryRow(ctx, `SELECT tenant_id,run_id,assessment_id,schema_version,idempotency_key,source_hash,COALESCE(snapshot_id,''),outcome,reason_code,retryable,repair_guidance,processed_at FROM assessment_snapshot_backfill_items WHERE tenant_id=$1 AND run_id=$2 AND assessment_id=$3`, tenantID.String(), runID.String(), assessmentID.String())
+		if err := row.Scan(&item.TenantID, &item.RunID, &item.AssessmentID, &item.SchemaVersion, &item.IdempotencyKey, &item.SourceHash, &item.SnapshotID, &item.Outcome, &item.ReasonCode, &item.Retryable, &item.RepairGuidance, &item.ProcessedAt); errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		} else if err != nil {
+			return fmt.Errorf("get assessment snapshot backfill item: %w", err)
+		}
+		return nil
+	})
+	return item, err
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) CommitAssessmentSnapshotBackfillItem(ctx context.Context, tenantID, runID, leaseToken shared.ID, now time.Time, build func(context.Context) (ports.AssessmentSnapshotBackfillItem, error)) (item ports.AssessmentSnapshotBackfillItem, created bool, err error) {
+	tenantID, now = shared.TenantOrDefault(tenantID), now.UTC()
+	if tenantID.IsZero() || runID.IsZero() || leaseToken.IsZero() || now.IsZero() || build == nil {
+		return item, false, fmt.Errorf("%w: assessment snapshot backfill commit identity is invalid", shared.ErrValidation)
+	}
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var active bool
+		if err := tx.QueryRow(ctx, `SELECT state='running' AND lease_token=$3 AND lease_expires_at>now() FROM assessment_snapshot_backfill_runs WHERE tenant_id=$1 AND id=$2 FOR UPDATE`, tenantID.String(), runID.String(), leaseToken.String()).Scan(&active); errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		} else if err != nil {
+			return fmt.Errorf("lock assessment snapshot backfill lease: %w", err)
+		}
+		if !active {
+			return fmt.Errorf("%w: assessment snapshot backfill lease is stale", shared.ErrConflict)
+		}
+		var err error
+		item, err = build(bindTenantTransaction(ctx, tenantID, tx))
+		if err != nil {
+			return err
+		}
+		if item.TenantID != tenantID || item.RunID != runID {
+			return fmt.Errorf("%w: assessment snapshot backfill item ownership differs from lease", shared.ErrValidation)
+		}
+		if err := validatePostgresAssessmentSnapshotBackfillItem(item); err != nil {
+			return err
+		}
+		result, err := tx.Exec(ctx, `INSERT INTO assessment_snapshot_backfill_items(
+			tenant_id,run_id,assessment_id,schema_version,idempotency_key,source_hash,snapshot_id,outcome,reason_code,retryable,repair_guidance,processed_at)
+			SELECT $1,$2,$3,$4,$5,$6,NULLIF($7,''),$8,$9,$10,$11,$12
+			WHERE EXISTS (SELECT 1 FROM assessment_snapshot_backfill_runs WHERE tenant_id=$1 AND id=$2 AND state='running')
+			ON CONFLICT DO NOTHING`, item.TenantID.String(), item.RunID.String(), item.AssessmentID.String(), item.SchemaVersion,
+			item.IdempotencyKey, item.SourceHash, item.SnapshotID.String(), item.Outcome, item.ReasonCode, item.Retryable, item.RepairGuidance, item.ProcessedAt)
+		if err != nil {
+			return mapPostgresError(err, "save assessment snapshot backfill item")
+		}
+		created = result.RowsAffected() == 1
+		if !created {
+			var exists bool
+			if err := tx.QueryRow(ctx, `SELECT EXISTS (SELECT 1 FROM assessment_snapshot_backfill_items WHERE tenant_id=$1 AND run_id=$2 AND assessment_id=$3)`, item.TenantID.String(), item.RunID.String(), item.AssessmentID.String()).Scan(&exists); err != nil {
+				return err
+			}
+			if !exists {
+				return fmt.Errorf("%w: assessment snapshot backfill run is not active", shared.ErrConflict)
+			}
+		}
+		return nil
+	})
+	return item, created, err
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) AdvanceAssessmentSnapshotBackfillRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken, checkpoint shared.ID, now time.Time, leaseDuration time.Duration) (run ports.AssessmentSnapshotBackfillRun, err error) {
+	tenantID, leaseOwner, now = shared.TenantOrDefault(tenantID), strings.TrimSpace(leaseOwner), now.UTC()
+	if leaseToken.IsZero() || leaseDuration <= 0 {
+		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: assessment snapshot backfill lease duration is invalid", shared.ErrValidation)
+	}
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		updated, err := scanAssessmentSnapshotBackfillRun(tx.QueryRow(ctx, `UPDATE assessment_snapshot_backfill_runs AS run SET checkpoint_assessment_id=$5,lease_expires_at=now()+($7 * interval '1 microsecond'),updated_at=$6,
+			processed_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id),
+			created_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='created'),
+			would_create_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='would_create'),
+			skipped_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='skipped'),
+			failed_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='failed')
+			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>now() AND run.checkpoint_assessment_id COLLATE "C" <= $5
+			RETURNING `+assessmentSnapshotBackfillRunColumns, tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), checkpoint.String(), now, leaseDuration.Microseconds()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: assessment snapshot backfill checkpoint rejected", shared.ErrConflict)
+		}
+		if err != nil {
+			return fmt.Errorf("advance assessment snapshot backfill run: %w", err)
+		}
+		run = updated
+		return nil
+	})
+	return run, err
+}
+
+func (repository *AssessmentSnapshotBackfillRepository) FinishAssessmentSnapshotBackfillRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken shared.ID, state ports.AssessmentSnapshotBackfillState, now time.Time) (run ports.AssessmentSnapshotBackfillRun, err error) {
+	if state != ports.AssessmentSnapshotBackfillCompleted && state != ports.AssessmentSnapshotBackfillCancelled && state != ports.AssessmentSnapshotBackfillFailed {
+		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: invalid assessment snapshot backfill terminal state", shared.ErrValidation)
+	}
+	tenantID, leaseOwner, now = shared.TenantOrDefault(tenantID), strings.TrimSpace(leaseOwner), now.UTC()
+	if tenantID.IsZero() || runID.IsZero() || leaseOwner == "" || leaseToken.IsZero() || now.IsZero() {
+		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: assessment snapshot backfill completion identity is invalid", shared.ErrValidation)
+	}
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		finished, err := scanAssessmentSnapshotBackfillRun(tx.QueryRow(ctx, `UPDATE assessment_snapshot_backfill_runs AS run SET state=$5,lease_owner='',lease_token='',lease_expires_at=NULL,updated_at=$6,completed_at=$6,
+			processed_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id),
+			created_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='created'),
+			would_create_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='would_create'),
+			skipped_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='skipped'),
+			failed_count=(SELECT count(*) FROM assessment_snapshot_backfill_items item WHERE item.tenant_id=run.tenant_id AND item.run_id=run.id AND item.outcome='failed')
+			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3 AND run.lease_token=$4 AND run.lease_expires_at>now() RETURNING `+assessmentSnapshotBackfillRunColumns,
+			tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), string(state), now))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: assessment snapshot backfill completion rejected", shared.ErrConflict)
+		}
+		if err != nil {
+			return fmt.Errorf("finish assessment snapshot backfill run: %w", err)
+		}
+		run = finished
+		return nil
+	})
+	return run, err
+}
+
+func scanAssessmentSnapshotBackfillRun(row rowScanner) (ports.AssessmentSnapshotBackfillRun, error) {
+	var (
+		run                       ports.AssessmentSnapshotBackfillRun
+		state                     string
+		leaseExpires, completedAt pgtype.Timestamptz
+	)
+	if err := row.Scan(&run.TenantID, &run.ID, &run.SchemaVersion, &run.DryRun, &run.BatchSize, &run.SnapshotAt, &run.CheckpointAssessment, &state, &run.LeaseOwner, &run.LeaseToken, &leaseExpires,
+		&run.ProcessedCount, &run.CreatedCount, &run.WouldCreateCount, &run.SkippedCount, &run.FailedCount, &run.CreatedBy, &run.CreatedAt, &run.UpdatedAt, &completedAt); err != nil {
+		return ports.AssessmentSnapshotBackfillRun{}, err
+	}
+	run.State = ports.AssessmentSnapshotBackfillState(state)
+	if leaseExpires.Valid {
+		run.LeaseExpiresAt = leaseExpires.Time
+	}
+	if completedAt.Valid {
+		completed := completedAt.Time
+		run.CompletedAt = &completed
+	}
+	return run, nil
+}
+
+func validatePostgresAssessmentSnapshotBackfillAcquire(request ports.AssessmentSnapshotBackfillAcquireRequest) error {
+	run := request.Run
+	if run.TenantID.IsZero() || run.ID.IsZero() || run.LeaseToken.IsZero() || run.SchemaVersion <= 0 || run.BatchSize < 1 || run.BatchSize > 2000 || run.SnapshotAt.IsZero() || run.State != ports.AssessmentSnapshotBackfillRunning || strings.TrimSpace(run.LeaseOwner) == "" || len(run.LeaseOwner) > 256 || strings.TrimSpace(run.CreatedBy) == "" || len(run.CreatedBy) > 256 || run.CreatedAt.IsZero() || request.LeaseDuration <= 0 {
+		return fmt.Errorf("%w: assessment snapshot backfill run is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validatePostgresAssessmentSnapshotBackfillItem(item ports.AssessmentSnapshotBackfillItem) error {
+	validOutcome := item.Outcome == "created" || item.Outcome == "would_create" || item.Outcome == "skipped" || item.Outcome == "failed"
+	_, hashErr := hex.DecodeString(item.SourceHash)
+	if item.TenantID.IsZero() || item.RunID.IsZero() || item.AssessmentID.IsZero() || item.SchemaVersion <= 0 || strings.TrimSpace(item.IdempotencyKey) == "" || len(item.IdempotencyKey) > 128 || len(item.SourceHash) != 64 || strings.ToLower(item.SourceHash) != item.SourceHash || hashErr != nil || !validOutcome || strings.TrimSpace(item.ReasonCode) == "" || len(item.ReasonCode) > 64 || len(item.RepairGuidance) > 1024 || item.ProcessedAt.IsZero() {
+		return fmt.Errorf("%w: assessment snapshot backfill item is invalid", shared.ErrValidation)
+	}
+	if item.Outcome == "created" && item.SnapshotID.IsZero() {
+		return fmt.Errorf("%w: created assessment snapshot backfill item requires a snapshot", shared.ErrValidation)
+	}
+	return nil
+}

--- a/internal/infrastructure/persistence/postgres/assessment_snapshot_backfill_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_snapshot_backfill_repo_test.go
@@ -1,0 +1,254 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestPostgresAssessmentSnapshotBackfillRunnerAndRLS(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.Up(db, "."); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	now := time.Now().UTC().Add(time.Hour)
+	clock := &postgresBackfillClock{now: now}
+	tenantID, otherTenantID := shared.ID("snapshot-backfill-pg"), shared.ID("snapshot-backfill-other")
+	assessmentID, otherAssessmentID := shared.ID("snapshot-backfill-assessment"), shared.ID("snapshot-backfill-other-assessment")
+	ensureTestTenantAndEngagement(t, ctx, pool, tenantID, assessmentID, "", "")
+	ensureTestTenantAndEngagement(t, ctx, pool, otherTenantID, otherAssessmentID, "", "")
+	cycles := NewAssessmentCycleRepository(pool)
+	cycle, err := assessmentcycle.NewAssessmentCycle("snapshot-backfill-cycle", tenantID, "Cycle", assessmentcycle.BoundaryStandalone, "", "", assessmentID, "operator", now.Add(-time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember(tenantID, cycle.ID, assessmentID, "operator", now.Add(-time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+	run := postgresNativeRun(t, tenantID, assessmentID, "snapshot-backfill-run", strings.Repeat("a", 64))
+	runRepository := NewScanRunStore(pool)
+	sealPostgresNativeRun(t, ctx, runRepository, &run, now)
+	storedRuns, err := runRepository.ListScanRuns(ctx, tenantID, assessmentID)
+	if err != nil || len(storedRuns) != 1 {
+		t.Fatalf("stored runs=%+v err=%v", storedRuns, err)
+	}
+	if !storedRuns[0].IsSealed() {
+		t.Fatalf("stored scan run is not sealed: %+v", storedRuns[0])
+	}
+	results := NewScanResultStore(pool)
+	if err := results.SaveResult(ctx, assessmentID, []byte(`{"source":"legacy-cache"}`)); err != nil {
+		t.Fatal(err)
+	}
+	snapshots := NewAssessmentSnapshotRepository(pool)
+	audit := NewAuditLog(pool)
+	projector, err := snapshotuc.NewLegacyProjector(snapshots, cycles, NewTenantTransactionRunner(pool), idgen.RandomID{}, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewAssessmentSnapshotBackfillRepository(pool)
+	runner, err := snapshotuc.NewBackfillRunner(projector, NewEngagementRepository(pool), store, runRepository, results, idgen.RandomID{}, clock, audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backfillRun, err := runner.Run(ctx, snapshotuc.BackfillRequest{TenantID: tenantID, Actor: "operator", LeaseOwner: "postgres", BatchSize: 1})
+	if err != nil || backfillRun.State != ports.AssessmentSnapshotBackfillCompleted || backfillRun.CreatedCount != 1 || backfillRun.FailedCount != 0 {
+		item, itemErr := store.GetAssessmentSnapshotBackfillItem(ctx, tenantID, backfillRun.ID, assessmentID)
+		t.Fatalf("postgres snapshot backfill=%+v item=%+v item_err=%v err=%v", backfillRun, item, itemErr, err)
+	}
+	projected, err := snapshots.ListByAssessment(ctx, tenantID, assessmentID)
+	if err != nil || len(projected) != 1 || projected[0].Provenance != assessmentsnapshot.ProvenanceLegacy || len(projected[0].Dimensions) != 1 || projected[0].Dimensions[0].State != assessmentsnapshot.CoverageUnknown {
+		t.Fatalf("postgres projected snapshots=%+v err=%v", projected, err)
+	}
+	if _, _, err := snapshots.GetDefault(ctx, tenantID, assessmentID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("legacy projection changed default: %v", err)
+	}
+	if _, err := store.GetAssessmentSnapshotBackfillRun(ctx, otherTenantID, backfillRun.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant run read=%v", err)
+	}
+	if _, err := store.GetAssessmentSnapshotBackfillItem(ctx, otherTenantID, backfillRun.ID, assessmentID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant item read=%v", err)
+	}
+}
+
+func TestPostgresAssessmentSnapshotBackfillLeaseAndCompositeOwnership(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.Up(db, "."); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	ensureTestTenantAndEngagement(t, ctx, pool, "snapshot-lease-a", "snapshot-assessment-a", "", "")
+	ensureTestTenantAndEngagement(t, ctx, pool, "snapshot-lease-b", "snapshot-assessment-b", "", "")
+	repository := NewAssessmentSnapshotBackfillRepository(pool)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	request := ports.AssessmentSnapshotBackfillAcquireRequest{Run: ports.AssessmentSnapshotBackfillRun{
+		TenantID: "snapshot-lease-a", ID: "run-a", SchemaVersion: 1, BatchSize: 500, SnapshotAt: now,
+		State: ports.AssessmentSnapshotBackfillRunning, LeaseOwner: "owner-a", LeaseToken: "token-a", LeaseExpiresAt: now.Add(time.Minute), CreatedBy: "operator", CreatedAt: now, UpdatedAt: now,
+	}, LeaseDuration: time.Minute}
+	if _, _, err := repository.AcquireAssessmentSnapshotBackfillRun(ctx, request); err != nil {
+		t.Fatal(err)
+	}
+	contender := request
+	contender.Run.ID, contender.Run.LeaseOwner, contender.Run.LeaseToken = "run-b", "owner-b", "token-b"
+	if _, _, err := repository.AcquireAssessmentSnapshotBackfillRun(ctx, contender); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("concurrent lease=%v", err)
+	}
+	if _, _, err := repository.CommitAssessmentSnapshotBackfillItem(ctx, "snapshot-lease-a", "run-a", "token-a", now, func(context.Context) (ports.AssessmentSnapshotBackfillItem, error) {
+		return ports.AssessmentSnapshotBackfillItem{TenantID: "snapshot-lease-a", RunID: "run-a", AssessmentID: "snapshot-assessment-b", SchemaVersion: 1,
+			IdempotencyKey: "source-v1", SourceHash: strings.Repeat("a", 64), Outcome: "failed", ReasonCode: "source_read_failed", ProcessedAt: now}, nil
+	}); err == nil {
+		t.Fatal("expected cross-tenant Assessment ownership rejection")
+	}
+	contender.Run.CreatedAt, contender.Run.SnapshotAt = now.Add(2*time.Minute), now
+	// Client clock skew must not steal a live lease; PostgreSQL owns expiry.
+	if _, _, err := repository.AcquireAssessmentSnapshotBackfillRun(ctx, contender); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("client clock stole a live lease: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE assessment_snapshot_backfill_runs SET lease_expires_at=now()-interval '1 second' WHERE tenant_id=$1 AND id=$2`, "snapshot-lease-a", "run-a"); err != nil {
+		t.Fatal(err)
+	}
+	resumed, wasResumed, err := repository.AcquireAssessmentSnapshotBackfillRun(ctx, contender)
+	if err != nil || !wasResumed || resumed.ID != "run-a" || resumed.LeaseOwner != "owner-b" {
+		t.Fatalf("expired lease resume=%+v resumed=%v err=%v", resumed, wasResumed, err)
+	}
+}
+
+func TestPostgresAssessmentSnapshotBackfillConcurrentStart(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.Up(db, "."); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES('snapshot-concurrent','Snapshot concurrent')`); err != nil {
+		t.Fatal(err)
+	}
+	repository := NewAssessmentSnapshotBackfillRepository(pool)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	start := make(chan struct{})
+	errorsCh := make(chan error, 2)
+	var wait sync.WaitGroup
+	for _, identity := range []string{"a", "b"} {
+		wait.Add(1)
+		go func(identity string) {
+			defer wait.Done()
+			<-start
+			_, _, err := repository.AcquireAssessmentSnapshotBackfillRun(ctx, ports.AssessmentSnapshotBackfillAcquireRequest{Run: ports.AssessmentSnapshotBackfillRun{
+				TenantID: "snapshot-concurrent", ID: shared.ID("run-" + identity), SchemaVersion: 1, BatchSize: 500, SnapshotAt: now,
+				State: ports.AssessmentSnapshotBackfillRunning, LeaseOwner: "owner-" + identity, LeaseToken: shared.ID("token-" + identity), LeaseExpiresAt: now.Add(time.Minute), CreatedBy: "operator", CreatedAt: now, UpdatedAt: now,
+			}, LeaseDuration: time.Minute})
+			errorsCh <- err
+		}(identity)
+	}
+	close(start)
+	wait.Wait()
+	close(errorsCh)
+	succeeded, conflicted := 0, 0
+	for err := range errorsCh {
+		switch {
+		case err == nil:
+			succeeded++
+		case errors.Is(err, shared.ErrConflict):
+			conflicted++
+		default:
+			t.Fatalf("concurrent start error=%v", err)
+		}
+	}
+	if succeeded != 1 || conflicted != 1 {
+		t.Fatalf("concurrent starts succeeded=%d conflicted=%d", succeeded, conflicted)
+	}
+}
+
+func TestPostgresAssessmentSnapshotBackfillProjectsUpgradedLegacyRun(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.Up(db, "."); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+	for _, statement := range []string{
+		`INSERT INTO tenants(id,name) VALUES('snapshot-upgrade-tenant','Snapshot upgrade')`,
+		`INSERT INTO engagements(id,tenant_id,name,created_at,updated_at) VALUES('snapshot-upgrade-assessment','snapshot-upgrade-tenant','Historical',now()-interval '2 hours',now()-interval '1 hour')`,
+		`INSERT INTO scan_runs(id,engagement_id,created_at,manifest,finding_keys) VALUES('snapshot-upgrade-run','snapshot-upgrade-assessment',now()-interval '1 hour','{}'::jsonb,'["legacy-key"]'::jsonb)`,
+	} {
+		if _, err := db.ExecContext(context.Background(), statement); err != nil {
+			t.Fatalf("seed upgraded legacy fixture: %v", err)
+		}
+	}
+	if err := goose.Up(db, "."); err != nil {
+		t.Fatalf("upgrade fixture to 0142: %v", err)
+	}
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	tenantID, assessmentID := shared.ID("snapshot-upgrade-tenant"), shared.ID("snapshot-upgrade-assessment")
+	cycles := NewAssessmentCycleRepository(pool)
+	now := time.Now().UTC()
+	cycle, err := assessmentcycle.NewAssessmentCycle("snapshot-upgrade-cycle", tenantID, "Cycle", assessmentcycle.BoundaryStandalone, "", "", assessmentID, "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember(tenantID, cycle.ID, assessmentID, "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+	clock := &postgresBackfillClock{now: now.Add(time.Minute)}
+	snapshots := NewAssessmentSnapshotRepository(pool)
+	audit := NewAuditLog(pool)
+	projector, err := snapshotuc.NewLegacyProjector(snapshots, cycles, NewTenantTransactionRunner(pool), idgen.RandomID{}, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner, err := snapshotuc.NewBackfillRunner(projector, NewEngagementRepository(pool), NewAssessmentSnapshotBackfillRepository(pool), NewScanRunStore(pool), NewScanResultStore(pool), idgen.RandomID{}, clock, audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := runner.Run(ctx, snapshotuc.BackfillRequest{TenantID: tenantID, Actor: "operator", LeaseOwner: "upgrade", BatchSize: 1})
+	if err != nil || run.CreatedCount != 1 {
+		t.Fatalf("upgraded legacy projection run=%+v err=%v", run, err)
+	}
+	projected, err := snapshots.ListByAssessment(ctx, tenantID, assessmentID)
+	if err != nil || len(projected) != 1 || projected[0].Provenance != assessmentsnapshot.ProvenanceLegacy || len(projected[0].RunReferences) != 1 || len(projected[0].Dimensions) != 0 {
+		t.Fatalf("upgraded legacy projection=%+v err=%v", projected, err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/assessment_snapshot_repo.go
+++ b/internal/infrastructure/persistence/postgres/assessment_snapshot_repo.go
@@ -1,0 +1,436 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const assessmentSnapshotColumns = `tenant_id,id,cycle_id,assessment_id,snapshot_number,default_version,lifecycle,provenance,boundary_kind,
+	COALESCE(business_asset_id,''),COALESCE(project_id,''),schema_version,content_hash,request_key,request_hash,
+	created_at,created_by,finalized_at,finalized_by,superseded_at,superseded_by`
+
+type AssessmentSnapshotRepository struct{ pool *pgxpool.Pool }
+
+func NewAssessmentSnapshotRepository(pool *pgxpool.Pool) *AssessmentSnapshotRepository {
+	return &AssessmentSnapshotRepository{pool: pool}
+}
+
+var _ ports.AssessmentSnapshotRepository = (*AssessmentSnapshotRepository)(nil)
+
+func (repository *AssessmentSnapshotRepository) CreateFinalizedCAS(ctx context.Context, snapshot *assessmentsnapshot.Snapshot, expectedDefaultVersion int64) (*assessmentsnapshot.Snapshot, bool, error) {
+	if snapshot == nil {
+		return nil, false, fmt.Errorf("%w: assessment snapshot is required", shared.ErrValidation)
+	}
+	if err := snapshot.Validate(); err != nil {
+		return nil, false, err
+	}
+	tenantID := shared.TenantOrDefault(snapshot.TenantID)
+	var stored *assessmentsnapshot.Snapshot
+	created := false
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO assessment_snapshot_counters(tenant_id,assessment_id,next_snapshot_number)
+			VALUES($1,$2,1) ON CONFLICT (tenant_id,assessment_id) DO NOTHING`, tenantID.String(), snapshot.AssessmentID.String()); err != nil {
+			return fmt.Errorf("initialize assessment snapshot counter: %w", err)
+		}
+		var snapshotNumber int
+		if err := tx.QueryRow(ctx, `SELECT next_snapshot_number FROM assessment_snapshot_counters
+			WHERE tenant_id=$1 AND assessment_id=$2 FOR UPDATE`, tenantID.String(), snapshot.AssessmentID.String()).Scan(&snapshotNumber); err != nil {
+			return fmt.Errorf("lock assessment snapshot counter: %w", err)
+		}
+		existing, err := loadAssessmentSnapshotByRequest(ctx, tx, tenantID, snapshot.AssessmentID, snapshot.RequestKey)
+		if err == nil {
+			if existing.RequestHash != snapshot.RequestHash {
+				return fmt.Errorf("%w: snapshot request key was reused with different content", shared.ErrConflict)
+			}
+			stored = existing
+			return nil
+		}
+		if !errors.Is(err, shared.ErrNotFound) {
+			return err
+		}
+
+		var currentSnapshotID string
+		var currentVersion int64
+		err = tx.QueryRow(ctx, `SELECT snapshot_id,version FROM assessment_snapshot_defaults
+			WHERE tenant_id=$1 AND assessment_id=$2 FOR UPDATE`, tenantID.String(), snapshot.AssessmentID.String()).Scan(&currentSnapshotID, &currentVersion)
+		if errors.Is(err, pgx.ErrNoRows) {
+			if expectedDefaultVersion != 0 {
+				return fmt.Errorf("%w: assessment snapshot default version mismatch", shared.ErrConflict)
+			}
+			currentSnapshotID, currentVersion = "", 0
+		} else if err != nil {
+			return fmt.Errorf("lock assessment snapshot default: %w", err)
+		} else if currentVersion != expectedDefaultVersion {
+			return fmt.Errorf("%w: assessment snapshot default version mismatch", shared.ErrConflict)
+		}
+
+		if _, err := tx.Exec(ctx, `UPDATE assessment_snapshot_counters SET next_snapshot_number=next_snapshot_number+1
+			WHERE tenant_id=$1 AND assessment_id=$2`, tenantID.String(), snapshot.AssessmentID.String()); err != nil {
+			return fmt.Errorf("allocate assessment snapshot number: %w", err)
+		}
+
+		defaultVersion := currentVersion + 1
+		if err := insertAndFinalizeAssessmentSnapshot(ctx, tx, tenantID, snapshot, snapshotNumber, defaultVersion); err != nil {
+			return err
+		}
+		var result pgconn.CommandTag
+		if currentSnapshotID != "" {
+			result, err = tx.Exec(ctx, `UPDATE assessment_snapshots SET lifecycle='superseded',superseded_at=$1,superseded_by=$2
+				WHERE tenant_id=$3 AND id=$4 AND lifecycle='finalized'`, snapshot.FinalizedAt, snapshot.FinalizedBy, tenantID.String(), currentSnapshotID)
+			if err != nil {
+				return fmt.Errorf("supersede assessment snapshot: %w", err)
+			}
+			if result.RowsAffected() != 1 {
+				return fmt.Errorf("%w: current assessment snapshot changed", shared.ErrConflict)
+			}
+		}
+		if currentVersion == 0 {
+			result, err = tx.Exec(ctx, `INSERT INTO assessment_snapshot_defaults(tenant_id,assessment_id,snapshot_id,version,updated_at,updated_by)
+				VALUES($1,$2,$3,1,$4,$5)`, tenantID.String(), snapshot.AssessmentID.String(), snapshot.ID.String(), snapshot.FinalizedAt, snapshot.FinalizedBy)
+		} else {
+			result, err = tx.Exec(ctx, `UPDATE assessment_snapshot_defaults SET snapshot_id=$1,version=version+1,updated_at=$2,updated_by=$3
+				WHERE tenant_id=$4 AND assessment_id=$5 AND version=$6`, snapshot.ID.String(), snapshot.FinalizedAt, snapshot.FinalizedBy,
+				tenantID.String(), snapshot.AssessmentID.String(), expectedDefaultVersion)
+		}
+		if err != nil {
+			return mapPostgresError(err, "update assessment snapshot default")
+		}
+		if result.RowsAffected() != 1 {
+			return fmt.Errorf("%w: assessment snapshot default changed", shared.ErrConflict)
+		}
+		stored = cloneFinalizedSnapshot(snapshot, snapshotNumber, defaultVersion)
+		created = true
+		return nil
+	})
+	return stored, created, err
+}
+
+func (repository *AssessmentSnapshotRepository) CreateLegacyProjection(ctx context.Context, snapshot *assessmentsnapshot.Snapshot) (*assessmentsnapshot.Snapshot, bool, error) {
+	if snapshot == nil || snapshot.Provenance != assessmentsnapshot.ProvenanceLegacy {
+		return nil, false, fmt.Errorf("%w: legacy assessment snapshot is required", shared.ErrValidation)
+	}
+	if err := snapshot.Validate(); err != nil {
+		return nil, false, err
+	}
+	tenantID := shared.TenantOrDefault(snapshot.TenantID)
+	var stored *assessmentsnapshot.Snapshot
+	created := false
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO assessment_snapshot_counters(tenant_id,assessment_id,next_snapshot_number)
+			VALUES($1,$2,1) ON CONFLICT (tenant_id,assessment_id) DO NOTHING`, tenantID.String(), snapshot.AssessmentID.String()); err != nil {
+			return fmt.Errorf("initialize assessment snapshot counter: %w", err)
+		}
+		var snapshotNumber int
+		if err := tx.QueryRow(ctx, `SELECT next_snapshot_number FROM assessment_snapshot_counters
+			WHERE tenant_id=$1 AND assessment_id=$2 FOR UPDATE`, tenantID.String(), snapshot.AssessmentID.String()).Scan(&snapshotNumber); err != nil {
+			return fmt.Errorf("lock assessment snapshot counter: %w", err)
+		}
+		existing, err := loadAssessmentSnapshotByRequest(ctx, tx, tenantID, snapshot.AssessmentID, snapshot.RequestKey)
+		if err == nil {
+			if existing.RequestHash != snapshot.RequestHash {
+				return fmt.Errorf("%w: snapshot request key was reused with different content", shared.ErrConflict)
+			}
+			stored = existing
+			return nil
+		}
+		if !errors.Is(err, shared.ErrNotFound) {
+			return err
+		}
+		if _, err := tx.Exec(ctx, `UPDATE assessment_snapshot_counters SET next_snapshot_number=next_snapshot_number+1
+			WHERE tenant_id=$1 AND assessment_id=$2`, tenantID.String(), snapshot.AssessmentID.String()); err != nil {
+			return fmt.Errorf("allocate assessment snapshot number: %w", err)
+		}
+		if err := insertAndFinalizeAssessmentSnapshot(ctx, tx, tenantID, snapshot, snapshotNumber, 0); err != nil {
+			return err
+		}
+		stored, created = cloneFinalizedSnapshot(snapshot, snapshotNumber, 0), true
+		return nil
+	})
+	return stored, created, err
+}
+
+func insertAndFinalizeAssessmentSnapshot(ctx context.Context, tx pgx.Tx, tenantID shared.ID, snapshot *assessmentsnapshot.Snapshot, snapshotNumber int, defaultVersion int64) error {
+	_, err := tx.Exec(ctx, `INSERT INTO assessment_snapshots(
+		tenant_id,id,cycle_id,assessment_id,snapshot_number,default_version,lifecycle,provenance,boundary_kind,business_asset_id,project_id,
+		schema_version,content_hash,request_key,request_hash,created_at,created_by)
+		VALUES($1,$2,$3,$4,$5,$6,'building',$7,$8,NULLIF($9,''),NULLIF($10,''),$11,$12,$13,$14,$15,$16)`,
+		tenantID.String(), snapshot.ID.String(), snapshot.CycleID.String(), snapshot.AssessmentID.String(), snapshotNumber, defaultVersion,
+		string(snapshot.Provenance), string(snapshot.Boundary.Kind), snapshot.Boundary.BusinessAssetID.String(), snapshot.Boundary.ProjectID.String(),
+		snapshot.SchemaVersion, snapshot.ContentHash, snapshot.RequestKey, snapshot.RequestHash, snapshot.CreatedAt, snapshot.CreatedBy)
+	if err != nil {
+		return mapPostgresError(err, "create assessment snapshot")
+	}
+	for runPosition, run := range snapshot.RunReferences {
+		if _, err := tx.Exec(ctx, `INSERT INTO assessment_snapshot_run_refs(tenant_id,snapshot_id,position,scan_run_id,manifest_hash)
+			VALUES($1,$2,$3,$4,$5)`, tenantID.String(), snapshot.ID.String(), runPosition, run.RunID, run.ManifestHash); err != nil {
+			return mapPostgresError(err, "create assessment snapshot run reference")
+		}
+		for _, lane := range run.LaneReferences {
+			if _, err := tx.Exec(ctx, `INSERT INTO assessment_snapshot_lane_refs(tenant_id,snapshot_id,run_position,scan_run_id,lane_key,manifest_hash)
+				VALUES($1,$2,$3,$4,$5,$6)`, tenantID.String(), snapshot.ID.String(), runPosition, run.RunID, lane.LaneKey, lane.ManifestHash); err != nil {
+				return mapPostgresError(err, "create assessment snapshot lane reference")
+			}
+		}
+	}
+	for position, dimension := range snapshot.Dimensions {
+		includedScope, err := json.Marshal(dimension.IncludedScope)
+		if err != nil {
+			return fmt.Errorf("marshal snapshot included scope: %w", err)
+		}
+		excludedScope, err := json.Marshal(dimension.ExcludedScope)
+		if err != nil {
+			return fmt.Errorf("marshal snapshot excluded scope: %w", err)
+		}
+		versions, err := json.Marshal(dimension.Versions)
+		if err != nil {
+			return fmt.Errorf("marshal snapshot versions: %w", err)
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO assessment_snapshot_dimensions(
+			tenant_id,snapshot_id,position,run_id,lane_key,lane_manifest_hash,producer,finding_kind,target_kind,target_schema_version,
+			target_canonical,evaluated_revision,coverage_state,reason_code,included_scope,excluded_scope,versions)
+			VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)`,
+			tenantID.String(), snapshot.ID.String(), position, dimension.RunID, dimension.LaneKey, dimension.LaneManifestHash,
+			dimension.Producer, dimension.FindingKind, string(dimension.Target.Kind), dimension.Target.SchemaVersion,
+			dimension.Target.Canonical, dimension.Target.EvaluatedRevision, string(dimension.State), dimension.ReasonCode,
+			includedScope, excludedScope, versions); err != nil {
+			return mapPostgresError(err, "create assessment snapshot dimension")
+		}
+	}
+	result, err := tx.Exec(ctx, `UPDATE assessment_snapshots SET lifecycle='finalized',finalized_at=$1,finalized_by=$2
+		WHERE tenant_id=$3 AND id=$4 AND lifecycle='building'`, snapshot.FinalizedAt, snapshot.FinalizedBy, tenantID.String(), snapshot.ID.String())
+	if err != nil {
+		return fmt.Errorf("finalize assessment snapshot: %w", err)
+	}
+	if result.RowsAffected() != 1 {
+		return fmt.Errorf("%w: assessment snapshot finalization lost", shared.ErrConflict)
+	}
+	return nil
+}
+
+func (repository *AssessmentSnapshotRepository) Get(ctx context.Context, tenantID, snapshotID shared.ID) (*assessmentsnapshot.Snapshot, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var snapshot *assessmentsnapshot.Snapshot
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var err error
+		snapshot, err = loadAssessmentSnapshot(ctx, tx, tenantID, snapshotID)
+		return err
+	})
+	return snapshot, err
+}
+
+func (repository *AssessmentSnapshotRepository) GetByRequestKey(ctx context.Context, tenantID, assessmentID shared.ID, requestKey string) (*assessmentsnapshot.Snapshot, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var snapshot *assessmentsnapshot.Snapshot
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var err error
+		snapshot, err = loadAssessmentSnapshotByRequest(ctx, tx, tenantID, assessmentID, requestKey)
+		return err
+	})
+	return snapshot, err
+}
+
+func (repository *AssessmentSnapshotRepository) GetDefault(ctx context.Context, tenantID, assessmentID shared.ID) (*assessmentsnapshot.Snapshot, ports.AssessmentSnapshotDefault, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var snapshot *assessmentsnapshot.Snapshot
+	var pointer ports.AssessmentSnapshotDefault
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var snapshotID string
+		if err := tx.QueryRow(ctx, `SELECT snapshot_id,version,updated_at,updated_by FROM assessment_snapshot_defaults
+			WHERE tenant_id=$1 AND assessment_id=$2`, tenantID.String(), assessmentID.String()).Scan(&snapshotID, &pointer.Version, &pointer.UpdatedAt, &pointer.UpdatedBy); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return shared.ErrNotFound
+			}
+			return fmt.Errorf("load default assessment snapshot: %w", err)
+		}
+		pointer.TenantID, pointer.AssessmentID, pointer.SnapshotID = tenantID, assessmentID, shared.ID(snapshotID)
+		var err error
+		snapshot, err = loadAssessmentSnapshot(ctx, tx, tenantID, pointer.SnapshotID)
+		return err
+	})
+	return snapshot, pointer, err
+}
+
+func (repository *AssessmentSnapshotRepository) ListByAssessment(ctx context.Context, tenantID, assessmentID shared.ID) ([]assessmentsnapshot.Snapshot, error) {
+	page, err := repository.ListAssessmentSnapshots(ctx, ports.AssessmentSnapshotListQuery{TenantID: tenantID, AssessmentID: assessmentID, Limit: 100})
+	return page.Items, err
+}
+
+func (repository *AssessmentSnapshotRepository) ListAssessmentSnapshots(ctx context.Context, query ports.AssessmentSnapshotListQuery) (ports.AssessmentSnapshotPage, error) {
+	if query.Limit < 1 || query.Limit > 100 || query.AfterSnapshotNumber < 0 {
+		return ports.AssessmentSnapshotPage{}, fmt.Errorf("%w: assessment snapshot page is invalid", shared.ErrValidation)
+	}
+	tenantID, assessmentID := shared.TenantOrDefault(query.TenantID), query.AssessmentID
+	page := ports.AssessmentSnapshotPage{}
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT id FROM assessment_snapshots WHERE tenant_id=$1 AND assessment_id=$2 AND snapshot_number>$3 ORDER BY snapshot_number LIMIT $4`, tenantID.String(), assessmentID.String(), query.AfterSnapshotNumber, query.Limit+1)
+		if err != nil {
+			return fmt.Errorf("list assessment snapshots: %w", err)
+		}
+		defer rows.Close()
+		var ids []shared.ID
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				return err
+			}
+			ids = append(ids, shared.ID(id))
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		if len(ids) > query.Limit {
+			ids, page.HasMore = ids[:query.Limit], true
+		}
+		for _, id := range ids {
+			snapshot, err := loadAssessmentSnapshot(ctx, tx, tenantID, id)
+			if err != nil {
+				return err
+			}
+			page.Items = append(page.Items, *snapshot)
+		}
+		return nil
+	})
+	return page, err
+}
+
+func loadAssessmentSnapshotByRequest(ctx context.Context, tx pgx.Tx, tenantID, assessmentID shared.ID, requestKey string) (*assessmentsnapshot.Snapshot, error) {
+	var id string
+	if err := tx.QueryRow(ctx, `SELECT id FROM assessment_snapshots WHERE tenant_id=$1 AND assessment_id=$2 AND request_key=$3`,
+		tenantID.String(), assessmentID.String(), requestKey).Scan(&id); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, shared.ErrNotFound
+		}
+		return nil, fmt.Errorf("load assessment snapshot request: %w", err)
+	}
+	return loadAssessmentSnapshot(ctx, tx, tenantID, shared.ID(id))
+}
+
+func loadAssessmentSnapshot(ctx context.Context, tx pgx.Tx, tenantID, snapshotID shared.ID) (*assessmentsnapshot.Snapshot, error) {
+	row := tx.QueryRow(ctx, `SELECT `+assessmentSnapshotColumns+` FROM assessment_snapshots WHERE tenant_id=$1 AND id=$2`, tenantID.String(), snapshotID.String())
+	snapshot, err := scanAssessmentSnapshot(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, shared.ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("scan assessment snapshot: %w", err)
+	}
+	runRows, err := tx.Query(ctx, `SELECT position,scan_run_id,manifest_hash FROM assessment_snapshot_run_refs
+		WHERE tenant_id=$1 AND snapshot_id=$2 ORDER BY position`, tenantID.String(), snapshotID.String())
+	if err != nil {
+		return nil, err
+	}
+	type persistedRunReference struct {
+		position  int
+		reference assessmentsnapshot.RunReference
+	}
+	var persistedRuns []persistedRunReference
+	for runRows.Next() {
+		var position int
+		var reference assessmentsnapshot.RunReference
+		if err := runRows.Scan(&position, &reference.RunID, &reference.ManifestHash); err != nil {
+			runRows.Close()
+			return nil, err
+		}
+		persistedRuns = append(persistedRuns, persistedRunReference{position: position, reference: reference})
+	}
+	if err := runRows.Err(); err != nil {
+		runRows.Close()
+		return nil, err
+	}
+	runRows.Close()
+	for _, persisted := range persistedRuns {
+		reference := persisted.reference
+		laneRows, err := tx.Query(ctx, `SELECT lane_key,manifest_hash FROM assessment_snapshot_lane_refs
+			WHERE tenant_id=$1 AND snapshot_id=$2 AND run_position=$3 ORDER BY lane_key`, tenantID.String(), snapshotID.String(), persisted.position)
+		if err != nil {
+			return nil, err
+		}
+		for laneRows.Next() {
+			var lane assessmentsnapshot.LaneReference
+			if err := laneRows.Scan(&lane.LaneKey, &lane.ManifestHash); err != nil {
+				laneRows.Close()
+				return nil, err
+			}
+			reference.LaneReferences = append(reference.LaneReferences, lane)
+		}
+		if err := laneRows.Err(); err != nil {
+			laneRows.Close()
+			return nil, err
+		}
+		laneRows.Close()
+		snapshot.RunReferences = append(snapshot.RunReferences, reference)
+	}
+
+	dimensionRows, err := tx.Query(ctx, `SELECT run_id,lane_key,lane_manifest_hash,producer,finding_kind,target_kind,target_schema_version,
+		target_canonical,evaluated_revision,coverage_state,reason_code,included_scope,excluded_scope,versions
+		FROM assessment_snapshot_dimensions WHERE tenant_id=$1 AND snapshot_id=$2 ORDER BY position`, tenantID.String(), snapshotID.String())
+	if err != nil {
+		return nil, err
+	}
+	defer dimensionRows.Close()
+	for dimensionRows.Next() {
+		var dimension assessmentsnapshot.Dimension
+		var targetKind, coverageState string
+		var includedScope, excludedScope, versions []byte
+		if err := dimensionRows.Scan(&dimension.RunID, &dimension.LaneKey, &dimension.LaneManifestHash, &dimension.Producer, &dimension.FindingKind,
+			&targetKind, &dimension.Target.SchemaVersion, &dimension.Target.Canonical, &dimension.Target.EvaluatedRevision,
+			&coverageState, &dimension.ReasonCode, &includedScope, &excludedScope, &versions); err != nil {
+			return nil, err
+		}
+		dimension.Target.Kind = scanrun.TargetKind(targetKind)
+		dimension.State = assessmentsnapshot.CoverageState(coverageState)
+		if err := json.Unmarshal(includedScope, &dimension.IncludedScope); err != nil {
+			return nil, fmt.Errorf("decode snapshot included scope: %w", err)
+		}
+		if err := json.Unmarshal(excludedScope, &dimension.ExcludedScope); err != nil {
+			return nil, fmt.Errorf("decode snapshot excluded scope: %w", err)
+		}
+		if err := json.Unmarshal(versions, &dimension.Versions); err != nil {
+			return nil, fmt.Errorf("decode snapshot versions: %w", err)
+		}
+		snapshot.Dimensions = append(snapshot.Dimensions, dimension)
+	}
+	if err := dimensionRows.Err(); err != nil {
+		return nil, err
+	}
+	if err := snapshot.Validate(); err != nil {
+		return nil, fmt.Errorf("validate persisted assessment snapshot: %w", err)
+	}
+	return snapshot, nil
+}
+
+func scanAssessmentSnapshot(row rowScanner) (*assessmentsnapshot.Snapshot, error) {
+	var snapshot assessmentsnapshot.Snapshot
+	var tenantID, id, cycleID, assessmentID, lifecycle, provenance, boundaryKind, businessAssetID, projectID string
+	var finalizedAt, supersededAt *time.Time
+	if err := row.Scan(&tenantID, &id, &cycleID, &assessmentID, &snapshot.SnapshotNumber, &snapshot.DefaultVersion, &lifecycle, &provenance, &boundaryKind,
+		&businessAssetID, &projectID, &snapshot.SchemaVersion, &snapshot.ContentHash, &snapshot.RequestKey, &snapshot.RequestHash,
+		&snapshot.CreatedAt, &snapshot.CreatedBy, &finalizedAt, &snapshot.FinalizedBy, &supersededAt, &snapshot.SupersededBy); err != nil {
+		return nil, err
+	}
+	snapshot.TenantID, snapshot.ID, snapshot.CycleID, snapshot.AssessmentID = shared.ID(tenantID), shared.ID(id), shared.ID(cycleID), shared.ID(assessmentID)
+	snapshot.Lifecycle, snapshot.Provenance = assessmentsnapshot.Lifecycle(lifecycle), assessmentsnapshot.Provenance(provenance)
+	snapshot.Boundary = assessmentsnapshot.Boundary{Kind: assessmentcycle.BoundaryKind(boundaryKind), BusinessAssetID: shared.ID(businessAssetID), ProjectID: shared.ID(projectID)}
+	snapshot.FinalizedAt, snapshot.SupersededAt = finalizedAt, supersededAt
+	return &snapshot, nil
+}
+
+func cloneFinalizedSnapshot(snapshot *assessmentsnapshot.Snapshot, snapshotNumber int, defaultVersion int64) *assessmentsnapshot.Snapshot {
+	copySnapshot := *snapshot
+	copySnapshot.SnapshotNumber = snapshotNumber
+	copySnapshot.DefaultVersion = defaultVersion
+	return &copySnapshot
+}

--- a/internal/infrastructure/persistence/postgres/assessment_snapshot_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_snapshot_repo_test.go
@@ -1,0 +1,361 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestPostgresAssessmentSnapshotRepositoryRLSCASReplayAndImmutability(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := time.Now().UnixNano()
+	tenantA := shared.ID(fmt.Sprintf("snapshot-tenant-a-%d", suffix))
+	tenantB := shared.ID(fmt.Sprintf("snapshot-tenant-b-%d", suffix))
+	assessmentID := shared.ID(fmt.Sprintf("snapshot-assessment-%d", suffix))
+	cycleID := shared.ID(fmt.Sprintf("snapshot-cycle-%d", suffix))
+	ensureTestTenantAndEngagement(t, ctx, pool, tenantA, assessmentID, "", "")
+	ensureTestTenantAndEngagement(t, ctx, pool, tenantB, shared.ID(fmt.Sprintf("snapshot-other-%d", suffix)), "", "")
+
+	cycleRepository := NewAssessmentCycleRepository(pool)
+	cycle, err := assessmentcycle.NewAssessmentCycle(cycleID, tenantA, "Snapshot cycle", assessmentcycle.BoundaryStandalone, "", "", assessmentID, "operator", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember(tenantA, cycleID, assessmentID, "operator", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycleRepository.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycleRepository.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+
+	runRepository := NewScanRunStore(pool)
+	runOne := postgresNativeRun(t, tenantA, assessmentID, shared.ID(fmt.Sprintf("snapshot-run-1-%d", suffix)), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	sealPostgresNativeRun(t, ctx, runRepository, &runOne, time.Now().UTC())
+
+	repository := NewAssessmentSnapshotRepository(pool)
+	first := postgresAssessmentSnapshot(t, tenantA, cycleID, assessmentID, "snapshot-first", "request-first", runOne)
+	stored, created, err := repository.CreateFinalizedCAS(ctx, first, 0)
+	if err != nil || !created || stored.SnapshotNumber != 1 {
+		t.Fatalf("create first snapshot=%+v created=%v err=%v", stored, created, err)
+	}
+	replayed, created, err := repository.CreateFinalizedCAS(ctx, postgresAssessmentSnapshot(t, tenantA, cycleID, assessmentID, "snapshot-replay", "request-first", runOne), 0)
+	if err != nil || created || replayed.ID != stored.ID {
+		t.Fatalf("replay snapshot=%+v created=%v err=%v", replayed, created, err)
+	}
+	if _, err := repository.Get(ctx, tenantB, stored.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant get=%v", err)
+	}
+
+	runTwo := postgresNativeRun(t, tenantA, assessmentID, shared.ID(fmt.Sprintf("snapshot-run-2-%d", suffix)), "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
+	sealPostgresNativeRun(t, ctx, runRepository, &runTwo, time.Now().UTC())
+	second := postgresAssessmentSnapshot(t, tenantA, cycleID, assessmentID, "snapshot-second", "request-second", runTwo)
+	storedSecond, created, err := repository.CreateFinalizedCAS(ctx, second, 1)
+	if err != nil || !created || storedSecond.SnapshotNumber != 2 {
+		t.Fatalf("create second snapshot=%+v created=%v err=%v", storedSecond, created, err)
+	}
+	old, err := repository.Get(ctx, tenantA, stored.ID)
+	if err != nil || old.Lifecycle != assessmentsnapshot.LifecycleSuperseded {
+		t.Fatalf("superseded snapshot=%+v err=%v", old, err)
+	}
+	if _, _, err := repository.CreateFinalizedCAS(ctx, postgresAssessmentSnapshot(t, tenantA, cycleID, assessmentID, "snapshot-stale", "request-stale", runOne), 1); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale default CAS=%v", err)
+	}
+
+	if err := WithTenant(ctx, pool, tenantA.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `UPDATE assessment_snapshots SET content_hash=$1 WHERE tenant_id=$2 AND id=$3`,
+			"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc", tenantA.String(), storedSecond.ID.String())
+		return err
+	}); err == nil {
+		t.Fatal("finalized snapshot accepted content mutation")
+	}
+
+	for _, table := range []string{"assessment_snapshots", "assessment_snapshot_run_refs", "assessment_snapshot_lane_refs", "assessment_snapshot_dimensions", "assessment_snapshot_counters", "assessment_snapshot_defaults"} {
+		var forced bool
+		if err := pool.QueryRow(ctx, `SELECT relforcerowsecurity FROM pg_class WHERE oid=$1::regclass`, table).Scan(&forced); err != nil || !forced {
+			t.Fatalf("FORCE RLS %s=%v err=%v", table, forced, err)
+		}
+	}
+}
+
+func TestPostgresAssessmentSnapshotRepositoryConcurrentInitialCASHasNoNumberGap(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := time.Now().UnixNano()
+	tenantID := shared.ID(fmt.Sprintf("snapshot-concurrent-tenant-%d", suffix))
+	assessmentID := shared.ID(fmt.Sprintf("snapshot-concurrent-assessment-%d", suffix))
+	cycleID := shared.ID(fmt.Sprintf("snapshot-concurrent-cycle-%d", suffix))
+	ensureTestTenantAndEngagement(t, ctx, pool, tenantID, assessmentID, "", "")
+
+	cycleRepository := NewAssessmentCycleRepository(pool)
+	cycle, err := assessmentcycle.NewAssessmentCycle(cycleID, tenantID, "Concurrent snapshot cycle", assessmentcycle.BoundaryStandalone, "", "", assessmentID, "operator", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember(tenantID, cycleID, assessmentID, "operator", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycleRepository.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycleRepository.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+
+	runRepository := NewScanRunStore(pool)
+	run := postgresNativeRun(t, tenantID, assessmentID, shared.ID(fmt.Sprintf("snapshot-concurrent-run-%d", suffix)), "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd")
+	sealPostgresNativeRun(t, ctx, runRepository, &run, time.Now().UTC())
+
+	repository := NewAssessmentSnapshotRepository(pool)
+	candidates := []*assessmentsnapshot.Snapshot{
+		postgresAssessmentSnapshot(t, tenantID, cycleID, assessmentID, fmt.Sprintf("snapshot-concurrent-a-%d", suffix), "request-a", run),
+		postgresAssessmentSnapshot(t, tenantID, cycleID, assessmentID, fmt.Sprintf("snapshot-concurrent-b-%d", suffix), "request-b", run),
+	}
+	type result struct {
+		snapshot *assessmentsnapshot.Snapshot
+		created  bool
+		err      error
+	}
+	start := make(chan struct{})
+	results := make(chan result, len(candidates))
+	var wait sync.WaitGroup
+	for _, candidate := range candidates {
+		wait.Add(1)
+		go func(candidate *assessmentsnapshot.Snapshot) {
+			defer wait.Done()
+			<-start
+			stored, created, err := repository.CreateFinalizedCAS(ctx, candidate, 0)
+			results <- result{snapshot: stored, created: created, err: err}
+		}(candidate)
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+
+	var winner *assessmentsnapshot.Snapshot
+	var successes, conflicts int
+	for result := range results {
+		switch {
+		case result.err == nil && result.created:
+			successes++
+			winner = result.snapshot
+		case errors.Is(result.err, shared.ErrConflict):
+			conflicts++
+		default:
+			t.Fatalf("concurrent initial CAS result=%+v", result)
+		}
+	}
+	if successes != 1 || conflicts != 1 || winner == nil || winner.SnapshotNumber != 1 {
+		t.Fatalf("concurrent initial CAS successes=%d conflicts=%d winner=%+v", successes, conflicts, winner)
+	}
+	defaultSnapshot, pointer, err := repository.GetDefault(ctx, tenantID, assessmentID)
+	if err != nil || pointer.Version != 1 || defaultSnapshot.ID != winner.ID {
+		t.Fatalf("default snapshot=%+v pointer=%+v err=%v", defaultSnapshot, pointer, err)
+	}
+	snapshots, err := repository.ListByAssessment(ctx, tenantID, assessmentID)
+	if err != nil || len(snapshots) != 1 || snapshots[0].SnapshotNumber != 1 {
+		t.Fatalf("snapshots=%+v err=%v", snapshots, err)
+	}
+}
+
+func TestPostgresAssessmentSnapshotConcurrentReplayAndAuditRollback(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := time.Now().UnixNano()
+	tenantID, assessmentID, cycleID, run := createPostgresSnapshotFixture(t, ctx, pool, fmt.Sprintf("replay-%d", suffix))
+	repository := NewAssessmentSnapshotRepository(pool)
+	candidate := postgresAssessmentSnapshot(t, tenantID, cycleID, assessmentID, fmt.Sprintf("snapshot-replay-%d", suffix), "request-replay", run)
+
+	type result struct {
+		snapshot *assessmentsnapshot.Snapshot
+		created  bool
+		err      error
+	}
+	start := make(chan struct{})
+	results := make(chan result, 2)
+	var wait sync.WaitGroup
+	for index := 0; index < 2; index++ {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			stored, created, err := repository.CreateFinalizedCAS(context.Background(), candidate, 0)
+			results <- result{snapshot: stored, created: created, err: err}
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	var createdCount, replayCount int
+	for result := range results {
+		if result.err != nil || result.snapshot == nil || result.snapshot.ID != candidate.ID {
+			t.Fatalf("concurrent replay result=%+v", result)
+		}
+		if result.created {
+			createdCount++
+		} else {
+			replayCount++
+		}
+	}
+	if createdCount != 1 || replayCount != 1 {
+		t.Fatalf("concurrent replay created=%d replayed=%d", createdCount, replayCount)
+	}
+
+	failureTenant, failureAssessment, _, failureRun := createPostgresSnapshotFixture(t, ctx, pool, fmt.Sprintf("rollback-%d", suffix))
+	failureRepository := NewAssessmentSnapshotRepository(pool)
+	service, err := snapshotuc.NewService(
+		failureRepository, NewAssessmentCycleRepository(pool), NewEngagementRepository(pool), NewScanRunStore(pool), NewTenantTransactionRunner(pool),
+		&snapshotPostgresIDs{prefix: fmt.Sprintf("snapshot-rollback-%d", suffix)},
+		snapshotPostgresClock{now: time.Date(2026, time.September, 1, 15, 0, 0, 0, time.UTC)}, snapshotFailureAudit{},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := service.Finalize(ctx, snapshotuc.FinalizeInput{
+		TenantID: failureTenant, AssessmentID: failureAssessment, SelectedRunIDs: []string{failureRun.ID},
+		RequestKey: "request-audit-failure", ExpectedDefaultVersion: 0, Actor: "operator",
+	}); err == nil || !strings.Contains(err.Error(), "forced snapshot audit failure") {
+		t.Fatalf("audit failure=%v", err)
+	}
+	if _, err := failureRepository.GetByRequestKey(ctx, failureTenant, failureAssessment, "request-audit-failure"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("audit failure retained snapshot=%v", err)
+	}
+	if snapshots, err := failureRepository.ListByAssessment(ctx, failureTenant, failureAssessment); err != nil || len(snapshots) != 0 {
+		t.Fatalf("audit rollback snapshots=%+v err=%v", snapshots, err)
+	}
+}
+
+func createPostgresSnapshotFixture(t *testing.T, ctx context.Context, pool *pgxpool.Pool, suffix string) (shared.ID, shared.ID, shared.ID, scanrun.ScanRun) {
+	t.Helper()
+	tenantID := shared.ID("snapshot-service-tenant-" + suffix)
+	assessmentID := shared.ID("snapshot-service-assessment-" + suffix)
+	cycleID := shared.ID("snapshot-service-cycle-" + suffix)
+	ensureTestTenantAndEngagement(t, ctx, pool, tenantID, assessmentID, "", "")
+	cycle, err := assessmentcycle.NewAssessmentCycle(cycleID, tenantID, "Snapshot service cycle", assessmentcycle.BoundaryStandalone, "", "", assessmentID, "operator", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember(tenantID, cycleID, assessmentID, "operator", time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cycles := NewAssessmentCycleRepository(pool)
+	if err := cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+	run := postgresNativeRun(t, tenantID, assessmentID, shared.ID("snapshot-service-run-"+suffix), strings.Repeat("e", 64))
+	runs := NewScanRunStore(pool)
+	sealPostgresNativeRun(t, ctx, runs, &run, time.Now().UTC())
+	return tenantID, assessmentID, cycleID, run
+}
+
+type snapshotFailureAudit struct{}
+
+func (snapshotFailureAudit) Record(context.Context, ports.AuditEntry) error {
+	return errors.New("forced snapshot audit failure")
+}
+
+type snapshotPostgresClock struct{ now time.Time }
+
+func (clock snapshotPostgresClock) Now() time.Time { return clock.now }
+
+type snapshotPostgresIDs struct {
+	prefix string
+	next   int
+}
+
+func (ids *snapshotPostgresIDs) NewID() shared.ID {
+	ids.next++
+	return shared.ID(fmt.Sprintf("%s-%d", ids.prefix, ids.next))
+}
+
+func postgresAssessmentSnapshot(t *testing.T, tenantID, cycleID, assessmentID shared.ID, snapshotID, requestKey string, run scanrun.ScanRun) *assessmentsnapshot.Snapshot {
+	t.Helper()
+	if !run.IsSealed() {
+		t.Fatal("expected sealed scan run")
+	}
+	snapshot, err := assessmentsnapshot.NewFinalized(tenantID, shared.ID(snapshotID), cycleID, assessmentID,
+		assessmentsnapshot.Boundary{Kind: assessmentcycle.BoundaryStandalone}, requestKey, "operator", time.Now().UTC(),
+		[]assessmentsnapshot.SelectedRun{{
+			ID: run.ID, ManifestHash: run.ManifestHash, Provenance: run.Provenance,
+			TerminalStatus: run.TerminalStatus, Trusted: true, Lanes: run.Lanes,
+		}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snapshot
+}
+
+func postgresNativeRun(t *testing.T, tenantID, assessmentID shared.ID, runID shared.ID, revision string) scanrun.ScanRun {
+	t.Helper()
+	started := time.Now().UTC().Add(-2 * time.Minute)
+	finished := started.Add(time.Minute)
+	target, err := scanrun.CanonicalizeRepositoryTarget("https://example.com/synapse/repo.git", revision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return scanrun.ScanRun{
+		TenantID: tenantID, EngagementID: assessmentID, ID: runID.String(), Provenance: scanrun.ProvenanceNative,
+		TerminalStatus: scanrun.StatusBuilding, ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion, CreatedAt: started, UpdatedAt: started,
+		Lanes: []scanrun.Lane{{
+			TenantID: tenantID, EngagementID: assessmentID, ScanRunID: runID.String(), LaneKey: "sca", Producer: "sca",
+			TerminalStatus: scanrun.StatusSucceeded, Target: target, AuthoritativeFindingKinds: []string{"vulnerability"},
+			IncludedScope: []string{"src/**"}, ExcludedScope: []string{"vendor/**"}, StartedAt: started, FinishedAt: &finished,
+			ResultSHA256: strings.Repeat("a", 64), ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion,
+			Versions: []scanrun.LaneVersion{{VersionKind: scanrun.VersionScanner, Name: "sca", Version: "1"}},
+			Stages:   []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSucceeded, StartedAt: started, FinishedAt: &finished}},
+		}},
+	}
+}
+
+func sealPostgresNativeRun(t *testing.T, ctx context.Context, repository *ScanRunStore, run *scanrun.ScanRun, sealedAt time.Time) {
+	t.Helper()
+	building := *run
+	building.Lanes = nil
+	if err := repository.SaveScanRun(ctx, building); err != nil {
+		t.Fatal(err)
+	}
+	lanes := append([]scanrun.Lane(nil), run.Lanes...)
+	for index := range lanes {
+		lanes[index].SealedAt = &sealedAt
+		hash, err := scanrun.ComputeManifestHash(lanes[index])
+		if err != nil {
+			t.Fatal(err)
+		}
+		lanes[index].ManifestHash = hash
+	}
+	manifestHash, err := scanrun.ComputeRunManifestHash(lanes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.SealScanRun(ctx, ports.SealScanRunCommand{
+		TenantID: run.TenantID, RunID: run.ID, TerminalStatus: scanrun.StatusSucceeded, Lanes: lanes,
+		ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion, ManifestHash: manifestHash, SealedAt: sealedAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	stored, err := repository.GetScanRun(ctx, run.TenantID, run.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	*run = stored
+}

--- a/internal/infrastructure/persistence/postgres/engagement_repo.go
+++ b/internal/infrastructure/persistence/postgres/engagement_repo.go
@@ -18,7 +18,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
-const engagementCols = `id, tenant_id, project_id, business_asset_id, name, client, status, authorized_from, authorized_to, created_at, updated_at, timezone, roe, live_recon, created_by, updated_by, host_asset_id, customer_contact, emergency_contact, risk_ceiling, exclusions_checked`
+const engagementCols = `id, tenant_id, project_id, business_asset_id, name, client, status, authorized_from, authorized_to, created_at, updated_at, timezone, roe, live_recon, created_by, updated_by, host_asset_id, customer_contact, emergency_contact, risk_ceiling, exclusions_checked, requires_explicit_execution_authorization, assessment_project_id`
 
 // EngagementRepository persists engagements and their scope to PostgreSQL.
 type EngagementRepository struct{ pool *pgxpool.Pool }
@@ -33,6 +33,7 @@ var _ ports.PromotionReconciliationScopeReader = (*EngagementRepository)(nil)
 var _ ports.VulnerabilityReconciliationTenantStore = (*EngagementRepository)(nil)
 var _ ports.DetectionReconciliationTenantStore = (*EngagementRepository)(nil)
 var _ ports.HostEngagementLister = (*EngagementRepository)(nil)
+var _ ports.AssessmentCycleBackfillSource = (*EngagementRepository)(nil)
 
 // Create inserts the engagement and its scope targets in one transaction.
 func (r *EngagementRepository) Create(ctx context.Context, e *engagement.Engagement) error {
@@ -44,11 +45,11 @@ func (r *EngagementRepository) Create(ctx context.Context, e *engagement.Engagem
 			return fmt.Errorf("marshal roe: %w", err)
 		}
 		if _, err := tx.Exec(ctx,
-			`INSERT INTO engagements (`+engagementCols+`) VALUES ($1,$2,NULLIF($3,''),NULLIF($4,''),$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,NULLIF($17,''),$18,$19,$20,$21)`,
+			`INSERT INTO engagements (`+engagementCols+`) VALUES ($1,$2,NULLIF($3,''),NULLIF($4,''),$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,NULLIF($17,''),$18,$19,$20,$21,$22,NULLIF($23,''))`,
 			e.ID.String(), tenantID.String(), e.ProjectID.String(), e.BusinessAssetID.String(), e.Name, e.Client, string(e.Status),
 			e.AuthorizedFrom, e.AuthorizedTo, e.Audit.CreatedAt, e.Audit.UpdatedAt, e.Timezone, roeJSON, e.LiveReconEnabled,
 			e.Audit.CreatedBy, e.Audit.UpdatedBy, e.HostAssetID.String(),
-			e.CustomerContact, e.EmergencyContact, e.RiskCeiling, e.ExclusionsChecked); err != nil {
+			e.CustomerContact, e.EmergencyContact, e.RiskCeiling, e.ExclusionsChecked, e.RequiresExplicitExecutionAuthorization, e.AssessmentProjectID.String()); err != nil {
 			return fmt.Errorf("insert engagement: %w", err)
 		}
 
@@ -113,10 +114,10 @@ func (r *EngagementRepository) Update(ctx context.Context, e *engagement.Engagem
 			return fmt.Errorf("marshal roe: %w", err)
 		}
 		ct, err := tx.Exec(ctx,
-			`UPDATE engagements SET name=$2, client=$3, status=$4, authorized_from=$5, authorized_to=$6, timezone=$7, updated_at=$8, roe=$9, live_recon=$10, updated_by=$11, business_asset_id=NULLIF($12,''), customer_contact=$13, emergency_contact=$14, risk_ceiling=$15, exclusions_checked=$16 WHERE id=$1`,
+			`UPDATE engagements SET name=$2, client=$3, status=$4, authorized_from=$5, authorized_to=$6, timezone=$7, updated_at=$8, roe=$9, live_recon=$10, updated_by=$11, business_asset_id=NULLIF($12,''), customer_contact=$13, emergency_contact=$14, risk_ceiling=$15, exclusions_checked=$16, requires_explicit_execution_authorization=$17, assessment_project_id=NULLIF($18,'') WHERE id=$1`,
 			e.ID.String(), e.Name, e.Client, string(e.Status),
 			e.AuthorizedFrom, e.AuthorizedTo, e.Timezone, e.Audit.UpdatedAt, roeJSON, e.LiveReconEnabled, e.Audit.UpdatedBy, e.BusinessAssetID.String(),
-			e.CustomerContact, e.EmergencyContact, e.RiskCeiling, e.ExclusionsChecked)
+			e.CustomerContact, e.EmergencyContact, e.RiskCeiling, e.ExclusionsChecked, e.RequiresExplicitExecutionAuthorization, e.AssessmentProjectID.String())
 		if err != nil {
 			return fmt.Errorf("update engagement: %w", err)
 		}
@@ -316,6 +317,10 @@ func (r *EngagementRepository) ListAssessmentCycleBackfillEngagements(ctx contex
 	return out, err
 }
 
+func (r *EngagementRepository) ListAssessmentSnapshotBackfillEngagements(ctx context.Context, tenantID, after shared.ID, snapshotAt time.Time, limit int) ([]*engagement.Engagement, error) {
+	return r.ListAssessmentCycleBackfillEngagements(ctx, tenantID, after, snapshotAt, limit)
+}
+
 // ListProjectEngagements returns the tenant's hidden Project analysis contexts for operational
 // aggregation. Normal engagement lists remain unchanged and continue to hide these rows.
 func (r *EngagementRepository) ListProjectEngagements(ctx context.Context, tenantID shared.ID) ([]*engagement.Engagement, error) {
@@ -462,10 +467,11 @@ func scanEngagement(row rowScanner) (*engagement.Engagement, error) {
 		idStr, ten, st             string
 		projectID, businessAssetID pgtype.Text
 		hostAssetID                pgtype.Text
+		assessmentProjectID        pgtype.Text
 		af, at                     pgtype.Timestamptz
 		roeJSON                    []byte
 	)
-	if err := row.Scan(&idStr, &ten, &projectID, &businessAssetID, &e.Name, &e.Client, &st, &af, &at, &e.Audit.CreatedAt, &e.Audit.UpdatedAt, &e.Timezone, &roeJSON, &e.LiveReconEnabled, &e.Audit.CreatedBy, &e.Audit.UpdatedBy, &hostAssetID, &e.CustomerContact, &e.EmergencyContact, &e.RiskCeiling, &e.ExclusionsChecked); err != nil {
+	if err := row.Scan(&idStr, &ten, &projectID, &businessAssetID, &e.Name, &e.Client, &st, &af, &at, &e.Audit.CreatedAt, &e.Audit.UpdatedAt, &e.Timezone, &roeJSON, &e.LiveReconEnabled, &e.Audit.CreatedBy, &e.Audit.UpdatedBy, &hostAssetID, &e.CustomerContact, &e.EmergencyContact, &e.RiskCeiling, &e.ExclusionsChecked, &e.RequiresExplicitExecutionAuthorization, &assessmentProjectID); err != nil {
 		return nil, err
 	}
 	if len(roeJSON) > 0 {
@@ -473,6 +479,7 @@ func scanEngagement(row rowScanner) (*engagement.Engagement, error) {
 			return nil, fmt.Errorf("unmarshal roe: %w", err)
 		}
 	}
+	e.AssessmentProjectID = shared.ID(assessmentProjectID.String)
 	e.ID = shared.ID(idStr)
 	e.TenantID = shared.ID(ten)
 	if projectID.Valid {

--- a/internal/infrastructure/persistence/postgres/tenant.go
+++ b/internal/infrastructure/persistence/postgres/tenant.go
@@ -133,8 +133,8 @@ func contextTenantTx(ctx context.Context, tenantID shared.ID) (pgx.Tx, bool, err
 }
 
 // bindTenantTransaction exposes an already-open tenant transaction to nested
-// repositories. Fenced backfill commits use it so the projected aggregate and
-// its accounting item share one database commit.
+// repositories. It is used by fenced backfill commits so the projected business
+// artifact and its accounting item share one database commit.
 func bindTenantTransaction(ctx context.Context, tenantID shared.ID, tx pgx.Tx) context.Context {
 	return shared.WithTenant(context.WithValue(ctx, tenantTransactionKey{}, tenantTransaction{tenantID: tenantID.String(), tx: tx}), tenantID)
 }

--- a/internal/usecase/assessmentsnapshot/backfill.go
+++ b/internal/usecase/assessmentsnapshot/backfill.go
@@ -1,0 +1,478 @@
+package assessmentsnapshot
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	AssessmentSnapshotBackfillSchemaVersion = 1
+	DefaultAssessmentSnapshotBackfillBatch  = 500
+	MaxAssessmentSnapshotBackfillBatch      = 2000
+	assessmentSnapshotBackfillRetries       = 3
+	defaultAssessmentSnapshotBackfillLease  = 10 * time.Minute
+)
+
+const (
+	SnapshotBackfillOutcomeCreated     = "created"
+	SnapshotBackfillOutcomeWouldCreate = "would_create"
+	SnapshotBackfillOutcomeSkipped     = "skipped"
+	SnapshotBackfillOutcomeFailed      = "failed"
+
+	SnapshotBackfillReasonCreated               = "created"
+	SnapshotBackfillReasonWouldCreate           = "would_create"
+	SnapshotBackfillReasonAlreadyProjected      = "already_projected"
+	SnapshotBackfillReasonCycleMissing          = "cycle_not_found"
+	SnapshotBackfillReasonScanRunMissing        = "scan_run_not_found"
+	SnapshotBackfillReasonVerifiedRunMissing    = "verified_run_unavailable"
+	SnapshotBackfillReasonInvalidSource         = "invalid_source"
+	SnapshotBackfillReasonSourceReadFailed      = "source_read_failed"
+	SnapshotBackfillReasonProjectionWriteFailed = "projection_write_failed"
+)
+
+type LegacyProjector struct {
+	snapshots ports.AssessmentSnapshotRepository
+	cycles    ports.AssessmentCycleRepository
+	tx        ports.TenantTransactionRunner
+	ids       ports.IDGenerator
+	clock     ports.Clock
+	audit     ports.AuditLogger
+}
+
+func NewLegacyProjector(snapshots ports.AssessmentSnapshotRepository, cycles ports.AssessmentCycleRepository, tx ports.TenantTransactionRunner, ids ports.IDGenerator, clock ports.Clock, audit ports.AuditLogger) (*LegacyProjector, error) {
+	if snapshots == nil || cycles == nil || tx == nil || ids == nil || clock == nil || audit == nil {
+		return nil, fmt.Errorf("%w: legacy assessment snapshot projector dependencies are required", shared.ErrValidation)
+	}
+	return &LegacyProjector{snapshots: snapshots, cycles: cycles, tx: tx, ids: ids, clock: clock, audit: audit}, nil
+}
+
+type LegacyProjectionInput struct {
+	TenantID     shared.ID
+	AssessmentID shared.ID
+	Actor        string
+	SourceHash   string
+	SelectedRun  domain.SelectedRun
+	DryRun       bool
+}
+
+type LegacyProjectionResult struct {
+	SnapshotID  shared.ID
+	Created     bool
+	WouldCreate bool
+	ReasonCode  string
+}
+
+func (projector *LegacyProjector) Project(ctx context.Context, input LegacyProjectionInput) (LegacyProjectionResult, error) {
+	tenantID, actor := shared.TenantOrDefault(input.TenantID), strings.TrimSpace(input.Actor)
+	if tenantID.IsZero() || input.AssessmentID.IsZero() || actor == "" || len(actor) > 256 || !validSnapshotBackfillHash(input.SourceHash) {
+		return LegacyProjectionResult{}, fmt.Errorf("%w: legacy assessment snapshot projection input is invalid", shared.ErrValidation)
+	}
+	requestKey := legacyProjectionRequestKey(input.SourceHash)
+	if existing, err := projector.snapshots.GetByRequestKey(ctx, tenantID, input.AssessmentID, requestKey); err == nil {
+		return LegacyProjectionResult{SnapshotID: existing.ID, ReasonCode: SnapshotBackfillReasonAlreadyProjected}, nil
+	} else if !errors.Is(err, shared.ErrNotFound) {
+		return LegacyProjectionResult{}, err
+	}
+	cycle, err := projector.cycles.GetCycleByAssessment(ctx, tenantID, input.AssessmentID)
+	if errors.Is(err, shared.ErrNotFound) {
+		return LegacyProjectionResult{ReasonCode: SnapshotBackfillReasonCycleMissing}, nil
+	}
+	if err != nil {
+		return LegacyProjectionResult{}, err
+	}
+	if _, err := projector.cycles.GetMember(ctx, tenantID, cycle.ID, input.AssessmentID); errors.Is(err, shared.ErrNotFound) {
+		return LegacyProjectionResult{ReasonCode: SnapshotBackfillReasonCycleMissing}, nil
+	} else if err != nil {
+		return LegacyProjectionResult{}, err
+	}
+	if input.DryRun {
+		return LegacyProjectionResult{WouldCreate: true, ReasonCode: SnapshotBackfillReasonWouldCreate}, nil
+	}
+
+	var result LegacyProjectionResult
+	err = projector.tx.Run(ctx, tenantID, func(txCtx context.Context) error {
+		locked, err := projector.cycles.LockCycleForUpdate(txCtx, tenantID, cycle.ID)
+		if err != nil {
+			return err
+		}
+		if _, err := projector.cycles.GetMember(txCtx, tenantID, locked.ID, input.AssessmentID); err != nil {
+			return err
+		}
+		now := projector.clock.Now().UTC()
+		candidate, err := domain.NewFinalized(tenantID, projector.ids.NewID(), locked.ID, input.AssessmentID, domain.Boundary{
+			Kind: locked.BoundaryKind, BusinessAssetID: locked.BusinessAssetID, ProjectID: locked.ProjectID,
+		}, requestKey, actor, now, []domain.SelectedRun{input.SelectedRun})
+		if err != nil {
+			return err
+		}
+		if candidate.Provenance != domain.ProvenanceLegacy {
+			return fmt.Errorf("%w: projected assessment snapshot must remain legacy", shared.ErrValidation)
+		}
+		candidate.RequestHash = legacyProjectionRequestHash(input.SourceHash, candidate.ContentHash)
+		stored, created, err := projector.snapshots.CreateLegacyProjection(txCtx, candidate)
+		if err != nil {
+			return err
+		}
+		result.SnapshotID = stored.ID
+		if !created {
+			result.ReasonCode = SnapshotBackfillReasonAlreadyProjected
+			return nil
+		}
+		result.Created, result.ReasonCode = true, SnapshotBackfillReasonCreated
+		if err := projector.audit.Record(txCtx, ports.AuditEntry{
+			Actor: actor, Action: "assessment_snapshot.legacy_projected", Target: stored.ID.String(), At: now,
+			Metadata: map[string]string{
+				"tenant_id": tenantID.String(), "cycle_id": locked.ID.String(), "assessment_id": input.AssessmentID.String(),
+				"source_hash": input.SourceHash, "content_hash": stored.ContentHash, "snapshot_number": strconv.Itoa(stored.SnapshotNumber),
+			},
+		}); err != nil {
+			return fmt.Errorf("audit legacy assessment snapshot projection: %w", err)
+		}
+		return nil
+	})
+	return result, err
+}
+
+type legacySnapshotProjector interface {
+	Project(context.Context, LegacyProjectionInput) (LegacyProjectionResult, error)
+}
+
+type AssessmentSnapshotBackfillObserver interface {
+	ObserveAssessmentSnapshotBackfillItem(outcome string)
+	ObserveAssessmentSnapshotBackfillRun(state string)
+}
+
+type BackfillRunner struct {
+	projector legacySnapshotProjector
+	source    ports.AssessmentSnapshotBackfillSource
+	store     ports.AssessmentSnapshotBackfillStore
+	runs      ports.AssessmentSnapshotRunReader
+	results   ports.ScanResultStore
+	ids       ports.IDGenerator
+	clock     ports.Clock
+	audit     ports.AuditLogger
+	observer  AssessmentSnapshotBackfillObserver
+}
+
+func NewBackfillRunner(projector legacySnapshotProjector, source ports.AssessmentSnapshotBackfillSource, store ports.AssessmentSnapshotBackfillStore, runs ports.AssessmentSnapshotRunReader, results ports.ScanResultStore, ids ports.IDGenerator, clock ports.Clock, audit ports.AuditLogger, observer AssessmentSnapshotBackfillObserver) (*BackfillRunner, error) {
+	if projector == nil || source == nil || store == nil || runs == nil || results == nil || ids == nil || clock == nil {
+		return nil, fmt.Errorf("%w: assessment snapshot backfill dependencies are required", shared.ErrValidation)
+	}
+	return &BackfillRunner{projector: projector, source: source, store: store, runs: runs, results: results, ids: ids, clock: clock, audit: audit, observer: observer}, nil
+}
+
+type BackfillRequest struct {
+	TenantID      shared.ID
+	Actor         string
+	LeaseOwner    string
+	DryRun        bool
+	BatchSize     int
+	ResumeAfter   shared.ID
+	LeaseDuration time.Duration
+}
+
+func (runner *BackfillRunner) Run(ctx context.Context, request BackfillRequest) (ports.AssessmentSnapshotBackfillRun, error) {
+	tenantID := shared.TenantOrDefault(request.TenantID)
+	actor, leaseOwner := strings.TrimSpace(request.Actor), strings.TrimSpace(request.LeaseOwner)
+	if tenantID.IsZero() || actor == "" || len(actor) > 256 || leaseOwner == "" || len(leaseOwner) > 256 {
+		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: tenant, actor, and lease owner are required", shared.ErrValidation)
+	}
+	batchSize := request.BatchSize
+	if batchSize == 0 {
+		batchSize = DefaultAssessmentSnapshotBackfillBatch
+	}
+	if batchSize < 1 || batchSize > MaxAssessmentSnapshotBackfillBatch {
+		return ports.AssessmentSnapshotBackfillRun{}, fmt.Errorf("%w: batch size must be between 1 and %d", shared.ErrValidation, MaxAssessmentSnapshotBackfillBatch)
+	}
+	leaseDuration := request.LeaseDuration
+	if leaseDuration <= 0 {
+		leaseDuration = defaultAssessmentSnapshotBackfillLease
+	}
+	now := runner.clock.Now().UTC()
+	acquisitionID := runner.ids.NewID()
+	run, resumed, err := runner.store.AcquireAssessmentSnapshotBackfillRun(ctx, ports.AssessmentSnapshotBackfillAcquireRequest{
+		Run: ports.AssessmentSnapshotBackfillRun{
+			TenantID: tenantID, ID: acquisitionID, SchemaVersion: AssessmentSnapshotBackfillSchemaVersion,
+			DryRun: request.DryRun, BatchSize: batchSize, SnapshotAt: now, State: ports.AssessmentSnapshotBackfillRunning,
+			LeaseOwner: leaseOwner, LeaseToken: acquisitionID, LeaseExpiresAt: now.Add(leaseDuration), CreatedBy: actor, CreatedAt: now, UpdatedAt: now,
+		},
+		InitialCheckpoint: request.ResumeAfter,
+		LeaseDuration:     leaseDuration,
+	})
+	if err != nil {
+		return ports.AssessmentSnapshotBackfillRun{}, err
+	}
+	if err := runner.record(ctx, actor, "assessment_snapshot.backfill_started", run.ID, map[string]string{
+		"tenant_id": tenantID.String(), "dry_run": strconv.FormatBool(run.DryRun), "resumed": strconv.FormatBool(resumed), "batch_size": strconv.Itoa(run.BatchSize),
+	}); err != nil {
+		return runner.finish(ctx, run, leaseOwner, ports.AssessmentSnapshotBackfillFailed, actor, fmt.Errorf("audit assessment Snapshot backfill start: %w", err))
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return runner.finish(ctx, run, leaseOwner, ports.AssessmentSnapshotBackfillCancelled, actor, err)
+		}
+		assessments, err := runner.source.ListAssessmentSnapshotBackfillEngagements(ctx, tenantID, run.CheckpointAssessment, run.SnapshotAt, run.BatchSize)
+		if err != nil {
+			return runner.finish(ctx, run, leaseOwner, snapshotBackfillTerminalState(err), actor, err)
+		}
+		if len(assessments) == 0 {
+			return runner.finish(ctx, run, leaseOwner, ports.AssessmentSnapshotBackfillCompleted, actor, nil)
+		}
+		if len(assessments) > run.BatchSize {
+			return runner.finish(ctx, run, leaseOwner, ports.AssessmentSnapshotBackfillFailed, actor, fmt.Errorf("backfill source returned %d rows for limit %d", len(assessments), run.BatchSize))
+		}
+		for _, assessment := range assessments {
+			if err := ctx.Err(); err != nil {
+				return runner.finish(ctx, run, leaseOwner, ports.AssessmentSnapshotBackfillCancelled, actor, err)
+			}
+			if _, err := runner.store.GetAssessmentSnapshotBackfillItem(ctx, tenantID, run.ID, assessment.ID); err == nil {
+				continue
+			} else if !errors.Is(err, shared.ErrNotFound) {
+				return runner.finish(ctx, run, leaseOwner, snapshotBackfillTerminalState(err), actor, err)
+			}
+			item, created, err := runner.store.CommitAssessmentSnapshotBackfillItem(ctx, tenantID, run.ID, run.LeaseToken, runner.clock.Now().UTC(), func(txCtx context.Context) (ports.AssessmentSnapshotBackfillItem, error) {
+				return runner.processItem(txCtx, run, assessment.ID, actor), nil
+			})
+			if err != nil {
+				return runner.finish(ctx, run, leaseOwner, snapshotBackfillTerminalState(err), actor, err)
+			}
+			if created && runner.observer != nil {
+				runner.observer.ObserveAssessmentSnapshotBackfillItem(item.Outcome)
+			}
+		}
+		checkpoint := assessments[len(assessments)-1].ID
+		run, err = runner.store.AdvanceAssessmentSnapshotBackfillRun(ctx, tenantID, run.ID, leaseOwner, run.LeaseToken, checkpoint, runner.clock.Now().UTC(), leaseDuration)
+		if err != nil {
+			return runner.finish(ctx, run, leaseOwner, snapshotBackfillTerminalState(err), actor, err)
+		}
+		if err := runner.record(ctx, actor, "assessment_snapshot.backfill_batch_committed", run.ID, map[string]string{
+			"tenant_id": tenantID.String(), "checkpoint_assessment_id": checkpoint.String(), "processed_count": strconv.Itoa(run.ProcessedCount),
+		}); err != nil {
+			return runner.finish(ctx, run, leaseOwner, ports.AssessmentSnapshotBackfillFailed, actor, fmt.Errorf("audit assessment Snapshot backfill batch: %w", err))
+		}
+	}
+}
+
+type projectionSource struct {
+	selected   domain.SelectedRun
+	sourceHash string
+	reasonCode string
+}
+
+func (runner *BackfillRunner) processItem(ctx context.Context, run ports.AssessmentSnapshotBackfillRun, assessmentID shared.ID, actor string) ports.AssessmentSnapshotBackfillItem {
+	source, sourceErr := runner.loadProjectionSource(ctx, run, assessmentID)
+	if source.sourceHash == "" {
+		source.sourceHash = fallbackProjectionSourceHash(assessmentID, run.SchemaVersion)
+	}
+	item := ports.AssessmentSnapshotBackfillItem{
+		TenantID: run.TenantID, RunID: run.ID, AssessmentID: assessmentID, SchemaVersion: run.SchemaVersion,
+		IdempotencyKey: snapshotBackfillIdempotencyKey(assessmentID, run.SchemaVersion, source.sourceHash), SourceHash: source.sourceHash,
+		ProcessedAt: runner.clock.Now().UTC(),
+	}
+	if sourceErr != nil {
+		item.Outcome, item.ReasonCode, item.Retryable, item.RepairGuidance = snapshotBackfillFailure(sourceErr, true)
+		return item
+	}
+	if source.reasonCode != "" {
+		item.Outcome, item.ReasonCode = SnapshotBackfillOutcomeSkipped, source.reasonCode
+		return item
+	}
+	var (
+		result LegacyProjectionResult
+		err    error
+	)
+	for attempt := 0; attempt < assessmentSnapshotBackfillRetries; attempt++ {
+		result, err = runner.projector.Project(ctx, LegacyProjectionInput{
+			TenantID: run.TenantID, AssessmentID: assessmentID, Actor: actor, SourceHash: source.sourceHash,
+			SelectedRun: source.selected, DryRun: run.DryRun,
+		})
+		if err == nil || !retryableAssessmentSnapshotBackfillError(err) {
+			break
+		}
+	}
+	if err != nil {
+		item.Outcome, item.ReasonCode, item.Retryable, item.RepairGuidance = snapshotBackfillFailure(err, false)
+		return item
+	}
+	item.SnapshotID = result.SnapshotID
+	switch {
+	case result.Created:
+		item.Outcome, item.ReasonCode = SnapshotBackfillOutcomeCreated, SnapshotBackfillReasonCreated
+	case result.WouldCreate:
+		item.Outcome, item.ReasonCode = SnapshotBackfillOutcomeWouldCreate, SnapshotBackfillReasonWouldCreate
+	default:
+		item.Outcome, item.ReasonCode = SnapshotBackfillOutcomeSkipped, result.ReasonCode
+	}
+	return item
+}
+
+func (runner *BackfillRunner) loadProjectionSource(ctx context.Context, run ports.AssessmentSnapshotBackfillRun, assessmentID shared.ID) (projectionSource, error) {
+	resultData, resultErr := runner.results.LatestResult(ctx, assessmentID)
+	if resultErr != nil && !errors.Is(resultErr, shared.ErrNotFound) {
+		return projectionSource{}, resultErr
+	}
+	resultHash := ""
+	if resultErr == nil {
+		// ponytail: scan_results is source evidence only, so raw stored bytes are sufficient here;
+		// switch to canonical JSON hashing if a second storage representation participates.
+		sum := sha256.Sum256(resultData)
+		resultHash = hex.EncodeToString(sum[:])
+	}
+	runs, err := runner.runs.ListScanRuns(ctx, run.TenantID, assessmentID)
+	if err != nil {
+		return projectionSource{}, err
+	}
+	eligible := make([]scanrun.ScanRun, 0, len(runs))
+	for _, candidate := range runs {
+		if !candidate.CreatedAt.After(run.SnapshotAt) {
+			eligible = append(eligible, candidate)
+		}
+	}
+	if len(eligible) == 0 {
+		return projectionSource{sourceHash: projectionSourceHash(assessmentID, run.SchemaVersion, "", "", resultHash), reasonCode: SnapshotBackfillReasonScanRunMissing}, nil
+	}
+	for _, candidate := range eligible {
+		if candidate.Provenance != scanrun.ProvenanceNative || validateTrustedScanRun(candidate) != nil {
+			continue
+		}
+		if err := validateProjectionRun(candidate, run.TenantID, assessmentID); err != nil {
+			return projectionSource{}, err
+		}
+		return projectionSource{
+			selected:   domain.SelectedRun{ID: candidate.ID, ManifestHash: candidate.ManifestHash, Provenance: scanrun.ProvenanceLegacy, TerminalStatus: candidate.TerminalStatus, Lanes: candidate.Lanes},
+			sourceHash: projectionSourceHash(assessmentID, run.SchemaVersion, candidate.ID, candidate.ManifestHash, resultHash),
+		}, nil
+	}
+	for _, candidate := range eligible {
+		if candidate.Provenance != scanrun.ProvenanceLegacy {
+			continue
+		}
+		if err := validateProjectionRun(candidate, run.TenantID, assessmentID); err != nil {
+			return projectionSource{}, err
+		}
+		hash := legacyRunHash(candidate)
+		return projectionSource{
+			selected:   domain.SelectedRun{ID: candidate.ID, ManifestHash: hash, Provenance: scanrun.ProvenanceLegacy, TerminalStatus: candidate.TerminalStatus, Lanes: candidate.Lanes},
+			sourceHash: projectionSourceHash(assessmentID, run.SchemaVersion, candidate.ID, hash, resultHash),
+		}, nil
+	}
+	return projectionSource{sourceHash: projectionSourceHash(assessmentID, run.SchemaVersion, "", "", resultHash), reasonCode: SnapshotBackfillReasonVerifiedRunMissing}, nil
+}
+
+func validateProjectionRun(run scanrun.ScanRun, tenantID, assessmentID shared.ID) error {
+	if strings.TrimSpace(run.ID) == "" || run.TenantID != tenantID || run.EngagementID != assessmentID || run.CreatedAt.IsZero() {
+		return fmt.Errorf("%w: assessment snapshot projection run ownership is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (runner *BackfillRunner) finish(ctx context.Context, run ports.AssessmentSnapshotBackfillRun, leaseOwner string, state ports.AssessmentSnapshotBackfillState, actor string, cause error) (ports.AssessmentSnapshotBackfillRun, error) {
+	finishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	finished, err := runner.store.FinishAssessmentSnapshotBackfillRun(finishCtx, run.TenantID, run.ID, leaseOwner, run.LeaseToken, state, runner.clock.Now().UTC())
+	if err != nil {
+		if cause != nil {
+			return run, errors.Join(cause, err)
+		}
+		return run, err
+	}
+	if runner.observer != nil {
+		runner.observer.ObserveAssessmentSnapshotBackfillRun(string(state))
+	}
+	auditErr := runner.record(finishCtx, actor, "assessment_snapshot.backfill_"+string(state), run.ID, map[string]string{
+		"tenant_id": run.TenantID.String(), "processed_count": strconv.Itoa(finished.ProcessedCount), "created_count": strconv.Itoa(finished.CreatedCount),
+		"would_create_count": strconv.Itoa(finished.WouldCreateCount), "skipped_count": strconv.Itoa(finished.SkippedCount), "failed_count": strconv.Itoa(finished.FailedCount),
+	})
+	if cause != nil {
+		if auditErr != nil {
+			return finished, errors.Join(cause, fmt.Errorf("audit assessment Snapshot backfill finish: %w", auditErr))
+		}
+		return finished, cause
+	}
+	if auditErr != nil {
+		return finished, fmt.Errorf("audit assessment Snapshot backfill finish: %w", auditErr)
+	}
+	return finished, nil
+}
+
+func (runner *BackfillRunner) record(ctx context.Context, actor, action string, target shared.ID, metadata map[string]string) error {
+	if runner.audit != nil {
+		return runner.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: action, Target: target.String(), Metadata: metadata, At: runner.clock.Now().UTC()})
+	}
+	return nil
+}
+
+func retryableAssessmentSnapshotBackfillError(err error) bool {
+	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, shared.ErrValidation) && !errors.Is(err, shared.ErrNotFound) && !errors.Is(err, shared.ErrConflict)
+}
+
+func snapshotBackfillTerminalState(err error) ports.AssessmentSnapshotBackfillState {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return ports.AssessmentSnapshotBackfillCancelled
+	}
+	return ports.AssessmentSnapshotBackfillFailed
+}
+
+func snapshotBackfillFailure(err error, sourceRead bool) (outcome, reason string, retryable bool, guidance string) {
+	switch {
+	case errors.Is(err, shared.ErrValidation):
+		return SnapshotBackfillOutcomeFailed, SnapshotBackfillReasonInvalidSource, false, "Correct the owned scan-run provenance before rerunning the projection."
+	case errors.Is(err, shared.ErrNotFound):
+		return SnapshotBackfillOutcomeSkipped, SnapshotBackfillReasonCycleMissing, false, "Run the singleton-Cycle backfill before rerunning the Snapshot projection."
+	case sourceRead:
+		return SnapshotBackfillOutcomeFailed, SnapshotBackfillReasonSourceReadFailed, true, "Retry after restoring source repository availability; source evidence is never copied into failure records."
+	default:
+		return SnapshotBackfillOutcomeFailed, SnapshotBackfillReasonProjectionWriteFailed, true, "Retry after restoring database availability; verify Snapshot integrity before cutover."
+	}
+}
+
+func legacyProjectionRequestKey(sourceHash string) string {
+	return "assessment-snapshot-backfill-v1-" + sourceHash
+}
+
+func legacyProjectionRequestHash(sourceHash, contentHash string) string {
+	sum := sha256.Sum256([]byte(sourceHash + "\x00" + contentHash))
+	return hex.EncodeToString(sum[:])
+}
+
+func projectionSourceHash(assessmentID shared.ID, schemaVersion int, runID, runHash, resultHash string) string {
+	payload, _ := json.Marshal(struct {
+		AssessmentID string `json:"assessment_id"`
+		ResultHash   string `json:"result_hash"`
+		RunHash      string `json:"run_hash"`
+		RunID        string `json:"run_id"`
+		Schema       int    `json:"schema_version"`
+	}{assessmentID.String(), resultHash, runHash, runID, schemaVersion})
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+func fallbackProjectionSourceHash(assessmentID shared.ID, schemaVersion int) string {
+	return projectionSourceHash(assessmentID, schemaVersion, "", "", "")
+}
+
+func snapshotBackfillIdempotencyKey(assessmentID shared.ID, schemaVersion int, sourceHash string) string {
+	sum := sha256.Sum256([]byte(assessmentID.String() + "\x00" + strconv.Itoa(schemaVersion) + "\x00" + sourceHash))
+	return "assessment-snapshot-backfill-v" + strconv.Itoa(schemaVersion) + "-" + hex.EncodeToString(sum[:])
+}
+
+func validSnapshotBackfillHash(value string) bool {
+	if len(value) != 64 || strings.ToLower(value) != value {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
+}

--- a/internal/usecase/assessmentsnapshot/backfill_test.go
+++ b/internal/usecase/assessmentsnapshot/backfill_test.go
@@ -1,0 +1,281 @@
+package assessmentsnapshot_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	uc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type snapshotBackfillClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (clock *snapshotBackfillClock) Now() time.Time {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	return clock.now
+}
+
+func (clock *snapshotBackfillClock) Advance(duration time.Duration) {
+	clock.mu.Lock()
+	clock.now = clock.now.Add(duration)
+	clock.mu.Unlock()
+}
+
+type staticBackfillRunStore struct{ runs []scanrun.ScanRun }
+
+func (store *staticBackfillRunStore) ListScanRuns(_ context.Context, tenantID, assessmentID shared.ID) ([]scanrun.ScanRun, error) {
+	var out []scanrun.ScanRun
+	for _, run := range store.runs {
+		if run.TenantID == tenantID && run.EngagementID == assessmentID {
+			out = append(out, run)
+		}
+	}
+	return out, nil
+}
+func (store *staticBackfillRunStore) GetScanRun(_ context.Context, tenantID shared.ID, runID string) (scanrun.ScanRun, error) {
+	for _, run := range store.runs {
+		if run.TenantID == tenantID && run.ID == runID {
+			return run, nil
+		}
+	}
+	return scanrun.ScanRun{}, shared.ErrNotFound
+}
+
+type retryingSnapshotProjector struct {
+	calls int
+	err   error
+}
+
+type cancellingSnapshotSource struct{ cancel context.CancelFunc }
+
+func (source cancellingSnapshotSource) ListAssessmentSnapshotBackfillEngagements(context.Context, shared.ID, shared.ID, time.Time, int) ([]*engagement.Engagement, error) {
+	source.cancel()
+	return nil, context.Canceled
+}
+
+func (projector *retryingSnapshotProjector) Project(context.Context, uc.LegacyProjectionInput) (uc.LegacyProjectionResult, error) {
+	projector.calls++
+	return uc.LegacyProjectionResult{}, projector.err
+}
+
+func TestSnapshotBackfillProjectsUnknownCoverageAndHashVersionedEvidence(t *testing.T) {
+	harness := newSnapshotBackfillHarness(t, nil)
+	run := nativeRun(t, "sealed-run", "assessment", "0123456789abcdef0123456789abcdef01234567")
+	harness.runs.runs = []scanrun.ScanRun{run}
+	if err := harness.results.SaveResult(context.Background(), "assessment", []byte(`{"findings":[{"id":"source-only"}]}`)); err != nil {
+		t.Fatal(err)
+	}
+
+	first, err := harness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "process-1", BatchSize: 1})
+	if err != nil || first.CreatedCount != 1 || first.FailedCount != 0 {
+		t.Fatalf("first snapshot backfill=%+v err=%v", first, err)
+	}
+	snapshots, err := harness.snapshots.ListByAssessment(context.Background(), "tenant", "assessment")
+	if err != nil || len(snapshots) != 1 {
+		t.Fatalf("snapshots=%+v err=%v", snapshots, err)
+	}
+	if snapshots[0].Provenance != assessmentsnapshot.ProvenanceLegacy || len(snapshots[0].Dimensions) != 1 || snapshots[0].Dimensions[0].State != assessmentsnapshot.CoverageUnknown || snapshots[0].Dimensions[0].ReasonCode != assessmentsnapshot.ReasonLegacyProvenance {
+		t.Fatalf("legacy projection coverage=%+v", snapshots[0])
+	}
+	if _, _, err := harness.snapshots.GetDefault(context.Background(), "tenant", "assessment"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("legacy projection changed default pointer: %v", err)
+	}
+
+	second, err := harness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "process-2", BatchSize: 1})
+	if err != nil || second.SkippedCount != 1 || second.CreatedCount != 0 {
+		t.Fatalf("idempotent rerun=%+v err=%v", second, err)
+	}
+	if err := harness.results.SaveResult(context.Background(), "assessment", []byte(`{"findings":[{"id":"changed-source"}]}`)); err != nil {
+		t.Fatal(err)
+	}
+	third, err := harness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "process-3", BatchSize: 1})
+	if err != nil || third.CreatedCount != 1 {
+		t.Fatalf("hash-versioned rerun=%+v err=%v", third, err)
+	}
+	snapshots, err = harness.snapshots.ListByAssessment(context.Background(), "tenant", "assessment")
+	if err != nil || len(snapshots) != 2 || snapshots[0].ContentHash != snapshots[1].ContentHash || snapshots[0].RequestHash == snapshots[1].RequestHash {
+		t.Fatalf("hash-versioned snapshots=%+v err=%v", snapshots, err)
+	}
+}
+
+func TestSnapshotBackfillProjectsLegacyRunWithoutInventedDimensions(t *testing.T) {
+	legacy := scanrun.ScanRun{
+		TenantID: "tenant", ID: "legacy-run", EngagementID: "assessment",
+		CreatedAt: time.Date(2026, 8, 31, 9, 0, 0, 0, time.UTC), UpdatedAt: time.Date(2026, 8, 31, 9, 0, 0, 0, time.UTC),
+		Provenance: scanrun.ProvenanceLegacy, TerminalStatus: scanrun.StatusUnknown, ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion,
+		LegacyFindingKeys: []string{"legacy-finding"},
+	}
+	harness := newSnapshotBackfillHarness(t, []scanrun.ScanRun{legacy})
+	run, err := harness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "legacy", BatchSize: 1})
+	if err != nil || run.CreatedCount != 1 {
+		t.Fatalf("legacy no-lane backfill=%+v err=%v", run, err)
+	}
+	snapshots, err := harness.snapshots.ListByAssessment(context.Background(), "tenant", "assessment")
+	if err != nil || len(snapshots) != 1 || len(snapshots[0].RunReferences) != 1 || len(snapshots[0].Dimensions) != 0 {
+		t.Fatalf("legacy no-lane projection=%+v err=%v", snapshots, err)
+	}
+}
+
+func TestLegacyProjectionRollsBackWhenAuditFails(t *testing.T) {
+	harness := newSnapshotBackfillHarness(t, nil)
+	auditErr := errors.New("audit unavailable")
+	projector, err := uc.NewLegacyProjector(
+		harness.snapshots,
+		harness.cycles,
+		memory.NewTenantTransactionRunner(),
+		harness.ids,
+		harness.clock,
+		failingAudit{err: auditErr},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = projector.Project(context.Background(), uc.LegacyProjectionInput{
+		TenantID:     "tenant",
+		AssessmentID: "assessment",
+		Actor:        "operator",
+		SourceHash:   strings.Repeat("a", 64),
+		SelectedRun: assessmentsnapshot.SelectedRun{
+			ID:             "legacy-run",
+			ManifestHash:   strings.Repeat("b", 64),
+			Provenance:     scanrun.ProvenanceLegacy,
+			TerminalStatus: scanrun.StatusUnknown,
+		},
+	})
+	if !errors.Is(err, auditErr) {
+		t.Fatalf("legacy projection audit failure=%v", err)
+	}
+	if snapshots, listErr := harness.snapshots.ListByAssessment(context.Background(), "tenant", "assessment"); listErr != nil || len(snapshots) != 0 {
+		t.Fatalf("legacy projection survived audit rollback: snapshots=%+v err=%v", snapshots, listErr)
+	}
+}
+
+func TestSnapshotBackfillLeaseResumeDryRunAndRedactedRetry(t *testing.T) {
+	harness := newSnapshotBackfillHarness(t, []scanrun.ScanRun{nativeRun(t, "sealed-run", "assessment", "0123456789abcdef0123456789abcdef01234567")})
+	dryRun, err := harness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "dry-run", DryRun: true, BatchSize: 1})
+	if err != nil || dryRun.WouldCreateCount != 1 {
+		t.Fatalf("dry run=%+v err=%v", dryRun, err)
+	}
+	if snapshots, _ := harness.snapshots.ListByAssessment(context.Background(), "tenant", "assessment"); len(snapshots) != 0 {
+		t.Fatalf("dry run created snapshots: %+v", snapshots)
+	}
+
+	lease := time.Minute
+	crashed, _, err := harness.store.AcquireAssessmentSnapshotBackfillRun(context.Background(), ports.AssessmentSnapshotBackfillAcquireRequest{Run: ports.AssessmentSnapshotBackfillRun{
+		TenantID: "tenant", ID: "crashed", SchemaVersion: uc.AssessmentSnapshotBackfillSchemaVersion, BatchSize: 1,
+		SnapshotAt: harness.clock.Now(), State: ports.AssessmentSnapshotBackfillRunning, LeaseOwner: "dead", LeaseToken: "dead-token", LeaseExpiresAt: harness.clock.Now().Add(lease),
+		CreatedBy: "operator", CreatedAt: harness.clock.Now(), UpdatedAt: harness.clock.Now(),
+	}, LeaseDuration: lease})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := harness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "live", BatchSize: 1, LeaseDuration: lease}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("concurrent lease=%v", err)
+	}
+	harness.clock.Advance(lease + time.Second)
+	resumed, err := harness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "live", BatchSize: 1, LeaseDuration: lease})
+	if err != nil || resumed.ID != crashed.ID || resumed.CreatedCount != 1 {
+		t.Fatalf("crash resume=%+v err=%v", resumed, err)
+	}
+
+	retryHarness := newSnapshotBackfillHarness(t, []scanrun.ScanRun{nativeRun(t, "retry-run", "assessment", "0123456789abcdef0123456789abcdef01234567")})
+	failing := &retryingSnapshotProjector{err: errors.New("database unavailable: secret-token")}
+	retryHarness.runner, err = uc.NewBackfillRunner(failing, retryHarness.engagements, retryHarness.store, retryHarness.runs, retryHarness.results, retryHarness.ids, retryHarness.clock, retryHarness.audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	failed, err := retryHarness.runner.Run(context.Background(), uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "retry", BatchSize: 1})
+	if err != nil || failed.FailedCount != 1 || failing.calls != 3 {
+		t.Fatalf("bounded retry=%+v calls=%d err=%v", failed, failing.calls, err)
+	}
+	item, err := retryHarness.store.GetAssessmentSnapshotBackfillItem(context.Background(), "tenant", failed.ID, "assessment")
+	if err != nil || item.ReasonCode != uc.SnapshotBackfillReasonProjectionWriteFailed || !item.Retryable || strings.Contains(item.RepairGuidance, "secret-token") {
+		t.Fatalf("redacted failure=%+v err=%v", item, err)
+	}
+
+	cancelHarness := newSnapshotBackfillHarness(t, []scanrun.ScanRun{nativeRun(t, "cancel-run", "assessment", "0123456789abcdef0123456789abcdef01234567")})
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancelRunner, err := uc.NewBackfillRunner(cancelHarness.projector, cancellingSnapshotSource{cancel: cancel}, cancelHarness.store, cancelHarness.runs, cancelHarness.results, cancelHarness.ids, cancelHarness.clock, cancelHarness.audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancelled, err := cancelRunner.Run(cancelCtx, uc.BackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "cancel", BatchSize: 1})
+	if !errors.Is(err, context.Canceled) || cancelled.State != ports.AssessmentSnapshotBackfillCancelled {
+		t.Fatalf("cancelled run=%+v err=%v", cancelled, err)
+	}
+}
+
+type snapshotBackfillHarness struct {
+	runner      *uc.BackfillRunner
+	snapshots   *memory.AssessmentSnapshotRepository
+	cycles      *memory.AssessmentCycleRepository
+	engagements *memory.EngagementRepository
+	store       *memory.AssessmentSnapshotBackfillRepository
+	runs        *staticBackfillRunStore
+	results     *memory.ScanResultStore
+	ids         *sequenceIDs
+	clock       *snapshotBackfillClock
+	audit       *auditRecorder
+	projector   *uc.LegacyProjector
+}
+
+func newSnapshotBackfillHarness(t *testing.T, runs []scanrun.ScanRun) *snapshotBackfillHarness {
+	t.Helper()
+	ctx := context.Background()
+	clock := &snapshotBackfillClock{now: time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)}
+	engagements := memory.NewEngagementRepository()
+	assessment, err := engagement.New("assessment", "tenant", "Assessment", "", clock.Now().Add(-24*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := assessment.Transition(engagement.StatusActive, clock.Now().Add(-23*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(ctx, assessment); err != nil {
+		t.Fatal(err)
+	}
+	cycles := memory.NewAssessmentCycleRepository()
+	cycle, err := assessmentcycle.NewAssessmentCycle("cycle", "tenant", "Cycle", assessmentcycle.BoundaryStandalone, "", "", "assessment", "operator", assessment.Audit.CreatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember("tenant", "cycle", "assessment", "operator", assessment.Audit.CreatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	store := memory.NewAssessmentSnapshotBackfillRepository()
+	runStore := &staticBackfillRunStore{runs: runs}
+	results := memory.NewScanResultStore()
+	ids := &sequenceIDs{}
+	audit := &auditRecorder{}
+	projector, err := uc.NewLegacyProjector(snapshots, cycles, memory.NewTenantTransactionRunner(), ids, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runner, err := uc.NewBackfillRunner(projector, engagements, store, runStore, results, ids, clock, audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &snapshotBackfillHarness{runner: runner, snapshots: snapshots, cycles: cycles, engagements: engagements, store: store, runs: runStore, results: results, ids: ids, clock: clock, audit: audit, projector: projector}
+}

--- a/internal/usecase/assessmentsnapshot/history.go
+++ b/internal/usecase/assessmentsnapshot/history.go
@@ -1,0 +1,26 @@
+package assessmentsnapshot
+
+import (
+	"context"
+	"fmt"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// ReadComparisonHistory bounds internal ancestry/review reads as well as the
+// public history endpoint. Refuse oversized histories rather than silently omit
+// evidence from a comparison. The canonical MVP targets ten snapshots per member.
+func ReadComparisonHistory(ctx context.Context, store ports.AssessmentSnapshotRepository, tenantID, assessmentID shared.ID) ([]domain.Snapshot, error) {
+	page, err := store.ListAssessmentSnapshots(ctx, ports.AssessmentSnapshotListQuery{
+		TenantID: tenantID, AssessmentID: assessmentID, Limit: 100,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if page.HasMore {
+		return nil, fmt.Errorf("%w: snapshot history exceeds supported comparison limit", shared.ErrValidation)
+	}
+	return page.Items, nil
+}

--- a/internal/usecase/assessmentsnapshot/history_test.go
+++ b/internal/usecase/assessmentsnapshot/history_test.go
@@ -1,0 +1,35 @@
+package assessmentsnapshot_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	uc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type boundedHistoryStore struct {
+	ports.AssessmentSnapshotRepository
+	query ports.AssessmentSnapshotListQuery
+	more  bool
+}
+
+func (store *boundedHistoryStore) ListAssessmentSnapshots(_ context.Context, query ports.AssessmentSnapshotListQuery) (ports.AssessmentSnapshotPage, error) {
+	store.query = query
+	return ports.AssessmentSnapshotPage{Items: make([]domain.Snapshot, 100), HasMore: store.more}, nil
+}
+
+func TestComparisonHistoryNeverSilentlyTruncates(t *testing.T) {
+	store := &boundedHistoryStore{}
+	items, err := uc.ReadComparisonHistory(context.Background(), store, "tenant", "assessment")
+	if err != nil || len(items) != 100 || store.query.Limit != 100 || store.query.TenantID != "tenant" || store.query.AssessmentID != "assessment" {
+		t.Fatalf("bounded history: %d %+v %v", len(items), store.query, err)
+	}
+	store.more = true
+	if items, err := uc.ReadComparisonHistory(context.Background(), store, "tenant", "assessment"); !errors.Is(err, shared.ErrValidation) || len(items) != 0 {
+		t.Fatalf("truncated history accepted: %d %v", len(items), err)
+	}
+}

--- a/internal/usecase/assessmentsnapshot/service.go
+++ b/internal/usecase/assessmentsnapshot/service.go
@@ -1,0 +1,481 @@
+package assessmentsnapshot
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	maxSelectedRuns         = 100
+	maxSelectedLanes        = 100
+	maxSelectionIDSize      = 256
+	maxRequestKeySize       = 128
+	defaultSnapshotPageSize = 50
+	maxSnapshotPageSize     = 100
+)
+
+var ErrIdempotencyBodyMismatch = errors.New("assessment snapshot idempotency body mismatch")
+
+type Service struct {
+	snapshots   ports.AssessmentSnapshotRepository
+	cycles      ports.AssessmentCycleRepository
+	engagements ports.EngagementRepository
+	runs        ports.AssessmentSnapshotRunReader
+	jobs        ports.ScanJobStore
+	tx          ports.TenantTransactionRunner
+	ids         ports.IDGenerator
+	clock       ports.Clock
+	audit       ports.AuditLogger
+	observer    FinalizationObserver
+}
+
+// FinalizationObserver performs tenant-gated shadow projections in the same
+// transaction as a newly finalized Snapshot. A failure aborts the Snapshot so
+// callers never observe a boundary without its required lineage projection.
+type FinalizationObserver interface {
+	AssessmentSnapshotFinalized(context.Context, *domain.Snapshot, string) error
+}
+
+func NewService(snapshots ports.AssessmentSnapshotRepository, cycles ports.AssessmentCycleRepository, engagements ports.EngagementRepository, runs ports.AssessmentSnapshotRunReader, tx ports.TenantTransactionRunner, ids ports.IDGenerator, clock ports.Clock, audit ports.AuditLogger) (*Service, error) {
+	if snapshots == nil || cycles == nil || engagements == nil || runs == nil || tx == nil || ids == nil || clock == nil || audit == nil {
+		return nil, fmt.Errorf("%w: assessment snapshot dependencies are required", shared.ErrValidation)
+	}
+	return &Service{snapshots: snapshots, cycles: cycles, engagements: engagements, runs: runs, tx: tx, ids: ids, clock: clock, audit: audit}, nil
+}
+
+func (service *Service) SetScanJobStore(jobs ports.ScanJobStore) { service.jobs = jobs }
+
+func (service *Service) SetFinalizationObserver(observer FinalizationObserver) {
+	service.observer = observer
+}
+
+type FinalizeInput struct {
+	TenantID               shared.ID
+	CycleID                shared.ID
+	AssessmentID           shared.ID
+	SelectedRunIDs         []string
+	SelectedRuns           []RunSelection
+	RequestKey             string
+	ExpectedDefaultVersion int64
+	Actor                  string
+}
+
+type RunSelection struct {
+	RunID    string
+	LaneKeys []string
+}
+
+func (service *Service) Finalize(ctx context.Context, input FinalizeInput) (*domain.Snapshot, bool, error) {
+	tenantID := shared.TenantOrDefault(input.TenantID)
+	requestKey := strings.TrimSpace(input.RequestKey)
+	actor := strings.TrimSpace(input.Actor)
+	selectedRuns, err := normalizedRunSelections(input.SelectedRunIDs, input.SelectedRuns)
+	if err != nil {
+		return nil, false, err
+	}
+	if tenantID.IsZero() || input.AssessmentID.IsZero() || requestKey == "" || actor == "" {
+		return nil, false, fmt.Errorf("%w: snapshot tenant, assessment, request key, and actor are required", shared.ErrValidation)
+	}
+	if len(requestKey) > maxRequestKeySize {
+		return nil, false, fmt.Errorf("%w: snapshot request key exceeds %d bytes", shared.ErrValidation, maxRequestKeySize)
+	}
+	if input.ExpectedDefaultVersion < 0 {
+		return nil, false, fmt.Errorf("%w: expected default version cannot be negative", shared.ErrValidation)
+	}
+	if input.CycleID.IsZero() {
+		cycle, err := service.cycles.GetCycleByAssessment(ctx, tenantID, input.AssessmentID)
+		if err != nil {
+			return nil, false, err
+		}
+		input.CycleID = cycle.ID
+	}
+	selectedRuns, err = service.expandRunSelections(ctx, tenantID, input.AssessmentID, selectedRuns)
+	if err != nil {
+		return nil, false, err
+	}
+	if replay, err := service.snapshots.GetByRequestKey(ctx, tenantID, input.AssessmentID, requestKey); err == nil {
+		if replay.CycleID != input.CycleID || !sameRunSelection(replay.RunReferences, selectedRuns) {
+			return nil, false, idempotencyBodyMismatch()
+		}
+		// The retained request was admitted against the pointer version immediately
+		// preceding this Snapshot. Keep the original precondition part of the
+		// idempotency identity so a caller cannot reuse a key with an arbitrary
+		// If-Match value while still returning the current pointer version below.
+		if input.ExpectedDefaultVersion != replay.DefaultVersion-1 {
+			return nil, false, fmt.Errorf("%w: assessment snapshot replay precondition mismatch", shared.ErrConflict)
+		}
+		_, pointer, err := service.snapshots.GetDefault(ctx, tenantID, input.AssessmentID)
+		if err != nil {
+			return nil, false, fmt.Errorf("load current assessment snapshot default: %w", err)
+		}
+		replay.DefaultVersion = pointer.Version
+		return replay, false, nil
+	} else if !errors.Is(err, shared.ErrNotFound) {
+		return nil, false, err
+	}
+
+	var finalized *domain.Snapshot
+	created := false
+	err = service.tx.Run(ctx, tenantID, func(txCtx context.Context) error {
+		cycle, err := service.cycles.LockCycleForUpdate(txCtx, tenantID, input.CycleID)
+		if err != nil {
+			return err
+		}
+		if cycle.Status != assessmentcycle.StatusOpen {
+			return fmt.Errorf("%w: snapshots require an open assessment cycle", shared.ErrValidation)
+		}
+		if _, err := service.cycles.GetMember(txCtx, tenantID, input.CycleID, input.AssessmentID); err != nil {
+			return err
+		}
+		assessment, err := service.engagements.GetByIDInTenant(txCtx, tenantID, input.AssessmentID)
+		if err != nil {
+			return err
+		}
+		if assessment.Status != engagement.StatusDraft && assessment.Status != engagement.StatusActive {
+			return fmt.Errorf("%w: snapshots require a draft or active assessment", shared.ErrValidation)
+		}
+
+		trustedRuns := make([]domain.SelectedRun, 0, len(selectedRuns))
+		for _, selection := range selectedRuns {
+			runID := selection.RunID
+			if service.jobs != nil {
+				job, jobErr := service.jobs.GetJob(txCtx, runID)
+				if jobErr == nil && job.Status == ports.ScanRunning {
+					return fmt.Errorf("%w: selected scan job %q is still running", shared.ErrConflict, runID)
+				}
+				if jobErr != nil && !errors.Is(jobErr, shared.ErrNotFound) {
+					return jobErr
+				}
+			}
+			run, err := service.runs.GetScanRun(txCtx, tenantID, runID)
+			if err != nil {
+				return err
+			}
+			if run.EngagementID != input.AssessmentID {
+				return fmt.Errorf("%w: selected scan run %q belongs to another assessment", shared.ErrValidation, runID)
+			}
+			if run.Provenance != scanrun.ProvenanceNative {
+				return fmt.Errorf("%w: interactive snapshot finalization requires native scan run provenance", shared.ErrValidation)
+			}
+			selected, err := trustedSelectedRun(run, selection.LaneKeys)
+			if err != nil {
+				return err
+			}
+			trustedRuns = append(trustedRuns, selected)
+		}
+
+		now := service.clock.Now().UTC()
+		candidate, err := domain.NewFinalized(tenantID, service.ids.NewID(), input.CycleID, input.AssessmentID, domain.Boundary{
+			Kind: cycle.BoundaryKind, BusinessAssetID: cycle.BusinessAssetID, ProjectID: cycle.ProjectID,
+		}, requestKey, actor, now, trustedRuns)
+		if err != nil {
+			return err
+		}
+		finalized, created, err = service.snapshots.CreateFinalizedCAS(txCtx, candidate, input.ExpectedDefaultVersion)
+		if err != nil {
+			return classifySnapshotError(err)
+		}
+		if !created {
+			return nil
+		}
+		if service.observer != nil {
+			if err := service.observer.AssessmentSnapshotFinalized(txCtx, finalized, actor); err != nil {
+				return fmt.Errorf("project finalized assessment snapshot: %w", err)
+			}
+		}
+		if err := service.audit.Record(txCtx, ports.AuditEntry{
+			Actor: actor, Action: "assessment_snapshot.finalized", Target: finalized.ID.String(), At: now,
+			Metadata: map[string]string{
+				"tenant_id": tenantID.String(), "cycle_id": input.CycleID.String(), "assessment_id": input.AssessmentID.String(),
+				"snapshot_number": fmt.Sprintf("%d", finalized.SnapshotNumber), "content_hash": finalized.ContentHash,
+			},
+		}); err != nil {
+			return fmt.Errorf("audit assessment snapshot finalization: %w", err)
+		}
+
+		return nil
+	})
+	return finalized, created, err
+}
+
+func (service *Service) Get(ctx context.Context, tenantID, snapshotID shared.ID) (*domain.Snapshot, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	if tenantID.IsZero() || snapshotID.IsZero() {
+		return nil, fmt.Errorf("%w: snapshot tenant and id are required", shared.ErrValidation)
+	}
+	return service.snapshots.Get(ctx, tenantID, snapshotID)
+}
+
+type SnapshotPage struct {
+	Items      []domain.Snapshot
+	NextCursor string
+}
+
+func (service *Service) ListByAssessment(ctx context.Context, tenantID, assessmentID shared.ID, cursor string, limit int) (SnapshotPage, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	if tenantID.IsZero() || assessmentID.IsZero() {
+		return SnapshotPage{}, fmt.Errorf("%w: snapshot tenant and assessment are required", shared.ErrValidation)
+	}
+	if limit == 0 {
+		limit = defaultSnapshotPageSize
+	}
+	if limit < 1 || limit > maxSnapshotPageSize {
+		return SnapshotPage{}, fmt.Errorf("%w: snapshot page size must be between 1 and %d", shared.ErrValidation, maxSnapshotPageSize)
+	}
+	after, err := decodeSnapshotCursor(cursor)
+	if err != nil {
+		return SnapshotPage{}, err
+	}
+	page, err := service.snapshots.ListAssessmentSnapshots(ctx, ports.AssessmentSnapshotListQuery{
+		TenantID: tenantID, AssessmentID: assessmentID, AfterSnapshotNumber: after, Limit: limit,
+	})
+	if err != nil {
+		return SnapshotPage{}, err
+	}
+	result := SnapshotPage{Items: page.Items}
+	if page.HasMore && len(page.Items) > 0 {
+		result.NextCursor = base64.RawURLEncoding.EncodeToString([]byte(strconv.Itoa(page.Items[len(page.Items)-1].SnapshotNumber)))
+	}
+	return result, nil
+}
+
+func decodeSnapshotCursor(cursor string) (int, error) {
+	cursor = strings.TrimSpace(cursor)
+	if cursor == "" {
+		return 0, nil
+	}
+	if len(cursor) > 128 {
+		return 0, fmt.Errorf("%w: snapshot cursor is invalid", shared.ErrValidation)
+	}
+	decoded, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return 0, fmt.Errorf("%w: snapshot cursor is invalid", shared.ErrValidation)
+	}
+	value, err := strconv.Atoi(string(decoded))
+	if err != nil || value < 1 {
+		return 0, fmt.Errorf("%w: snapshot cursor is invalid", shared.ErrValidation)
+	}
+	return value, nil
+}
+
+func (service *Service) GetDefault(ctx context.Context, tenantID, assessmentID shared.ID) (*domain.Snapshot, ports.AssessmentSnapshotDefault, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	if tenantID.IsZero() || assessmentID.IsZero() {
+		return nil, ports.AssessmentSnapshotDefault{}, fmt.Errorf("%w: snapshot tenant and assessment are required", shared.ErrValidation)
+	}
+	return service.snapshots.GetDefault(ctx, tenantID, assessmentID)
+}
+
+func (service *Service) Compare(ctx context.Context, tenantID, baselineSnapshotID, currentSnapshotID shared.ID) ([]domain.DimensionComparison, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	baseline, err := service.snapshots.Get(ctx, tenantID, baselineSnapshotID)
+	if err != nil {
+		return nil, err
+	}
+	current, err := service.snapshots.Get(ctx, tenantID, currentSnapshotID)
+	if err != nil {
+		return nil, err
+	}
+	return domain.Compare(baseline, current)
+}
+
+func trustedSelectedRun(run scanrun.ScanRun, laneKeys []string) (domain.SelectedRun, error) {
+	selected := domain.SelectedRun{ID: run.ID, Provenance: run.Provenance, TerminalStatus: run.TerminalStatus, Lanes: run.Lanes}
+	switch run.Provenance {
+	case scanrun.ProvenanceNative:
+		if err := validateTrustedScanRun(run); err != nil {
+			return domain.SelectedRun{}, fmt.Errorf("selected scan run %q is not trusted: %w", run.ID, err)
+		}
+		selected.ManifestHash, selected.Trusted = run.ManifestHash, true
+	case scanrun.ProvenanceLegacy:
+		selected.ManifestHash = legacyRunHash(run)
+	default:
+		return domain.SelectedRun{}, fmt.Errorf("%w: selected scan run provenance is invalid", shared.ErrValidation)
+	}
+	lanes, err := selectRunLanes(run.Lanes, laneKeys)
+	if err != nil {
+		return domain.SelectedRun{}, fmt.Errorf("selected scan run %q: %w", run.ID, err)
+	}
+	selected.Lanes = lanes
+	return selected, nil
+}
+
+func validateTrustedScanRun(run scanrun.ScanRun) error {
+	if err := run.Validate(); err != nil {
+		return err
+	}
+	if run.Provenance != scanrun.ProvenanceNative || !run.TerminalStatus.IsTerminal() || !run.IsSealed() || len(run.Lanes) == 0 {
+		return fmt.Errorf("%w: native run must have terminal, sealed provenance", shared.ErrValidation)
+	}
+	want, err := scanrun.ComputeRunManifestHash(run.Lanes)
+	if err != nil {
+		return err
+	}
+	if want == "" || want != run.ManifestHash {
+		return fmt.Errorf("%w: run manifest hash mismatch", shared.ErrValidation)
+	}
+	return nil
+}
+
+func legacyRunHash(run scanrun.ScanRun) string {
+	findingKeys := append([]string(nil), run.LegacyFindingKeys...)
+	sort.Strings(findingKeys)
+	payload, _ := json.Marshal(struct {
+		CreatedAt    string          `json:"created_at"`
+		EngagementID string          `json:"engagement_id"`
+		FindingKeys  []string        `json:"finding_keys"`
+		ID           string          `json:"id"`
+		Manifest     json.RawMessage `json:"manifest"`
+	}{run.CreatedAt.UTC().Format("2006-01-02T15:04:05.999999999Z07:00"), run.EngagementID.String(), findingKeys, run.ID, run.LegacyManifest})
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:])
+}
+
+func normalizedRunSelections(runIDs []string, selections []RunSelection) ([]RunSelection, error) {
+	if len(runIDs) > 0 && len(selections) > 0 {
+		return nil, fmt.Errorf("%w: use either selected run ids or selected runs", shared.ErrValidation)
+	}
+	if len(selections) == 0 {
+		selections = make([]RunSelection, len(runIDs))
+		for index, runID := range runIDs {
+			selections[index].RunID = runID
+		}
+	}
+	if len(selections) == 0 {
+		return nil, fmt.Errorf("%w: at least one selected scan run is required", shared.ErrValidation)
+	}
+	if len(selections) > maxSelectedRuns {
+		return nil, fmt.Errorf("%w: at most %d scan runs may be selected", shared.ErrValidation, maxSelectedRuns)
+	}
+	seen := map[string]struct{}{}
+	out := make([]RunSelection, 0, len(selections))
+	for _, selection := range selections {
+		selection.RunID = strings.TrimSpace(selection.RunID)
+		if selection.RunID == "" || len(selection.RunID) > maxSelectionIDSize {
+			return nil, fmt.Errorf("%w: selected scan run id is required", shared.ErrValidation)
+		}
+		if _, exists := seen[selection.RunID]; exists {
+			return nil, fmt.Errorf("%w: selected scan run %q is duplicated", shared.ErrValidation, selection.RunID)
+		}
+		seen[selection.RunID] = struct{}{}
+		if len(selection.LaneKeys) > maxSelectedLanes {
+			return nil, fmt.Errorf("%w: at most %d lanes may be selected per run", shared.ErrValidation, maxSelectedLanes)
+		}
+		laneSeen := map[string]struct{}{}
+		lanes := make([]string, 0, len(selection.LaneKeys))
+		for _, laneKey := range selection.LaneKeys {
+			laneKey = strings.TrimSpace(laneKey)
+			if laneKey == "" || len(laneKey) > maxSelectionIDSize {
+				return nil, fmt.Errorf("%w: selected lane key is invalid", shared.ErrValidation)
+			}
+			if _, exists := laneSeen[laneKey]; exists {
+				return nil, fmt.Errorf("%w: selected lane %q is duplicated", shared.ErrValidation, laneKey)
+			}
+			laneSeen[laneKey] = struct{}{}
+			lanes = append(lanes, laneKey)
+		}
+		sort.Strings(lanes)
+		selection.LaneKeys = lanes
+		out = append(out, selection)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].RunID < out[j].RunID })
+	return out, nil
+}
+
+func sameRunSelection(references []domain.RunReference, selected []RunSelection) bool {
+	if len(references) != len(selected) {
+		return false
+	}
+	byRun := make(map[string]domain.RunReference, len(references))
+	for _, reference := range references {
+		byRun[reference.RunID] = reference
+	}
+	for _, selection := range selected {
+		reference, ok := byRun[selection.RunID]
+		if !ok {
+			return false
+		}
+		if len(reference.LaneReferences) != len(selection.LaneKeys) {
+			return false
+		}
+		for index, lane := range reference.LaneReferences {
+			if lane.LaneKey != selection.LaneKeys[index] {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (service *Service) expandRunSelections(ctx context.Context, tenantID, assessmentID shared.ID, selections []RunSelection) ([]RunSelection, error) {
+	for index := range selections {
+		if len(selections[index].LaneKeys) > 0 {
+			continue
+		}
+		run, err := service.runs.GetScanRun(ctx, tenantID, selections[index].RunID)
+		if err != nil {
+			return nil, err
+		}
+		if run.EngagementID != assessmentID {
+			return nil, fmt.Errorf("%w: selected scan run %q belongs to another assessment", shared.ErrValidation, run.ID)
+		}
+		if len(run.Lanes) == 0 {
+			return nil, fmt.Errorf("%w: selected scan run %q has no provenance lanes", shared.ErrValidation, run.ID)
+		}
+		laneKeys := make([]string, len(run.Lanes))
+		for laneIndex, lane := range run.Lanes {
+			laneKeys[laneIndex] = lane.LaneKey
+		}
+		sort.Strings(laneKeys)
+		selections[index].LaneKeys = laneKeys
+	}
+	return selections, nil
+}
+
+func selectRunLanes(lanes []scanrun.Lane, selectedKeys []string) ([]scanrun.Lane, error) {
+	if len(lanes) == 0 {
+		return nil, fmt.Errorf("%w: selected run has no provenance lanes", shared.ErrValidation)
+	}
+	if len(selectedKeys) == 0 {
+		return append([]scanrun.Lane(nil), lanes...), nil
+	}
+	byKey := make(map[string]scanrun.Lane, len(lanes))
+	for _, lane := range lanes {
+		byKey[lane.LaneKey] = lane
+	}
+	selected := make([]scanrun.Lane, 0, len(selectedKeys))
+	for _, key := range selectedKeys {
+		lane, ok := byKey[key]
+		if !ok {
+			return nil, fmt.Errorf("%w: lane %q does not belong to the run", shared.ErrValidation, key)
+		}
+		selected = append(selected, lane)
+	}
+	return selected, nil
+}
+
+func idempotencyBodyMismatch() error {
+	return fmt.Errorf("%w: %w", shared.ErrConflict, ErrIdempotencyBodyMismatch)
+}
+
+func classifySnapshotError(err error) error {
+	if errors.Is(err, shared.ErrConflict) && strings.Contains(err.Error(), "request key was reused with different content") {
+		return idempotencyBodyMismatch()
+	}
+	return err
+}

--- a/internal/usecase/assessmentsnapshot/service_test.go
+++ b/internal/usecase/assessmentsnapshot/service_test.go
@@ -1,0 +1,315 @@
+package assessmentsnapshot_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	uc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type fixedClock struct{ now time.Time }
+
+func (clock fixedClock) Now() time.Time { return clock.now }
+
+type sequenceIDs struct{ next int }
+
+func (ids *sequenceIDs) NewID() shared.ID {
+	ids.next++
+	return shared.ID(fmt.Sprintf("snapshot-%d", ids.next))
+}
+
+type auditRecorder struct{ entries []ports.AuditEntry }
+
+func (audit *auditRecorder) Record(_ context.Context, entry ports.AuditEntry) error {
+	audit.entries = append(audit.entries, entry)
+	return nil
+}
+
+type failingAudit struct{ err error }
+
+func (audit failingAudit) Record(context.Context, ports.AuditEntry) error { return audit.err }
+
+func TestFinalizeReplayReplacementAndCAS(t *testing.T) {
+	harness := newHarness(t)
+	first, created, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"run-1"},
+		RequestKey: "request-1", ExpectedDefaultVersion: 0, Actor: "operator",
+	})
+	if err != nil || !created || first.SnapshotNumber != 1 || first.Lifecycle != assessmentsnapshot.LifecycleFinalized {
+		t.Fatalf("first finalize=%+v created=%v err=%v", first, created, err)
+	}
+	replay, created, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"run-1"},
+		RequestKey: "request-1", ExpectedDefaultVersion: 0, Actor: "operator",
+	})
+	if err != nil || created || replay.ID != first.ID {
+		t.Fatalf("replay=%+v created=%v err=%v", replay, created, err)
+	}
+
+	harness.saveRun(t, nativeRun(t, "run-2", "assessment", "0123456789abcdef0123456789abcdef01234568"))
+	second, created, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"run-2"},
+		RequestKey: "request-2", ExpectedDefaultVersion: 1, Actor: "operator",
+	})
+	if err != nil || !created || second.SnapshotNumber != 2 {
+		t.Fatalf("second finalize=%+v created=%v err=%v", second, created, err)
+	}
+	replayedOld, created, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"run-1"},
+		RequestKey: "request-1", ExpectedDefaultVersion: 0, Actor: "operator",
+	})
+	if err != nil || created || replayedOld.DefaultVersion != 2 {
+		t.Fatalf("old replay must return current default version: replay=%+v created=%v err=%v", replayedOld, created, err)
+	}
+	if _, _, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"run-1"},
+		RequestKey: "request-1", ExpectedDefaultVersion: 77, Actor: "operator",
+	}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("replay with mismatched precondition error=%v", err)
+	}
+	old, err := harness.snapshots.Get(context.Background(), "tenant", first.ID)
+	if err != nil || old.Lifecycle != assessmentsnapshot.LifecycleSuperseded {
+		t.Fatalf("old snapshot=%+v err=%v", old, err)
+	}
+	if _, _, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"run-1"},
+		RequestKey: "request-stale", ExpectedDefaultVersion: 1, Actor: "operator",
+	}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale CAS error=%v", err)
+	}
+	if len(harness.audit.entries) != 2 {
+		t.Fatalf("audit entries=%d, want 2", len(harness.audit.entries))
+	}
+	for _, entry := range harness.audit.entries {
+		for key, value := range entry.Metadata {
+			joined := key + "=" + value
+			if strings.Contains(joined, "request-") || strings.Contains(joined, "result:") || strings.Contains(joined, "evidence:") {
+				t.Fatalf("snapshot audit leaked request/evidence material: %s", joined)
+			}
+		}
+	}
+}
+
+func TestFinalizeRejectsLegacyRunAndRollsBackOnAuditFailure(t *testing.T) {
+	harness := newHarness(t)
+	legacy := scanrun.ScanRun{
+		TenantID: "tenant", ID: "legacy-run", EngagementID: "assessment", CreatedAt: harness.clock.now, UpdatedAt: harness.clock.now,
+		Provenance: scanrun.ProvenanceLegacy, TerminalStatus: scanrun.StatusUnknown, ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion,
+		LegacyFindingKeys: []string{"legacy-finding"},
+	}
+	harness.saveRun(t, legacy)
+	if _, _, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"legacy-run"},
+		RequestKey: "legacy-interactive", Actor: "operator",
+	}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("interactive legacy finalization error=%v", err)
+	}
+
+	auditErr := errors.New("audit unavailable")
+	failing := newHarnessWithAudit(t, failingAudit{err: auditErr})
+	if _, _, err := failing.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"run-1"},
+		RequestKey: "audit-failure", Actor: "operator",
+	}); !errors.Is(err, auditErr) {
+		t.Fatalf("audit failure=%v", err)
+	}
+	if _, err := failing.snapshots.GetByRequestKey(context.Background(), "tenant", "assessment", "audit-failure"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("snapshot survived failed audit: %v", err)
+	}
+}
+
+func TestSnapshotHistoryUsesBoundedCursorPages(t *testing.T) {
+	harness := newHarness(t)
+	for index, runID := range []string{"run-2", "run-3", "run-4"} {
+		harness.saveRun(t, nativeRun(t, runID, "assessment", fmt.Sprintf("%040d", index+1)))
+		if _, created, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+			TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{runID},
+			RequestKey: "page-" + runID, ExpectedDefaultVersion: int64(index), Actor: "operator",
+		}); err != nil || !created {
+			t.Fatalf("finalize %s created=%v err=%v", runID, created, err)
+		}
+	}
+	first, err := harness.service.ListByAssessment(context.Background(), "tenant", "assessment", "", 1)
+	if err != nil || len(first.Items) != 1 || first.NextCursor == "" || first.Items[0].SnapshotNumber != 1 {
+		t.Fatalf("first page=%+v err=%v", first, err)
+	}
+	second, err := harness.service.ListByAssessment(context.Background(), "tenant", "assessment", first.NextCursor, 1)
+	if err != nil || len(second.Items) != 1 || second.NextCursor == "" || second.Items[0].SnapshotNumber != 2 {
+		t.Fatalf("second page=%+v err=%v", second, err)
+	}
+	if _, err := harness.service.ListByAssessment(context.Background(), "tenant", "assessment", "not-base64!", 1); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("invalid cursor=%v", err)
+	}
+}
+
+func TestFinalizeRejectsTerminalAssessmentAndBuildingRun(t *testing.T) {
+	harness := newHarness(t)
+	assessment, err := harness.engagements.GetByIDInTenant(context.Background(), "tenant", "assessment")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := assessment.Transition(engagement.StatusCompleted, harness.clock.now); err != nil {
+		t.Fatal(err)
+	}
+	if err := harness.engagements.Update(context.Background(), assessment); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"run-1"},
+		RequestKey: "completed", Actor: "operator",
+	}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("completed assessment error=%v", err)
+	}
+
+	other := newHarness(t)
+	building := scanrun.ScanRun{TenantID: "tenant", ID: "building", EngagementID: "assessment", CreatedAt: other.clock.now, UpdatedAt: other.clock.now, Provenance: scanrun.ProvenanceNative, TerminalStatus: scanrun.StatusBuilding, ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion}
+	if err := other.runs.SaveScanRun(context.Background(), building); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := other.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", CycleID: "cycle", AssessmentID: "assessment", SelectedRunIDs: []string{"building"},
+		RequestKey: "building", Actor: "operator",
+	}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("building run error=%v", err)
+	}
+}
+
+func TestFinalizeDerivesCycleAndScopesIdempotencyToSelectedLanes(t *testing.T) {
+	harness := newHarness(t)
+	finalized, created, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", AssessmentID: "assessment",
+		SelectedRuns: []uc.RunSelection{{RunID: "run-1", LaneKeys: []string{"sca"}}},
+		RequestKey:   "derived-cycle", ExpectedDefaultVersion: 0, Actor: "operator",
+	})
+	if err != nil || !created || finalized.CycleID != "cycle" || len(finalized.RunReferences) != 1 || len(finalized.RunReferences[0].LaneReferences) != 1 {
+		t.Fatalf("derived cycle finalize=%+v created=%v err=%v", finalized, created, err)
+	}
+	if _, _, err := harness.service.Finalize(context.Background(), uc.FinalizeInput{
+		TenantID: "tenant", AssessmentID: "assessment",
+		SelectedRuns: []uc.RunSelection{{RunID: "run-1", LaneKeys: []string{"other"}}},
+		RequestKey:   "derived-cycle", ExpectedDefaultVersion: 0, Actor: "operator",
+	}); !errors.Is(err, uc.ErrIdempotencyBodyMismatch) || !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("selected-lane idempotency mismatch=%v", err)
+	}
+}
+
+type harness struct {
+	service     *uc.Service
+	snapshots   *memory.AssessmentSnapshotRepository
+	engagements *memory.EngagementRepository
+	runs        *memory.ScanRunStore
+	audit       *auditRecorder
+	clock       fixedClock
+}
+
+func newHarness(t *testing.T) *harness {
+	audit := &auditRecorder{}
+	return newHarnessWithAudit(t, audit)
+}
+
+func newHarnessWithAudit(t *testing.T, audit ports.AuditLogger) *harness {
+	t.Helper()
+	clock := fixedClock{now: time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)}
+	engagements := memory.NewEngagementRepository()
+	assessment, err := engagement.New("assessment", "tenant", "Assessment", "", clock.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := assessment.Transition(engagement.StatusActive, clock.now); err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(context.Background(), assessment); err != nil {
+		t.Fatal(err)
+	}
+	cycles := memory.NewAssessmentCycleRepository()
+	cycle, err := assessmentcycle.NewAssessmentCycle("cycle", "tenant", "Cycle", assessmentcycle.BoundaryStandalone, "", "", "assessment", "operator", clock.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember("tenant", "cycle", "assessment", "operator", clock.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateCycle(context.Background(), cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(context.Background(), member); err != nil {
+		t.Fatal(err)
+	}
+	runs := memory.NewScanRunStore()
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	service, err := uc.NewService(snapshots, cycles, engagements, runs, memory.NewTenantTransactionRunner(), &sequenceIDs{}, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recorder, _ := audit.(*auditRecorder)
+	h := &harness{service: service, snapshots: snapshots, engagements: engagements, runs: runs, audit: recorder, clock: clock}
+	h.saveRun(t, nativeRun(t, "run-1", "assessment", "0123456789abcdef0123456789abcdef01234567"))
+	return h
+}
+
+func (h *harness) saveRun(t *testing.T, run scanrun.ScanRun) {
+	t.Helper()
+	building := run
+	building.Lanes, building.ManifestHash, building.SealedAt = nil, "", nil
+	if run.Provenance == scanrun.ProvenanceNative {
+		building.TerminalStatus = scanrun.StatusBuilding
+	}
+	if err := h.runs.SaveScanRun(context.Background(), building); err != nil {
+		t.Fatal(err)
+	}
+	if run.SealedAt != nil {
+		if err := h.runs.SealScanRun(context.Background(), ports.SealScanRunCommand{
+			TenantID: run.TenantID, RunID: run.ID, TerminalStatus: run.TerminalStatus,
+			Lanes: run.Lanes, ManifestSchemaVersion: run.ManifestSchemaVersion, ManifestHash: run.ManifestHash, SealedAt: *run.SealedAt,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func nativeRun(t *testing.T, id, assessmentID, revision string) scanrun.ScanRun {
+	t.Helper()
+	started := time.Date(2026, 8, 31, 11, 0, 0, 0, time.UTC)
+	finished := started.Add(time.Minute)
+	target, err := scanrun.CanonicalizeRepositoryTarget("https://example.com/repo.git", revision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := scanrun.ScanRun{
+		TenantID: "tenant", ID: id, EngagementID: shared.ID(assessmentID), CreatedAt: started, UpdatedAt: started,
+		Provenance: scanrun.ProvenanceNative, TerminalStatus: scanrun.StatusBuilding,
+		ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion,
+		Lanes: []scanrun.Lane{{
+			TenantID: "tenant", EngagementID: shared.ID(assessmentID), ScanRunID: id,
+			LaneKey: "sca", Producer: "sca", TerminalStatus: scanrun.StatusSucceeded, Target: target,
+			AuthoritativeFindingKinds: []string{"vulnerability"}, IncludedScope: []string{"src/**"}, ExcludedScope: []string{"vendor/**"},
+			StartedAt: started, FinishedAt: &finished, ResultRef: "result:" + id, EvidenceRef: "evidence:" + id,
+			ResultSHA256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ManifestSchemaVersion: 1,
+			Versions: []scanrun.LaneVersion{{VersionKind: scanrun.VersionScanner, Name: "sca", Version: "1"}, {VersionKind: scanrun.VersionRulePack, Name: "rules", Version: "1"}},
+			Stages:   []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSucceeded, StartedAt: started, FinishedAt: &finished}},
+		}},
+	}
+	run.Lanes[0].SealedAt = &finished
+	run.Lanes[0].ManifestHash, err = scanrun.ComputeManifestHash(run.Lanes[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.ManifestHash, err = scanrun.ComputeRunManifestHash(run.Lanes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.TerminalStatus, run.SealedAt, run.UpdatedAt = scanrun.StatusSucceeded, &finished, finished
+	return run
+}

--- a/internal/usecase/egressgrant/service_test.go
+++ b/internal/usecase/egressgrant/service_test.go
@@ -234,6 +234,9 @@ func TestAuthorizeFailsClosedBeforeSigning(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			f := newFixture(t)
 			test.mutate(t, f)
+			if err := f.engagements.Update(f.ctx, f.engagement); err != nil {
+				t.Fatal(err)
+			}
 			if _, err := f.service.Authorize(f.ctx, f.request); err == nil {
 				t.Fatal("expected authorization failure")
 			}


### PR DESCRIPTION
Finalize tenant-owned assessment snapshots with stable default pointers and history. Add snapshot backfill, paginated engagement readers and transaction rollback support.

Phase 3/10. Base: `codex/868-phase-03-lifecycle-contracts-schema`. Keep #868 as tracking/reference only; do not merge it.

## Review follow-up: migration 0145 collision

Addressed the new review on #884 and the dependent holds on #885–#893. Main `9a7bae2d` includes #921's `0145_advisory_alias_index.sql`; the entire unmerged assessment block moves from 0145–0159 to **0146–0160**. #884 adds only 0146; #885 adds 0147–0160. All 15 assessment SQL bodies and their relative order are preserved. Existing main migrations (including 0145), core ScanRun and governed response/correlation code remain unchanged.

Updated migration test filenames and embedded-file references, Goose UpTo/DownTo targets, upgrade fixtures from main version 0145, diagnostics, and operational documentation. The complete payload is preserved through an explicit old/new filename map; runtime assessment code is unchanged by renumbering. Each PR still contains one capability commit against its immediate predecessor.

## Validation

Local validation after this update: all 10 phases passed scoped tests and repository-wide Go builds; the final stack passed repository-wide Go tests and vet. Isolated PostgreSQL 17 tests passed for duplicate migration inventory, authoritative main migrations, assessment upgrade/rollback paths, tenant isolation, immutable evidence and source bindings. Frontend typecheck, 116 test files / 694 tests, production build and lint passed (0 errors, 10 existing warnings); Helm lint/render assertions passed. CI is disabled, so these are explicitly local results. Final GitHub heads, bases and incremental file diffs are checked against the tested commits.

## Stack merge order

#884 → #885 → #886 → #887 → #888 → #889 → #890 → #891 → #892 → #893

Merge #884 first, then proceed in order. Prefer merge commits to retain ancestry; after each predecessor merges, retarget the next PR to `main` and inspect its remaining diff. Branch names remain stable. See the [preservation and migration audit](https://github.com/KKloudTarus/synapse-ce/blob/codex/868-phase-11-operations-docs/docs/architecture/assessment-stack-868-audit.md).
