### PR TITLE
feat(assessment): [4/10] preserve finding lineage and native evidence

### DIFF
--- a/cmd/synapse-finding-lineage-backfill/main.go
+++ b/cmd/synapse-finding-lineage-backfill/main.go
@@ -1,0 +1,168 @@
+// Command synapse-finding-lineage-backfill projects legacy Findings into versioned Identities and immutable Observations.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/postgres"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/config"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/logging"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
+)
+
+type lineageBackfillOptions struct {
+	tenants       []shared.ID
+	producers     []string
+	actor         string
+	dryRun        bool
+	batchSize     int
+	resumeAfter   shared.ID
+	timeout       time.Duration
+	leaseDuration time.Duration
+}
+
+func main() {
+	if err := run(os.Args[1:], os.Stderr); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, output io.Writer) error {
+	options, err := parseLineageBackfillOptions(args, output)
+	if err != nil {
+		return err
+	}
+	cfg := config.Load()
+	log := logging.New(cfg.LogLevel)
+	if cfg.DBDSN == "" {
+		return errors.New("synapse-finding-lineage-backfill requires SYNAPSE_DB_DSN")
+	}
+	signalCtx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	ctx, cancel := context.WithTimeout(signalCtx, options.timeout)
+	defer cancel()
+	pool, err := postgres.Connect(ctx, cfg.DBDSN)
+	if err != nil {
+		return err
+	}
+	defer pool.Close()
+	if err := postgres.CheckRLSRuntimeRole(ctx, pool); err != nil {
+		return err
+	}
+
+	clock, ids := idgen.SystemClock{}, idgen.RandomID{}
+	audit := postgres.NewAuditLog(pool)
+	lineage, err := lineageuc.NewService(postgres.NewFindingLineageRepository(pool), postgres.NewTenantTransactionRunner(pool), audit, clock, ids, nil)
+	if err != nil {
+		return err
+	}
+	backfillRepository := postgres.NewFindingLineageBackfillRepository(pool)
+	runner, err := lineageuc.NewFindingLineageBackfillRunner(
+		lineage, backfillRepository, backfillRepository, postgres.NewAssessmentSnapshotRepository(pool),
+		postgres.NewVulnerabilityOccurrenceStore(pool), postgres.NewJudgmentRepository(pool), ids, clock, audit, nil,
+	)
+	if err != nil {
+		return err
+	}
+	hostname, _ := os.Hostname()
+	if len(hostname) > 160 {
+		hostname = hostname[:160]
+	}
+	ctx, cancelRuns := context.WithCancel(ctx)
+	defer cancelRuns()
+	errorsCh := make(chan error, len(options.tenants))
+	var wait sync.WaitGroup
+	for index, tenantID := range options.tenants {
+		wait.Add(1)
+		go func(index int, tenantID shared.ID) {
+			defer wait.Done()
+			leaseOwner := strings.Join([]string{hostname, strconv.Itoa(os.Getpid()), strconv.Itoa(index)}, "-")
+			log.Info("finding lineage backfill started", "tenant_id", tenantID, "dry_run", options.dryRun, "batch_size", options.batchSize)
+			run, err := runner.RunBackfill(ctx, lineageuc.FindingLineageBackfillRequest{
+				TenantID: tenantID, Actor: options.actor, LeaseOwner: leaseOwner, DryRun: options.dryRun,
+				BatchSize: options.batchSize, ProducerFilter: options.producers, ResumeAfter: options.resumeAfter, LeaseDuration: options.leaseDuration,
+			})
+			if err != nil {
+				errorsCh <- fmt.Errorf("tenant %s: %w", tenantID, err)
+				cancelRuns()
+				return
+			}
+			log.Info("finding lineage backfill completed", "tenant_id", tenantID, "run_id", run.ID, "processed", run.ProcessedCount,
+				"observation_created", run.ObservationCreatedCount, "provisional_candidate_created", run.ProvisionalCandidateCount, "skipped", run.SkippedCount, "checkpoint", run.CheckpointFinding)
+		}(index, tenantID)
+	}
+	wait.Wait()
+	close(errorsCh)
+	var combined error
+	for err := range errorsCh {
+		combined = errors.Join(combined, err)
+	}
+	return combined
+}
+
+func parseLineageBackfillOptions(args []string, output io.Writer) (lineageBackfillOptions, error) {
+	flags := flag.NewFlagSet("synapse-finding-lineage-backfill", flag.ContinueOnError)
+	flags.SetOutput(output)
+	tenantsValue := flags.String("tenants", "", "comma-separated tenant IDs; maximum four")
+	producersValue := flags.String("producers", "", "optional comma-separated producer filters")
+	actor := flags.String("actor", "finding-lineage-backfill", "audit actor")
+	dryRun := flags.Bool("dry-run", false, "plan outcomes without writing lineage objects")
+	batchSize := flags.Int("batch-size", lineageuc.DefaultFindingLineageBackfillBatch, "source Findings per committed batch")
+	resumeAfter := flags.String("resume-after", "", "initial Finding ID checkpoint; single tenant only")
+	timeout := flags.Duration("timeout", 30*time.Minute, "overall command timeout")
+	leaseDuration := flags.Duration("lease-duration", 10*time.Minute, "per-tenant job lease")
+	if err := flags.Parse(args); err != nil {
+		return lineageBackfillOptions{}, err
+	}
+	if flags.NArg() != 0 {
+		return lineageBackfillOptions{}, fmt.Errorf("unexpected arguments: %s", strings.Join(flags.Args(), " "))
+	}
+	seen := map[shared.ID]bool{}
+	tenants := make([]shared.ID, 0, 4)
+	for _, value := range strings.Split(*tenantsValue, ",") {
+		tenantID := shared.ID(strings.TrimSpace(value))
+		if tenantID.IsZero() || seen[tenantID] {
+			continue
+		}
+		seen[tenantID] = true
+		tenants = append(tenants, tenantID)
+	}
+	if len(tenants) == 0 || len(tenants) > 4 {
+		return lineageBackfillOptions{}, errors.New("--tenants requires between one and four unique tenant IDs")
+	}
+	if *batchSize < 1 || *batchSize > lineageuc.MaxFindingLineageBackfillBatch {
+		return lineageBackfillOptions{}, fmt.Errorf("--batch-size must be between 1 and %d", lineageuc.MaxFindingLineageBackfillBatch)
+	}
+	if strings.TrimSpace(*actor) == "" || len(strings.TrimSpace(*actor)) > 256 {
+		return lineageBackfillOptions{}, errors.New("--actor must contain between 1 and 256 characters")
+	}
+	if *timeout <= 0 || *leaseDuration <= 0 {
+		return lineageBackfillOptions{}, errors.New("--timeout and --lease-duration must be positive")
+	}
+	if strings.TrimSpace(*resumeAfter) != "" && len(tenants) != 1 {
+		return lineageBackfillOptions{}, errors.New("--resume-after requires exactly one tenant")
+	}
+	producerValues := strings.Split(*producersValue, ",")
+	producers, err := lineageuc.NormalizeFindingLineageProducerFilters(producerValues)
+	if err != nil {
+		return lineageBackfillOptions{}, err
+	}
+	return lineageBackfillOptions{
+		tenants: tenants, producers: producers, actor: strings.TrimSpace(*actor), dryRun: *dryRun, batchSize: *batchSize,
+		resumeAfter: shared.ID(strings.TrimSpace(*resumeAfter)), timeout: *timeout, leaseDuration: *leaseDuration,
+	}, nil
+}

--- a/cmd/synapse-finding-lineage-backfill/main_test.go
+++ b/cmd/synapse-finding-lineage-backfill/main_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/postgres"
+)
+
+func TestParseLineageBackfillOptions(t *testing.T) {
+	options, err := parseLineageBackfillOptions([]string{"--tenants", "tenant-a,tenant-b", "--producers", "sca,iac,offensive", "--dry-run", "--batch-size", "2000"}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(options.tenants) != 2 || len(options.producers) != 4 || !options.dryRun || options.batchSize != 2000 {
+		t.Fatalf("unexpected options: %+v", options)
+	}
+}
+
+func TestParseLineageBackfillOptionsRejectsUnsafeLimits(t *testing.T) {
+	for _, args := range [][]string{
+		{"--tenants", ""},
+		{"--tenants", "a,b,c,d,e"},
+		{"--tenants", "a", "--batch-size", "2001"},
+		{"--tenants", "a,b", "--resume-after", "finding"},
+		{"--tenants", "a", "--producers", "unknown"},
+	} {
+		if _, err := parseLineageBackfillOptions(args, &bytes.Buffer{}); err == nil {
+			t.Fatalf("expected rejection for %v", args)
+		}
+	}
+}
+
+func TestRunRejectsRLSBypassingRole(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_TEST_DB_DSN")
+	if dsn == "" {
+		t.Skip("set SYNAPSE_TEST_DB_DSN for the PostgreSQL startup guard test")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	pool, err := postgres.Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	guardErr := postgres.CheckRLSRuntimeRole(ctx, pool)
+	pool.Close()
+	if guardErr == nil {
+		t.Skip("test requires a privileged database fixture role")
+	}
+	if !strings.Contains(guardErr.Error(), "cannot enforce isolation") {
+		t.Fatal(guardErr)
+	}
+	t.Setenv("SYNAPSE_DB_DSN", dsn)
+	err = run([]string{"--tenants", "assessment-cycle-role-guard-test", "--dry-run", "--timeout", "10s"}, io.Discard)
+	if err == nil || !strings.Contains(err.Error(), "cannot enforce isolation") {
+		t.Fatalf("expected startup rejection before backfill writes, got %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/memory/assessment_evidence_tx.go
+++ b/internal/infrastructure/persistence/memory/assessment_evidence_tx.go
@@ -1,0 +1,30 @@
+package memory
+
+import (
+	"context"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func (repository *FindingLineageRepository) registerRollback(ctx context.Context) {
+	registerTenantCheckpoint(ctx, repository, func(tenantID shared.ID) func() {
+		identities := captureTenantEntries(repository.identities, func(k lineageKey, _ findinglineage.Identity) bool { return k.tenantID == tenantID })
+		observations := captureTenantEntries(repository.observations, func(k lineageKey, _ findinglineage.Observation) bool { return k.tenantID == tenantID })
+		aliases := captureTenantEntries(repository.aliases, func(k lineageKey, _ findinglineage.Alias) bool { return k.tenantID == tenantID })
+		candidates := captureTenantEntries(repository.candidates, func(k lineageKey, _ findinglineage.MatchCandidate) bool { return k.tenantID == tenantID })
+		resolutions := captureTenantEntries(repository.resolutions, func(k lineageKey, _ findinglineage.ResolutionEvent) bool { return k.tenantID == tenantID })
+		overrides := captureTenantEntries(repository.overrides, func(k lineageKey, _ findinglineage.OverrideEvent) bool { return k.tenantID == tenantID })
+		skips := captureTenantEntries(repository.skips, func(k lineageKey, _ findinglineage.SkipRecord) bool { return k.tenantID == tenantID })
+		return func() {
+			repository.mu.Lock()
+			defer repository.mu.Unlock()
+			identities()
+			observations()
+			aliases()
+			candidates()
+			resolutions()
+			overrides()
+			skips()
+		}
+	})
+}

--- a/internal/infrastructure/persistence/memory/finding_lineage_backfill_repo.go
+++ b/internal/infrastructure/persistence/memory/finding_lineage_backfill_repo.go
@@ -1,0 +1,304 @@
+package memory
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type FindingLineageBackfillRepository struct {
+	mu      sync.Mutex
+	runs    map[shared.ID]map[shared.ID]ports.FindingLineageBackfillRun
+	items   map[shared.ID]map[shared.ID]map[shared.ID]ports.FindingLineageBackfillItem
+	sources map[shared.ID][]ports.FindingLineageBackfillSourceRow
+}
+
+func NewFindingLineageBackfillRepository() *FindingLineageBackfillRepository {
+	return &FindingLineageBackfillRepository{
+		runs:    map[shared.ID]map[shared.ID]ports.FindingLineageBackfillRun{},
+		items:   map[shared.ID]map[shared.ID]map[shared.ID]ports.FindingLineageBackfillItem{},
+		sources: map[shared.ID][]ports.FindingLineageBackfillSourceRow{},
+	}
+}
+
+var _ ports.FindingLineageBackfillSource = (*FindingLineageBackfillRepository)(nil)
+var _ ports.FindingLineageBackfillStore = (*FindingLineageBackfillRepository)(nil)
+
+func (repository *FindingLineageBackfillRepository) SetSources(tenantID shared.ID, sources []ports.FindingLineageBackfillSourceRow) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.sources[tenantID] = append([]ports.FindingLineageBackfillSourceRow(nil), sources...)
+	sort.Slice(repository.sources[tenantID], func(left, right int) bool {
+		return findingLineageSourceLess(repository.sources[tenantID][left], repository.sources[tenantID][right])
+	})
+}
+
+func (repository *FindingLineageBackfillRepository) ListFindingLineageBackfillSources(ctx context.Context, tenantID, after shared.ID, snapshotAt time.Time, producerFilters []string, limit int) ([]ports.FindingLineageBackfillSourceRow, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if limit < 1 || limit > 2000 || snapshotAt.IsZero() {
+		return nil, fmt.Errorf("%w: finding lineage backfill source query is invalid", shared.ErrValidation)
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	allowed := map[string]struct{}{}
+	for _, producer := range producerFilters {
+		allowed[producer] = struct{}{}
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	var checkpoint *ports.FindingLineageBackfillSourceRow
+	if !after.IsZero() {
+		for index := range repository.sources[tenantID] {
+			if repository.sources[tenantID][index].FindingID == after {
+				checkpoint = &repository.sources[tenantID][index]
+				break
+			}
+		}
+		if checkpoint == nil {
+			return nil, shared.ErrNotFound
+		}
+	}
+	out := make([]ports.FindingLineageBackfillSourceRow, 0, limit)
+	for _, source := range repository.sources[tenantID] {
+		if checkpoint != nil && !findingLineageSourceLess(*checkpoint, source) || source.CreatedAt.After(snapshotAt) || source.ObservedAt.After(snapshotAt) {
+			continue
+		}
+		if len(allowed) > 0 {
+			kind := string(source.Kind)
+			if kind == "" {
+				kind = "sca"
+			}
+			if _, ok := allowed[kind]; !ok {
+				continue
+			}
+		}
+		out = append(out, source)
+		if len(out) == limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func findingLineageSourceLess(left, right ports.FindingLineageBackfillSourceRow) bool {
+	leftAt, rightAt := left.CreatedAt, right.CreatedAt
+	if leftAt.IsZero() {
+		leftAt = left.ObservedAt
+	}
+	if rightAt.IsZero() {
+		rightAt = right.ObservedAt
+	}
+	if !leftAt.Equal(rightAt) {
+		return leftAt.Before(rightAt)
+	}
+	return left.FindingID < right.FindingID
+}
+
+func (repository *FindingLineageBackfillRepository) AcquireFindingLineageBackfillRun(_ context.Context, request ports.FindingLineageBackfillAcquireRequest) (ports.FindingLineageBackfillRun, bool, error) {
+	if err := validateFindingLineageBackfillAcquire(request); err != nil {
+		return ports.FindingLineageBackfillRun{}, false, err
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantRuns := repository.runs[request.Run.TenantID]
+	if tenantRuns == nil {
+		tenantRuns = map[shared.ID]ports.FindingLineageBackfillRun{}
+		repository.runs[request.Run.TenantID] = tenantRuns
+	}
+	for id, run := range tenantRuns {
+		if run.State != ports.FindingLineageBackfillRunning {
+			continue
+		}
+		if run.LeaseOwner != request.Run.LeaseOwner && run.LeaseExpiresAt.After(request.Run.CreatedAt) {
+			return ports.FindingLineageBackfillRun{}, false, fmt.Errorf("%w: finding lineage backfill already running for tenant", shared.ErrConflict)
+		}
+		if run.SchemaVersion != request.Run.SchemaVersion || run.DryRun != request.Run.DryRun || run.BatchSize != request.Run.BatchSize || strings.Join(run.ProducerFilters, "\x00") != strings.Join(request.Run.ProducerFilters, "\x00") {
+			return ports.FindingLineageBackfillRun{}, false, fmt.Errorf("%w: resumed finding lineage backfill options changed", shared.ErrConflict)
+		}
+		run.LeaseOwner, run.LeaseToken, run.LeaseExpiresAt, run.UpdatedAt = request.Run.LeaseOwner, request.Run.LeaseToken, request.Run.CreatedAt.Add(request.LeaseDuration), request.Run.CreatedAt
+		tenantRuns[id] = run
+		return cloneFindingLineageBackfillRun(run), true, nil
+	}
+	run := request.Run
+	run.CheckpointFinding = request.InitialCheckpoint
+	run.LeaseExpiresAt = run.CreatedAt.Add(request.LeaseDuration)
+	tenantRuns[run.ID] = run
+	return cloneFindingLineageBackfillRun(run), false, nil
+}
+
+func (repository *FindingLineageBackfillRepository) GetFindingLineageBackfillRun(_ context.Context, tenantID, runID shared.ID) (ports.FindingLineageBackfillRun, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	run, ok := repository.runs[shared.TenantOrDefault(tenantID)][runID]
+	if !ok {
+		return ports.FindingLineageBackfillRun{}, shared.ErrNotFound
+	}
+	return cloneFindingLineageBackfillRun(run), nil
+}
+
+func (repository *FindingLineageBackfillRepository) GetFindingLineageBackfillItem(_ context.Context, tenantID, runID, sourceFindingID shared.ID) (ports.FindingLineageBackfillItem, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	item, ok := repository.items[shared.TenantOrDefault(tenantID)][runID][sourceFindingID]
+	if !ok {
+		return ports.FindingLineageBackfillItem{}, shared.ErrNotFound
+	}
+	return item, nil
+}
+
+func (repository *FindingLineageBackfillRepository) CommitFindingLineageBackfillItem(ctx context.Context, tenantID, runID, leaseToken shared.ID, now time.Time, build func(context.Context) (ports.FindingLineageBackfillItem, error)) (ports.FindingLineageBackfillItem, bool, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID, now = shared.TenantOrDefault(tenantID), now.UTC()
+	run, ok := repository.runs[tenantID][runID]
+	if !ok {
+		return ports.FindingLineageBackfillItem{}, false, shared.ErrNotFound
+	}
+	if run.State != ports.FindingLineageBackfillRunning || run.LeaseToken != leaseToken || !run.LeaseExpiresAt.After(now) {
+		return ports.FindingLineageBackfillItem{}, false, fmt.Errorf("%w: finding lineage backfill lease is stale", shared.ErrConflict)
+	}
+	item, err := build(shared.WithTenant(ctx, tenantID))
+	if err != nil {
+		return ports.FindingLineageBackfillItem{}, false, err
+	}
+	if item.TenantID != tenantID || item.RunID != runID {
+		return ports.FindingLineageBackfillItem{}, false, fmt.Errorf("%w: finding lineage backfill item ownership differs from lease", shared.ErrValidation)
+	}
+	if err := validateFindingLineageBackfillItem(item); err != nil {
+		return ports.FindingLineageBackfillItem{}, false, err
+	}
+	tenantItems := repository.items[item.TenantID]
+	if tenantItems == nil {
+		tenantItems = map[shared.ID]map[shared.ID]ports.FindingLineageBackfillItem{}
+		repository.items[item.TenantID] = tenantItems
+	}
+	runItems := tenantItems[item.RunID]
+	if runItems == nil {
+		runItems = map[shared.ID]ports.FindingLineageBackfillItem{}
+		tenantItems[item.RunID] = runItems
+	}
+	if _, exists := runItems[item.SourceFindingID]; exists {
+		return item, false, nil
+	}
+	runItems[item.SourceFindingID] = item
+	return item, true, nil
+}
+
+func (repository *FindingLineageBackfillRepository) AdvanceFindingLineageBackfillRun(_ context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken, checkpoint shared.ID, now time.Time, leaseDuration time.Duration) (ports.FindingLineageBackfillRun, error) {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	run, ok := repository.runs[tenantID][runID]
+	if !ok {
+		return ports.FindingLineageBackfillRun{}, shared.ErrNotFound
+	}
+	monotonic := run.CheckpointFinding.IsZero() || repository.findingLineageCheckpointMonotonic(tenantID, run.CheckpointFinding, checkpoint)
+	if run.State != ports.FindingLineageBackfillRunning || run.LeaseOwner != strings.TrimSpace(leaseOwner) || run.LeaseToken != leaseToken || !run.LeaseExpiresAt.After(now.UTC()) || !monotonic || leaseDuration <= 0 {
+		return ports.FindingLineageBackfillRun{}, fmt.Errorf("%w: finding lineage backfill checkpoint rejected", shared.ErrConflict)
+	}
+	run.CheckpointFinding, run.UpdatedAt, run.LeaseExpiresAt = checkpoint, now.UTC(), now.UTC().Add(leaseDuration)
+	recomputeFindingLineageBackfillCounts(&run, repository.items[tenantID][runID])
+	repository.runs[tenantID][runID] = run
+	return cloneFindingLineageBackfillRun(run), nil
+}
+
+func (repository *FindingLineageBackfillRepository) findingLineageCheckpointMonotonic(tenantID, previousID, nextID shared.ID) bool {
+	var previous, next *ports.FindingLineageBackfillSourceRow
+	for index := range repository.sources[tenantID] {
+		item := &repository.sources[tenantID][index]
+		if item.FindingID == previousID {
+			previous = item
+		}
+		if item.FindingID == nextID {
+			next = item
+		}
+	}
+	return previous != nil && next != nil && (previous.FindingID == next.FindingID || findingLineageSourceLess(*previous, *next))
+}
+
+func (repository *FindingLineageBackfillRepository) FinishFindingLineageBackfillRun(_ context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken shared.ID, state ports.FindingLineageBackfillState, now time.Time) (ports.FindingLineageBackfillRun, error) {
+	if state != ports.FindingLineageBackfillCompleted && state != ports.FindingLineageBackfillCancelled && state != ports.FindingLineageBackfillFailed {
+		return ports.FindingLineageBackfillRun{}, fmt.Errorf("%w: invalid finding lineage backfill terminal state", shared.ErrValidation)
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	tenantID = shared.TenantOrDefault(tenantID)
+	run, ok := repository.runs[tenantID][runID]
+	if !ok {
+		return ports.FindingLineageBackfillRun{}, shared.ErrNotFound
+	}
+	if run.State != ports.FindingLineageBackfillRunning || run.LeaseOwner != strings.TrimSpace(leaseOwner) || run.LeaseToken != leaseToken || !run.LeaseExpiresAt.After(now.UTC()) {
+		return ports.FindingLineageBackfillRun{}, fmt.Errorf("%w: finding lineage backfill completion rejected", shared.ErrConflict)
+	}
+	completedAt := now.UTC()
+	run.State, run.UpdatedAt, run.CompletedAt = state, completedAt, &completedAt
+	run.LeaseOwner, run.LeaseToken, run.LeaseExpiresAt = "", "", time.Time{}
+	recomputeFindingLineageBackfillCounts(&run, repository.items[tenantID][runID])
+	repository.runs[tenantID][runID] = run
+	return cloneFindingLineageBackfillRun(run), nil
+}
+
+func validateFindingLineageBackfillAcquire(request ports.FindingLineageBackfillAcquireRequest) error {
+	run := request.Run
+	if run.TenantID.IsZero() || run.ID.IsZero() || run.LeaseToken.IsZero() || run.SchemaVersion <= 0 || run.BatchSize < 1 || run.BatchSize > 2000 || run.SnapshotAt.IsZero() || run.State != ports.FindingLineageBackfillRunning || strings.TrimSpace(run.LeaseOwner) == "" || len(run.LeaseOwner) > 256 || run.LeaseExpiresAt.IsZero() || strings.TrimSpace(run.CreatedBy) == "" || len(run.CreatedBy) > 256 || run.CreatedAt.IsZero() || request.LeaseDuration <= 0 {
+		return fmt.Errorf("%w: finding lineage backfill run is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validateFindingLineageBackfillItem(item ports.FindingLineageBackfillItem) error {
+	validOutcome := item.Outcome == "observation_created" || item.Outcome == "provisional_candidate_created" || item.Outcome == "skipped"
+	_, hashErr := hex.DecodeString(item.SourceHash)
+	if item.TenantID.IsZero() || item.RunID.IsZero() || item.AssessmentID.IsZero() || item.SourceFindingID.IsZero() || item.SchemaVersion <= 0 || item.MatcherVersion <= 0 || strings.TrimSpace(item.IdempotencyKey) == "" || len(item.IdempotencyKey) > 128 || len(item.SourceHash) != 64 || strings.ToLower(item.SourceHash) != item.SourceHash || hashErr != nil || !validOutcome || !validBackfillReasonCode(item.ReasonCode) || item.ProcessedAt.IsZero() {
+		return fmt.Errorf("%w: finding lineage backfill item is invalid", shared.ErrValidation)
+	}
+	if item.Outcome != "skipped" && (item.CycleID.IsZero() || item.SnapshotID.IsZero()) {
+		return fmt.Errorf("%w: created lineage backfill outcome requires Cycle and Snapshot", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validBackfillReasonCode(value string) bool {
+	if len(value) < 1 || len(value) > 64 {
+		return false
+	}
+	for _, char := range value {
+		if char != '_' && (char < 'a' || char > 'z') && (char < '0' || char > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func recomputeFindingLineageBackfillCounts(run *ports.FindingLineageBackfillRun, items map[shared.ID]ports.FindingLineageBackfillItem) {
+	run.ProcessedCount, run.ObservationCreatedCount, run.ProvisionalCandidateCount, run.SkippedCount = 0, 0, 0, 0
+	for _, item := range items {
+		run.ProcessedCount++
+		switch item.Outcome {
+		case "observation_created":
+			run.ObservationCreatedCount++
+		case "provisional_candidate_created":
+			run.ProvisionalCandidateCount++
+		case "skipped":
+			run.SkippedCount++
+		}
+	}
+}
+
+func cloneFindingLineageBackfillRun(run ports.FindingLineageBackfillRun) ports.FindingLineageBackfillRun {
+	run.ProducerFilters = append([]string(nil), run.ProducerFilters...)
+	if run.CompletedAt != nil {
+		completedAt := *run.CompletedAt
+		run.CompletedAt = &completedAt
+	}
+	return run
+}

--- a/internal/infrastructure/persistence/memory/finding_lineage_backfill_repo_test.go
+++ b/internal/infrastructure/persistence/memory/finding_lineage_backfill_repo_test.go
@@ -1,0 +1,27 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestFindingLineageBackfillSourcesUseChronologyThenID(t *testing.T) {
+	repository := NewFindingLineageBackfillRepository()
+	now := time.Date(2026, 9, 7, 0, 0, 0, 0, time.UTC)
+	repository.SetSources("tenant", []ports.FindingLineageBackfillSourceRow{
+		{TenantID: "tenant", FindingID: "a-newer", CreatedAt: now.Add(time.Minute), ObservedAt: now.Add(time.Minute)},
+		{TenantID: "tenant", FindingID: "z-older", CreatedAt: now, ObservedAt: now},
+		{TenantID: "tenant", FindingID: "a-oldest", CreatedAt: now, ObservedAt: now},
+	})
+	first, err := repository.ListFindingLineageBackfillSources(context.Background(), "tenant", "", now.Add(time.Hour), nil, 2)
+	if err != nil || len(first) != 2 || first[0].FindingID != "a-oldest" || first[1].FindingID != "z-older" {
+		t.Fatalf("first page=%+v err=%v", first, err)
+	}
+	second, err := repository.ListFindingLineageBackfillSources(context.Background(), "tenant", "z-older", now.Add(time.Hour), nil, 2)
+	if err != nil || len(second) != 1 || second[0].FindingID != "a-newer" {
+		t.Fatalf("second page=%+v err=%v", second, err)
+	}
+}

--- a/internal/infrastructure/persistence/memory/finding_lineage_repo.go
+++ b/internal/infrastructure/persistence/memory/finding_lineage_repo.go
@@ -1,0 +1,672 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type lineageKey struct {
+	tenantID shared.ID
+	cycleID  shared.ID
+	id       shared.ID
+}
+
+type FindingLineageRepository struct {
+	mu           sync.RWMutex
+	identities   map[lineageKey]findinglineage.Identity
+	observations map[lineageKey]findinglineage.Observation
+	aliases      map[lineageKey]findinglineage.Alias
+	candidates   map[lineageKey]findinglineage.MatchCandidate
+	resolutions  map[lineageKey]findinglineage.ResolutionEvent
+	overrides    map[lineageKey]findinglineage.OverrideEvent
+	skips        map[lineageKey]findinglineage.SkipRecord
+}
+
+func NewFindingLineageRepository() *FindingLineageRepository {
+	return &FindingLineageRepository{
+		identities: map[lineageKey]findinglineage.Identity{}, observations: map[lineageKey]findinglineage.Observation{},
+		aliases: map[lineageKey]findinglineage.Alias{}, candidates: map[lineageKey]findinglineage.MatchCandidate{},
+		resolutions: map[lineageKey]findinglineage.ResolutionEvent{}, overrides: map[lineageKey]findinglineage.OverrideEvent{},
+		skips: map[lineageKey]findinglineage.SkipRecord{},
+	}
+}
+
+var _ ports.FindingLineageRepository = (*FindingLineageRepository)(nil)
+
+func (repository *FindingLineageRepository) LockCorrelationNamespace(ctx context.Context, tenantID, cycleID shared.ID, producerKind, findingKind, targetCanonical, discriminator string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if shared.TenantOrDefault(tenantID).IsZero() || cycleID.IsZero() || strings.TrimSpace(producerKind) == "" || strings.TrimSpace(findingKind) == "" || strings.TrimSpace(targetCanonical) == "" || strings.TrimSpace(discriminator) == "" {
+		return fmt.Errorf("%w: finding correlation lock namespace is invalid", shared.ErrValidation)
+	}
+	// The production in-memory TenantTransactionRunner serializes the complete
+	// correlation callback; repository operations remain individually mutex-safe.
+	return nil
+}
+
+
+func (repository *FindingLineageRepository) CreateIdentityWithObservation(ctx context.Context, identity findinglineage.Identity, observation findinglineage.Observation) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	identity.TenantID = shared.TenantOrDefault(identity.TenantID)
+	observation.TenantID = shared.TenantOrDefault(observation.TenantID)
+	if err := identity.Validate(); err != nil {
+		return err
+	}
+	if err := observation.Validate(); err != nil {
+		return err
+	}
+	if identity.TenantID != observation.TenantID || identity.CycleID != observation.CycleID || identity.ID != observation.IdentityID ||
+		identity.FirstSeenSnapshotID != observation.SnapshotID || identity.ProducerKind != observation.ProducerKind ||
+		identity.FindingKind != observation.FindingKind || identity.TargetIdentityCanonical != observation.TargetCanonical {
+		return fmt.Errorf("%w: identity and first observation do not share ownership", shared.ErrValidation)
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	repository.registerRollback(ctx)
+	identityKey := key(identity.TenantID, identity.CycleID, identity.ID)
+	observationKey := key(observation.TenantID, observation.CycleID, observation.ID)
+	if _, exists := repository.identities[identityKey]; exists {
+		return fmt.Errorf("%w: finding identity already exists", shared.ErrConflict)
+	}
+	if _, exists := repository.observations[observationKey]; exists || repository.observationSourceExistsLocked(observation) {
+		return fmt.Errorf("%w: finding observation already exists", shared.ErrConflict)
+	}
+	repository.identities[identityKey] = cloneLineageIdentity(identity)
+	repository.observations[observationKey] = cloneLineageObservation(observation)
+	return nil
+}
+
+func (repository *FindingLineageRepository) AppendObservation(ctx context.Context, observation findinglineage.Observation) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	observation.TenantID = shared.TenantOrDefault(observation.TenantID)
+	if err := observation.Validate(); err != nil {
+		return err
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	repository.registerRollback(ctx)
+	identity, exists := repository.identities[key(observation.TenantID, observation.CycleID, observation.IdentityID)]
+	if !exists {
+		return shared.ErrNotFound
+	}
+	if identity.ProducerKind != observation.ProducerKind || identity.FindingKind != observation.FindingKind || identity.TargetIdentityCanonical != observation.TargetCanonical {
+		return fmt.Errorf("%w: observation does not match identity namespace", shared.ErrValidation)
+	}
+	observationKey := key(observation.TenantID, observation.CycleID, observation.ID)
+	if existing, exists := repository.observations[observationKey]; exists {
+		if reflect.DeepEqual(existing, observation) {
+			return nil
+		}
+		return fmt.Errorf("%w: observation id was reused", shared.ErrConflict)
+	}
+	if repository.observationSourceExistsLocked(observation) {
+		return fmt.Errorf("%w: source observation already exists in snapshot", shared.ErrConflict)
+	}
+	repository.observations[observationKey] = cloneLineageObservation(observation)
+	return nil
+}
+
+func (repository *FindingLineageRepository) AppendAlias(ctx context.Context, alias findinglineage.Alias) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+	alias.TenantID = shared.TenantOrDefault(alias.TenantID)
+	if err := alias.Validate(); err != nil {
+		return false, err
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	repository.registerRollback(ctx)
+	if _, exists := repository.identities[key(alias.TenantID, alias.CycleID, alias.IdentityID)]; !exists {
+		return false, shared.ErrNotFound
+	}
+	for _, existing := range repository.aliases {
+		if sameAlias(existing, alias) {
+			return false, nil
+		}
+	}
+	aliasKey := key(alias.TenantID, alias.CycleID, alias.ID)
+	if _, exists := repository.aliases[aliasKey]; exists {
+		return false, fmt.Errorf("%w: alias id was reused", shared.ErrConflict)
+	}
+	repository.aliases[aliasKey] = alias
+	return true, nil
+}
+
+func (repository *FindingLineageRepository) GetIdentity(ctx context.Context, tenantID, cycleID, identityID shared.ID) (findinglineage.Identity, error) {
+	if err := ctx.Err(); err != nil {
+		return findinglineage.Identity{}, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	identity, exists := repository.identities[key(tenantID, cycleID, identityID)]
+	if !exists {
+		return findinglineage.Identity{}, shared.ErrNotFound
+	}
+	return cloneLineageIdentity(identity), nil
+}
+
+func (repository *FindingLineageRepository) GetObservation(ctx context.Context, tenantID, cycleID, observationID shared.ID) (findinglineage.Observation, error) {
+	if err := ctx.Err(); err != nil {
+		return findinglineage.Observation{}, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	observation, exists := repository.observations[key(tenantID, cycleID, observationID)]
+	if !exists {
+		return findinglineage.Observation{}, shared.ErrNotFound
+	}
+	return cloneLineageObservation(observation), nil
+}
+
+func (repository *FindingLineageRepository) GetObservationBySource(ctx context.Context, tenantID, cycleID, snapshotID shared.ID, producerKind, findingKind, targetCanonical, sourceFindingID, sourceOccurrenceID string) (findinglineage.Observation, error) {
+	if err := ctx.Err(); err != nil {
+		return findinglineage.Observation{}, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	for _, observation := range repository.observations {
+		if observation.TenantID == tenantID && observation.CycleID == cycleID && observation.SnapshotID == snapshotID &&
+			observation.ProducerKind == producerKind && observation.FindingKind == findingKind && observation.TargetCanonical == targetCanonical &&
+			observation.SourceFindingID == sourceFindingID && observation.SourceOccurrenceID == sourceOccurrenceID {
+			return cloneLineageObservation(observation), nil
+		}
+	}
+	return findinglineage.Observation{}, shared.ErrNotFound
+}
+
+func (repository *FindingLineageRepository) FindIdentitiesByProducerID(ctx context.Context, tenantID, cycleID shared.ID, producerKind, findingKind, targetCanonical, sourceID string) ([]findinglineage.Identity, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	seen := map[shared.ID]struct{}{}
+	identities := make([]findinglineage.Identity, 0)
+	for _, observation := range repository.observations {
+		if observation.TenantID != tenantID || observation.CycleID != cycleID || observation.ProducerKind != producerKind || observation.FindingKind != findingKind || observation.TargetCanonical != targetCanonical ||
+			(observation.SourceFindingID != sourceID && observation.SourceOccurrenceID != sourceID) {
+			continue
+		}
+		if _, exists := seen[observation.IdentityID]; exists {
+			continue
+		}
+		seen[observation.IdentityID] = struct{}{}
+		identities = append(identities, cloneLineageIdentity(repository.identities[key(tenantID, cycleID, observation.IdentityID)]))
+	}
+	sortLineageIdentities(identities)
+	return identities, nil
+}
+
+func (repository *FindingLineageRepository) FindIdentitiesByFingerprint(ctx context.Context, tenantID, cycleID shared.ID, producerKind, findingKind string, schemaVersion int, targetCanonical, fingerprint string) ([]findinglineage.Identity, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	identities := make([]findinglineage.Identity, 0)
+	for _, identity := range repository.identities {
+		if identity.TenantID == tenantID && identity.CycleID == cycleID && identity.ProducerKind == producerKind && identity.FindingKind == findingKind &&
+			identity.FingerprintSchemaVersion == schemaVersion && identity.TargetIdentityCanonical == targetCanonical && identity.LineageFingerprint == fingerprint {
+			identities = append(identities, cloneLineageIdentity(identity))
+		}
+	}
+	sortLineageIdentities(identities)
+	return identities, nil
+}
+
+func (repository *FindingLineageRepository) FindIdentitiesByAlias(ctx context.Context, tenantID, cycleID shared.ID, producerKind, findingKind string, schemaVersion int, targetCanonical, fingerprint string) ([]findinglineage.Identity, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	seen := map[shared.ID]struct{}{}
+	identities := make([]findinglineage.Identity, 0)
+	for _, alias := range repository.aliases {
+		if alias.TenantID != tenantID || alias.CycleID != cycleID || alias.ProducerKind != producerKind || alias.FindingKind != findingKind ||
+			alias.SchemaVersion != schemaVersion || alias.TargetCanonical != targetCanonical || alias.Fingerprint != fingerprint {
+			continue
+		}
+		if _, exists := seen[alias.IdentityID]; exists {
+			continue
+		}
+		seen[alias.IdentityID] = struct{}{}
+		identities = append(identities, cloneLineageIdentity(repository.identities[key(tenantID, cycleID, alias.IdentityID)]))
+	}
+	sortLineageIdentities(identities)
+	return identities, nil
+}
+
+func (repository *FindingLineageRepository) ListObservationsBySnapshot(ctx context.Context, tenantID, cycleID, snapshotID shared.ID) ([]findinglineage.Observation, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	observations := make([]findinglineage.Observation, 0)
+	for _, observation := range repository.observations {
+		if observation.TenantID == tenantID && observation.CycleID == cycleID && observation.SnapshotID == snapshotID {
+			observations = append(observations, cloneLineageObservation(observation))
+		}
+	}
+	sort.Slice(observations, func(left, right int) bool { return observations[left].ID < observations[right].ID })
+	return observations, nil
+}
+
+func (repository *FindingLineageRepository) ListOpenCandidatesBySnapshot(ctx context.Context, tenantID, cycleID, snapshotID shared.ID) ([]findinglineage.MatchCandidate, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	candidates := make([]findinglineage.MatchCandidate, 0)
+	for _, candidate := range repository.candidates {
+		if candidate.TenantID == tenantID && candidate.CycleID == cycleID && candidate.SnapshotID == snapshotID && candidate.Status == findinglineage.CandidateOpen {
+			candidates = append(candidates, cloneMatchCandidate(candidate))
+		}
+	}
+	sort.Slice(candidates, func(left, right int) bool { return candidates[left].ID < candidates[right].ID })
+	return candidates, nil
+}
+
+func (repository *FindingLineageRepository) ListActiveOverridesBySnapshot(ctx context.Context, tenantID, cycleID, snapshotID shared.ID) ([]findinglineage.OverrideEvent, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	latest := map[shared.ID]findinglineage.OverrideEvent{}
+	for _, event := range repository.overrides {
+		observation, exists := repository.observations[key(tenantID, cycleID, event.SourceObservationID)]
+		if !exists || observation.SnapshotID != snapshotID {
+			continue
+		}
+		if current, exists := latest[event.SourceObservationID]; !exists || event.Version > current.Version {
+			latest[event.SourceObservationID] = event
+		}
+	}
+	events := make([]findinglineage.OverrideEvent, 0, len(latest))
+	for _, event := range latest {
+		events = append(events, event)
+	}
+	sort.Slice(events, func(left, right int) bool {
+		return events[left].SourceObservationID < events[right].SourceObservationID
+	})
+	return events, nil
+}
+
+func (repository *FindingLineageRepository) CreateCandidate(ctx context.Context, candidate findinglineage.MatchCandidate, supersessionEventID shared.ID) (findinglineage.MatchCandidate, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return findinglineage.MatchCandidate{}, false, err
+	}
+	candidate.TenantID = shared.TenantOrDefault(candidate.TenantID)
+	if err := candidate.Validate(); err != nil {
+		return findinglineage.MatchCandidate{}, false, err
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	repository.registerRollback(ctx)
+	for _, existing := range repository.candidates {
+		if sameCandidateIdempotency(existing, candidate) {
+			return cloneMatchCandidate(existing), false, nil
+		}
+	}
+	candidateKey := key(candidate.TenantID, candidate.CycleID, candidate.ID)
+	if _, exists := repository.candidates[candidateKey]; exists {
+		return findinglineage.MatchCandidate{}, false, fmt.Errorf("%w: candidate id was reused", shared.ErrConflict)
+	}
+	for existingKey, existing := range repository.candidates {
+		if !sameOpenCandidateSubject(existing, candidate) {
+			continue
+		}
+		if supersessionEventID.IsZero() {
+			return findinglineage.MatchCandidate{}, false, fmt.Errorf("%w: supersession event id is required", shared.ErrValidation)
+		}
+		prior := repository.latestResolutionIDLocked(existing.TenantID, existing.CycleID, existing.ID)
+		updated, event, err := findinglineage.ResolveCandidate(existing, supersessionEventID, findinglineage.ResolutionSupersede,
+			"system:finding-lineage", "candidate_ref_set_changed", candidate.Refs, candidate.ID, existing.Version, prior, candidate.CreatedAt)
+		if err != nil {
+			return findinglineage.MatchCandidate{}, false, err
+		}
+		if _, exists := repository.resolutions[key(event.TenantID, event.CycleID, event.ID)]; exists {
+			return findinglineage.MatchCandidate{}, false, fmt.Errorf("%w: supersession event id was reused", shared.ErrConflict)
+		}
+		repository.candidates[existingKey] = cloneMatchCandidate(updated)
+		repository.resolutions[key(event.TenantID, event.CycleID, event.ID)] = cloneResolutionEvent(event)
+		break
+	}
+	repository.candidates[candidateKey] = cloneMatchCandidate(candidate)
+	return cloneMatchCandidate(candidate), true, nil
+}
+
+func (repository *FindingLineageRepository) GetCandidate(ctx context.Context, tenantID, cycleID, candidateID shared.ID) (findinglineage.MatchCandidate, error) {
+	if err := ctx.Err(); err != nil {
+		return findinglineage.MatchCandidate{}, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	candidate, exists := repository.candidates[key(tenantID, cycleID, candidateID)]
+	if !exists {
+		return findinglineage.MatchCandidate{}, shared.ErrNotFound
+	}
+	return cloneMatchCandidate(candidate), nil
+}
+
+func (repository *FindingLineageRepository) ResolveCandidateCAS(ctx context.Context, updated findinglineage.MatchCandidate, event findinglineage.ResolutionEvent) (findinglineage.MatchCandidate, findinglineage.ResolutionEvent, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return findinglineage.MatchCandidate{}, findinglineage.ResolutionEvent{}, false, err
+	}
+	updated.TenantID = shared.TenantOrDefault(updated.TenantID)
+	event.TenantID = shared.TenantOrDefault(event.TenantID)
+	if err := updated.Validate(); err != nil {
+		return findinglineage.MatchCandidate{}, findinglineage.ResolutionEvent{}, false, err
+	}
+	if err := event.Validate(); err != nil {
+		return findinglineage.MatchCandidate{}, findinglineage.ResolutionEvent{}, false, err
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	repository.registerRollback(ctx)
+	eventKey := key(event.TenantID, event.CycleID, event.ID)
+	if existing, exists := repository.resolutions[eventKey]; exists {
+		if existing.ContentHash != event.ContentHash {
+			return findinglineage.MatchCandidate{}, findinglineage.ResolutionEvent{}, false, fmt.Errorf("%w: resolution event id was reused", shared.ErrConflict)
+		}
+		current := repository.candidates[key(event.TenantID, event.CycleID, event.CandidateID)]
+		return cloneMatchCandidate(current), cloneResolutionEvent(existing), false, nil
+	}
+	candidateKey := key(event.TenantID, event.CycleID, event.CandidateID)
+	current, exists := repository.candidates[candidateKey]
+	if !exists {
+		return findinglineage.MatchCandidate{}, findinglineage.ResolutionEvent{}, false, shared.ErrNotFound
+	}
+	if repository.latestResolutionIDLocked(event.TenantID, event.CycleID, event.CandidateID) != event.PriorEventID {
+		return findinglineage.MatchCandidate{}, findinglineage.ResolutionEvent{}, false, fmt.Errorf("%w: resolution prior event changed", shared.ErrConflict)
+	}
+	wantUpdated, wantEvent, err := findinglineage.ResolveCandidate(current, event.ID, event.Action, event.Actor, event.Reason,
+		event.AfterRefs, event.SuccessorCandidateID, event.ExpectedVersion, event.PriorEventID, event.CreatedAt)
+	if err != nil {
+		return findinglineage.MatchCandidate{}, findinglineage.ResolutionEvent{}, false, err
+	}
+	if !sameCandidateResolution(wantUpdated, updated) || wantEvent.ContentHash != event.ContentHash {
+		return findinglineage.MatchCandidate{}, findinglineage.ResolutionEvent{}, false, fmt.Errorf("%w: resolution event does not match candidate", shared.ErrValidation)
+	}
+	repository.candidates[candidateKey] = cloneMatchCandidate(wantUpdated)
+	repository.resolutions[eventKey] = cloneResolutionEvent(wantEvent)
+	return cloneMatchCandidate(wantUpdated), cloneResolutionEvent(wantEvent), true, nil
+}
+
+func (repository *FindingLineageRepository) ListCandidateResolutions(ctx context.Context, tenantID, cycleID, candidateID shared.ID) ([]findinglineage.ResolutionEvent, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	events := make([]findinglineage.ResolutionEvent, 0)
+	for _, event := range repository.resolutions {
+		if event.TenantID == tenantID && event.CycleID == cycleID && event.CandidateID == candidateID {
+			events = append(events, cloneResolutionEvent(event))
+		}
+	}
+	sort.Slice(events, func(left, right int) bool { return events[left].Version < events[right].Version })
+	return events, nil
+}
+
+func (repository *FindingLineageRepository) GetActiveOverride(ctx context.Context, tenantID, cycleID, sourceObservationID shared.ID) (findinglineage.OverrideEvent, error) {
+	if err := ctx.Err(); err != nil {
+		return findinglineage.OverrideEvent{}, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	var active findinglineage.OverrideEvent
+	for _, event := range repository.overrides {
+		if event.TenantID == tenantID && event.CycleID == cycleID && event.SourceObservationID == sourceObservationID && event.Version > active.Version {
+			active = event
+		}
+	}
+	if active.ID.IsZero() {
+		return findinglineage.OverrideEvent{}, shared.ErrNotFound
+	}
+	return active, nil
+}
+
+func (repository *FindingLineageRepository) AppendOverrideCAS(ctx context.Context, event findinglineage.OverrideEvent) (findinglineage.OverrideEvent, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return findinglineage.OverrideEvent{}, false, err
+	}
+	event.TenantID = shared.TenantOrDefault(event.TenantID)
+	if err := event.Validate(); err != nil {
+		return findinglineage.OverrideEvent{}, false, err
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	repository.registerRollback(ctx)
+	eventKey := key(event.TenantID, event.CycleID, event.ID)
+	if existing, exists := repository.overrides[eventKey]; exists {
+		if existing.ContentHash != event.ContentHash {
+			return findinglineage.OverrideEvent{}, false, fmt.Errorf("%w: override event id was reused", shared.ErrConflict)
+		}
+		return existing, false, nil
+	}
+	if _, exists := repository.observations[key(event.TenantID, event.CycleID, event.SourceObservationID)]; !exists {
+		return findinglineage.OverrideEvent{}, false, shared.ErrNotFound
+	}
+	if _, exists := repository.identities[key(event.TenantID, event.CycleID, event.TargetIdentityID)]; !exists {
+		return findinglineage.OverrideEvent{}, false, shared.ErrNotFound
+	}
+	if !event.SourceIdentityID.IsZero() {
+		if _, exists := repository.identities[key(event.TenantID, event.CycleID, event.SourceIdentityID)]; !exists {
+			return findinglineage.OverrideEvent{}, false, shared.ErrNotFound
+		}
+	}
+	if !event.TargetObservationID.IsZero() {
+		if _, exists := repository.observations[key(event.TenantID, event.CycleID, event.TargetObservationID)]; !exists {
+			return findinglineage.OverrideEvent{}, false, shared.ErrNotFound
+		}
+	}
+	var active findinglineage.OverrideEvent
+	for _, existing := range repository.overrides {
+		if existing.TenantID == event.TenantID && existing.CycleID == event.CycleID && existing.SourceObservationID == event.SourceObservationID && existing.Version > active.Version {
+			active = existing
+		}
+	}
+	if active.Version != event.ExpectedVersion || active.ID != event.PriorEventID {
+		return findinglineage.OverrideEvent{}, false, fmt.Errorf("%w: override version changed", shared.ErrConflict)
+	}
+	repository.overrides[eventKey] = event
+	return event, true, nil
+}
+
+func (repository *FindingLineageRepository) ListOverrideEvents(ctx context.Context, tenantID, cycleID, sourceObservationID shared.ID) ([]findinglineage.OverrideEvent, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	events := make([]findinglineage.OverrideEvent, 0)
+	for _, event := range repository.overrides {
+		if event.TenantID == tenantID && event.CycleID == cycleID && event.SourceObservationID == sourceObservationID {
+			events = append(events, event)
+		}
+	}
+	sort.Slice(events, func(left, right int) bool { return events[left].Version < events[right].Version })
+	return events, nil
+}
+
+func (repository *FindingLineageRepository) AppendSkip(ctx context.Context, record findinglineage.SkipRecord) (findinglineage.SkipRecord, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return findinglineage.SkipRecord{}, false, err
+	}
+	record.TenantID = shared.TenantOrDefault(record.TenantID)
+	if err := record.Validate(); err != nil {
+		return findinglineage.SkipRecord{}, false, err
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	repository.registerRollback(ctx)
+	for _, existing := range repository.skips {
+		if existing.TenantID == record.TenantID && existing.CycleID == record.CycleID && existing.SnapshotID == record.SnapshotID &&
+			existing.ProducerKind == record.ProducerKind && existing.Reason == record.Reason && existing.SourceReferenceHash == record.SourceReferenceHash {
+			if existing.FindingKind != record.FindingKind || existing.DetailCode != record.DetailCode {
+				return findinglineage.SkipRecord{}, false, fmt.Errorf("%w: skip replay body differs", shared.ErrConflict)
+			}
+			return existing, false, nil
+		}
+	}
+	recordKey := key(record.TenantID, record.CycleID, record.ID)
+	if _, exists := repository.skips[recordKey]; exists {
+		return findinglineage.SkipRecord{}, false, fmt.Errorf("%w: skip record id was reused", shared.ErrConflict)
+	}
+	repository.skips[recordKey] = record
+	return record, true, nil
+}
+
+func (repository *FindingLineageRepository) ListSkipsBySnapshot(ctx context.Context, tenantID, cycleID, snapshotID shared.ID) ([]findinglineage.SkipRecord, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	records := make([]findinglineage.SkipRecord, 0)
+	for _, record := range repository.skips {
+		if record.TenantID == tenantID && record.CycleID == cycleID && record.SnapshotID == snapshotID {
+			records = append(records, record)
+		}
+	}
+	sort.Slice(records, func(left, right int) bool { return records[left].ID < records[right].ID })
+	return records, nil
+}
+
+func (repository *FindingLineageRepository) observationSourceExistsLocked(observation findinglineage.Observation) bool {
+	for _, existing := range repository.observations {
+		if existing.TenantID == observation.TenantID && existing.CycleID == observation.CycleID && existing.SnapshotID == observation.SnapshotID &&
+			existing.ProducerKind == observation.ProducerKind && existing.FindingKind == observation.FindingKind && existing.TargetCanonical == observation.TargetCanonical &&
+			existing.SourceFindingID == observation.SourceFindingID && existing.SourceOccurrenceID == observation.SourceOccurrenceID {
+			return true
+		}
+	}
+	return false
+}
+
+func (repository *FindingLineageRepository) latestResolutionIDLocked(tenantID, cycleID, candidateID shared.ID) shared.ID {
+	var latest findinglineage.ResolutionEvent
+	for _, event := range repository.resolutions {
+		if event.TenantID == tenantID && event.CycleID == cycleID && event.CandidateID == candidateID && event.Version > latest.Version {
+			latest = event
+		}
+	}
+	return latest.ID
+}
+
+func sameAlias(left, right findinglineage.Alias) bool {
+	return left.TenantID == right.TenantID && left.CycleID == right.CycleID && left.IdentityID == right.IdentityID &&
+		left.ProducerKind == right.ProducerKind && left.FindingKind == right.FindingKind && left.TargetCanonical == right.TargetCanonical &&
+		left.SchemaVersion == right.SchemaVersion && left.Fingerprint == right.Fingerprint
+}
+
+func sameCandidateIdempotency(left, right findinglineage.MatchCandidate) bool {
+	return left.TenantID == right.TenantID && left.CycleID == right.CycleID && left.SnapshotID == right.SnapshotID &&
+		left.ProducerKind == right.ProducerKind && left.Reason == right.Reason && left.CandidateSetHash == right.CandidateSetHash
+}
+
+func sameOpenCandidateSubject(left, right findinglineage.MatchCandidate) bool {
+	return left.Status == findinglineage.CandidateOpen && left.TenantID == right.TenantID && left.CycleID == right.CycleID &&
+		left.SnapshotID == right.SnapshotID && left.ProducerKind == right.ProducerKind && left.Reason == right.Reason &&
+		left.SourceReferenceHash == right.SourceReferenceHash
+}
+
+func key(tenantID, cycleID, id shared.ID) lineageKey {
+	return lineageKey{tenantID: tenantID, cycleID: cycleID, id: id}
+}
+
+func cloneLineageIdentity(identity findinglineage.Identity) findinglineage.Identity {
+	identity.CanonicalIdentityFields = append([]byte(nil), identity.CanonicalIdentityFields...)
+	return identity
+}
+
+func cloneLineageObservation(observation findinglineage.Observation) findinglineage.Observation {
+	if observation.RiskScoreMilli != nil {
+		value := *observation.RiskScoreMilli
+		observation.RiskScoreMilli = &value
+	}
+	return observation
+}
+
+func cloneMatchCandidate(candidate findinglineage.MatchCandidate) findinglineage.MatchCandidate {
+	candidate.Refs = cloneLineageRefs(candidate.Refs)
+	if candidate.ResolvedAt != nil {
+		value := *candidate.ResolvedAt
+		candidate.ResolvedAt = &value
+	}
+	if candidate.SupersededAt != nil {
+		value := *candidate.SupersededAt
+		candidate.SupersededAt = &value
+	}
+	return candidate
+}
+
+func cloneResolutionEvent(event findinglineage.ResolutionEvent) findinglineage.ResolutionEvent {
+	event.BeforeRefs = cloneLineageRefs(event.BeforeRefs)
+	event.AfterRefs = cloneLineageRefs(event.AfterRefs)
+	return event
+}
+
+func cloneLineageRefs(input []findinglineage.CandidateRef) []findinglineage.CandidateRef {
+	output := make([]findinglineage.CandidateRef, len(input))
+	for index, reference := range input {
+		output[index] = reference
+		if reference.ReasonPayload != nil {
+			output[index].ReasonPayload = make(map[string]string, len(reference.ReasonPayload))
+			for key, value := range reference.ReasonPayload {
+				output[index].ReasonPayload[key] = value
+			}
+		}
+	}
+	return output
+}
+
+func sortLineageIdentities(identities []findinglineage.Identity) {
+	sort.Slice(identities, func(left, right int) bool { return identities[left].ID < identities[right].ID })
+}
+
+func sameCandidateResolution(left, right findinglineage.MatchCandidate) bool {
+	return left.TenantID == right.TenantID && left.CycleID == right.CycleID && left.ID == right.ID &&
+		left.Status == right.Status && left.Version == right.Version && left.SupersededByCandidateID == right.SupersededByCandidateID &&
+		sameOptionalTime(left.ResolvedAt, right.ResolvedAt) && sameOptionalTime(left.SupersededAt, right.SupersededAt)
+}
+
+func sameOptionalTime(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return left.Equal(*right)
+}

--- a/internal/infrastructure/persistence/memory/scan_run_evidence.go
+++ b/internal/infrastructure/persistence/memory/scan_run_evidence.go
@@ -1,0 +1,60 @@
+package memory
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var _ ports.ScanRunEvidenceStore = (*ScanRunStore)(nil)
+
+func (s *ScanRunStore) SaveScanRunEvidence(ctx context.Context, item ports.ScanRunEvidence) error {
+	if err := item.Validate(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := scanRunKey{TenantID: item.TenantID, ID: item.RunID}
+	run, exists := s.runs[key]
+	if !exists {
+		return shared.ErrNotFound
+	}
+	if prior, exists := s.evidence[key]; exists {
+		if prior.ContentHash != item.ContentHash || !bytes.Equal(prior.Payload, item.Payload) {
+			return fmt.Errorf("%w: scan evidence replay differs", shared.ErrConflict)
+		}
+		return nil
+	}
+	if run.IsSealed() {
+		return fmt.Errorf("%w: cannot append evidence to a sealed run", shared.ErrConflict)
+	}
+	s.registerRollback(ctx)
+	item.Payload = bytes.Clone(item.Payload)
+	s.evidence[key] = item
+	return nil
+}
+
+func (s *ScanRunStore) GetScanRunEvidence(ctx context.Context, tenantID shared.ID, runID string) (ports.ScanRunEvidence, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.ScanRunEvidence{}, err
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	item, exists := s.evidence[scanRunKey{TenantID: tenantID, ID: runID}]
+	if !exists {
+		return ports.ScanRunEvidence{}, shared.ErrNotFound
+	}
+	item.Payload = bytes.Clone(item.Payload)
+	return item, item.Validate()
+}
+
+func (s *ScanRunStore) registerRollback(ctx context.Context) {
+	registerTenantCheckpoint(ctx, s, func(tenantID shared.ID) func() {
+		runs := captureTenantEntries(s.runs, func(k scanRunKey, _ scanrun.ScanRun) bool { return k.TenantID == tenantID })
+		evidence := captureTenantEntries(s.evidence, func(k scanRunKey, _ ports.ScanRunEvidence) bool { return k.TenantID == tenantID })
+		return func() { s.mu.Lock(); defer s.mu.Unlock(); runs(); evidence() }
+	})
+}

--- a/internal/infrastructure/persistence/memory/scan_run_repo.go
+++ b/internal/infrastructure/persistence/memory/scan_run_repo.go
@@ -21,14 +21,16 @@ type scanRunKey struct {
 
 // ScanRunStore is an in-memory store of scan-run manifests and sealed provenance.
 type ScanRunStore struct {
-	mu   sync.RWMutex
-	runs map[scanRunKey]scanrun.ScanRun
+	mu       sync.RWMutex
+	runs     map[scanRunKey]scanrun.ScanRun
+	evidence map[scanRunKey]ports.ScanRunEvidence
 }
 
 // NewScanRunStore returns an empty in-memory scan-run store.
 func NewScanRunStore() *ScanRunStore {
 	return &ScanRunStore{
-		runs: make(map[scanRunKey]scanrun.ScanRun),
+		runs:     make(map[scanRunKey]scanrun.ScanRun),
+		evidence: make(map[scanRunKey]ports.ScanRunEvidence),
 	}
 }
 
@@ -41,6 +43,7 @@ var (
 func (s *ScanRunStore) Save(ctx context.Context, run ports.ScanRun) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.registerRollback(ctx)
 
 	tenantID, ok := shared.TenantFrom(ctx)
 	if !ok || tenantID.IsZero() {
@@ -134,6 +137,7 @@ func (s *ScanRunStore) SaveScanRun(ctx context.Context, run scanrun.ScanRun) err
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.registerRollback(ctx)
 
 	key := scanRunKey{TenantID: run.TenantID, ID: run.ID}
 	if _, ok := s.runs[key]; ok {
@@ -187,7 +191,7 @@ func (s *ScanRunStore) ListScanRuns(_ context.Context, tenantID, engagementID sh
 }
 
 // SealScanRun atomically seals a scan run and records its normalized lanes, versions, and stages.
-func (s *ScanRunStore) SealScanRun(_ context.Context, command ports.SealScanRunCommand) error {
+func (s *ScanRunStore) SealScanRun(ctx context.Context, command ports.SealScanRunCommand) error {
 	tenantID := command.TenantID
 	runID := command.RunID
 	terminalStatus := command.TerminalStatus
@@ -217,6 +221,7 @@ func (s *ScanRunStore) SealScanRun(_ context.Context, command ports.SealScanRunC
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.registerRollback(ctx)
 
 	key := scanRunKey{TenantID: tenantID, ID: runID}
 	existing, ok := s.runs[key]

--- a/internal/infrastructure/persistence/postgres/finding_lineage_backfill_repo.go
+++ b/internal/infrastructure/persistence/postgres/finding_lineage_backfill_repo.go
@@ -1,0 +1,351 @@
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const findingLineageBackfillRunColumns = `tenant_id,id,schema_version,dry_run,batch_size,producer_filters,snapshot_at,checkpoint_finding_id,state,lease_owner,lease_token,lease_expires_at,processed_count,observation_created_count,provisional_candidate_count,skipped_count,created_by,created_at,updated_at,completed_at`
+
+type FindingLineageBackfillRepository struct{ pool *pgxpool.Pool }
+
+func NewFindingLineageBackfillRepository(pool *pgxpool.Pool) *FindingLineageBackfillRepository {
+	return &FindingLineageBackfillRepository{pool: pool}
+}
+
+var _ ports.FindingLineageBackfillSource = (*FindingLineageBackfillRepository)(nil)
+var _ ports.FindingLineageBackfillStore = (*FindingLineageBackfillRepository)(nil)
+
+func (repository *FindingLineageBackfillRepository) ListFindingLineageBackfillSources(ctx context.Context, tenantID, after shared.ID, snapshotAt time.Time, producerFilters []string, limit int) ([]ports.FindingLineageBackfillSourceRow, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	if tenantID.IsZero() || snapshotAt.IsZero() || limit < 1 || limit > 2000 {
+		return nil, fmt.Errorf("%w: finding lineage backfill source query is invalid", shared.ErrValidation)
+	}
+	var out []ports.FindingLineageBackfillSourceRow
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT f.tenant_id,f.engagement_id,f.id,COALESCE(NULLIF(f.kind,''),'sca'),COALESCE(f.rule_key,''),COALESCE(f.dedup_key,''),
+			COALESCE(f.advisory_id,''),COALESCE(f.occurrence_id,''),COALESCE(f.component_fingerprint,''),
+			f.severity,f.risk_score,COALESCE(f.reachability,''),f.created_at,f.updated_at,f.data_flow,
+			COALESCE(m.cycle_id,''),COALESCE(m.membership_count,0)=1,COALESCE(s.id,''),COALESCE(s.content_hash,'')
+		FROM findings f
+		LEFT JOIN LATERAL (
+			SELECT min(cycle_id) AS cycle_id,count(*) AS membership_count
+			FROM assessment_cycle_members
+			WHERE tenant_id=f.tenant_id AND assessment_id=f.engagement_id AND archived_at IS NULL
+		) m ON TRUE
+		LEFT JOIN LATERAL (
+			SELECT snap.id,snap.content_hash
+			FROM assessment_snapshots snap
+			WHERE snap.tenant_id=f.tenant_id AND snap.assessment_id=f.engagement_id AND snap.cycle_id=m.cycle_id
+			ORDER BY EXISTS (
+				SELECT 1 FROM assessment_snapshot_defaults pointer
+				WHERE pointer.tenant_id=snap.tenant_id AND pointer.assessment_id=snap.assessment_id AND pointer.snapshot_id=snap.id
+			) DESC,(snap.provenance='native') DESC,snap.snapshot_number DESC
+			LIMIT 1
+		) s ON m.membership_count=1
+		WHERE f.tenant_id=$1 AND f.created_at<=$3 AND f.updated_at<=$3
+			AND ($2='' OR (f.created_at,f.id COLLATE "C") > (
+				SELECT checkpoint.created_at,checkpoint.id COLLATE "C" FROM findings checkpoint
+				WHERE checkpoint.tenant_id=$1 AND checkpoint.id=$2
+			))
+			AND (COALESCE(cardinality($4::text[]),0)=0 OR COALESCE(NULLIF(f.kind,''),'sca')=ANY($4::text[]))
+		ORDER BY f.created_at,f.id COLLATE "C" LIMIT $5`, tenantID.String(), after.String(), snapshotAt.UTC(), producerFilters, limit)
+		if err != nil {
+			return fmt.Errorf("list finding lineage backfill sources: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var (
+				source         ports.FindingLineageBackfillSourceRow
+				kind, severity string
+				dataFlowJSON   []byte
+			)
+			if err := rows.Scan(&source.TenantID, &source.AssessmentID, &source.FindingID, &kind, &source.RuleKey, &source.DedupKey,
+				&source.AdvisoryID, &source.OccurrenceID, &source.ComponentFingerprint,
+				&severity, &source.RiskScore, &source.Reachability, &source.CreatedAt, &source.ObservedAt, &dataFlowJSON,
+				&source.CycleID, &source.OwnershipValid, &source.SnapshotID, &source.SnapshotContentHash); err != nil {
+				return fmt.Errorf("scan finding lineage backfill source: %w", err)
+			}
+			source.Kind, source.Severity = finding.Kind(kind), shared.Severity(severity)
+			source.SourceLocation = backfillSourceLocation(dataFlowJSON)
+			out = append(out, source)
+		}
+		return rows.Err()
+	})
+	return out, err
+}
+
+func (repository *FindingLineageBackfillRepository) AcquireFindingLineageBackfillRun(ctx context.Context, request ports.FindingLineageBackfillAcquireRequest) (run ports.FindingLineageBackfillRun, resumed bool, err error) {
+	if request.Run.ProducerFilters == nil {
+		request.Run.ProducerFilters = []string{}
+	}
+	if err := validatePostgresFindingLineageBackfillAcquire(request); err != nil {
+		return ports.FindingLineageBackfillRun{}, false, err
+	}
+	err = WithTenant(ctx, repository.pool, request.Run.TenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `SELECT id FROM tenants WHERE id=$1 FOR UPDATE`, request.Run.TenantID.String()); err != nil {
+			return fmt.Errorf("lock finding lineage backfill tenant: %w", err)
+		}
+		existing, scanErr := scanFindingLineageBackfillRun(tx.QueryRow(ctx, `SELECT `+findingLineageBackfillRunColumns+` FROM finding_lineage_backfill_runs WHERE tenant_id=$1 AND state='running' FOR UPDATE`, request.Run.TenantID.String()))
+		if scanErr == nil {
+			if existing.LeaseOwner != request.Run.LeaseOwner && existing.LeaseExpiresAt.After(request.Run.CreatedAt) {
+				return fmt.Errorf("%w: finding lineage backfill already running for tenant", shared.ErrConflict)
+			}
+			if existing.SchemaVersion != request.Run.SchemaVersion || existing.DryRun != request.Run.DryRun || existing.BatchSize != request.Run.BatchSize || strings.Join(existing.ProducerFilters, "\x00") != strings.Join(request.Run.ProducerFilters, "\x00") {
+				return fmt.Errorf("%w: resumed finding lineage backfill options changed", shared.ErrConflict)
+			}
+			updated, err := scanFindingLineageBackfillRun(tx.QueryRow(ctx, `UPDATE finding_lineage_backfill_runs SET lease_owner=$3,lease_token=$4,lease_expires_at=$5,updated_at=$6 WHERE tenant_id=$1 AND id=$2 AND state='running' RETURNING `+findingLineageBackfillRunColumns,
+				request.Run.TenantID.String(), existing.ID.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.Run.CreatedAt.Add(request.LeaseDuration), request.Run.CreatedAt))
+			if err != nil {
+				return fmt.Errorf("resume finding lineage backfill run: %w", err)
+			}
+			run, resumed = updated, true
+			return nil
+		}
+		if !errors.Is(scanErr, pgx.ErrNoRows) {
+			return fmt.Errorf("find active finding lineage backfill run: %w", scanErr)
+		}
+		created, err := scanFindingLineageBackfillRun(tx.QueryRow(ctx, `INSERT INTO finding_lineage_backfill_runs (`+findingLineageBackfillRunColumns+`) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,'running',$9,$10,$11,0,0,0,0,$12,$13,$13,NULL) RETURNING `+findingLineageBackfillRunColumns,
+			request.Run.TenantID.String(), request.Run.ID.String(), request.Run.SchemaVersion, request.Run.DryRun, request.Run.BatchSize, request.Run.ProducerFilters,
+			request.Run.SnapshotAt, request.InitialCheckpoint.String(), request.Run.LeaseOwner, request.Run.LeaseToken.String(), request.Run.CreatedAt.Add(request.LeaseDuration), request.Run.CreatedBy, request.Run.CreatedAt))
+		if err != nil {
+			return fmt.Errorf("create finding lineage backfill run: %w", err)
+		}
+		run = created
+		return nil
+	})
+	return run, resumed, err
+}
+
+func (repository *FindingLineageBackfillRepository) GetFindingLineageBackfillRun(ctx context.Context, tenantID, runID shared.ID) (run ports.FindingLineageBackfillRun, err error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		item, err := scanFindingLineageBackfillRun(tx.QueryRow(ctx, `SELECT `+findingLineageBackfillRunColumns+` FROM finding_lineage_backfill_runs WHERE tenant_id=$1 AND id=$2`, tenantID.String(), runID.String()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("get finding lineage backfill run: %w", err)
+		}
+		run = item
+		return nil
+	})
+	return run, err
+}
+
+func (repository *FindingLineageBackfillRepository) GetFindingLineageBackfillItem(ctx context.Context, tenantID, runID, sourceFindingID shared.ID) (item ports.FindingLineageBackfillItem, err error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var cycleID, snapshotID pgtype.Text
+		err := tx.QueryRow(ctx, `SELECT tenant_id,run_id,assessment_id,cycle_id,snapshot_id,source_finding_id,schema_version,matcher_version,idempotency_key,source_hash,outcome,reason_code,processed_at
+			FROM finding_lineage_backfill_items WHERE tenant_id=$1 AND run_id=$2 AND source_finding_id=$3`, tenantID.String(), runID.String(), sourceFindingID.String()).Scan(
+			&item.TenantID, &item.RunID, &item.AssessmentID, &cycleID, &snapshotID, &item.SourceFindingID, &item.SchemaVersion, &item.MatcherVersion,
+			&item.IdempotencyKey, &item.SourceHash, &item.Outcome, &item.ReasonCode, &item.ProcessedAt)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return fmt.Errorf("get finding lineage backfill item: %w", err)
+		}
+		if cycleID.Valid {
+			item.CycleID = shared.ID(cycleID.String)
+		}
+		if snapshotID.Valid {
+			item.SnapshotID = shared.ID(snapshotID.String)
+		}
+		return nil
+	})
+	return item, err
+}
+
+func (repository *FindingLineageBackfillRepository) CommitFindingLineageBackfillItem(ctx context.Context, tenantID, runID, leaseToken shared.ID, now time.Time, build func(context.Context) (ports.FindingLineageBackfillItem, error)) (item ports.FindingLineageBackfillItem, created bool, err error) {
+	tenantID, now = shared.TenantOrDefault(tenantID), now.UTC()
+	if tenantID.IsZero() || runID.IsZero() || leaseToken.IsZero() || now.IsZero() || build == nil {
+		return item, false, fmt.Errorf("%w: finding lineage backfill commit identity is invalid", shared.ErrValidation)
+	}
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var active bool
+		if err := tx.QueryRow(ctx, `SELECT state='running' AND lease_token=$3 AND lease_expires_at>$4 FROM finding_lineage_backfill_runs WHERE tenant_id=$1 AND id=$2 FOR UPDATE`, tenantID.String(), runID.String(), leaseToken.String(), now).Scan(&active); errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		} else if err != nil {
+			return fmt.Errorf("lock finding lineage backfill lease: %w", err)
+		}
+		if !active {
+			return fmt.Errorf("%w: finding lineage backfill lease is stale", shared.ErrConflict)
+		}
+		var err error
+		item, err = build(bindTenantTransaction(ctx, tenantID, tx))
+		if err != nil {
+			return err
+		}
+		if item.TenantID != tenantID || item.RunID != runID {
+			return fmt.Errorf("%w: finding lineage backfill item ownership differs from lease", shared.ErrValidation)
+		}
+		if err := validatePostgresFindingLineageBackfillItem(item); err != nil {
+			return err
+		}
+		command, err := tx.Exec(ctx, `INSERT INTO finding_lineage_backfill_items (tenant_id,run_id,assessment_id,cycle_id,snapshot_id,source_finding_id,schema_version,matcher_version,idempotency_key,source_hash,outcome,reason_code,processed_at)
+			SELECT $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13 FROM finding_lineage_backfill_runs run
+			WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running'
+			ON CONFLICT (tenant_id,run_id,source_finding_id) DO NOTHING`, item.TenantID.String(), item.RunID.String(), item.AssessmentID.String(), nullableFindingID(item.CycleID), nullableFindingID(item.SnapshotID), item.SourceFindingID.String(),
+			item.SchemaVersion, item.MatcherVersion, item.IdempotencyKey, item.SourceHash, item.Outcome, item.ReasonCode, item.ProcessedAt.UTC())
+		if err != nil {
+			return fmt.Errorf("save finding lineage backfill item: %w", err)
+		}
+		created = command.RowsAffected() == 1
+		return nil
+	})
+	return item, created, err
+}
+
+func (repository *FindingLineageBackfillRepository) AdvanceFindingLineageBackfillRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken, checkpoint shared.ID, now time.Time, leaseDuration time.Duration) (run ports.FindingLineageBackfillRun, err error) {
+	tenantID, leaseOwner, now = shared.TenantOrDefault(tenantID), strings.TrimSpace(leaseOwner), now.UTC()
+	if leaseToken.IsZero() || checkpoint.IsZero() || leaseDuration <= 0 {
+		return ports.FindingLineageBackfillRun{}, fmt.Errorf("%w: finding lineage backfill checkpoint is invalid", shared.ErrValidation)
+	}
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		updated, err := scanFindingLineageBackfillRun(tx.QueryRow(ctx, `WITH counts AS (
+			SELECT count(*)::int AS c_processed,
+				count(*) FILTER (WHERE outcome='observation_created')::int AS c_observations,
+				count(*) FILTER (WHERE outcome='provisional_candidate_created')::int AS c_candidates,
+				count(*) FILTER (WHERE outcome='skipped')::int AS c_skipped
+			FROM finding_lineage_backfill_items WHERE tenant_id=$1 AND run_id=$2
+		) UPDATE finding_lineage_backfill_runs AS run SET checkpoint_finding_id=$5,updated_at=$6,lease_expires_at=$7,
+			processed_count=counts.c_processed,observation_created_count=counts.c_observations,
+			provisional_candidate_count=counts.c_candidates,skipped_count=counts.c_skipped
+			FROM counts WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3
+			AND run.lease_token=$4 AND run.lease_expires_at>$6 AND (
+				run.checkpoint_finding_id='' OR EXISTS (
+					SELECT 1 FROM findings previous,findings next
+					WHERE previous.tenant_id=$1 AND previous.id=run.checkpoint_finding_id
+						AND next.tenant_id=$1 AND next.id=$5
+						AND (next.created_at,next.id COLLATE "C") >= (previous.created_at,previous.id COLLATE "C")
+				)
+			) RETURNING `+findingLineageBackfillRunColumns,
+			tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), checkpoint.String(), now, now.Add(leaseDuration)))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: finding lineage backfill checkpoint rejected", shared.ErrConflict)
+		}
+		if err != nil {
+			return fmt.Errorf("advance finding lineage backfill run: %w", err)
+		}
+		run = updated
+		return nil
+	})
+	return run, err
+}
+
+func (repository *FindingLineageBackfillRepository) FinishFindingLineageBackfillRun(ctx context.Context, tenantID, runID shared.ID, leaseOwner string, leaseToken shared.ID, state ports.FindingLineageBackfillState, now time.Time) (run ports.FindingLineageBackfillRun, err error) {
+	if state != ports.FindingLineageBackfillCompleted && state != ports.FindingLineageBackfillCancelled && state != ports.FindingLineageBackfillFailed {
+		return ports.FindingLineageBackfillRun{}, fmt.Errorf("%w: invalid finding lineage backfill terminal state", shared.ErrValidation)
+	}
+	tenantID, leaseOwner, now = shared.TenantOrDefault(tenantID), strings.TrimSpace(leaseOwner), now.UTC()
+	if tenantID.IsZero() || runID.IsZero() || leaseOwner == "" || leaseToken.IsZero() || now.IsZero() {
+		return ports.FindingLineageBackfillRun{}, fmt.Errorf("%w: finding lineage backfill completion identity is invalid", shared.ErrValidation)
+	}
+	err = WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		finished, err := scanFindingLineageBackfillRun(tx.QueryRow(ctx, `WITH counts AS (
+			SELECT count(*)::int AS c_processed,
+				count(*) FILTER (WHERE outcome='observation_created')::int AS c_observations,
+				count(*) FILTER (WHERE outcome='provisional_candidate_created')::int AS c_candidates,
+				count(*) FILTER (WHERE outcome='skipped')::int AS c_skipped
+			FROM finding_lineage_backfill_items WHERE tenant_id=$1 AND run_id=$2
+		) UPDATE finding_lineage_backfill_runs AS run SET state=$5,lease_owner='',lease_token='',lease_expires_at=NULL,updated_at=$6,completed_at=$6,
+			processed_count=counts.c_processed,observation_created_count=counts.c_observations,
+			provisional_candidate_count=counts.c_candidates,skipped_count=counts.c_skipped
+			FROM counts WHERE run.tenant_id=$1 AND run.id=$2 AND run.state='running' AND run.lease_owner=$3
+			AND run.lease_token=$4 AND run.lease_expires_at>$6 RETURNING `+findingLineageBackfillRunColumns,
+			tenantID.String(), runID.String(), leaseOwner, leaseToken.String(), string(state), now))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: finding lineage backfill completion rejected", shared.ErrConflict)
+		}
+		if err != nil {
+			return fmt.Errorf("finish finding lineage backfill run: %w", err)
+		}
+		run = finished
+		return nil
+	})
+	return run, err
+}
+
+func scanFindingLineageBackfillRun(row rowScanner) (ports.FindingLineageBackfillRun, error) {
+	var (
+		run                       ports.FindingLineageBackfillRun
+		state                     string
+		leaseExpires, completedAt pgtype.Timestamptz
+	)
+	if err := row.Scan(&run.TenantID, &run.ID, &run.SchemaVersion, &run.DryRun, &run.BatchSize, &run.ProducerFilters, &run.SnapshotAt, &run.CheckpointFinding, &state, &run.LeaseOwner, &run.LeaseToken, &leaseExpires,
+		&run.ProcessedCount, &run.ObservationCreatedCount, &run.ProvisionalCandidateCount, &run.SkippedCount, &run.CreatedBy, &run.CreatedAt, &run.UpdatedAt, &completedAt); err != nil {
+		return ports.FindingLineageBackfillRun{}, err
+	}
+	run.State = ports.FindingLineageBackfillState(state)
+	if leaseExpires.Valid {
+		run.LeaseExpiresAt = leaseExpires.Time
+	}
+	if completedAt.Valid {
+		completed := completedAt.Time
+		run.CompletedAt = &completed
+	}
+	return run, nil
+}
+
+func validatePostgresFindingLineageBackfillAcquire(request ports.FindingLineageBackfillAcquireRequest) error {
+	run := request.Run
+	if run.TenantID.IsZero() || run.ID.IsZero() || run.LeaseToken.IsZero() || run.SchemaVersion <= 0 || run.BatchSize < 1 || run.BatchSize > 2000 || run.SnapshotAt.IsZero() || run.State != ports.FindingLineageBackfillRunning || strings.TrimSpace(run.LeaseOwner) == "" || len(run.LeaseOwner) > 256 || strings.TrimSpace(run.CreatedBy) == "" || len(run.CreatedBy) > 256 || run.CreatedAt.IsZero() || request.LeaseDuration <= 0 {
+		return fmt.Errorf("%w: finding lineage backfill run is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validatePostgresFindingLineageBackfillItem(item ports.FindingLineageBackfillItem) error {
+	validOutcome := item.Outcome == "observation_created" || item.Outcome == "provisional_candidate_created" || item.Outcome == "skipped"
+	_, hashErr := hex.DecodeString(item.SourceHash)
+	if item.TenantID.IsZero() || item.RunID.IsZero() || item.AssessmentID.IsZero() || item.SourceFindingID.IsZero() || item.SchemaVersion <= 0 || item.MatcherVersion <= 0 || strings.TrimSpace(item.IdempotencyKey) == "" || len(item.IdempotencyKey) > 128 || len(item.SourceHash) != 64 || strings.ToLower(item.SourceHash) != item.SourceHash || hashErr != nil || !validOutcome || !validPostgresBackfillReason(item.ReasonCode) || item.ProcessedAt.IsZero() {
+		return fmt.Errorf("%w: finding lineage backfill item is invalid", shared.ErrValidation)
+	}
+	if item.Outcome != "skipped" && (item.CycleID.IsZero() || item.SnapshotID.IsZero()) {
+		return fmt.Errorf("%w: created lineage backfill outcome requires Cycle and Snapshot", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validPostgresBackfillReason(value string) bool {
+	if len(value) < 1 || len(value) > 64 {
+		return false
+	}
+	for _, char := range value {
+		if char != '_' && (char < 'a' || char > 'z') && (char < '0' || char > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func backfillSourceLocation(data []byte) *finding.SourceLocation {
+	if len(data) == 0 {
+		return nil
+	}
+	var trace finding.DataFlowTrace
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if decoder.Decode(&trace) != nil || decoder.Decode(&struct{}{}) != io.EOF || trace.Validate() != nil {
+		return nil
+	}
+	sink := trace.Sink
+	return &sink
+}

--- a/internal/infrastructure/persistence/postgres/finding_lineage_backfill_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/finding_lineage_backfill_repo_test.go
@@ -1,0 +1,222 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestPostgresFindingLineageBackfillRunnerRLSAndReconciliation(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.Up(db, "."); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	tenantID, otherTenantID := shared.ID("lineage-backfill-pg"), shared.ID("lineage-backfill-other")
+	suffix := "backfill-pg"
+	assessmentID := shared.ID("lineage-assessment-" + suffix)
+	cycleID, snapshotID := createFindingLineageSnapshot(t, ctx, pool, tenantID, suffix)
+	ensureTestTenantAndEngagement(t, ctx, pool, otherTenantID, "lineage-backfill-other-assessment", "", "")
+	now := time.Now().UTC().Add(time.Minute)
+	findings := []finding.Finding{
+		{ID: "lineage-backfill-manual", EngagementID: assessmentID, Title: "Manual", Severity: shared.SeverityHigh, Status: finding.StatusOpen, Kind: finding.KindManual, DedupKey: "manual:lineage-backfill-manual", Audit: shared.Audit{CreatedAt: now.Add(-time.Minute), UpdatedAt: now.Add(-time.Minute)}},
+		{ID: "lineage-backfill-sast", EngagementID: assessmentID, Title: "SAST", Severity: shared.SeverityHigh, Status: finding.StatusOpen, Kind: finding.KindSAST, RuleKey: "go-sql", DedupKey: "cq:sast:go-sql:src/db.go:42", Audit: shared.Audit{CreatedAt: now.Add(-time.Minute), UpdatedAt: now.Add(-time.Minute)}},
+		{ID: "lineage-backfill-dast", EngagementID: assessmentID, Title: "DAST", Severity: shared.SeverityMedium, Status: finding.StatusOpen, Kind: finding.KindDAST, DedupKey: "dast:legacy", Audit: shared.Audit{CreatedAt: now.Add(-time.Minute), UpdatedAt: now.Add(-time.Minute)}},
+	}
+	if err := NewFindingRepository(pool).Upsert(shared.WithTenant(ctx, tenantID), findings); err != nil {
+		t.Fatal(err)
+	}
+	audit := NewAuditLog(pool)
+	clock := postgresLineageClock{now: now}
+	ids := &postgresLineageIDs{prefix: "lineage-backfill-generated"}
+	lineage, err := lineageuc.NewService(NewFindingLineageRepository(pool), NewTenantTransactionRunner(pool), audit, clock, ids, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backfillRepository := NewFindingLineageBackfillRepository(pool)
+	filtered, err := backfillRepository.ListFindingLineageBackfillSources(ctx, tenantID, "", now, []string{"manual"}, 10)
+	if err != nil || len(filtered) != 1 || filtered[0].FindingID != findings[0].ID {
+		t.Fatalf("producer-filtered sources=%+v err=%v", filtered, err)
+	}
+	runner, err := lineageuc.NewFindingLineageBackfillRunner(
+		lineage, backfillRepository, backfillRepository, NewAssessmentSnapshotRepository(pool),
+		NewVulnerabilityOccurrenceStore(pool), NewJudgmentRepository(pool), ids, clock, audit, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := runner.RunBackfill(ctx, lineageuc.FindingLineageBackfillRequest{TenantID: tenantID, Actor: "operator", LeaseOwner: "postgres", BatchSize: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.State != ports.FindingLineageBackfillCompleted || run.ProcessedCount != 3 || run.ObservationCreatedCount != 1 || run.ProvisionalCandidateCount != 1 || run.SkippedCount != 1 {
+		t.Fatalf("unexpected PostgreSQL backfill run: %+v", run)
+	}
+	if run.ProcessedCount != run.ObservationCreatedCount+run.ProvisionalCandidateCount+run.SkippedCount {
+		t.Fatalf("PostgreSQL counts do not reconcile: %+v", run)
+	}
+	lineageRepository := NewFindingLineageRepository(pool)
+	observations, err := lineageRepository.ListObservationsBySnapshot(ctx, tenantID, cycleID, snapshotID)
+	if err != nil || len(observations) != 2 {
+		t.Fatalf("observations=%+v err=%v", observations, err)
+	}
+	candidates, err := lineageRepository.ListOpenCandidatesBySnapshot(ctx, tenantID, cycleID, snapshotID)
+	if err != nil || len(candidates) != 1 {
+		t.Fatalf("candidates=%+v err=%v", candidates, err)
+	}
+	skips, err := lineageRepository.ListSkipsBySnapshot(ctx, tenantID, cycleID, snapshotID)
+	if err != nil || len(skips) != 1 || skips[0].DetailCode != lineageuc.BackfillReasonProducerMatcherUnavailable {
+		t.Fatalf("skips=%+v err=%v", skips, err)
+	}
+	if _, err := backfillRepository.GetFindingLineageBackfillRun(ctx, otherTenantID, run.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant run read=%v", err)
+	}
+	if _, err := backfillRepository.GetFindingLineageBackfillItem(ctx, otherTenantID, run.ID, findings[0].ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant item read=%v", err)
+	}
+}
+
+func TestPostgresFindingLineageBackfillConcurrentLeaseAndCompositeOwnership(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.Up(db, "."); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	tenantID := shared.ID("lineage-backfill-lease")
+	assessmentID := shared.ID("lineage-assessment-lineage-backfill-lease")
+	createFindingLineageSnapshot(t, ctx, pool, tenantID, "lineage-backfill-lease")
+	now := time.Date(2026, 9, 1, 1, 0, 0, 0, time.UTC)
+	if err := NewFindingRepository(pool).Upsert(shared.WithTenant(ctx, tenantID), []finding.Finding{{
+		ID: "lineage-backfill-lease-finding", EngagementID: assessmentID, Title: "Manual", Severity: shared.SeverityHigh,
+		Status: finding.StatusOpen, Kind: finding.KindManual, DedupKey: "manual:lineage-backfill-lease-finding", Audit: shared.Audit{CreatedAt: now.Add(-time.Minute), UpdatedAt: now.Add(-time.Minute)},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	repository := NewFindingLineageBackfillRepository(pool)
+	requests := []ports.FindingLineageBackfillAcquireRequest{
+		{Run: ports.FindingLineageBackfillRun{TenantID: tenantID, ID: "lease-run-a", SchemaVersion: 1, BatchSize: 500, SnapshotAt: now, State: ports.FindingLineageBackfillRunning, LeaseOwner: "owner-a", LeaseToken: "token-a", CreatedBy: "operator", CreatedAt: now, UpdatedAt: now}, LeaseDuration: time.Minute},
+		{Run: ports.FindingLineageBackfillRun{TenantID: tenantID, ID: "lease-run-b", SchemaVersion: 1, BatchSize: 500, SnapshotAt: now, State: ports.FindingLineageBackfillRunning, LeaseOwner: "owner-b", LeaseToken: "token-b", CreatedBy: "operator", CreatedAt: now, UpdatedAt: now}, LeaseDuration: time.Minute},
+	}
+	var wait sync.WaitGroup
+	results := make(chan error, 2)
+	for _, request := range requests {
+		request := request
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			_, _, err := repository.AcquireFindingLineageBackfillRun(ctx, request)
+			results <- err
+		}()
+	}
+	wait.Wait()
+	close(results)
+	succeeded, conflicted := 0, 0
+	for err := range results {
+		switch {
+		case err == nil:
+			succeeded++
+		case errors.Is(err, shared.ErrConflict):
+			conflicted++
+		default:
+			t.Fatalf("unexpected lease error: %v", err)
+		}
+	}
+	if succeeded != 1 || conflicted != 1 {
+		t.Fatalf("lease results succeeded=%d conflicted=%d", succeeded, conflicted)
+	}
+
+	var active ports.FindingLineageBackfillRun
+	for _, runID := range []shared.ID{"lease-run-a", "lease-run-b"} {
+		if run, err := repository.GetFindingLineageBackfillRun(ctx, tenantID, runID); err == nil {
+			active = run
+		}
+	}
+	resumed, wasResumed, err := repository.AcquireFindingLineageBackfillRun(ctx, ports.FindingLineageBackfillAcquireRequest{
+		Run: ports.FindingLineageBackfillRun{
+			TenantID: tenantID, ID: "lease-run-resume", SchemaVersion: 1, BatchSize: active.BatchSize, ProducerFilters: active.ProducerFilters,
+			SnapshotAt: active.SnapshotAt, State: ports.FindingLineageBackfillRunning, LeaseOwner: "owner-resumed", LeaseToken: "lease-token-resume", CreatedBy: "operator", CreatedAt: now.Add(2 * time.Minute), UpdatedAt: now.Add(2 * time.Minute),
+		},
+		LeaseDuration: time.Minute,
+	})
+	if err != nil || !wasResumed || resumed.ID != active.ID || resumed.LeaseOwner != "owner-resumed" {
+		t.Fatalf("expired lease resume=%+v resumed=%v err=%v", resumed, wasResumed, err)
+	}
+	active = resumed
+	item := ports.FindingLineageBackfillItem{
+		TenantID: tenantID, RunID: active.ID, AssessmentID: "wrong-assessment", SourceFindingID: "lineage-backfill-lease-finding",
+		SchemaVersion: 1, MatcherVersion: 1, IdempotencyKey: "ownership-key", SourceHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		Outcome: lineageuc.BackfillOutcomeSkipped, ReasonCode: lineageuc.BackfillReasonInvalidOwnership, ProcessedAt: now,
+	}
+	if _, _, err := repository.CommitFindingLineageBackfillItem(ctx, tenantID, active.ID, active.LeaseToken, now.Add(2*time.Minute), func(context.Context) (ports.FindingLineageBackfillItem, error) { return item, nil }); err == nil {
+		t.Fatal("composite Finding ownership accepted a mismatched Assessment")
+	}
+}
+
+func TestPostgresFindingLineageBackfillKeysetUsesChronologyAndBytewiseTieBreaker(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.Up(db, "."); err != nil {
+		t.Fatalf("migrate test database: %v", err)
+	}
+	ctx := context.Background()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	tenantID := shared.ID("lineage-keyset-tenant")
+	assessmentID := shared.ID("lineage-assessment-keyset")
+	createFindingLineageSnapshot(t, ctx, pool, tenantID, "keyset")
+	now := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+	items := []finding.Finding{
+		{ID: "ab", EngagementID: assessmentID, Title: "ab", Severity: shared.SeverityHigh, Status: finding.StatusOpen, Kind: finding.KindManual, Audit: shared.Audit{CreatedAt: now.Add(-time.Minute), UpdatedAt: now.Add(-time.Minute)}},
+		{ID: "z-older", EngagementID: assessmentID, Title: "old", Severity: shared.SeverityHigh, Status: finding.StatusOpen, Kind: finding.KindManual, Audit: shared.Audit{CreatedAt: now.Add(-2 * time.Minute), UpdatedAt: now.Add(-2 * time.Minute)}},
+		{ID: "a-b", EngagementID: assessmentID, Title: "a-b", Severity: shared.SeverityHigh, Status: finding.StatusOpen, Kind: finding.KindManual, Audit: shared.Audit{CreatedAt: now.Add(-time.Minute), UpdatedAt: now.Add(-time.Minute)}},
+		{ID: "A1", EngagementID: assessmentID, Title: "A1", Severity: shared.SeverityHigh, Status: finding.StatusOpen, Kind: finding.KindManual, Audit: shared.Audit{CreatedAt: now.Add(-time.Minute), UpdatedAt: now.Add(-time.Minute)}},
+	}
+	historicalTimes := make(map[shared.ID]shared.Audit, len(items))
+	for index := range items {
+		items[index].DedupKey = items[index].ID.String()
+		historicalTimes[items[index].ID] = items[index].Audit
+	}
+	if err := NewFindingRepository(pool).Upsert(shared.WithTenant(ctx, tenantID), items); err != nil {
+		t.Fatal(err)
+	}
+	// The live write path stamps ingestion time. This historical fixture pins the
+	// database timestamps so all rows precede the backfill's cutoff.
+	for _, item := range items {
+		if _, err := pool.Exec(ctx, `UPDATE findings SET created_at=$3,updated_at=$4 WHERE tenant_id=$1 AND id=$2`, tenantID.String(), item.ID.String(), historicalTimes[item.ID].CreatedAt, historicalTimes[item.ID].UpdatedAt); err != nil {
+			t.Fatal(err)
+		}
+	}
+	repository := NewFindingLineageBackfillRepository(pool)
+	first, err := repository.ListFindingLineageBackfillSources(ctx, tenantID, "", now, nil, 2)
+	if err != nil || len(first) != 2 || first[0].FindingID != "z-older" || first[1].FindingID != "A1" {
+		t.Fatalf("first=%+v err=%v", first, err)
+	}
+	second, err := repository.ListFindingLineageBackfillSources(ctx, tenantID, first[1].FindingID, now, nil, 2)
+	if err != nil || len(second) != 2 || second[0].FindingID != "a-b" || second[1].FindingID != "ab" {
+		t.Fatalf("second=%+v err=%v", second, err)
+	}
+}
+
+var _ ports.IDGenerator = idgen.RandomID{}

--- a/internal/infrastructure/persistence/postgres/finding_lineage_repo.go
+++ b/internal/infrastructure/persistence/postgres/finding_lineage_repo.go
@@ -1,0 +1,985 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const findingIdentityColumns = `tenant_id,cycle_id,id,producer_kind,finding_kind,canonicalization_version,
+	fingerprint_schema_version,lineage_fingerprint,target_identity_schema_version,target_identity_canonical,
+	canonical_identity_fields,first_seen_snapshot_id,created_at`
+
+const findingObservationColumns = `tenant_id,cycle_id,id,snapshot_id,identity_id,producer_kind,finding_kind,target_canonical,
+	source_finding_id,source_occurrence_id,severity,risk_score_milli,component_version,location,reachability,
+	evidence_digest,scanner_provenance,observed_at`
+
+const findingCandidateColumns = `tenant_id,cycle_id,snapshot_id,id,producer_kind,finding_kind,reason,fingerprint_schema_version,
+	fingerprint,source_reference_hash,candidate_set_hash,status,version,created_at,resolved_at,superseded_at,
+	COALESCE(superseded_by_candidate_id,'')`
+
+type FindingLineageRepository struct{ pool *pgxpool.Pool }
+
+func NewFindingLineageRepository(pool *pgxpool.Pool) *FindingLineageRepository {
+	return &FindingLineageRepository{pool: pool}
+}
+
+var _ ports.FindingLineageRepository = (*FindingLineageRepository)(nil)
+
+func (repository *FindingLineageRepository) LockCorrelationNamespace(ctx context.Context, tenantID, cycleID shared.ID, producerKind, findingKind, targetCanonical, discriminator string) error {
+	tenantID = shared.TenantOrDefault(tenantID)
+	if tenantID.IsZero() || cycleID.IsZero() || strings.TrimSpace(producerKind) == "" || strings.TrimSpace(findingKind) == "" || strings.TrimSpace(targetCanonical) == "" || strings.TrimSpace(discriminator) == "" {
+		return fmt.Errorf("%w: finding correlation lock namespace is invalid", shared.ErrValidation)
+	}
+	return WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		key := lineageLockKey(tenantID.String(), cycleID.String(), producerKind, findingKind, targetCanonical, discriminator)
+		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1,0))`, key); err != nil {
+			return fmt.Errorf("lock finding correlation namespace: %w", err)
+		}
+		return nil
+	})
+}
+
+func (repository *FindingLineageRepository) CreateIdentityWithObservation(ctx context.Context, identity findinglineage.Identity, observation findinglineage.Observation) error {
+	identity.TenantID = shared.TenantOrDefault(identity.TenantID)
+	observation.TenantID = shared.TenantOrDefault(observation.TenantID)
+	if err := identity.Validate(); err != nil {
+		return err
+	}
+	if err := observation.Validate(); err != nil {
+		return err
+	}
+	if identity.TenantID != observation.TenantID || identity.CycleID != observation.CycleID || identity.ID != observation.IdentityID ||
+		identity.FirstSeenSnapshotID != observation.SnapshotID || identity.ProducerKind != observation.ProducerKind ||
+		identity.FindingKind != observation.FindingKind || identity.TargetIdentityCanonical != observation.TargetCanonical {
+		return fmt.Errorf("%w: identity and first observation do not share ownership", shared.ErrValidation)
+	}
+	provenance, err := json.Marshal(observation.ScannerProvenance)
+	if err != nil {
+		return fmt.Errorf("encode finding observation provenance: %w", err)
+	}
+	return WithTenant(ctx, repository.pool, identity.TenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO finding_identities(
+			tenant_id,cycle_id,id,producer_kind,finding_kind,canonicalization_version,fingerprint_schema_version,
+			lineage_fingerprint,target_identity_schema_version,target_identity_canonical,canonical_identity_fields,
+			first_seen_snapshot_id,created_at) VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13)`,
+			identity.TenantID.String(), identity.CycleID.String(), identity.ID.String(), identity.ProducerKind, identity.FindingKind,
+			identity.CanonicalizationVersion, identity.FingerprintSchemaVersion, identity.LineageFingerprint,
+			identity.TargetIdentitySchemaVersion, identity.TargetIdentityCanonical, identity.CanonicalIdentityFields,
+			identity.FirstSeenSnapshotID.String(), identity.CreatedAt); err != nil {
+			return mapPostgresError(err, "create finding identity")
+		}
+		if err := insertFindingObservation(ctx, tx, observation, provenance); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (repository *FindingLineageRepository) AppendObservation(ctx context.Context, observation findinglineage.Observation) error {
+	observation.TenantID = shared.TenantOrDefault(observation.TenantID)
+	if err := observation.Validate(); err != nil {
+		return err
+	}
+	provenance, err := json.Marshal(observation.ScannerProvenance)
+	if err != nil {
+		return fmt.Errorf("encode finding observation provenance: %w", err)
+	}
+	return WithTenant(ctx, repository.pool, observation.TenantID.String(), func(tx pgx.Tx) error {
+		existing, err := loadFindingObservation(ctx, tx, observation.TenantID, observation.CycleID, observation.ID, "")
+		if err == nil {
+			if reflect.DeepEqual(existing, observation) {
+				return nil
+			}
+			return fmt.Errorf("%w: observation id was reused", shared.ErrConflict)
+		}
+		if !errors.Is(err, shared.ErrNotFound) {
+			return err
+		}
+		if err := insertFindingObservation(ctx, tx, observation, provenance); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+func (repository *FindingLineageRepository) AppendAlias(ctx context.Context, alias findinglineage.Alias) (bool, error) {
+	alias.TenantID = shared.TenantOrDefault(alias.TenantID)
+	if err := alias.Validate(); err != nil {
+		return false, err
+	}
+	created := false
+	err := WithTenant(ctx, repository.pool, alias.TenantID.String(), func(tx pgx.Tx) error {
+		var id string
+		err := tx.QueryRow(ctx, `INSERT INTO finding_identity_aliases(
+			tenant_id,cycle_id,id,identity_id,producer_kind,finding_kind,target_canonical,schema_version,fingerprint,approved_by,approved_at)
+			VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11) ON CONFLICT DO NOTHING RETURNING id`,
+			alias.TenantID.String(), alias.CycleID.String(), alias.ID.String(), alias.IdentityID.String(), alias.ProducerKind,
+			alias.FindingKind, alias.TargetCanonical, alias.SchemaVersion, alias.Fingerprint, alias.ApprovedBy, alias.ApprovedAt).Scan(&id)
+		if err == nil {
+			created = true
+			return nil
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return mapPostgresError(err, "append finding identity alias")
+		}
+		var existingID string
+		err = tx.QueryRow(ctx, `SELECT id FROM finding_identity_aliases WHERE tenant_id=$1 AND cycle_id=$2 AND identity_id=$3
+			AND producer_kind=$4 AND finding_kind=$5 AND target_canonical=$6 AND schema_version=$7 AND fingerprint=$8`,
+			alias.TenantID.String(), alias.CycleID.String(), alias.IdentityID.String(), alias.ProducerKind, alias.FindingKind,
+			alias.TargetCanonical, alias.SchemaVersion, alias.Fingerprint).Scan(&existingID)
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: alias id was reused", shared.ErrConflict)
+		}
+		return fmt.Errorf("read finding alias replay: %w", err)
+	})
+	return created, err
+}
+
+func (repository *FindingLineageRepository) GetIdentity(ctx context.Context, tenantID, cycleID, identityID shared.ID) (findinglineage.Identity, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var identity findinglineage.Identity
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		loaded, err := loadFindingIdentity(ctx, tx, tenantID, cycleID, identityID)
+		if err != nil {
+			return err
+		}
+		identity = loaded
+		return nil
+	})
+	return identity, err
+}
+
+func (repository *FindingLineageRepository) GetObservation(ctx context.Context, tenantID, cycleID, observationID shared.ID) (findinglineage.Observation, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var observation findinglineage.Observation
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		loaded, err := loadFindingObservation(ctx, tx, tenantID, cycleID, observationID, "")
+		if err != nil {
+			return err
+		}
+		observation = loaded
+		return nil
+	})
+	return observation, err
+}
+
+func (repository *FindingLineageRepository) GetObservationBySource(ctx context.Context, tenantID, cycleID, snapshotID shared.ID, producerKind, findingKind, targetCanonical, sourceFindingID, sourceOccurrenceID string) (findinglineage.Observation, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var observation findinglineage.Observation
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		loaded, err := scanFindingObservation(tx.QueryRow(ctx, `SELECT `+findingObservationColumns+` FROM finding_observations
+			WHERE tenant_id=$1 AND cycle_id=$2 AND snapshot_id=$3 AND producer_kind=$4 AND finding_kind=$5
+			AND target_canonical=$6 AND source_finding_id=$7 AND source_occurrence_id=$8`, tenantID.String(), cycleID.String(),
+			snapshotID.String(), producerKind, findingKind, targetCanonical, sourceFindingID, sourceOccurrenceID))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if err != nil {
+			return err
+		}
+		observation = loaded
+		return nil
+	})
+	return observation, err
+}
+
+func (repository *FindingLineageRepository) FindIdentitiesByProducerID(ctx context.Context, tenantID, cycleID shared.ID, producerKind, findingKind, targetCanonical, sourceID string) ([]findinglineage.Identity, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	return repository.findIdentities(ctx, tenantID, `SELECT DISTINCT `+prefixedColumns("i", findingIdentityColumns)+`
+		FROM finding_identities i JOIN finding_observations o
+		ON o.tenant_id=i.tenant_id AND o.cycle_id=i.cycle_id AND o.identity_id=i.id
+		WHERE o.tenant_id=$1 AND o.cycle_id=$2 AND o.producer_kind=$3 AND o.finding_kind=$4 AND o.target_canonical=$5
+		AND (o.source_finding_id=$6 OR o.source_occurrence_id=$6) ORDER BY i.id`,
+		tenantID.String(), cycleID.String(), producerKind, findingKind, targetCanonical, sourceID)
+}
+
+func (repository *FindingLineageRepository) FindIdentitiesByFingerprint(ctx context.Context, tenantID, cycleID shared.ID, producerKind, findingKind string, schemaVersion int, targetCanonical, fingerprint string) ([]findinglineage.Identity, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	return repository.findIdentities(ctx, tenantID, `SELECT `+findingIdentityColumns+` FROM finding_identities
+		WHERE tenant_id=$1 AND cycle_id=$2 AND producer_kind=$3 AND finding_kind=$4 AND fingerprint_schema_version=$5
+		AND target_identity_canonical=$6 AND lineage_fingerprint=$7 ORDER BY id`,
+		tenantID.String(), cycleID.String(), producerKind, findingKind, schemaVersion, targetCanonical, fingerprint)
+}
+
+func (repository *FindingLineageRepository) FindIdentitiesByAlias(ctx context.Context, tenantID, cycleID shared.ID, producerKind, findingKind string, schemaVersion int, targetCanonical, fingerprint string) ([]findinglineage.Identity, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	return repository.findIdentities(ctx, tenantID, `SELECT DISTINCT `+prefixedColumns("i", findingIdentityColumns)+`
+		FROM finding_identities i JOIN finding_identity_aliases a
+		ON a.tenant_id=i.tenant_id AND a.cycle_id=i.cycle_id AND a.identity_id=i.id
+		WHERE a.tenant_id=$1 AND a.cycle_id=$2 AND a.producer_kind=$3 AND a.finding_kind=$4 AND a.schema_version=$5
+		AND a.target_canonical=$6 AND a.fingerprint=$7 ORDER BY i.id`,
+		tenantID.String(), cycleID.String(), producerKind, findingKind, schemaVersion, targetCanonical, fingerprint)
+}
+
+func (repository *FindingLineageRepository) ListObservationsBySnapshot(ctx context.Context, tenantID, cycleID, snapshotID shared.ID) ([]findinglineage.Observation, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	observations := make([]findinglineage.Observation, 0)
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT `+findingObservationColumns+` FROM finding_observations
+			WHERE tenant_id=$1 AND cycle_id=$2 AND snapshot_id=$3 ORDER BY id`, tenantID.String(), cycleID.String(), snapshotID.String())
+		if err != nil {
+			return fmt.Errorf("list finding observations: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			observation, err := scanFindingObservation(rows)
+			if err != nil {
+				return err
+			}
+			observations = append(observations, observation)
+		}
+		return rows.Err()
+	})
+	return observations, err
+}
+
+func (repository *FindingLineageRepository) ListOpenCandidatesBySnapshot(ctx context.Context, tenantID, cycleID, snapshotID shared.ID) ([]findinglineage.MatchCandidate, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	candidates := make([]findinglineage.MatchCandidate, 0)
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT id FROM finding_match_candidates
+			WHERE tenant_id=$1 AND cycle_id=$2 AND snapshot_id=$3 AND status='open' ORDER BY id`,
+			tenantID.String(), cycleID.String(), snapshotID.String())
+		if err != nil {
+			return fmt.Errorf("list open finding candidates: %w", err)
+		}
+		var ids []shared.ID
+		for rows.Next() {
+			var id shared.ID
+			if err := rows.Scan(&id); err != nil {
+				rows.Close()
+				return err
+			}
+			ids = append(ids, id)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return err
+		}
+		rows.Close()
+		for _, id := range ids {
+			candidate, err := loadFindingCandidate(ctx, tx, tenantID, cycleID, id, false)
+			if err != nil {
+				return err
+			}
+			candidates = append(candidates, candidate)
+		}
+		return nil
+	})
+	return candidates, err
+}
+
+func (repository *FindingLineageRepository) ListActiveOverridesBySnapshot(ctx context.Context, tenantID, cycleID, snapshotID shared.ID) ([]findinglineage.OverrideEvent, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	events := make([]findinglineage.OverrideEvent, 0)
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT DISTINCT ON (e.source_observation_id)
+			e.tenant_id,e.cycle_id,e.id,e.action,e.source_observation_id,COALESCE(e.source_identity_id,''),
+			COALESCE(e.target_observation_id,''),e.target_identity_id,e.actor,e.reason,e.expected_version,e.version,
+			COALESCE(e.prior_event_id,''),e.content_hash,e.created_at
+			FROM finding_match_override_events e
+			JOIN finding_observations o ON o.tenant_id=e.tenant_id AND o.cycle_id=e.cycle_id AND o.id=e.source_observation_id
+			WHERE e.tenant_id=$1 AND e.cycle_id=$2 AND o.snapshot_id=$3
+			ORDER BY e.source_observation_id,e.version DESC`, tenantID.String(), cycleID.String(), snapshotID.String())
+		if err != nil {
+			return fmt.Errorf("list active finding overrides by snapshot: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			event, err := scanFindingOverride(rows)
+			if err != nil {
+				return err
+			}
+			events = append(events, event)
+		}
+		return rows.Err()
+	})
+	return events, err
+}
+
+func (repository *FindingLineageRepository) CreateCandidate(ctx context.Context, candidate findinglineage.MatchCandidate, supersessionEventID shared.ID) (findinglineage.MatchCandidate, bool, error) {
+	candidate.TenantID = shared.TenantOrDefault(candidate.TenantID)
+	if err := candidate.Validate(); err != nil {
+		return findinglineage.MatchCandidate{}, false, err
+	}
+	var stored findinglineage.MatchCandidate
+	created := false
+	err := WithTenant(ctx, repository.pool, candidate.TenantID.String(), func(tx pgx.Tx) error {
+		lockKey := lineageLockKey(candidate.TenantID.String(), candidate.CycleID.String(), candidate.SnapshotID.String(), candidate.ProducerKind, string(candidate.Reason), candidate.SourceReferenceHash)
+		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1,0))`, lockKey); err != nil {
+			return fmt.Errorf("lock finding match candidate subject: %w", err)
+		}
+		existing, err := loadFindingCandidateByIdempotency(ctx, tx, candidate)
+		if err == nil {
+			stored = existing
+			return nil
+		}
+		if !errors.Is(err, shared.ErrNotFound) {
+			return err
+		}
+		prior, err := loadOpenFindingCandidateBySubject(ctx, tx, candidate)
+		if err != nil && !errors.Is(err, shared.ErrNotFound) {
+			return err
+		}
+		if err == nil {
+			if supersessionEventID.IsZero() {
+				return fmt.Errorf("%w: supersession event id is required", shared.ErrValidation)
+			}
+			priorEventID, err := latestFindingResolutionID(ctx, tx, prior.TenantID, prior.CycleID, prior.ID)
+			if err != nil {
+				return err
+			}
+			updated, event, err := findinglineage.ResolveCandidate(prior, supersessionEventID, findinglineage.ResolutionSupersede,
+				"system:finding-lineage", "candidate_ref_set_changed", candidate.Refs, candidate.ID, prior.Version, priorEventID, candidate.CreatedAt)
+			if err != nil {
+				return err
+			}
+			if err := updateFindingCandidateCAS(ctx, tx, updated, prior.Version); err != nil {
+				return err
+			}
+			if err := insertFindingResolution(ctx, tx, event); err != nil {
+				return err
+			}
+		}
+		if err := insertFindingCandidate(ctx, tx, candidate); err != nil {
+			return err
+		}
+		stored, created = candidate, true
+		return nil
+	})
+	return stored, created, err
+}
+
+func (repository *FindingLineageRepository) GetCandidate(ctx context.Context, tenantID, cycleID, candidateID shared.ID) (findinglineage.MatchCandidate, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var candidate findinglineage.MatchCandidate
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		loaded, err := loadFindingCandidate(ctx, tx, tenantID, cycleID, candidateID, false)
+		if err != nil {
+			return err
+		}
+		candidate = loaded
+		return nil
+	})
+	return candidate, err
+}
+
+func (repository *FindingLineageRepository) ResolveCandidateCAS(ctx context.Context, updated findinglineage.MatchCandidate, event findinglineage.ResolutionEvent) (findinglineage.MatchCandidate, findinglineage.ResolutionEvent, bool, error) {
+	updated.TenantID = shared.TenantOrDefault(updated.TenantID)
+	event.TenantID = shared.TenantOrDefault(event.TenantID)
+	if err := updated.Validate(); err != nil {
+		return findinglineage.MatchCandidate{}, findinglineage.ResolutionEvent{}, false, err
+	}
+	if err := event.Validate(); err != nil {
+		return findinglineage.MatchCandidate{}, findinglineage.ResolutionEvent{}, false, err
+	}
+	var storedCandidate findinglineage.MatchCandidate
+	var storedEvent findinglineage.ResolutionEvent
+	applied := false
+	err := WithTenant(ctx, repository.pool, event.TenantID.String(), func(tx pgx.Tx) error {
+		existing, err := loadFindingResolutionByID(ctx, tx, event.TenantID, event.CycleID, event.ID)
+		if err == nil {
+			if existing.ContentHash != event.ContentHash {
+				return fmt.Errorf("%w: resolution event id was reused", shared.ErrConflict)
+			}
+			storedEvent = existing
+			storedCandidate, err = loadFindingCandidate(ctx, tx, event.TenantID, event.CycleID, event.CandidateID, false)
+			return err
+		}
+		if !errors.Is(err, shared.ErrNotFound) {
+			return err
+		}
+		current, err := loadFindingCandidate(ctx, tx, event.TenantID, event.CycleID, event.CandidateID, true)
+		if err != nil {
+			return err
+		}
+		priorEventID, err := latestFindingResolutionID(ctx, tx, event.TenantID, event.CycleID, event.CandidateID)
+		if err != nil {
+			return err
+		}
+		if priorEventID != event.PriorEventID {
+			return fmt.Errorf("%w: resolution prior event changed", shared.ErrConflict)
+		}
+		wantUpdated, wantEvent, err := findinglineage.ResolveCandidate(current, event.ID, event.Action, event.Actor, event.Reason,
+			event.AfterRefs, event.SuccessorCandidateID, event.ExpectedVersion, event.PriorEventID, event.CreatedAt)
+		if err != nil {
+			return err
+		}
+		if !samePostgresCandidateResolution(wantUpdated, updated) || wantEvent.ContentHash != event.ContentHash {
+			return fmt.Errorf("%w: resolution event does not match candidate", shared.ErrValidation)
+		}
+		if err := updateFindingCandidateCAS(ctx, tx, wantUpdated, event.ExpectedVersion); err != nil {
+			return err
+		}
+		if err := insertFindingResolution(ctx, tx, wantEvent); err != nil {
+			return err
+		}
+		storedCandidate, storedEvent, applied = wantUpdated, wantEvent, true
+		return nil
+	})
+	return storedCandidate, storedEvent, applied, err
+}
+
+func (repository *FindingLineageRepository) ListCandidateResolutions(ctx context.Context, tenantID, cycleID, candidateID shared.ID) ([]findinglineage.ResolutionEvent, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	events := make([]findinglineage.ResolutionEvent, 0)
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT tenant_id,cycle_id,candidate_id,id,action,actor,reason,before_refs,after_refs,
+			COALESCE(successor_candidate_id,''),expected_version,version,COALESCE(prior_event_id,''),content_hash,created_at
+			FROM finding_match_resolution_events WHERE tenant_id=$1 AND cycle_id=$2 AND candidate_id=$3 ORDER BY version`,
+			tenantID.String(), cycleID.String(), candidateID.String())
+		if err != nil {
+			return fmt.Errorf("list finding match resolutions: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			event, err := scanFindingResolution(rows)
+			if err != nil {
+				return err
+			}
+			events = append(events, event)
+		}
+		return rows.Err()
+	})
+	return events, err
+}
+
+func (repository *FindingLineageRepository) GetActiveOverride(ctx context.Context, tenantID, cycleID, sourceObservationID shared.ID) (findinglineage.OverrideEvent, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var event findinglineage.OverrideEvent
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		loaded, err := loadActiveFindingOverride(ctx, tx, tenantID, cycleID, sourceObservationID, false)
+		if err != nil {
+			return err
+		}
+		event = loaded
+		return nil
+	})
+	return event, err
+}
+
+func (repository *FindingLineageRepository) AppendOverrideCAS(ctx context.Context, event findinglineage.OverrideEvent) (findinglineage.OverrideEvent, bool, error) {
+	event.TenantID = shared.TenantOrDefault(event.TenantID)
+	if err := event.Validate(); err != nil {
+		return findinglineage.OverrideEvent{}, false, err
+	}
+	var stored findinglineage.OverrideEvent
+	applied := false
+	err := WithTenant(ctx, repository.pool, event.TenantID.String(), func(tx pgx.Tx) error {
+		lockKey := lineageLockKey(event.TenantID.String(), event.CycleID.String(), event.SourceObservationID.String())
+		if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtextextended($1,0))`, lockKey); err != nil {
+			return fmt.Errorf("lock finding override stream: %w", err)
+		}
+		existing, err := loadFindingOverrideByID(ctx, tx, event.TenantID, event.CycleID, event.ID)
+		if err == nil {
+			if existing.ContentHash != event.ContentHash {
+				return fmt.Errorf("%w: override event id was reused", shared.ErrConflict)
+			}
+			stored = existing
+			return nil
+		}
+		if !errors.Is(err, shared.ErrNotFound) {
+			return err
+		}
+		active, err := loadActiveFindingOverride(ctx, tx, event.TenantID, event.CycleID, event.SourceObservationID, true)
+		if errors.Is(err, shared.ErrNotFound) {
+			active = findinglineage.OverrideEvent{}
+		} else if err != nil {
+			return err
+		}
+		if active.Version != event.ExpectedVersion || active.ID != event.PriorEventID {
+			return fmt.Errorf("%w: override version changed", shared.ErrConflict)
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO finding_match_override_events(
+			tenant_id,cycle_id,id,action,source_observation_id,source_identity_id,target_observation_id,target_identity_id,
+			actor,reason,expected_version,version,prior_event_id,content_hash,created_at)
+			VALUES($1,$2,$3,$4,$5,NULLIF($6,''),NULLIF($7,''),$8,$9,$10,$11,$12,NULLIF($13,''),$14,$15)`,
+			event.TenantID.String(), event.CycleID.String(), event.ID.String(), string(event.Action), event.SourceObservationID.String(),
+			event.SourceIdentityID.String(), event.TargetObservationID.String(), event.TargetIdentityID.String(), event.Actor, event.Reason,
+			event.ExpectedVersion, event.Version, event.PriorEventID.String(), event.ContentHash, event.CreatedAt); err != nil {
+			return mapPostgresError(err, "append finding match override")
+		}
+		stored, applied = event, true
+		return nil
+	})
+	return stored, applied, err
+}
+
+func (repository *FindingLineageRepository) ListOverrideEvents(ctx context.Context, tenantID, cycleID, sourceObservationID shared.ID) ([]findinglineage.OverrideEvent, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	events := make([]findinglineage.OverrideEvent, 0)
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT tenant_id,cycle_id,id,action,source_observation_id,COALESCE(source_identity_id,''),
+			COALESCE(target_observation_id,''),target_identity_id,actor,reason,expected_version,version,COALESCE(prior_event_id,''),content_hash,created_at
+			FROM finding_match_override_events WHERE tenant_id=$1 AND cycle_id=$2 AND source_observation_id=$3 ORDER BY version`,
+			tenantID.String(), cycleID.String(), sourceObservationID.String())
+		if err != nil {
+			return fmt.Errorf("list finding match overrides: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			event, err := scanFindingOverride(rows)
+			if err != nil {
+				return err
+			}
+			events = append(events, event)
+		}
+		return rows.Err()
+	})
+	return events, err
+}
+
+func (repository *FindingLineageRepository) AppendSkip(ctx context.Context, record findinglineage.SkipRecord) (findinglineage.SkipRecord, bool, error) {
+	record.TenantID = shared.TenantOrDefault(record.TenantID)
+	if err := record.Validate(); err != nil {
+		return findinglineage.SkipRecord{}, false, err
+	}
+	stored := record
+	created := false
+	err := WithTenant(ctx, repository.pool, record.TenantID.String(), func(tx pgx.Tx) error {
+		var id string
+		err := tx.QueryRow(ctx, `INSERT INTO finding_lineage_skip_records(
+			tenant_id,cycle_id,snapshot_id,id,producer_kind,finding_kind,reason,source_reference_hash,detail_code,created_at)
+			VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) ON CONFLICT DO NOTHING RETURNING id`,
+			record.TenantID.String(), record.CycleID.String(), record.SnapshotID.String(), record.ID.String(), record.ProducerKind,
+			record.FindingKind, string(record.Reason), record.SourceReferenceHash, record.DetailCode, record.CreatedAt).Scan(&id)
+		if err == nil {
+			created = true
+			return nil
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return mapPostgresError(err, "append finding lineage skip")
+		}
+		err = tx.QueryRow(ctx, `SELECT tenant_id,cycle_id,snapshot_id,id,producer_kind,finding_kind,reason,source_reference_hash,detail_code,created_at
+			FROM finding_lineage_skip_records WHERE tenant_id=$1 AND cycle_id=$2 AND snapshot_id=$3
+			AND producer_kind=$4 AND reason=$5 AND source_reference_hash=$6`, record.TenantID.String(), record.CycleID.String(),
+			record.SnapshotID.String(), record.ProducerKind, string(record.Reason), record.SourceReferenceHash).Scan(
+			&stored.TenantID, &stored.CycleID, &stored.SnapshotID, &stored.ID, &stored.ProducerKind, &stored.FindingKind,
+			&stored.Reason, &stored.SourceReferenceHash, &stored.DetailCode, &stored.CreatedAt)
+		if err == nil {
+			if stored.FindingKind != record.FindingKind || stored.DetailCode != record.DetailCode {
+				return fmt.Errorf("%w: skip replay body differs", shared.ErrConflict)
+			}
+			return nil
+		}
+		if errors.Is(err, pgx.ErrNoRows) {
+			return fmt.Errorf("%w: skip record id was reused", shared.ErrConflict)
+		}
+		return fmt.Errorf("read finding lineage skip replay: %w", err)
+	})
+	return stored, created, err
+}
+
+func (repository *FindingLineageRepository) ListSkipsBySnapshot(ctx context.Context, tenantID, cycleID, snapshotID shared.ID) ([]findinglineage.SkipRecord, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	records := make([]findinglineage.SkipRecord, 0)
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT tenant_id,cycle_id,snapshot_id,id,producer_kind,finding_kind,reason,source_reference_hash,detail_code,created_at
+			FROM finding_lineage_skip_records WHERE tenant_id=$1 AND cycle_id=$2 AND snapshot_id=$3 ORDER BY id`,
+			tenantID.String(), cycleID.String(), snapshotID.String())
+		if err != nil {
+			return fmt.Errorf("list finding lineage skips: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var record findinglineage.SkipRecord
+			var tenant, cycle, snapshot, id, reason string
+			if err := rows.Scan(&tenant, &cycle, &snapshot, &id, &record.ProducerKind, &record.FindingKind, &reason,
+				&record.SourceReferenceHash, &record.DetailCode, &record.CreatedAt); err != nil {
+				return fmt.Errorf("scan finding lineage skip: %w", err)
+			}
+			record.TenantID, record.CycleID, record.SnapshotID, record.ID = shared.ID(tenant), shared.ID(cycle), shared.ID(snapshot), shared.ID(id)
+			record.Reason = findinglineage.SkipReason(reason)
+			records = append(records, record)
+		}
+		return rows.Err()
+	})
+	return records, err
+}
+
+func (repository *FindingLineageRepository) findIdentities(ctx context.Context, tenantID shared.ID, query string, args ...any) ([]findinglineage.Identity, error) {
+	identities := make([]findinglineage.Identity, 0)
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, query, args...)
+		if err != nil {
+			return fmt.Errorf("find finding identities: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			identity, err := scanFindingIdentity(rows)
+			if err != nil {
+				return err
+			}
+			identities = append(identities, identity)
+		}
+		return rows.Err()
+	})
+	return identities, err
+}
+
+func insertFindingObservation(ctx context.Context, tx pgx.Tx, observation findinglineage.Observation, provenance []byte) error {
+	if _, err := tx.Exec(ctx, `INSERT INTO finding_observations(
+		tenant_id,cycle_id,id,snapshot_id,identity_id,producer_kind,finding_kind,target_canonical,source_finding_id,
+		source_occurrence_id,severity,risk_score_milli,component_version,location,reachability,evidence_digest,scanner_provenance,observed_at)
+		VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18)`,
+		observation.TenantID.String(), observation.CycleID.String(), observation.ID.String(), observation.SnapshotID.String(),
+		observation.IdentityID.String(), observation.ProducerKind, observation.FindingKind, observation.TargetCanonical,
+		observation.SourceFindingID, observation.SourceOccurrenceID, string(observation.Severity), observation.RiskScoreMilli,
+		observation.ComponentVersion, observation.Location, observation.Reachability, observation.EvidenceDigest, provenance, observation.ObservedAt); err != nil {
+		return mapPostgresError(err, "append finding observation")
+	}
+	return nil
+}
+
+func insertFindingCandidate(ctx context.Context, tx pgx.Tx, candidate findinglineage.MatchCandidate) error {
+	if _, err := tx.Exec(ctx, `INSERT INTO finding_match_candidates(
+		tenant_id,cycle_id,snapshot_id,id,producer_kind,finding_kind,reason,fingerprint_schema_version,fingerprint,
+		source_reference_hash,candidate_set_hash,status,version,created_at,resolved_at,superseded_at,superseded_by_candidate_id)
+		VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,NULLIF($17,''))`,
+		candidate.TenantID.String(), candidate.CycleID.String(), candidate.SnapshotID.String(), candidate.ID.String(),
+		candidate.ProducerKind, candidate.FindingKind, string(candidate.Reason), candidate.FingerprintSchemaVersion,
+		candidate.Fingerprint, candidate.SourceReferenceHash, candidate.CandidateSetHash, string(candidate.Status), candidate.Version,
+		candidate.CreatedAt, candidate.ResolvedAt, candidate.SupersededAt, candidate.SupersededByCandidateID.String()); err != nil {
+		return mapPostgresError(err, "create finding match candidate")
+	}
+	for _, reference := range candidate.Refs {
+		payload := reference.ReasonPayload
+		if payload == nil {
+			payload = map[string]string{}
+		}
+		encoded, err := json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("encode finding candidate reference payload: %w", err)
+		}
+		if _, err := tx.Exec(ctx, `INSERT INTO finding_match_candidate_refs(
+			tenant_id,cycle_id,candidate_id,position,role,identity_id,observation_id,external_reference_hash,
+			match_method,score_milli,confidence,reason_payload)
+			VALUES($1,$2,$3,$4,$5,NULLIF($6,''),NULLIF($7,''),NULLIF($8,''),$9,$10,$11,$12)`,
+			candidate.TenantID.String(), candidate.CycleID.String(), candidate.ID.String(), reference.Position, string(reference.Role),
+			reference.IdentityID.String(), reference.ObservationID.String(), reference.ExternalReferenceHash, string(reference.Method),
+			reference.ScoreMilli, string(reference.Confidence), encoded); err != nil {
+			return mapPostgresError(err, "create finding match candidate reference")
+		}
+	}
+	return nil
+}
+
+func updateFindingCandidateCAS(ctx context.Context, tx pgx.Tx, candidate findinglineage.MatchCandidate, expectedVersion int64) error {
+	result, err := tx.Exec(ctx, `UPDATE finding_match_candidates SET status=$4,version=$5,resolved_at=$6,superseded_at=$7,
+		superseded_by_candidate_id=NULLIF($8,'') WHERE tenant_id=$1 AND cycle_id=$2 AND id=$3 AND status='open' AND version=$9`,
+		candidate.TenantID.String(), candidate.CycleID.String(), candidate.ID.String(), string(candidate.Status), candidate.Version,
+		candidate.ResolvedAt, candidate.SupersededAt, candidate.SupersededByCandidateID.String(), expectedVersion)
+	if err != nil {
+		return mapPostgresError(err, "resolve finding match candidate")
+	}
+	if result.RowsAffected() != 1 {
+		return fmt.Errorf("%w: candidate version or status changed", shared.ErrConflict)
+	}
+	return nil
+}
+
+func insertFindingResolution(ctx context.Context, tx pgx.Tx, event findinglineage.ResolutionEvent) error {
+	beforeValues := event.BeforeRefs
+	if beforeValues == nil {
+		beforeValues = []findinglineage.CandidateRef{}
+	}
+	afterValues := event.AfterRefs
+	if afterValues == nil {
+		afterValues = []findinglineage.CandidateRef{}
+	}
+	beforeRefs, err := json.Marshal(beforeValues)
+	if err != nil {
+		return fmt.Errorf("encode finding resolution before refs: %w", err)
+	}
+	afterRefs, err := json.Marshal(afterValues)
+	if err != nil {
+		return fmt.Errorf("encode finding resolution after refs: %w", err)
+	}
+	if _, err := tx.Exec(ctx, `INSERT INTO finding_match_resolution_events(
+		tenant_id,cycle_id,candidate_id,id,action,actor,reason,before_refs,after_refs,successor_candidate_id,
+		expected_version,version,prior_event_id,content_hash,created_at)
+		VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,NULLIF($10,''),$11,$12,NULLIF($13,''),$14,$15)`,
+		event.TenantID.String(), event.CycleID.String(), event.CandidateID.String(), event.ID.String(), string(event.Action),
+		event.Actor, event.Reason, beforeRefs, afterRefs, event.SuccessorCandidateID.String(), event.ExpectedVersion,
+		event.Version, event.PriorEventID.String(), event.ContentHash, event.CreatedAt); err != nil {
+		return mapPostgresError(err, "append finding match resolution")
+	}
+	return nil
+}
+
+func loadFindingIdentity(ctx context.Context, tx pgx.Tx, tenantID, cycleID, identityID shared.ID) (findinglineage.Identity, error) {
+	identity, err := scanFindingIdentity(tx.QueryRow(ctx, `SELECT `+findingIdentityColumns+` FROM finding_identities
+		WHERE tenant_id=$1 AND cycle_id=$2 AND id=$3`, tenantID.String(), cycleID.String(), identityID.String()))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return findinglineage.Identity{}, shared.ErrNotFound
+	}
+	return identity, err
+}
+
+func scanFindingIdentity(row rowScanner) (findinglineage.Identity, error) {
+	var identity findinglineage.Identity
+	var tenantID, cycleID, id, firstSnapshotID string
+	if err := row.Scan(&tenantID, &cycleID, &id, &identity.ProducerKind, &identity.FindingKind, &identity.CanonicalizationVersion,
+		&identity.FingerprintSchemaVersion, &identity.LineageFingerprint, &identity.TargetIdentitySchemaVersion,
+		&identity.TargetIdentityCanonical, &identity.CanonicalIdentityFields, &firstSnapshotID, &identity.CreatedAt); err != nil {
+		return findinglineage.Identity{}, err
+	}
+	identity.TenantID, identity.CycleID, identity.ID, identity.FirstSeenSnapshotID = shared.ID(tenantID), shared.ID(cycleID), shared.ID(id), shared.ID(firstSnapshotID)
+	if err := identity.Validate(); err != nil {
+		return findinglineage.Identity{}, fmt.Errorf("validate persisted finding identity: %w", err)
+	}
+	return identity, nil
+}
+
+func loadFindingObservation(ctx context.Context, tx pgx.Tx, tenantID, cycleID, observationID shared.ID, suffix string) (findinglineage.Observation, error) {
+	observation, err := scanFindingObservation(tx.QueryRow(ctx, `SELECT `+findingObservationColumns+` FROM finding_observations
+		WHERE tenant_id=$1 AND cycle_id=$2 AND id=$3 `+suffix, tenantID.String(), cycleID.String(), observationID.String()))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return findinglineage.Observation{}, shared.ErrNotFound
+	}
+	return observation, err
+}
+
+func scanFindingObservation(row rowScanner) (findinglineage.Observation, error) {
+	var observation findinglineage.Observation
+	var tenantID, cycleID, id, snapshotID, identityID, severity string
+	var provenance []byte
+	if err := row.Scan(&tenantID, &cycleID, &id, &snapshotID, &identityID, &observation.ProducerKind, &observation.FindingKind,
+		&observation.TargetCanonical, &observation.SourceFindingID, &observation.SourceOccurrenceID, &severity,
+		&observation.RiskScoreMilli, &observation.ComponentVersion, &observation.Location, &observation.Reachability,
+		&observation.EvidenceDigest, &provenance, &observation.ObservedAt); err != nil {
+		return findinglineage.Observation{}, err
+	}
+	observation.TenantID, observation.CycleID, observation.ID = shared.ID(tenantID), shared.ID(cycleID), shared.ID(id)
+	observation.SnapshotID, observation.IdentityID, observation.Severity = shared.ID(snapshotID), shared.ID(identityID), shared.Severity(severity)
+	if err := json.Unmarshal(provenance, &observation.ScannerProvenance); err != nil {
+		return findinglineage.Observation{}, fmt.Errorf("decode finding observation provenance: %w", err)
+	}
+	if err := observation.Validate(); err != nil {
+		return findinglineage.Observation{}, fmt.Errorf("validate persisted finding observation: %w", err)
+	}
+	return observation, nil
+}
+
+func loadFindingCandidateByIdempotency(ctx context.Context, tx pgx.Tx, candidate findinglineage.MatchCandidate) (findinglineage.MatchCandidate, error) {
+	loaded, err := scanFindingCandidate(tx.QueryRow(ctx, `SELECT `+findingCandidateColumns+` FROM finding_match_candidates
+		WHERE tenant_id=$1 AND cycle_id=$2 AND snapshot_id=$3 AND producer_kind=$4 AND reason=$5 AND candidate_set_hash=$6`,
+		candidate.TenantID.String(), candidate.CycleID.String(), candidate.SnapshotID.String(), candidate.ProducerKind,
+		string(candidate.Reason), candidate.CandidateSetHash))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return findinglineage.MatchCandidate{}, shared.ErrNotFound
+	}
+	if err != nil {
+		return findinglineage.MatchCandidate{}, err
+	}
+	return loadFindingCandidateRefs(ctx, tx, loaded)
+}
+
+func loadOpenFindingCandidateBySubject(ctx context.Context, tx pgx.Tx, candidate findinglineage.MatchCandidate) (findinglineage.MatchCandidate, error) {
+	loaded, err := scanFindingCandidate(tx.QueryRow(ctx, `SELECT `+findingCandidateColumns+` FROM finding_match_candidates
+		WHERE tenant_id=$1 AND cycle_id=$2 AND snapshot_id=$3 AND producer_kind=$4 AND reason=$5 AND source_reference_hash=$6
+		AND status='open' FOR UPDATE`, candidate.TenantID.String(), candidate.CycleID.String(), candidate.SnapshotID.String(),
+		candidate.ProducerKind, string(candidate.Reason), candidate.SourceReferenceHash))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return findinglineage.MatchCandidate{}, shared.ErrNotFound
+	}
+	if err != nil {
+		return findinglineage.MatchCandidate{}, err
+	}
+	return loadFindingCandidateRefs(ctx, tx, loaded)
+}
+
+func loadFindingCandidate(ctx context.Context, tx pgx.Tx, tenantID, cycleID, candidateID shared.ID, forUpdate bool) (findinglineage.MatchCandidate, error) {
+	suffix := ""
+	if forUpdate {
+		suffix = " FOR UPDATE"
+	}
+	loaded, err := scanFindingCandidate(tx.QueryRow(ctx, `SELECT `+findingCandidateColumns+` FROM finding_match_candidates
+		WHERE tenant_id=$1 AND cycle_id=$2 AND id=$3`+suffix, tenantID.String(), cycleID.String(), candidateID.String()))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return findinglineage.MatchCandidate{}, shared.ErrNotFound
+	}
+	if err != nil {
+		return findinglineage.MatchCandidate{}, err
+	}
+	return loadFindingCandidateRefs(ctx, tx, loaded)
+}
+
+func scanFindingCandidate(row rowScanner) (findinglineage.MatchCandidate, error) {
+	var candidate findinglineage.MatchCandidate
+	var tenantID, cycleID, snapshotID, id, reason, status, successorID string
+	if err := row.Scan(&tenantID, &cycleID, &snapshotID, &id, &candidate.ProducerKind, &candidate.FindingKind, &reason,
+		&candidate.FingerprintSchemaVersion, &candidate.Fingerprint, &candidate.SourceReferenceHash, &candidate.CandidateSetHash,
+		&status, &candidate.Version, &candidate.CreatedAt, &candidate.ResolvedAt, &candidate.SupersededAt, &successorID); err != nil {
+		return findinglineage.MatchCandidate{}, err
+	}
+	candidate.TenantID, candidate.CycleID, candidate.SnapshotID, candidate.ID = shared.ID(tenantID), shared.ID(cycleID), shared.ID(snapshotID), shared.ID(id)
+	candidate.Reason, candidate.Status = findinglineage.CandidateReason(reason), findinglineage.CandidateStatus(status)
+	candidate.SupersededByCandidateID = shared.ID(successorID)
+	return candidate, nil
+}
+
+func loadFindingCandidateRefs(ctx context.Context, tx pgx.Tx, candidate findinglineage.MatchCandidate) (findinglineage.MatchCandidate, error) {
+	rows, err := tx.Query(ctx, `SELECT position,role,COALESCE(identity_id,''),COALESCE(observation_id,''),
+		COALESCE(external_reference_hash,''),match_method,score_milli,confidence,reason_payload
+		FROM finding_match_candidate_refs WHERE tenant_id=$1 AND cycle_id=$2 AND candidate_id=$3 ORDER BY position`,
+		candidate.TenantID.String(), candidate.CycleID.String(), candidate.ID.String())
+	if err != nil {
+		return findinglineage.MatchCandidate{}, fmt.Errorf("load finding candidate refs: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var reference findinglineage.CandidateRef
+		var role, identityID, observationID, method, confidence string
+		var payload []byte
+		if err := rows.Scan(&reference.Position, &role, &identityID, &observationID, &reference.ExternalReferenceHash,
+			&method, &reference.ScoreMilli, &confidence, &payload); err != nil {
+			return findinglineage.MatchCandidate{}, fmt.Errorf("scan finding candidate ref: %w", err)
+		}
+		reference.Role, reference.IdentityID, reference.ObservationID = findinglineage.ReferenceRole(role), shared.ID(identityID), shared.ID(observationID)
+		reference.Method, reference.Confidence = findinglineage.MatchMethod(method), findinglineage.Confidence(confidence)
+		if err := json.Unmarshal(payload, &reference.ReasonPayload); err != nil {
+			return findinglineage.MatchCandidate{}, fmt.Errorf("decode finding candidate ref payload: %w", err)
+		}
+		candidate.Refs = append(candidate.Refs, reference)
+	}
+	if err := rows.Err(); err != nil {
+		return findinglineage.MatchCandidate{}, err
+	}
+	if err := candidate.Validate(); err != nil {
+		return findinglineage.MatchCandidate{}, fmt.Errorf("validate persisted finding candidate: %w", err)
+	}
+	return candidate, nil
+}
+
+func latestFindingResolutionID(ctx context.Context, tx pgx.Tx, tenantID, cycleID, candidateID shared.ID) (shared.ID, error) {
+	var id string
+	err := tx.QueryRow(ctx, `SELECT id FROM finding_match_resolution_events WHERE tenant_id=$1 AND cycle_id=$2 AND candidate_id=$3
+		ORDER BY version DESC LIMIT 1`, tenantID.String(), cycleID.String(), candidateID.String()).Scan(&id)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("load latest finding resolution: %w", err)
+	}
+	return shared.ID(id), nil
+}
+
+func loadFindingResolutionByID(ctx context.Context, tx pgx.Tx, tenantID, cycleID, eventID shared.ID) (findinglineage.ResolutionEvent, error) {
+	event, err := scanFindingResolution(tx.QueryRow(ctx, `SELECT tenant_id,cycle_id,candidate_id,id,action,actor,reason,before_refs,after_refs,
+		COALESCE(successor_candidate_id,''),expected_version,version,COALESCE(prior_event_id,''),content_hash,created_at
+		FROM finding_match_resolution_events WHERE tenant_id=$1 AND cycle_id=$2 AND id=$3`, tenantID.String(), cycleID.String(), eventID.String()))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return findinglineage.ResolutionEvent{}, shared.ErrNotFound
+	}
+	return event, err
+}
+
+func scanFindingResolution(row rowScanner) (findinglineage.ResolutionEvent, error) {
+	var event findinglineage.ResolutionEvent
+	var tenantID, cycleID, candidateID, id, action, successorID, priorEventID string
+	var beforeRefs, afterRefs []byte
+	if err := row.Scan(&tenantID, &cycleID, &candidateID, &id, &action, &event.Actor, &event.Reason, &beforeRefs, &afterRefs,
+		&successorID, &event.ExpectedVersion, &event.Version, &priorEventID, &event.ContentHash, &event.CreatedAt); err != nil {
+		return findinglineage.ResolutionEvent{}, err
+	}
+	event.TenantID, event.CycleID, event.CandidateID, event.ID = shared.ID(tenantID), shared.ID(cycleID), shared.ID(candidateID), shared.ID(id)
+	event.Action, event.SuccessorCandidateID, event.PriorEventID = findinglineage.ResolutionAction(action), shared.ID(successorID), shared.ID(priorEventID)
+	if err := json.Unmarshal(beforeRefs, &event.BeforeRefs); err != nil {
+		return findinglineage.ResolutionEvent{}, fmt.Errorf("decode finding resolution before refs: %w", err)
+	}
+	if err := json.Unmarshal(afterRefs, &event.AfterRefs); err != nil {
+		return findinglineage.ResolutionEvent{}, fmt.Errorf("decode finding resolution after refs: %w", err)
+	}
+	if err := event.Validate(); err != nil {
+		return findinglineage.ResolutionEvent{}, fmt.Errorf("validate persisted finding resolution: %w", err)
+	}
+	return event, nil
+}
+
+func loadActiveFindingOverride(ctx context.Context, tx pgx.Tx, tenantID, cycleID, sourceObservationID shared.ID, forUpdate bool) (findinglineage.OverrideEvent, error) {
+	suffix := ""
+	if forUpdate {
+		suffix = " FOR UPDATE"
+	}
+	event, err := scanFindingOverride(tx.QueryRow(ctx, `SELECT tenant_id,cycle_id,id,action,source_observation_id,COALESCE(source_identity_id,''),
+		COALESCE(target_observation_id,''),target_identity_id,actor,reason,expected_version,version,COALESCE(prior_event_id,''),content_hash,created_at
+		FROM finding_match_override_events WHERE tenant_id=$1 AND cycle_id=$2 AND source_observation_id=$3
+		ORDER BY version DESC LIMIT 1`+suffix, tenantID.String(), cycleID.String(), sourceObservationID.String()))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return findinglineage.OverrideEvent{}, shared.ErrNotFound
+	}
+	return event, err
+}
+
+func loadFindingOverrideByID(ctx context.Context, tx pgx.Tx, tenantID, cycleID, eventID shared.ID) (findinglineage.OverrideEvent, error) {
+	event, err := scanFindingOverride(tx.QueryRow(ctx, `SELECT tenant_id,cycle_id,id,action,source_observation_id,COALESCE(source_identity_id,''),
+		COALESCE(target_observation_id,''),target_identity_id,actor,reason,expected_version,version,COALESCE(prior_event_id,''),content_hash,created_at
+		FROM finding_match_override_events WHERE tenant_id=$1 AND cycle_id=$2 AND id=$3`, tenantID.String(), cycleID.String(), eventID.String()))
+	if errors.Is(err, pgx.ErrNoRows) {
+		return findinglineage.OverrideEvent{}, shared.ErrNotFound
+	}
+	return event, err
+}
+
+func scanFindingOverride(row rowScanner) (findinglineage.OverrideEvent, error) {
+	var event findinglineage.OverrideEvent
+	var tenantID, cycleID, id, action, sourceObservationID, sourceIdentityID, targetObservationID, targetIdentityID, priorEventID string
+	if err := row.Scan(&tenantID, &cycleID, &id, &action, &sourceObservationID, &sourceIdentityID, &targetObservationID,
+		&targetIdentityID, &event.Actor, &event.Reason, &event.ExpectedVersion, &event.Version, &priorEventID,
+		&event.ContentHash, &event.CreatedAt); err != nil {
+		return findinglineage.OverrideEvent{}, err
+	}
+	event.TenantID, event.CycleID, event.ID, event.Action = shared.ID(tenantID), shared.ID(cycleID), shared.ID(id), findinglineage.OverrideAction(action)
+	event.SourceObservationID, event.SourceIdentityID = shared.ID(sourceObservationID), shared.ID(sourceIdentityID)
+	event.TargetObservationID, event.TargetIdentityID = shared.ID(targetObservationID), shared.ID(targetIdentityID)
+	event.PriorEventID = shared.ID(priorEventID)
+	if err := event.Validate(); err != nil {
+		return findinglineage.OverrideEvent{}, fmt.Errorf("validate persisted finding override: %w", err)
+	}
+	return event, nil
+}
+
+func prefixedColumns(prefix, columns string) string {
+	parts := strings.Split(columns, ",")
+	for index, part := range parts {
+		parts[index] = prefix + "." + strings.TrimSpace(part)
+	}
+	return strings.Join(parts, ",")
+}
+
+func lineageLockKey(parts ...string) string {
+	var builder strings.Builder
+	for _, part := range parts {
+		fmt.Fprintf(&builder, "%d:%s", len(part), part)
+	}
+	return builder.String()
+}
+
+func samePostgresCandidateResolution(left, right findinglineage.MatchCandidate) bool {
+	return left.TenantID == right.TenantID && left.CycleID == right.CycleID && left.ID == right.ID &&
+		left.Status == right.Status && left.Version == right.Version && left.SupersededByCandidateID == right.SupersededByCandidateID &&
+		samePostgresOptionalTime(left.ResolvedAt, right.ResolvedAt) && samePostgresOptionalTime(left.SupersededAt, right.SupersededAt)
+}
+
+func samePostgresOptionalTime(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return left.Equal(*right)
+}

--- a/internal/infrastructure/persistence/postgres/finding_lineage_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/finding_lineage_repo_test.go
@@ -1,0 +1,958 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestPostgresFindingLineageRepositoryRLSCollisionCASAndImmutability(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := time.Now().UnixNano()
+	tenantA := shared.ID(fmt.Sprintf("lineage-tenant-a-%d", suffix))
+	tenantB := shared.ID(fmt.Sprintf("lineage-tenant-b-%d", suffix))
+	cycleID, snapshotID := createFindingLineageSnapshot(t, ctx, pool, tenantA, fmt.Sprintf("a-%d", suffix))
+	ensureTestTenantAndEngagement(t, ctx, pool, tenantB, shared.ID(fmt.Sprintf("lineage-other-%d", suffix)), "", "")
+	repository := NewFindingLineageRepository(pool)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	identityOne, observationOne := postgresFindingLineagePair(t, tenantA, cycleID, snapshotID, "identity-one", "observation-one", "source-one", "collision", now)
+	identityTwo, observationTwo := postgresFindingLineagePair(t, tenantA, cycleID, snapshotID, "identity-two", "observation-two", "source-two", "collision", now.Add(time.Second))
+	if err := repository.CreateIdentityWithObservation(ctx, identityOne, observationOne); err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.CreateIdentityWithObservation(ctx, identityTwo, observationTwo); err != nil {
+		t.Fatal(err)
+	}
+	identities, err := repository.FindIdentitiesByFingerprint(ctx, tenantA, cycleID, "sca", "vulnerability", 1, "repo:example", identityOne.LineageFingerprint)
+	if err != nil || len(identities) != 2 {
+		t.Fatalf("fingerprint identities=%+v err=%v", identities, err)
+	}
+	if _, err := repository.GetIdentity(ctx, tenantB, cycleID, identityOne.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant identity read=%v", err)
+	}
+
+	aliasFingerprint, err := findinglineage.HashAlias("sca", "vulnerability", "repo:example", 1, "legacy:one")
+	if err != nil {
+		t.Fatal(err)
+	}
+	alias := findinglineage.Alias{
+		TenantID: tenantA, CycleID: cycleID, ID: "alias-one", IdentityID: identityOne.ID, ProducerKind: "sca",
+		FindingKind: "vulnerability", TargetCanonical: "repo:example", SchemaVersion: 1, Fingerprint: aliasFingerprint,
+		ApprovedBy: "reviewer", ApprovedAt: now,
+	}
+	if created, err := repository.AppendAlias(ctx, alias); err != nil || !created {
+		t.Fatalf("append alias created=%v err=%v", created, err)
+	}
+	if created, err := repository.AppendAlias(ctx, alias); err != nil || created {
+		t.Fatalf("replay alias created=%v err=%v", created, err)
+	}
+	wrongAlias := alias
+	wrongAlias.ID, wrongAlias.TargetCanonical = "alias-wrong-namespace", "repo:other"
+	wrongAlias.Fingerprint, err = findinglineage.HashAlias("sca", "vulnerability", wrongAlias.TargetCanonical, 1, "legacy:other")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.AppendAlias(ctx, wrongAlias); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-namespace alias error=%v", err)
+	}
+	wrongObservation := observationOne
+	wrongObservation.ID, wrongObservation.SourceFindingID, wrongObservation.FindingKind = "observation-wrong-namespace", "source-wrong", "sast"
+	if err := repository.AppendObservation(ctx, wrongObservation); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-namespace observation error=%v", err)
+	}
+	aliased, err := repository.FindIdentitiesByAlias(ctx, tenantA, cycleID, "sca", "vulnerability", 1, "repo:example", aliasFingerprint)
+	if err != nil || len(aliased) != 1 || aliased[0].ID != identityOne.ID {
+		t.Fatalf("aliased identities=%+v err=%v", aliased, err)
+	}
+
+	sourceHash, err := findinglineage.SourceReferenceHash("sca", "vulnerability", "repo:example", "incoming", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	refs := []findinglineage.CandidateRef{
+		{Position: 0, Role: findinglineage.RoleSource, ExternalReferenceHash: sourceHash, Method: findinglineage.MethodFingerprint, ScoreMilli: 1000, Confidence: findinglineage.ConfidenceHigh},
+		{Position: 1, Role: findinglineage.RoleCandidate, IdentityID: identityOne.ID, Method: findinglineage.MethodFingerprint, ScoreMilli: 1000, Confidence: findinglineage.ConfidenceHigh},
+		{Position: 2, Role: findinglineage.RoleCandidate, IdentityID: identityTwo.ID, Method: findinglineage.MethodFingerprint, ScoreMilli: 1000, Confidence: findinglineage.ConfidenceHigh},
+	}
+	newCandidate := func(id shared.ID) findinglineage.MatchCandidate {
+		candidate, err := findinglineage.NewMatchCandidate(findinglineage.MatchCandidate{
+			TenantID: tenantA, CycleID: cycleID, SnapshotID: snapshotID, ID: id, ProducerKind: "sca", FindingKind: "vulnerability",
+			Reason: findinglineage.ReasonFingerprintCollision, FingerprintSchemaVersion: 1, Fingerprint: identityOne.LineageFingerprint,
+			SourceReferenceHash: sourceHash, Refs: refs, CreatedAt: now.Add(2 * time.Second),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return candidate
+	}
+
+	type candidateResult struct {
+		candidate findinglineage.MatchCandidate
+		created   bool
+		err       error
+	}
+	results := make(chan candidateResult, 2)
+	var wait sync.WaitGroup
+	for index := 0; index < 2; index++ {
+		wait.Add(1)
+		go func(index int) {
+			defer wait.Done()
+			candidate, created, err := repository.CreateCandidate(context.Background(), newCandidate(shared.ID(fmt.Sprintf("candidate-%d", index))), shared.ID(fmt.Sprintf("supersession-%d", index)))
+			results <- candidateResult{candidate: candidate, created: created, err: err}
+		}(index)
+	}
+	wait.Wait()
+	close(results)
+	var winner findinglineage.MatchCandidate
+	var creates, replays int
+	for result := range results {
+		if result.err != nil {
+			t.Fatal(result.err)
+		}
+		if result.created {
+			creates++
+			winner = result.candidate
+		} else {
+			replays++
+		}
+	}
+	if creates != 1 || replays != 1 || winner.ID.IsZero() {
+		t.Fatalf("candidate concurrency creates=%d replays=%d winner=%+v", creates, replays, winner)
+	}
+
+	identityThree, observationThree := postgresFindingLineagePair(t, tenantA, cycleID, snapshotID, "identity-three", "observation-three", "source-three", "collision", now.Add(3*time.Second))
+	if err := repository.CreateIdentityWithObservation(ctx, identityThree, observationThree); err != nil {
+		t.Fatal(err)
+	}
+	changedRefs := append(append([]findinglineage.CandidateRef(nil), refs...), findinglineage.CandidateRef{
+		Position: 3, Role: findinglineage.RoleCandidate, IdentityID: identityThree.ID, Method: findinglineage.MethodFingerprint, ScoreMilli: 1000, Confidence: findinglineage.ConfidenceHigh,
+	})
+	changed, err := findinglineage.NewMatchCandidate(findinglineage.MatchCandidate{
+		TenantID: tenantA, CycleID: cycleID, SnapshotID: snapshotID, ID: "candidate-changed", ProducerKind: "sca", FindingKind: "vulnerability",
+		Reason: findinglineage.ReasonFingerprintCollision, FingerprintSchemaVersion: 1, Fingerprint: identityOne.LineageFingerprint,
+		SourceReferenceHash: sourceHash, Refs: changedRefs, CreatedAt: now.Add(4 * time.Second),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed, created, err := repository.CreateCandidate(ctx, changed, "candidate-auto-supersession")
+	if err != nil || !created {
+		t.Fatalf("changed candidate=%+v created=%v err=%v", changed, created, err)
+	}
+	prior, err := repository.GetCandidate(ctx, tenantA, cycleID, winner.ID)
+	if err != nil || prior.Status != findinglineage.CandidateSuperseded || prior.SupersededByCandidateID != changed.ID {
+		t.Fatalf("prior candidate=%+v err=%v", prior, err)
+	}
+	resolutionEvents, err := repository.ListCandidateResolutions(ctx, tenantA, cycleID, winner.ID)
+	if err != nil || len(resolutionEvents) != 1 || resolutionEvents[0].Action != findinglineage.ResolutionSupersede {
+		t.Fatalf("automatic resolutions=%+v err=%v", resolutionEvents, err)
+	}
+
+	if err := WithTenant(ctx, pool, tenantA.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `UPDATE finding_match_candidates SET fingerprint=$1 WHERE tenant_id=$2 AND cycle_id=$3 AND id=$4`, strings.Repeat("f", 64), tenantA.String(), cycleID.String(), changed.ID.String())
+		return err
+	}); err == nil {
+		t.Fatal("candidate immutable fingerprint accepted mutation")
+	}
+
+	updated, resolution, err := findinglineage.ResolveCandidate(changed, "resolution-dismiss", findinglineage.ResolutionDismiss,
+		"reviewer", "not actionable", nil, "", 1, "", now.Add(5*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleUpdated, staleResolution, err := findinglineage.ResolveCandidate(changed, "resolution-stale", findinglineage.ResolutionDismiss,
+		"reviewer", "duplicate decision", nil, "", 1, "", now.Add(6*time.Second))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved, storedResolution, applied, err := repository.ResolveCandidateCAS(ctx, updated, resolution)
+	if err != nil || !applied || resolved.Status != findinglineage.CandidateResolved || storedResolution.Version != 2 {
+		t.Fatalf("resolved=%+v event=%+v applied=%v err=%v", resolved, storedResolution, applied, err)
+	}
+	if _, _, _, err := repository.ResolveCandidateCAS(ctx, staleUpdated, staleResolution); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale resolution=%v", err)
+	}
+	if replayed, _, applied, err := repository.ResolveCandidateCAS(ctx, updated, resolution); err != nil || applied || replayed.ID != resolved.ID {
+		t.Fatalf("resolution replay=%+v applied=%v err=%v", replayed, applied, err)
+	}
+
+	override, err := findinglineage.NewOverrideEvent(findinglineage.OverrideEvent{
+		TenantID: tenantA, CycleID: cycleID, ID: "override-one", Action: findinglineage.OverrideConfirm,
+		SourceObservationID: observationOne.ID, SourceIdentityID: identityOne.ID, TargetObservationID: observationTwo.ID,
+		TargetIdentityID: identityTwo.ID, Actor: "reviewer", Reason: "confirmed merge", Version: 1, CreatedAt: now.Add(7 * time.Second),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, applied, err := repository.AppendOverrideCAS(ctx, override); err != nil || !applied {
+		t.Fatalf("append override applied=%v err=%v", applied, err)
+	}
+	if _, applied, err := repository.AppendOverrideCAS(ctx, override); err != nil || applied {
+		t.Fatalf("override replay applied=%v err=%v", applied, err)
+	}
+	staleOverride, err := findinglineage.NewOverrideEvent(findinglineage.OverrideEvent{
+		TenantID: tenantA, CycleID: cycleID, ID: "override-stale", Action: findinglineage.OverrideUnlink,
+		SourceObservationID: observationOne.ID, TargetIdentityID: identityTwo.ID, Actor: "reviewer", Reason: "stale unlink",
+		Version: 1, CreatedAt: now.Add(8 * time.Second),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := repository.AppendOverrideCAS(ctx, staleOverride); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale override=%v", err)
+	}
+	active, err := repository.GetActiveOverride(ctx, tenantA, cycleID, observationOne.ID)
+	if err != nil || active.ID != override.ID {
+		t.Fatalf("active override=%+v err=%v", active, err)
+	}
+
+	if err := WithTenant(ctx, pool, tenantA.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `UPDATE finding_identities SET lineage_fingerprint=$1 WHERE tenant_id=$2 AND cycle_id=$3 AND id=$4`, strings.Repeat("e", 64), tenantA.String(), cycleID.String(), identityOne.ID.String())
+		return err
+	}); err == nil {
+		t.Fatal("identity accepted mutation")
+	}
+	if err := WithTenant(ctx, pool, tenantA.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `DELETE FROM finding_match_resolution_events WHERE tenant_id=$1 AND cycle_id=$2 AND id=$3`, tenantA.String(), cycleID.String(), resolution.ID.String())
+		return err
+	}); err == nil {
+		t.Fatal("resolution event accepted deletion")
+	}
+
+	for _, table := range []string{
+		"finding_identities", "finding_identity_aliases", "finding_observations", "finding_match_candidates",
+		"finding_match_candidate_refs", "finding_match_resolution_events", "finding_match_override_events", "finding_lineage_skip_records",
+	} {
+		var enabled, forced bool
+		if err := pool.QueryRow(ctx, `SELECT relrowsecurity,relforcerowsecurity FROM pg_class WHERE oid=$1::regclass`, table).Scan(&enabled, &forced); err != nil || !enabled || !forced {
+			t.Fatalf("RLS %s enabled=%v forced=%v err=%v", table, enabled, forced, err)
+		}
+	}
+}
+
+func TestPostgresFindingLineageConcurrentFirstObservationCreatesOneIdentity(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := time.Now().UnixNano()
+	tenantID := shared.ID(fmt.Sprintf("lineage-first-tenant-%d", suffix))
+	cycleID, snapshotID := createFindingLineageSnapshot(t, ctx, pool, tenantID, fmt.Sprintf("first-%d", suffix))
+	repository := NewFindingLineageRepository(pool)
+	clock := postgresLineageClock{now: time.Now().UTC().Truncate(time.Microsecond)}
+	services := make([]*lineageuc.Service, 2)
+	for index := range services {
+		var err error
+		services[index], err = lineageuc.NewService(repository, NewTenantTransactionRunner(pool), postgresLineageAudit{}, clock, &postgresLineageIDs{prefix: fmt.Sprintf("first-%d", index)}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	results := make(chan lineageuc.Result, 2)
+	errorsOut := make(chan error, 2)
+	var wait sync.WaitGroup
+	for index := range services {
+		index := index
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			result, err := services[index].Correlate(context.Background(), lineageuc.CorrelateInput{
+				TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshotID,
+				ProducerKind: "sca", FindingKind: "vulnerability", FingerprintSchemaVersion: 1,
+				FingerprintInput: findinglineage.FingerprintCanonicalInputV1{
+					CanonicalizationVersion: 1, ProducerKind: "sca", TargetIdentitySchemaVersion: 1,
+					TargetIdentityCanonical: "repo:concurrent", IdentityFields: map[string]findinglineage.CanonicalValue{"rule": findinglineage.Text("same")},
+				},
+				InputTrusted: true, OwnershipValidated: true, RedactionComplete: true, Actor: "scanner",
+				Observation: lineageuc.ObservationInput{
+					ID: shared.ID(fmt.Sprintf("first-observation-%d", index)), SourceFindingID: fmt.Sprintf("first-source-%d", index),
+					Severity: shared.SeverityHigh, ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "scanner"}, ObservedAt: clock.now,
+				},
+			})
+			if err != nil {
+				errorsOut <- err
+				return
+			}
+			results <- result
+		}()
+	}
+	wait.Wait()
+	close(results)
+	close(errorsOut)
+	for err := range errorsOut {
+		t.Fatal(err)
+	}
+	created, matched := 0, 0
+	for result := range results {
+		switch result.Outcome {
+		case lineageuc.OutcomeCreated:
+			created++
+		case lineageuc.OutcomeMatched:
+			matched++
+		}
+	}
+	fingerprint, err := findinglineage.CanonicalizeFingerprintV1(findinglineage.FingerprintCanonicalInputV1{
+		CanonicalizationVersion: 1, ProducerKind: "sca", TargetIdentitySchemaVersion: 1,
+		TargetIdentityCanonical: "repo:concurrent", IdentityFields: map[string]findinglineage.CanonicalValue{"rule": findinglineage.Text("same")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	identities, err := repository.FindIdentitiesByFingerprint(ctx, tenantID, cycleID, "sca", "vulnerability", 1, "repo:concurrent", fingerprint.Fingerprint)
+	if err != nil || created != 1 || matched != 1 || len(identities) != 1 {
+		t.Fatalf("created=%d matched=%d identities=%+v err=%v", created, matched, identities, err)
+	}
+}
+
+func TestPostgresSCAMatcherProvisionalIdentityAndCandidate(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := time.Now().UnixNano()
+	tenantID := shared.ID(fmt.Sprintf("sca-lineage-tenant-%d", suffix))
+	cycleID, snapshotID := createFindingLineageSnapshot(t, ctx, pool, tenantID, fmt.Sprintf("sca-%d", suffix))
+	clock := postgresLineageClock{now: time.Now().UTC().Truncate(time.Microsecond)}
+	ids := &postgresLineageIDs{prefix: fmt.Sprintf("sca-%d", suffix)}
+	service, err := lineageuc.NewService(NewFindingLineageRepository(pool), NewTenantTransactionRunner(pool), postgresLineageAudit{}, clock, ids, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matcher, err := lineageuc.NewSCAMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := matcher.Build(lineageuc.SCAFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", AdvisoryID: "CVE-2026-9090", PackagePURL: "pkg:npm/left-pad@1.0.0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := plan.Apply(lineageuc.CorrelateInput{
+		TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshotID,
+		InputTrusted: true, OwnershipValidated: true, RedactionComplete: true,
+		Observation: lineageuc.ObservationInput{
+			SourceFindingID: fmt.Sprintf("sca-source-%d", suffix), Severity: shared.SeverityHigh,
+			ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "sca-matcher-test"}, ObservedAt: clock.now,
+		},
+		Actor: "integration-test",
+	})
+	result, err := service.Correlate(ctx, input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != lineageuc.OutcomeReview || result.Identity == nil || result.Observation == nil || result.Candidate == nil {
+		t.Fatalf("provisional result=%+v", result)
+	}
+	if result.Candidate.Reason != findinglineage.ReasonInsufficientAnchor || len(result.Candidate.Refs) != 2 || result.Candidate.Refs[1].IdentityID != result.Identity.ID {
+		t.Fatalf("provisional candidate=%+v", result.Candidate)
+	}
+	repository := NewFindingLineageRepository(pool)
+	if _, err := repository.GetIdentity(ctx, tenantID, cycleID, result.Identity.ID); err != nil {
+		t.Fatalf("load provisional identity: %v", err)
+	}
+	if _, err := repository.GetCandidate(ctx, tenantID, cycleID, result.Candidate.ID); err != nil {
+		t.Fatalf("load provisional candidate: %v", err)
+	}
+}
+
+func TestPostgresSASTMatcherCanonicalIdentityAndTenantIsolation(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := time.Now().UnixNano()
+	tenantID := shared.ID(fmt.Sprintf("sast-lineage-tenant-%d", suffix))
+	otherTenantID := shared.ID(fmt.Sprintf("sast-lineage-other-%d", suffix))
+	cycleID, snapshotID := createFindingLineageSnapshot(t, ctx, pool, tenantID, fmt.Sprintf("sast-%d", suffix))
+	ensureTestTenantAndEngagement(t, ctx, pool, otherTenantID, shared.ID(fmt.Sprintf("sast-lineage-other-assessment-%d", suffix)), "", "")
+	clock := postgresLineageClock{now: time.Now().UTC().Truncate(time.Microsecond)}
+	ids := &postgresLineageIDs{prefix: fmt.Sprintf("sast-%d", suffix)}
+	service, err := lineageuc.NewService(NewFindingLineageRepository(pool), NewTenantTransactionRunner(pool), postgresLineageAudit{}, clock, ids, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matcher, err := lineageuc.NewSASTMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := matcher.Build(lineageuc.SASTFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", RepoPath: "src/handler.go", RuleKey: "go:sqli",
+		Anchor: lineageuc.SASTAnchorV1{Kind: lineageuc.SASTAnchorSymbol, SchemaVersion: 1, LanguageID: "go", QualifiedSymbol: "example.Handler.Serve"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := plan.Apply(lineageuc.CorrelateInput{
+		TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshotID,
+		InputTrusted: true, OwnershipValidated: true, RedactionComplete: true,
+		Observation: lineageuc.ObservationInput{
+			SourceFindingID: fmt.Sprintf("sast-source-%d", suffix), Severity: shared.SeverityHigh, Location: "src/handler.go:42",
+			ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "sast-matcher-test"}, ObservedAt: clock.now,
+		},
+		Actor: "integration-test",
+	})
+	result, err := service.Correlate(ctx, input)
+	if err != nil || result.Outcome != lineageuc.OutcomeCreated || result.Identity == nil || result.Observation == nil {
+		t.Fatalf("SAST result=%+v err=%v", result, err)
+	}
+	repository := NewFindingLineageRepository(pool)
+	stored, err := repository.GetIdentity(ctx, tenantID, cycleID, result.Identity.ID)
+	if err != nil || stored.ProducerKind != "sast" || stored.FindingKind != "sast" || !strings.Contains(string(stored.CanonicalIdentityFields), "example.Handler.Serve") {
+		t.Fatalf("stored SAST identity=%+v err=%v", stored, err)
+	}
+	if _, err := repository.GetIdentity(ctx, otherTenantID, cycleID, result.Identity.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant SAST identity read=%v", err)
+	}
+
+	provisionalPlan, err := matcher.Build(lineageuc.SASTFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", LegacyDedupKey: "cq:sast:broken",
+		LegacySourceValidated: true, LegacyOwnershipValid: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provisionalInput := provisionalPlan.Apply(lineageuc.CorrelateInput{
+		TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshotID,
+		InputTrusted: true, OwnershipValidated: true, RedactionComplete: true,
+		Observation: lineageuc.ObservationInput{
+			SourceFindingID: fmt.Sprintf("sast-legacy-source-%d", suffix), Severity: shared.SeverityHigh,
+			ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "sast-matcher-test"}, ObservedAt: clock.now,
+		},
+		Actor: "integration-test",
+	})
+	provisional, err := service.Correlate(ctx, provisionalInput)
+	if err != nil || provisional.Outcome != lineageuc.OutcomeReview || provisional.Identity == nil || provisional.Candidate == nil {
+		t.Fatalf("provisional SAST result=%+v err=%v", provisional, err)
+	}
+	if _, err := repository.GetCandidate(ctx, tenantID, cycleID, provisional.Candidate.ID); err != nil {
+		t.Fatalf("load provisional SAST candidate: %v", err)
+	}
+}
+
+func TestPostgresQualityMatcherParityAndTenantIsolation(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := time.Now().UnixNano()
+	tenantID := shared.ID(fmt.Sprintf("quality-lineage-tenant-%d", suffix))
+	otherTenantID := shared.ID(fmt.Sprintf("quality-lineage-other-%d", suffix))
+	cycleID, snapshotID := createFindingLineageSnapshot(t, ctx, pool, tenantID, fmt.Sprintf("quality-%d", suffix))
+	ensureTestTenantAndEngagement(t, ctx, pool, otherTenantID, shared.ID(fmt.Sprintf("quality-lineage-other-assessment-%d", suffix)), "", "")
+	clock := postgresLineageClock{now: time.Now().UTC().Truncate(time.Microsecond)}
+	ids := &postgresLineageIDs{prefix: fmt.Sprintf("quality-%d", suffix)}
+	service, err := lineageuc.NewService(NewFindingLineageRepository(pool), NewTenantTransactionRunner(pool), postgresLineageAudit{}, clock, ids, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matcher, err := lineageuc.NewQualityMatcherV1([]lineageuc.QualityRuleProfileV1{{Primary: "quality:file-license", OneFindingPerFile: true}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := matcher.Build(lineageuc.QualityFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", FindingClass: "quality", RepoPath: "src/app.go", RuleKey: "quality:file-license",
+		Anchor: lineageuc.QualityAnchorV1{Kind: lineageuc.QualityAnchorFile, SchemaVersion: 1},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := plan.Apply(lineageuc.CorrelateInput{
+		TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshotID,
+		InputTrusted: true, OwnershipValidated: true, RedactionComplete: true,
+		Observation: lineageuc.ObservationInput{
+			SourceFindingID: fmt.Sprintf("quality-source-%d", suffix), Severity: shared.SeverityLow, Location: "src/app.go:42",
+			ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "quality-matcher-test"}, ObservedAt: clock.now,
+		},
+		Actor: "integration-test",
+	})
+	result, err := service.Correlate(ctx, input)
+	if err != nil || result.Outcome != lineageuc.OutcomeCreated || result.Identity == nil {
+		t.Fatalf("quality result=%+v err=%v", result, err)
+	}
+	repository := NewFindingLineageRepository(pool)
+	stored, err := repository.GetIdentity(ctx, tenantID, cycleID, result.Identity.ID)
+	if err != nil || stored.ProducerKind != "quality" || stored.FindingKind != "quality" || !strings.Contains(string(stored.CanonicalIdentityFields), `"scope": "file"`) {
+		t.Fatalf("stored quality identity=%+v err=%v", stored, err)
+	}
+	if _, err := repository.GetIdentity(ctx, otherTenantID, cycleID, result.Identity.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant quality identity read=%v", err)
+	}
+
+	provisionalPlan, err := matcher.Build(lineageuc.QualityFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", FindingClass: "reliability", LegacyDedupKey: "cq:reliability:reliability-empty-catch:src/app.go:9",
+		LegacySourceValidated: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provisionalInput := provisionalPlan.Apply(lineageuc.CorrelateInput{
+		TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshotID,
+		InputTrusted: true, OwnershipValidated: true, RedactionComplete: true,
+		Observation: lineageuc.ObservationInput{
+			SourceFindingID: fmt.Sprintf("reliability-source-%d", suffix), Severity: shared.SeverityMedium,
+			ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "quality-matcher-test"}, ObservedAt: clock.now,
+		},
+		Actor: "integration-test",
+	})
+	provisional, err := service.Correlate(ctx, provisionalInput)
+	if err != nil || provisional.Outcome != lineageuc.OutcomeReview || provisional.Identity == nil || provisional.Candidate == nil {
+		t.Fatalf("provisional quality result=%+v err=%v", provisional, err)
+	}
+	if provisional.Identity.ProducerKind != "reliability" || provisional.Candidate.Reason != findinglineage.ReasonInsufficientAnchor {
+		t.Fatalf("provisional quality identity=%+v candidate=%+v", provisional.Identity, provisional.Candidate)
+	}
+}
+
+func TestPostgresSecretMatcherRedactionParityAndTenantIsolation(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := time.Now().UnixNano()
+	tenantID := shared.ID(fmt.Sprintf("secret-lineage-tenant-%d", suffix))
+	otherTenantID := shared.ID(fmt.Sprintf("secret-lineage-other-%d", suffix))
+	cycleID, snapshotID := createFindingLineageSnapshot(t, ctx, pool, tenantID, fmt.Sprintf("secret-%d", suffix))
+	ensureTestTenantAndEngagement(t, ctx, pool, otherTenantID, shared.ID(fmt.Sprintf("secret-lineage-other-assessment-%d", suffix)), "", "")
+	clock := postgresLineageClock{now: time.Now().UTC().Truncate(time.Microsecond)}
+	ids := &postgresLineageIDs{prefix: fmt.Sprintf("secret-%d", suffix)}
+	service, err := lineageuc.NewService(NewFindingLineageRepository(pool), NewTenantTransactionRunner(pool), postgresLineageAudit{}, clock, ids, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matcher, err := lineageuc.NewSecretMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sanitized, err := lineageuc.RedactSecretProducerInputV1(lineageuc.SecretProducerInputV1{
+		TargetIdentityCanonical: "repo:example", DetectorKey: "aws-access-key-id", SecretClass: "aws_access_key", RepoPath: "config/app.env",
+		Anchor: lineageuc.SecretAnchorV1{Kind: lineageuc.SecretAnchorEnvName, SchemaVersion: 1, ContainerName: "AWS_ACCESS_KEY_ID", ContainerApproved: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := matcher.Build(sanitized)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := plan.Apply(lineageuc.CorrelateInput{
+		TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshotID,
+		InputTrusted: true, OwnershipValidated: true, RedactionComplete: true,
+		Observation: lineageuc.ObservationInput{
+			SourceFindingID: fmt.Sprintf("secret-source-%d", suffix), Severity: shared.SeverityCritical, Location: "config/app.env:42",
+			ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "secret-matcher-test"}, ObservedAt: clock.now,
+		},
+		Actor: "integration-test",
+	})
+	result, err := service.Correlate(ctx, input)
+	if err != nil || result.Outcome != lineageuc.OutcomeCreated || result.Identity == nil {
+		t.Fatalf("secret result=%+v err=%v", result, err)
+	}
+	repository := NewFindingLineageRepository(pool)
+	stored, err := repository.GetIdentity(ctx, tenantID, cycleID, result.Identity.ID)
+	if err != nil || stored.ProducerKind != "secret" || stored.FindingKind != "secret" || !strings.Contains(string(stored.CanonicalIdentityFields), "AWS_ACCESS_KEY_ID") {
+		t.Fatalf("stored secret identity=%+v err=%v", stored, err)
+	}
+	if _, err := repository.GetIdentity(ctx, otherTenantID, cycleID, result.Identity.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant secret identity read=%v", err)
+	}
+
+	provisionalPlan, err := matcher.Build(lineageuc.SecretFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", SecretClass: "credential", LegacyDedupKey: "secret:generic-secret:config/app.env:9",
+		LegacySourceValidated: true, RedactionComplete: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provisionalInput := provisionalPlan.Apply(lineageuc.CorrelateInput{
+		TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshotID,
+		InputTrusted: true, OwnershipValidated: true, RedactionComplete: true,
+		Observation: lineageuc.ObservationInput{
+			SourceFindingID: fmt.Sprintf("secret-legacy-source-%d", suffix), Severity: shared.SeverityHigh,
+			ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "secret-matcher-test"}, ObservedAt: clock.now,
+		},
+		Actor: "integration-test",
+	})
+	provisional, err := service.Correlate(ctx, provisionalInput)
+	if err != nil || provisional.Outcome != lineageuc.OutcomeReview || provisional.Identity == nil || provisional.Candidate == nil {
+		t.Fatalf("provisional secret result=%+v err=%v", provisional, err)
+	}
+	if provisional.Candidate.Reason != findinglineage.ReasonInsufficientAnchor {
+		t.Fatalf("provisional secret candidate=%+v", provisional.Candidate)
+	}
+}
+
+func TestPostgresIaCMatcherAddressParityAndTenantIsolation(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := time.Now().UnixNano()
+	tenantID := shared.ID(fmt.Sprintf("iac-lineage-tenant-%d", suffix))
+	otherTenantID := shared.ID(fmt.Sprintf("iac-lineage-other-%d", suffix))
+	cycleID, snapshotID := createFindingLineageSnapshot(t, ctx, pool, tenantID, fmt.Sprintf("iac-%d", suffix))
+	ensureTestTenantAndEngagement(t, ctx, pool, otherTenantID, shared.ID(fmt.Sprintf("iac-lineage-other-assessment-%d", suffix)), "", "")
+	clock := postgresLineageClock{now: time.Now().UTC().Truncate(time.Microsecond)}
+	ids := &postgresLineageIDs{prefix: fmt.Sprintf("iac-%d", suffix)}
+	service, err := lineageuc.NewService(NewFindingLineageRepository(pool), NewTenantTransactionRunner(pool), postgresLineageAudit{}, clock, ids, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	matcher, err := lineageuc.NewIaCMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := matcher.Build(lineageuc.IaCFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", ConfigKind: lineageuc.IaCTerraform, RuleKey: "terraform-public-instance", RepoPath: "infra/main.tf",
+		SemanticConfigAnchorDigest: strings.Repeat("a", 64), TerraformAddress: `module.network[0].aws_instance.web["blue"]`,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := plan.Apply(lineageuc.CorrelateInput{
+		TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshotID,
+		InputTrusted: true, OwnershipValidated: true, RedactionComplete: true,
+		Observation: lineageuc.ObservationInput{
+			SourceFindingID: fmt.Sprintf("iac-source-%d", suffix), Severity: shared.SeverityHigh, Location: "infra/main.tf:42",
+			ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "iac-matcher-test"}, ObservedAt: clock.now,
+		},
+		Actor: "integration-test",
+	})
+	result, err := service.Correlate(ctx, input)
+	if err != nil || result.Outcome != lineageuc.OutcomeCreated || result.Identity == nil {
+		t.Fatalf("IaC result=%+v err=%v", result, err)
+	}
+	repository := NewFindingLineageRepository(pool)
+	stored, err := repository.GetIdentity(ctx, tenantID, cycleID, result.Identity.ID)
+	if err != nil || stored.ProducerKind != "iac" || stored.FindingKind != "misconfig" || !strings.Contains(string(stored.CanonicalIdentityFields), `aws_instance.web[\"blue\"]`) {
+		t.Fatalf("stored IaC identity=%+v err=%v", stored, err)
+	}
+	if _, err := repository.GetIdentity(ctx, otherTenantID, cycleID, result.Identity.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant IaC identity read=%v", err)
+	}
+
+	provisionalPlan, err := matcher.Build(lineageuc.IaCFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", ConfigKind: lineageuc.IaCKubernetes, RuleKey: "kubernetes-privileged", RepoPath: "deploy/app.yaml",
+		SemanticConfigAnchorDigest: strings.Repeat("b", 64), KubernetesAPIVersion: "apps/v1", KubernetesKind: "Deployment", KubernetesName: "api",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provisionalInput := provisionalPlan.Apply(lineageuc.CorrelateInput{
+		TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshotID,
+		InputTrusted: true, OwnershipValidated: true, RedactionComplete: true,
+		Observation: lineageuc.ObservationInput{
+			SourceFindingID: fmt.Sprintf("iac-kubernetes-source-%d", suffix), Severity: shared.SeverityHigh,
+			ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "iac-matcher-test"}, ObservedAt: clock.now,
+		},
+		Actor: "integration-test",
+	})
+	provisional, err := service.Correlate(ctx, provisionalInput)
+	if err != nil || provisional.Outcome != lineageuc.OutcomeReview || provisional.Identity == nil || provisional.Candidate == nil {
+		t.Fatalf("provisional IaC result=%+v err=%v", provisional, err)
+	}
+	if provisional.Candidate.Reason != findinglineage.ReasonInsufficientAnchor {
+		t.Fatalf("provisional IaC candidate=%+v", provisional.Candidate)
+	}
+
+	// The same unsupported semantic anchor must remain reviewable in every
+	// snapshot, even when the source-scoped provisional fingerprint matches.
+	assessmentID := shared.ID(fmt.Sprintf("lineage-assessment-iac-%d", suffix))
+	snapshotIDs := []shared.ID{snapshotID}
+	for number := 2; number <= 3; number++ {
+		runID := shared.ID(fmt.Sprintf("iac-repeat-run-%d-%d", suffix, number))
+		run := postgresNativeRun(t, tenantID, assessmentID, runID, strings.Repeat(fmt.Sprint(number), 64))
+		sealPostgresNativeRun(t, ctx, NewScanRunStore(pool), &run, time.Now().UTC())
+		snapshot := postgresAssessmentSnapshot(t, tenantID, cycleID, assessmentID,
+			fmt.Sprintf("iac-repeat-snapshot-%d-%d", suffix, number), fmt.Sprintf("iac-repeat-request-%d-%d", suffix, number), run)
+		stored, created, err := NewAssessmentSnapshotRepository(pool).CreateFinalizedCAS(ctx, snapshot, int64(number-1))
+		if err != nil || !created || stored.SnapshotNumber != number {
+			t.Fatalf("create repeated IaC snapshot=%+v created=%v err=%v", stored, created, err)
+		}
+		snapshotIDs = append(snapshotIDs, stored.ID)
+	}
+	for _, config := range []struct {
+		kind lineageuc.IaCConfigKind
+		rule string
+		path string
+	}{
+		{lineageuc.IaCDockerfile, "dockerfile-user-root", "Dockerfile"},
+		{lineageuc.IaCCompose, "compose-privileged", "compose.yaml"},
+		{lineageuc.IaCGitHubActions, "gha-permissions-write-all", ".github/workflows/ci.yml"},
+		{lineageuc.IaCARM, "arm-storage-public-blob", "azuredeploy.json"},
+	} {
+		t.Run(string(config.kind), func(t *testing.T) {
+			plan, err := matcher.Build(lineageuc.IaCFingerprintInputV1{
+				TargetIdentityCanonical: "repo:example", RuleKey: config.rule, RepoPath: config.path,
+			})
+			if err != nil || !plan.ProvisionalIdentity || plan.ReasonCode != "resource_identity_unavailable" {
+				t.Fatalf("unadapted IaC family plan=%+v err=%v", plan, err)
+			}
+			var identityID shared.ID
+			observationIDs, candidateIDs := make(map[shared.ID]bool), make(map[shared.ID]bool)
+			for index, currentSnapshotID := range snapshotIDs {
+				input := plan.Apply(lineageuc.CorrelateInput{
+					TenantID: tenantID, CycleID: cycleID, SnapshotID: currentSnapshotID,
+					InputTrusted: true, OwnershipValidated: true, RedactionComplete: true,
+					Observation: lineageuc.ObservationInput{
+						SourceFindingID: "iac-repeat-" + string(config.kind), Severity: shared.SeverityHigh,
+						Location: config.path + ":2", ObservedAt: clock.now.Add(time.Duration(index) * time.Second),
+						ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "iac-matcher-test"},
+					}, Actor: "integration-test",
+				})
+				result, err := service.Correlate(ctx, input)
+				if err != nil || result.Outcome != lineageuc.OutcomeReview || result.Identity == nil || result.Observation == nil || result.Candidate == nil {
+					t.Fatalf("snapshot %d lost provisional review: result=%+v err=%v", index+1, result, err)
+				}
+				if index == 0 {
+					identityID = result.Identity.ID
+				}
+				if result.Identity.ID != identityID || observationIDs[result.Observation.ID] || candidateIDs[result.Candidate.ID] {
+					t.Fatalf("snapshot %d must reuse identity but retain distinct observation/review: %+v", index+1, result)
+				}
+				observationIDs[result.Observation.ID], candidateIDs[result.Candidate.ID] = true, true
+				storedIdentity, err := repository.GetIdentity(ctx, tenantID, cycleID, identityID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var fields struct {
+					ConfigKind string `json:"config_kind"`
+				}
+				if err := json.Unmarshal(storedIdentity.CanonicalIdentityFields, &fields); err != nil || fields.ConfigKind != string(config.kind) {
+					t.Fatalf("config family lost on PostgreSQL roundtrip: kind=%q err=%v", fields.ConfigKind, err)
+				}
+				storedObservation, err := repository.GetObservation(ctx, tenantID, cycleID, result.Observation.ID)
+				if err != nil || storedObservation.SnapshotID != currentSnapshotID || storedObservation.IdentityID != identityID || storedObservation.SourceFindingID != input.Observation.SourceFindingID {
+					t.Fatalf("observation retention=%+v err=%v", storedObservation, err)
+				}
+				for range 2 {
+					replay, err := service.Correlate(ctx, input)
+					if err != nil || replay.Identity == nil || replay.Identity.ID != identityID || replay.Observation == nil || replay.Observation.ID != result.Observation.ID {
+						t.Fatalf("snapshot %d replay=%+v err=%v", index+1, replay, err)
+					}
+				}
+				storedCandidate, err := repository.GetCandidate(ctx, tenantID, cycleID, result.Candidate.ID)
+				if err != nil || storedCandidate.SnapshotID != currentSnapshotID || storedCandidate.Status != findinglineage.CandidateOpen || storedCandidate.Reason != findinglineage.ReasonInsufficientAnchor {
+					t.Fatalf("review must remain open after observation replay: %+v err=%v", storedCandidate, err)
+				}
+				if _, err := repository.GetIdentity(ctx, otherTenantID, cycleID, identityID); !errors.Is(err, shared.ErrNotFound) {
+					t.Fatalf("cross-tenant provisional identity read=%v", err)
+				}
+				if _, err := repository.GetObservation(ctx, otherTenantID, cycleID, result.Observation.ID); !errors.Is(err, shared.ErrNotFound) {
+					t.Fatalf("cross-tenant provisional observation read=%v", err)
+				}
+				if _, err := repository.GetCandidate(ctx, otherTenantID, cycleID, result.Candidate.ID); !errors.Is(err, shared.ErrNotFound) {
+					t.Fatalf("cross-tenant provisional candidate read=%v", err)
+				}
+			}
+		})
+	}
+	for index, currentSnapshotID := range snapshotIDs {
+		wantObservations, wantCandidates := 4, 4
+		if index == 0 {
+			wantObservations, wantCandidates = 6, 5 // Original Terraform and Kubernetes cases above.
+		}
+		observations, err := repository.ListObservationsBySnapshot(ctx, tenantID, cycleID, currentSnapshotID)
+		if err != nil || len(observations) != wantObservations {
+			t.Fatalf("snapshot %d replay duplicated/lost observations: count=%d want=%d err=%v", index+1, len(observations), wantObservations, err)
+		}
+		candidates, err := repository.ListOpenCandidatesBySnapshot(ctx, tenantID, cycleID, currentSnapshotID)
+		if err != nil || len(candidates) != wantCandidates {
+			t.Fatalf("snapshot %d replay duplicated/lost review candidates: count=%d want=%d err=%v", index+1, len(candidates), wantCandidates, err)
+		}
+	}
+}
+
+func TestPostgresManualLineageWorkflowParityAndTenantIsolation(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := time.Now().UnixNano()
+	tenantID := shared.ID(fmt.Sprintf("manual-lineage-tenant-%d", suffix))
+	otherTenantID := shared.ID(fmt.Sprintf("manual-lineage-other-%d", suffix))
+	cycleID, snapshotID := createFindingLineageSnapshot(t, ctx, pool, tenantID, fmt.Sprintf("manual-%d", suffix))
+	ensureTestTenantAndEngagement(t, ctx, pool, otherTenantID, shared.ID(fmt.Sprintf("manual-lineage-other-assessment-%d", suffix)), "", "")
+	clock := postgresLineageClock{now: time.Now().UTC().Truncate(time.Microsecond)}
+	ids := &postgresLineageIDs{prefix: fmt.Sprintf("manual-%d", suffix)}
+	repository := NewFindingLineageRepository(pool)
+	service, err := lineageuc.NewService(repository, NewTenantTransactionRunner(pool), postgresLineageAudit{}, clock, ids, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assessmentA := shared.ID(fmt.Sprintf("manual-assessment-a-%d", suffix))
+	assessmentB := shared.ID(fmt.Sprintf("manual-assessment-b-%d", suffix))
+	identityA := shared.ID(fmt.Sprintf("manual-identity-a-%d", suffix))
+	first, err := service.CorrelateNativeManual(ctx, lineageuc.NativeManualInput{
+		TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshotID, AssessmentID: assessmentA, IdentityID: identityA,
+		FindingClass: lineageuc.ManualFindingOffensive,
+		Observation: lineageuc.ObservationInput{
+			ID: shared.ID(fmt.Sprintf("manual-observation-a1-%d", suffix)), SourceFindingID: fmt.Sprintf("manual-source-a1-%d", suffix),
+			Severity: shared.SeverityHigh, Location: "endpoint:/admin", ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "manual-workflow-test"}, ObservedAt: clock.now,
+		},
+		Actor: "analyst-a",
+	})
+	if err != nil || first.Outcome != lineageuc.OutcomeCreated || first.Identity == nil || first.Identity.ID != identityA {
+		t.Fatalf("first native manual result=%+v err=%v", first, err)
+	}
+	second, err := service.CorrelateNativeManual(ctx, lineageuc.NativeManualInput{
+		TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshotID, AssessmentID: assessmentA, IdentityID: identityA,
+		FindingClass: lineageuc.ManualFindingOffensive,
+		Observation: lineageuc.ObservationInput{
+			ID: shared.ID(fmt.Sprintf("manual-observation-a2-%d", suffix)), SourceFindingID: fmt.Sprintf("manual-source-a2-%d", suffix),
+			Severity: shared.SeverityLow, Location: "endpoint:/renamed", ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "manual-workflow-test"}, ObservedAt: clock.now,
+		},
+		Actor: "analyst-a",
+	})
+	if err != nil || second.Outcome != lineageuc.OutcomeMatched || second.Identity == nil || second.Identity.ID != identityA {
+		t.Fatalf("same-Assessment native reuse=%+v err=%v", second, err)
+	}
+	if _, err := service.CorrelateNativeManual(ctx, lineageuc.NativeManualInput{
+		TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshotID, AssessmentID: assessmentB, IdentityID: identityA,
+		FindingClass: lineageuc.ManualFindingOffensive,
+		Observation: lineageuc.ObservationInput{
+			SourceFindingID: fmt.Sprintf("manual-source-conflict-%d", suffix), Severity: shared.SeverityHigh,
+			ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "manual-workflow-test"}, ObservedAt: clock.now,
+		},
+		Actor: "analyst-b",
+	}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("cross-Assessment explicit identity reuse error=%v", err)
+	}
+	source, err := service.CorrelateNativeManual(ctx, lineageuc.NativeManualInput{
+		TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshotID, AssessmentID: assessmentB,
+		IdentityID: shared.ID(fmt.Sprintf("manual-identity-b-%d", suffix)), FindingClass: lineageuc.ManualFindingOffensive,
+		Observation: lineageuc.ObservationInput{
+			ID: shared.ID(fmt.Sprintf("manual-observation-b-%d", suffix)), SourceFindingID: fmt.Sprintf("manual-source-b-%d", suffix),
+			Severity: shared.SeverityHigh, Location: "endpoint:/admin-v2", ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "manual-workflow-test"}, ObservedAt: clock.now,
+		},
+		Actor: "analyst-b",
+	})
+	if err != nil || source.Observation == nil || source.Identity == nil {
+		t.Fatalf("cross-Assessment source=%+v err=%v", source, err)
+	}
+	if _, err := repository.GetIdentity(ctx, otherTenantID, cycleID, identityA); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant native identity read=%v", err)
+	}
+
+	importPlan, err := lineageuc.BuildManualImportMatchPlanV1(lineageuc.ManualImportFingerprintInputV1{
+		TargetIdentityCanonical: "project:example", AssessmentID: assessmentA, FindingClass: lineageuc.ManualFindingNative,
+		ImporterNamespace: "csv-import", ImporterSchemaVersion: 1, ExternalStableID: fmt.Sprintf("row-%d", suffix),
+		SourceValidated: true, RedactionComplete: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	importInput := importPlan.Apply(lineageuc.CorrelateInput{
+		TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshotID,
+		InputTrusted: true, OwnershipValidated: true, RedactionComplete: true,
+		Observation: lineageuc.ObservationInput{
+			ID: shared.ID(fmt.Sprintf("manual-import-observation-%d", suffix)), SourceFindingID: fmt.Sprintf("manual-import-source-%d", suffix),
+			Severity: shared.SeverityHigh, Location: "endpoint:/imported", ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "manual-import-test"}, ObservedAt: clock.now,
+		},
+		Actor: "importer",
+	})
+	imported, err := service.Correlate(ctx, importInput)
+	if err != nil || imported.Outcome != lineageuc.OutcomeReview || imported.Identity == nil || imported.Candidate == nil {
+		t.Fatalf("import candidate=%+v err=%v", imported, err)
+	}
+	replay := importInput
+	replay.Observation.Location = "endpoint:/different-body"
+	if _, err := service.Correlate(ctx, replay); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("same-key different-body import replay error=%v", err)
+	}
+	if _, err := repository.GetCandidate(ctx, otherTenantID, cycleID, imported.Candidate.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant manual candidate read=%v", err)
+	}
+
+	linkInput := lineageuc.ConfirmManualCrossAssessmentLinkInput{
+		TenantID: tenantID, CycleID: cycleID, EventID: shared.ID(fmt.Sprintf("manual-link-%d", suffix)),
+		SourceObservationID: source.Observation.ID, TargetIdentityID: identityA,
+		Actor: "reviewer", Role: userdom.RoleReviewer, Reason: "same verified offensive issue", IfMatchProvided: true, ExpectedVersion: 0,
+	}
+	event, applied, err := service.ConfirmManualCrossAssessmentLink(ctx, linkInput)
+	if err != nil || !applied || event.Action != findinglineage.OverrideConfirm || event.Version != 1 {
+		t.Fatalf("manual link event=%+v applied=%v err=%v", event, applied, err)
+	}
+	replayed, applied, err := service.ConfirmManualCrossAssessmentLink(ctx, linkInput)
+	if err != nil || applied || replayed.ID != event.ID {
+		t.Fatalf("manual link replay=%+v applied=%v err=%v", replayed, applied, err)
+	}
+	if _, err := repository.GetActiveOverride(ctx, otherTenantID, cycleID, source.Observation.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant manual override read=%v", err)
+	}
+}
+
+func createFindingLineageSnapshot(t *testing.T, ctx context.Context, pool *pgxpool.Pool, tenantID shared.ID, suffix string) (shared.ID, shared.ID) {
+	t.Helper()
+	assessmentID := shared.ID("lineage-assessment-" + suffix)
+	cycleID := shared.ID("lineage-cycle-" + suffix)
+	runID := shared.ID("lineage-run-" + suffix)
+	snapshotID := shared.ID("lineage-snapshot-" + suffix)
+	ensureTestTenantAndEngagement(t, ctx, pool, tenantID, assessmentID, "", "")
+	now := time.Now().UTC()
+	cycle, err := assessmentcycle.NewAssessmentCycle(cycleID, tenantID, "Lineage cycle", assessmentcycle.BoundaryStandalone, "", "", assessmentID, "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember(tenantID, cycleID, assessmentID, "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cycleRepository := NewAssessmentCycleRepository(pool)
+	// This fixture also exercises the pre-lineage schema during upgrades.
+	// Do not use a current-schema writer that depends on later closure columns.
+	if _, err := pool.Exec(ctx, `INSERT INTO assessment_cycles
+		(tenant_id,id,name,boundary_kind,status,root_assessment_id,selected_head_assessment_id,created_at,updated_at,created_by,updated_by)
+		VALUES ($1,$2,$3,'standalone','open',$4,$4,$5,$5,'operator','operator')`,
+		tenantID.String(), cycle.ID.String(), cycle.Name, assessmentID.String(), now); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycleRepository.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+	run := postgresNativeRun(t, tenantID, assessmentID, runID, strings.Repeat("a", 64))
+	runRepository := NewScanRunStore(pool)
+	sealPostgresNativeRun(t, ctx, runRepository, &run, now)
+	snapshot := postgresAssessmentSnapshot(t, tenantID, cycleID, assessmentID, snapshotID.String(), "lineage-request-"+suffix, run)
+	stored, created, err := NewAssessmentSnapshotRepository(pool).CreateFinalizedCAS(ctx, snapshot, 0)
+	if err != nil || !created {
+		t.Fatalf("create lineage snapshot=%+v created=%v err=%v", stored, created, err)
+	}
+	return cycleID, stored.ID
+}
+
+func postgresFindingLineagePair(t *testing.T, tenantID, cycleID, snapshotID shared.ID, identityID, observationID, sourceID, rule string, now time.Time) (findinglineage.Identity, findinglineage.Observation) {
+	t.Helper()
+	fingerprint, err := findinglineage.CanonicalizeFingerprintV1(findinglineage.FingerprintCanonicalInputV1{
+		CanonicalizationVersion: 1, ProducerKind: "sca", TargetIdentitySchemaVersion: 1,
+		TargetIdentityCanonical: "repo:example", IdentityFields: map[string]findinglineage.CanonicalValue{"rule_id": findinglineage.Text(rule)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := findinglineage.Identity{
+		TenantID: tenantID, CycleID: cycleID, ID: shared.ID(identityID), ProducerKind: "sca", FindingKind: "vulnerability",
+		CanonicalizationVersion: 1, FingerprintSchemaVersion: 1, LineageFingerprint: fingerprint.Fingerprint,
+		TargetIdentitySchemaVersion: 1, TargetIdentityCanonical: "repo:example", CanonicalIdentityFields: fingerprint.IdentityFields,
+		FirstSeenSnapshotID: snapshotID, CreatedAt: now,
+	}
+	observation := findinglineage.Observation{
+		TenantID: tenantID, CycleID: cycleID, ID: shared.ID(observationID), SnapshotID: snapshotID, IdentityID: identity.ID,
+		ProducerKind: "sca", FindingKind: "vulnerability", TargetCanonical: "repo:example", SourceFindingID: sourceID,
+		Severity: shared.SeverityHigh, ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "scanner"}, ObservedAt: now,
+	}
+	return identity, observation
+}
+
+type postgresLineageClock struct{ now time.Time }
+
+func (clock postgresLineageClock) Now() time.Time { return clock.now }
+
+type postgresLineageIDs struct {
+	prefix string
+	next   int
+}
+
+func (ids *postgresLineageIDs) NewID() shared.ID {
+	ids.next++
+	return shared.ID(fmt.Sprintf("%s-%d", ids.prefix, ids.next))
+}
+
+type postgresLineageAudit struct{}
+
+func (postgresLineageAudit) Record(context.Context, ports.AuditEntry) error { return nil }

--- a/internal/infrastructure/persistence/postgres/scan_run_evidence.go
+++ b/internal/infrastructure/persistence/postgres/scan_run_evidence.go
@@ -1,0 +1,61 @@
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/jackc/pgx/v5"
+)
+
+var _ ports.ScanRunEvidenceStore = (*ScanRunStore)(nil)
+
+func (r *ScanRunStore) SaveScanRunEvidence(ctx context.Context, item ports.ScanRunEvidence) error {
+	if err := item.Validate(); err != nil {
+		return err
+	}
+	return WithTenant(ctx, r.pool, item.TenantID.String(), func(tx pgx.Tx) error {
+		var sealed bool
+		if err := tx.QueryRow(ctx, "SELECT sealed_at IS NOT NULL FROM scan_runs WHERE tenant_id=$1 AND id=$2 FOR UPDATE", item.TenantID.String(), item.RunID).Scan(&sealed); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return shared.ErrNotFound
+			}
+			return err
+		}
+		var hash string
+		var payload []byte
+		err := tx.QueryRow(ctx, "SELECT content_hash,payload FROM scan_run_comparison_evidence WHERE tenant_id=$1 AND run_id=$2", item.TenantID.String(), item.RunID).Scan(&hash, &payload)
+		if err == nil {
+			if hash != item.ContentHash || !bytes.Equal(payload, item.Payload) {
+				return fmt.Errorf("%w: scan evidence replay differs", shared.ErrConflict)
+			}
+			return nil
+		}
+		if !errors.Is(err, pgx.ErrNoRows) {
+			return err
+		}
+		if sealed {
+			return fmt.Errorf("%w: cannot append evidence to a sealed run", shared.ErrConflict)
+		}
+		_, err = tx.Exec(ctx, "INSERT INTO scan_run_comparison_evidence(tenant_id,run_id,content_hash,payload) VALUES ($1,$2,$3,$4)", item.TenantID.String(), item.RunID, item.ContentHash, item.Payload)
+		return err
+	})
+}
+
+func (r *ScanRunStore) GetScanRunEvidence(ctx context.Context, tenantID shared.ID, runID string) (ports.ScanRunEvidence, error) {
+	item := ports.ScanRunEvidence{TenantID: tenantID, RunID: runID}
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		err := tx.QueryRow(ctx, "SELECT content_hash,payload FROM scan_run_comparison_evidence WHERE tenant_id=$1 AND run_id=$2", tenantID.String(), runID).Scan(&item.ContentHash, &item.Payload)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		return err
+	})
+	if err == nil {
+		err = item.Validate()
+	}
+	return item, err
+}

--- a/internal/usecase/findinglineage/backfill.go
+++ b/internal/usecase/findinglineage/backfill.go
@@ -1,0 +1,750 @@
+package findinglineage
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	snapshotdom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	lineagedom "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityoccurrence"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	FindingLineageBackfillSchemaVersion = 1
+	DefaultFindingLineageBackfillBatch  = 500
+	MaxFindingLineageBackfillBatch      = 2000
+	findingLineageBackfillRetries       = 3
+	defaultFindingLineageBackfillLease  = 10 * time.Minute
+)
+
+const (
+	BackfillOutcomeObservationCreated   = "observation_created"
+	BackfillOutcomeProvisionalCandidate = "provisional_candidate_created"
+	BackfillOutcomeSkipped              = "skipped"
+
+	BackfillReasonInvalidOwnership           = "invalid_ownership_reference"
+	BackfillReasonMissingSnapshot            = "snapshot_not_found"
+	BackfillReasonMalformedTrustBoundary     = "malformed_trust_boundary"
+	BackfillReasonProducerMatcherUnavailable = "producer_matcher_unavailable"
+	BackfillReasonMissingTarget              = "missing_target_identity"
+	BackfillReasonAmbiguousTarget            = "ambiguous_target_identity"
+	BackfillReasonMissingTrustedJudgment     = "missing_trusted_judgment"
+)
+
+type FindingLineageBackfillObserver interface {
+	ObserveFindingLineageBackfillItem(outcome string)
+	ObserveFindingLineageBackfillRun(state string)
+}
+
+type lineageBackfillCorrelator interface {
+	Correlate(context.Context, CorrelateInput) (Result, error)
+	CorrelateNativeManual(context.Context, NativeManualInput) (Result, error)
+}
+
+type BackfillRunner struct {
+	lineage     lineageBackfillCorrelator
+	source      ports.FindingLineageBackfillSource
+	store       ports.FindingLineageBackfillStore
+	snapshots   ports.AssessmentSnapshotRepository
+	occurrences ports.VulnerabilityOccurrenceStore
+	judgments   ports.JudgmentStore
+	ids         ports.IDGenerator
+	clock       ports.Clock
+	audit       ports.AuditLogger
+	observer    FindingLineageBackfillObserver
+	sca         SCAMatcherV1
+	sast        SASTMatcherV1
+	quality     QualityMatcherV1
+	secret      SecretMatcherV1
+	iac         IaCMatcherV1
+}
+
+func NewFindingLineageBackfillRunner(lineage lineageBackfillCorrelator, source ports.FindingLineageBackfillSource, store ports.FindingLineageBackfillStore, snapshots ports.AssessmentSnapshotRepository, occurrences ports.VulnerabilityOccurrenceStore, judgments ports.JudgmentStore, ids ports.IDGenerator, clock ports.Clock, audit ports.AuditLogger, observer FindingLineageBackfillObserver) (*BackfillRunner, error) {
+	if lineage == nil || source == nil || store == nil || snapshots == nil || occurrences == nil || judgments == nil || ids == nil || clock == nil {
+		return nil, fmt.Errorf("%w: finding lineage backfill dependencies are required", shared.ErrValidation)
+	}
+	sca, err := NewSCAMatcherV1(nil)
+	if err != nil {
+		return nil, err
+	}
+	sast, err := NewSASTMatcherV1(nil)
+	if err != nil {
+		return nil, err
+	}
+	quality, err := NewQualityMatcherV1(nil)
+	if err != nil {
+		return nil, err
+	}
+	secret, err := NewSecretMatcherV1(nil)
+	if err != nil {
+		return nil, err
+	}
+	iac, err := NewIaCMatcherV1(nil)
+	if err != nil {
+		return nil, err
+	}
+	return &BackfillRunner{
+		lineage: lineage, source: source, store: store, snapshots: snapshots, occurrences: occurrences, judgments: judgments,
+		ids: ids, clock: clock, audit: audit, observer: observer, sca: sca, sast: sast, quality: quality, secret: secret, iac: iac,
+	}, nil
+}
+
+type FindingLineageBackfillRequest struct {
+	TenantID       shared.ID
+	Actor          string
+	LeaseOwner     string
+	DryRun         bool
+	BatchSize      int
+	ProducerFilter []string
+	ResumeAfter    shared.ID
+	LeaseDuration  time.Duration
+}
+
+func (runner *BackfillRunner) RunBackfill(ctx context.Context, request FindingLineageBackfillRequest) (ports.FindingLineageBackfillRun, error) {
+	tenantID := shared.TenantOrDefault(request.TenantID)
+	actor, leaseOwner := strings.TrimSpace(request.Actor), strings.TrimSpace(request.LeaseOwner)
+	if tenantID.IsZero() || actor == "" || len(actor) > 256 || leaseOwner == "" || len(leaseOwner) > 256 {
+		return ports.FindingLineageBackfillRun{}, fmt.Errorf("%w: tenant, actor, and lease owner are required", shared.ErrValidation)
+	}
+	batchSize := request.BatchSize
+	if batchSize == 0 {
+		batchSize = DefaultFindingLineageBackfillBatch
+	}
+	if batchSize < 1 || batchSize > MaxFindingLineageBackfillBatch {
+		return ports.FindingLineageBackfillRun{}, fmt.Errorf("%w: batch size must be between 1 and %d", shared.ErrValidation, MaxFindingLineageBackfillBatch)
+	}
+	producerFilters, err := NormalizeFindingLineageProducerFilters(request.ProducerFilter)
+	if err != nil {
+		return ports.FindingLineageBackfillRun{}, err
+	}
+	leaseDuration := request.LeaseDuration
+	if leaseDuration <= 0 {
+		leaseDuration = defaultFindingLineageBackfillLease
+	}
+	now := runner.clock.Now().UTC()
+	acquisitionID := runner.ids.NewID()
+	run, resumed, err := runner.store.AcquireFindingLineageBackfillRun(ctx, ports.FindingLineageBackfillAcquireRequest{
+		Run: ports.FindingLineageBackfillRun{
+			TenantID: tenantID, ID: acquisitionID, SchemaVersion: FindingLineageBackfillSchemaVersion,
+			DryRun: request.DryRun, BatchSize: batchSize, ProducerFilters: producerFilters, SnapshotAt: now,
+			State: ports.FindingLineageBackfillRunning, LeaseOwner: leaseOwner, LeaseToken: acquisitionID, LeaseExpiresAt: now.Add(leaseDuration),
+			CreatedBy: actor, CreatedAt: now, UpdatedAt: now,
+		},
+		InitialCheckpoint: request.ResumeAfter,
+		LeaseDuration:     leaseDuration,
+	})
+	if err != nil {
+		return ports.FindingLineageBackfillRun{}, err
+	}
+	ctx = shared.WithTenant(ctx, tenantID)
+	if auditErr := runner.record(ctx, actor, "finding_lineage.backfill_started", run.ID, map[string]string{
+		"tenant_id": tenantID.String(), "dry_run": strconv.FormatBool(run.DryRun), "resumed": strconv.FormatBool(resumed), "batch_size": strconv.Itoa(run.BatchSize),
+	}); auditErr != nil {
+		return runner.finishBackfill(ctx, run, leaseOwner, ports.FindingLineageBackfillFailed, actor, &ports.PartialWriteError{Operation: "finding lineage backfill start audit", IDs: []shared.ID{run.ID}, Err: auditErr})
+	}
+	cache := backfillCache{snapshots: map[shared.ID]*snapshotdom.Snapshot{}}
+	for {
+		if err := ctx.Err(); err != nil {
+			return runner.finishBackfill(ctx, run, leaseOwner, ports.FindingLineageBackfillCancelled, actor, err)
+		}
+		sources, err := runner.source.ListFindingLineageBackfillSources(ctx, tenantID, run.CheckpointFinding, run.SnapshotAt, run.ProducerFilters, run.BatchSize)
+		if err != nil {
+			return runner.finishBackfill(ctx, run, leaseOwner, findingLineageBackfillTerminalState(err), actor, err)
+		}
+		if len(sources) == 0 {
+			return runner.finishBackfill(ctx, run, leaseOwner, ports.FindingLineageBackfillCompleted, actor, nil)
+		}
+		if len(sources) > run.BatchSize {
+			return runner.finishBackfill(ctx, run, leaseOwner, ports.FindingLineageBackfillFailed, actor, fmt.Errorf("backfill source returned %d rows for limit %d", len(sources), run.BatchSize))
+		}
+		for _, source := range sources {
+			if err := ctx.Err(); err != nil {
+				return runner.finishBackfill(ctx, run, leaseOwner, ports.FindingLineageBackfillCancelled, actor, err)
+			}
+			if source.TenantID != tenantID || source.FindingID.IsZero() || source.AssessmentID.IsZero() {
+				return runner.finishBackfill(ctx, run, leaseOwner, ports.FindingLineageBackfillFailed, actor, fmt.Errorf("%w: backfill source ownership is invalid", shared.ErrValidation))
+			}
+			if _, err := runner.store.GetFindingLineageBackfillItem(ctx, tenantID, run.ID, source.FindingID); err == nil {
+				continue
+			} else if !errors.Is(err, shared.ErrNotFound) {
+				return runner.finishBackfill(ctx, run, leaseOwner, findingLineageBackfillTerminalState(err), actor, err)
+			}
+			item, created, err := runner.store.CommitFindingLineageBackfillItem(ctx, tenantID, run.ID, run.LeaseToken, runner.clock.Now().UTC(), func(txCtx context.Context) (ports.FindingLineageBackfillItem, error) {
+				return runner.processFindingSource(txCtx, run, source, actor, &cache)
+			})
+			if err != nil {
+				return runner.finishBackfill(ctx, run, leaseOwner, findingLineageBackfillTerminalState(err), actor, err)
+			}
+			if created && runner.observer != nil {
+				runner.observer.ObserveFindingLineageBackfillItem(item.Outcome)
+			}
+		}
+		checkpoint := sources[len(sources)-1].FindingID
+		run, err = runner.store.AdvanceFindingLineageBackfillRun(ctx, tenantID, run.ID, leaseOwner, run.LeaseToken, checkpoint, runner.clock.Now().UTC(), leaseDuration)
+		if err != nil {
+			return runner.finishBackfill(ctx, run, leaseOwner, findingLineageBackfillTerminalState(err), actor, err)
+		}
+		if auditErr := runner.record(ctx, actor, "finding_lineage.backfill_batch_committed", run.ID, map[string]string{
+			"tenant_id": tenantID.String(), "checkpoint_finding_id": checkpoint.String(), "processed_count": strconv.Itoa(run.ProcessedCount),
+		}); auditErr != nil {
+			return runner.finishBackfill(ctx, run, leaseOwner, ports.FindingLineageBackfillFailed, actor, &ports.PartialWriteError{Operation: "finding lineage backfill batch audit", IDs: []shared.ID{run.ID}, Err: auditErr})
+		}
+	}
+}
+
+type backfillCache struct {
+	snapshots map[shared.ID]*snapshotdom.Snapshot
+}
+
+type backfillJudgmentGetter interface {
+	GetByID(context.Context, shared.ID, shared.ID) (judgment.Judgment, error)
+}
+
+type preparedBackfill struct {
+	correlate      *CorrelateInput
+	manual         *NativeManualInput
+	matcherVersion int
+	reasonCode     string
+	plannedOutcome string
+}
+
+func (runner *BackfillRunner) processFindingSource(ctx context.Context, run ports.FindingLineageBackfillRun, source ports.FindingLineageBackfillSourceRow, actor string, cache *backfillCache) (ports.FindingLineageBackfillItem, error) {
+	item := ports.FindingLineageBackfillItem{
+		TenantID: run.TenantID, RunID: run.ID, AssessmentID: source.AssessmentID, CycleID: source.CycleID,
+		SnapshotID: source.SnapshotID, SourceFindingID: source.FindingID, SchemaVersion: run.SchemaVersion, ProcessedAt: runner.clock.Now().UTC(),
+	}
+	if !source.OwnershipValid || source.CycleID.IsZero() {
+		item.MatcherVersion, item.Outcome, item.ReasonCode = 1, BackfillOutcomeSkipped, BackfillReasonInvalidOwnership
+		finalizeFindingLineageBackfillItem(&item, source.SnapshotContentHash)
+		return item, nil
+	}
+	if source.SnapshotID.IsZero() || source.SnapshotContentHash == "" {
+		item.MatcherVersion, item.Outcome, item.ReasonCode = 1, BackfillOutcomeSkipped, BackfillReasonMissingSnapshot
+		finalizeFindingLineageBackfillItem(&item, source.SnapshotContentHash)
+		return item, nil
+	}
+	snapshot, err := runner.loadSnapshot(ctx, run.TenantID, source.SnapshotID, cache)
+	if err != nil {
+		return ports.FindingLineageBackfillItem{}, err
+	}
+	if snapshot.CycleID != source.CycleID || snapshot.AssessmentID != source.AssessmentID || snapshot.ContentHash != source.SnapshotContentHash {
+		return ports.FindingLineageBackfillItem{}, fmt.Errorf("%w: source Snapshot ownership or content hash changed", shared.ErrConflict)
+	}
+	var prepared preparedBackfill
+	for attempt := 0; attempt < findingLineageBackfillRetries; attempt++ {
+		prepared, err = runner.prepareFinding(ctx, source, *snapshot, actor, cache)
+		if err == nil || !retryableFindingLineageBackfillError(err) {
+			break
+		}
+	}
+	if err != nil {
+		if retryableFindingLineageBackfillError(err) {
+			return ports.FindingLineageBackfillItem{}, err
+		}
+		prepared = runner.prepareSkip(source, *snapshot, actor, BackfillReasonMalformedTrustBoundary, false, false)
+	}
+	item.MatcherVersion = prepared.matcherVersion
+	finalizeFindingLineageBackfillItem(&item, source.SnapshotContentHash)
+	if run.DryRun {
+		item.Outcome, item.ReasonCode = prepared.plannedOutcome, prepared.reasonCode
+		return item, nil
+	}
+	var result Result
+	for attempt := 0; attempt < findingLineageBackfillRetries; attempt++ {
+		if prepared.manual != nil {
+			result, err = runner.lineage.CorrelateNativeManual(ctx, *prepared.manual)
+		} else {
+			result, err = runner.lineage.Correlate(ctx, *prepared.correlate)
+		}
+		if err == nil || !retryableFindingLineageBackfillError(err) {
+			break
+		}
+	}
+	if err != nil {
+		return ports.FindingLineageBackfillItem{}, err
+	}
+	item.ReasonCode = prepared.reasonCode
+	if item.ReasonCode == "" {
+		item.ReasonCode = result.Reason
+	}
+	switch result.Outcome {
+	case OutcomeCreated:
+		item.Outcome = BackfillOutcomeObservationCreated
+	case OutcomeMatched:
+		item.Outcome = prepared.plannedOutcome
+	case OutcomeReview:
+		item.Outcome = BackfillOutcomeProvisionalCandidate
+	case OutcomeSkipped:
+		item.Outcome = BackfillOutcomeSkipped
+	default:
+		return ports.FindingLineageBackfillItem{}, fmt.Errorf("%w: unsupported lineage backfill result %q", shared.ErrValidation, result.Outcome)
+	}
+	return item, nil
+}
+
+func (runner *BackfillRunner) prepareFinding(ctx context.Context, source ports.FindingLineageBackfillSourceRow, snapshot snapshotdom.Snapshot, actor string, cache *backfillCache) (preparedBackfill, error) {
+	producer, findingKind := legacyProducer(source.Kind)
+	target := selectBackfillTarget(snapshot, producer, findingKind, source.AssessmentID)
+	observation, err := backfillObservation(source, target)
+	if err != nil {
+		return preparedBackfill{}, err
+	}
+	base := CorrelateInput{
+		TenantID: source.TenantID, CycleID: source.CycleID, SnapshotID: source.SnapshotID,
+		InputTrusted: true, OwnershipValidated: true, RedactionComplete: true, Observation: observation, Actor: actor,
+	}
+	var prepared preparedBackfill
+	switch source.Kind {
+	case "", finding.KindSCA:
+		occurrence, occurrenceFound, occurrenceErr := runner.findOccurrence(ctx, source, cache)
+		if occurrenceErr != nil {
+			if errors.Is(occurrenceErr, shared.ErrNotFound) {
+				return runner.prepareSkip(source, snapshot, actor, "invalid_source_reference", false, true), nil
+			}
+			return preparedBackfill{}, occurrenceErr
+		}
+		input := SCAFingerprintInputV1{TargetIdentityCanonical: target.canonical, AdvisoryID: source.AdvisoryID, LegacyDedupKey: source.DedupKey}
+		if occurrenceFound {
+			input.AdvisoryID, input.PackageEcosystem, input.PackageName = occurrence.AdvisoryID, occurrence.Ecosystem, occurrence.Package
+			base.Observation.ComponentVersion = occurrence.ComponentVersion
+		}
+		plan, err := runner.sca.Build(input)
+		if err != nil {
+			return preparedBackfill{}, err
+		}
+		correlate := plan.Apply(base)
+		prepared = preparedBackfill{correlate: &correlate, matcherVersion: SCAMatcherVersionV1, reasonCode: plan.ReasonCode}
+	case finding.KindSAST:
+		var judgmentAnchor *SASTAnchorV1
+		if judgmentID := legacySASTJudgmentID(source.DedupKey); !judgmentID.IsZero() {
+			current, found, err := runner.findJudgment(ctx, source.AssessmentID, judgmentID, cache)
+			if err != nil {
+				return preparedBackfill{}, err
+			}
+			if found {
+				anchor, anchorErr := SASTJudgmentAnchorV1(source.AssessmentID, current)
+				if anchorErr == nil {
+					judgmentAnchor = &anchor
+				}
+			}
+		}
+		plan, err := runner.sast.Build(SASTFingerprintInputV1{
+			TargetIdentityCanonical: target.canonical, RepoPath: sourcePath(source), RuleKey: source.RuleKey,
+			LegacyDedupKey: source.DedupKey, LegacySourceValidated: true, LegacyOwnershipValid: true, JudgmentAnchor: judgmentAnchor,
+		})
+		if err != nil {
+			return preparedBackfill{}, err
+		}
+		correlate := plan.Apply(base)
+		prepared = preparedBackfill{correlate: &correlate, matcherVersion: SASTMatcherVersionV1, reasonCode: plan.ReasonCode}
+		if !legacySASTJudgmentID(source.DedupKey).IsZero() && judgmentAnchor == nil {
+			correlate.ReviewDetailCode = BackfillReasonMissingTrustedJudgment
+			prepared.reasonCode = BackfillReasonMissingTrustedJudgment
+		}
+	case finding.KindQuality, finding.KindReliability:
+		plan, err := runner.quality.Build(QualityFingerprintInputV1{
+			TargetIdentityCanonical: target.canonical, FindingClass: string(source.Kind), RepoPath: sourcePath(source),
+			RuleKey: source.RuleKey, LegacyDedupKey: source.DedupKey, LegacySourceValidated: true,
+		})
+		if err != nil {
+			return preparedBackfill{}, err
+		}
+		correlate := plan.Apply(base)
+		prepared = preparedBackfill{correlate: &correlate, matcherVersion: QualityMatcherVersionV1, reasonCode: plan.ReasonCode}
+	case finding.KindSecret:
+		if unsafeLegacySecretKey(source.DedupKey) {
+			return preparedBackfill{}, ErrSecretMaterialRejected
+		}
+		redacted, err := RedactSecretProducerInputV1(SecretProducerInputV1{
+			TargetIdentityCanonical: target.canonical, DetectorKey: source.RuleKey, RepoPath: sourcePath(source),
+			LegacyDedupKey: source.DedupKey, LegacySourceValidated: true,
+		})
+		if err != nil {
+			return preparedBackfill{}, err
+		}
+		plan, err := runner.secret.Build(redacted)
+		if err != nil {
+			return preparedBackfill{}, err
+		}
+		correlate := plan.Apply(base)
+		prepared = preparedBackfill{correlate: &correlate, matcherVersion: SecretMatcherVersionV1, reasonCode: plan.ReasonCode}
+	case finding.KindMisconfig:
+		plan, err := runner.iac.Build(IaCFingerprintInputV1{
+			TargetIdentityCanonical: target.canonical, RuleKey: source.RuleKey, RepoPath: sourcePath(source),
+			LegacyDedupKey: source.DedupKey, LegacySourceValidated: true,
+		})
+		if err != nil {
+			return preparedBackfill{}, err
+		}
+		correlate := plan.Apply(base)
+		prepared = preparedBackfill{correlate: &correlate, matcherVersion: IaCMatcherVersionV1, reasonCode: plan.ReasonCode}
+	case finding.KindManual, finding.KindRecon, finding.KindExploitation:
+		class := ManualFindingNative
+		if source.Kind != finding.KindManual {
+			class = ManualFindingOffensive
+		}
+		if nativeManualSource(source) {
+			manual := NativeManualInput{
+				TenantID: source.TenantID, CycleID: source.CycleID, SnapshotID: source.SnapshotID, AssessmentID: source.AssessmentID,
+				IdentityID: legacyManualIdentityID(source.FindingID), FindingClass: class, Observation: observation, Actor: actor,
+			}
+			prepared = preparedBackfill{manual: &manual, matcherVersion: ManualNativeFingerprintSchemaVersionV1, reasonCode: "manual_native_explicit_id", plannedOutcome: BackfillOutcomeObservationCreated}
+			return prepared, nil
+		}
+		plan, err := BuildManualImportMatchPlanV1(ManualImportFingerprintInputV1{
+			TargetIdentityCanonical: "assessment:" + source.AssessmentID.String(), AssessmentID: source.AssessmentID,
+			FindingClass: class, ImporterNamespace: "legacy-finding", ImporterSchemaVersion: 1, SourceValidated: true, RedactionComplete: true,
+		})
+		if err != nil {
+			return preparedBackfill{}, err
+		}
+		correlate := plan.Apply(base)
+		prepared = preparedBackfill{correlate: &correlate, matcherVersion: ManualImportFingerprintSchemaVersionV1, reasonCode: plan.ReasonCode}
+	default:
+		return runner.prepareSkip(source, snapshot, actor, BackfillReasonProducerMatcherUnavailable, false, false), nil
+	}
+	if prepared.correlate != nil && target.reasonCode != "" && !prepared.correlate.ReviewReason.Valid() {
+		prepared.correlate.ProvisionalIdentity = true
+		prepared.correlate.ReviewReason = lineagedom.ReasonInsufficientAnchor
+		prepared.correlate.ReviewDetailCode = target.reasonCode
+		prepared.reasonCode = target.reasonCode
+	}
+	prepared.plannedOutcome = BackfillOutcomeObservationCreated
+	if prepared.correlate != nil && (prepared.correlate.ProvisionalIdentity || prepared.correlate.ReviewReason.Valid()) {
+		prepared.plannedOutcome = BackfillOutcomeProvisionalCandidate
+	}
+	return prepared, nil
+}
+
+func (runner *BackfillRunner) prepareSkip(source ports.FindingLineageBackfillSourceRow, snapshot snapshotdom.Snapshot, actor, detailCode string, redactionInvalid, ownershipInvalid bool) preparedBackfill {
+	producer, findingKind := legacyProducer(source.Kind)
+	target := selectBackfillTarget(snapshot, producer, findingKind, source.AssessmentID)
+	correlate := CorrelateInput{
+		TenantID: source.TenantID, CycleID: source.CycleID, SnapshotID: source.SnapshotID,
+		ProducerKind: producer, FindingKind: findingKind, FingerprintSchemaVersion: 1,
+		FingerprintInput: lineagedom.FingerprintCanonicalInputV1{
+			CanonicalizationVersion: lineagedom.CanonicalizationVersionV1, ProducerKind: producer,
+			TargetIdentitySchemaVersion: 1, TargetIdentityCanonical: target.canonical, IdentityFields: map[string]lineagedom.CanonicalValue{},
+		},
+		InputTrusted:       detailCode != BackfillReasonProducerMatcherUnavailable && detailCode != BackfillReasonMalformedTrustBoundary,
+		OwnershipValidated: !ownershipInvalid, RedactionComplete: !redactionInvalid, SkipDetailCode: detailCode,
+		Observation: ObservationInput{SourceFindingID: source.FindingID.String(), Severity: validBackfillSeverity(source.Severity), ScannerProvenance: lineagedom.ScannerProvenance{ToolName: "legacy-" + producer}, ObservedAt: source.ObservedAt},
+		Actor:       actor,
+	}
+	return preparedBackfill{correlate: &correlate, matcherVersion: 1, reasonCode: detailCode, plannedOutcome: BackfillOutcomeSkipped}
+}
+
+type backfillTarget struct {
+	canonical  string
+	reasonCode string
+	provenance lineagedom.ScannerProvenance
+}
+
+func selectBackfillTarget(snapshot snapshotdom.Snapshot, producer, findingKind string, assessmentID shared.ID) backfillTarget {
+	targets := map[string]lineagedom.ScannerProvenance{}
+	for _, dimension := range snapshot.Dimensions {
+		if dimension.Producer != producer || dimension.FindingKind != findingKind {
+			continue
+		}
+		targets[dimension.Target.Canonical] = lineagedom.ScannerProvenance{
+			ScanRunID: dimension.RunID, LaneKey: dimension.LaneKey, ToolName: dimension.Producer,
+		}
+	}
+	if len(targets) == 1 {
+		for canonical, provenance := range targets {
+			if strings.TrimSpace(provenance.ToolName) == "" {
+				provenance.ToolName = "legacy-" + producer
+			}
+			return backfillTarget{canonical: canonical, provenance: provenance}
+		}
+	}
+	reason := BackfillReasonMissingTarget
+	if len(targets) > 1 {
+		reason = BackfillReasonAmbiguousTarget
+	}
+	// Legacy Findings have no direct target FK; keep the assessment-scoped fallback
+	// provisional until producers persist an exact Snapshot dimension reference.
+	return backfillTarget{
+		canonical: "assessment:" + assessmentID.String(), reasonCode: reason,
+		provenance: lineagedom.ScannerProvenance{ToolName: "legacy-" + producer},
+	}
+}
+
+func backfillObservation(source ports.FindingLineageBackfillSourceRow, target backfillTarget) (ObservationInput, error) {
+	severity := validBackfillSeverity(source.Severity)
+	var riskScore *int
+	if source.RiskScore != 0 {
+		if math.IsNaN(source.RiskScore) || math.IsInf(source.RiskScore, 0) || source.RiskScore < 0 || source.RiskScore > 10 {
+			return ObservationInput{}, fmt.Errorf("%w: legacy risk score is outside the supported range", shared.ErrValidation)
+		}
+		value := int(math.Round(source.RiskScore * 1000))
+		riskScore = &value
+	}
+	componentVersion := ""
+	if source.Kind == "" || source.Kind == finding.KindSCA {
+		_, _, version, ok := vulnerability.ParseDedupKey(source.DedupKey)
+		if componentVersion == "" && ok {
+			componentVersion = version
+		}
+	}
+	return ObservationInput{
+		SourceFindingID: source.FindingID.String(), SourceOccurrenceID: source.OccurrenceID.String(), Severity: severity,
+		RiskScoreMilli: riskScore, ComponentVersion: componentVersion, Location: sourceLocation(source), Reachability: strings.TrimSpace(source.Reachability),
+		ScannerProvenance: target.provenance, ObservedAt: source.ObservedAt,
+	}, nil
+}
+
+func (runner *BackfillRunner) findOccurrence(ctx context.Context, source ports.FindingLineageBackfillSourceRow, cache *backfillCache) (vulnerabilityoccurrence.Occurrence, bool, error) {
+	if source.OccurrenceID.IsZero() {
+		return vulnerabilityoccurrence.Occurrence{}, false, nil
+	}
+	item, err := runner.occurrences.Get(ctx, source.TenantID, source.AssessmentID, source.AdvisoryID, source.ComponentFingerprint)
+	if errors.Is(err, shared.ErrNotFound) {
+		return vulnerabilityoccurrence.Occurrence{}, false, shared.ErrNotFound
+	}
+	if err != nil {
+		return vulnerabilityoccurrence.Occurrence{}, false, err
+	}
+	if item.ID != source.OccurrenceID || item.TenantID != source.TenantID || item.EngagementID != source.AssessmentID {
+		return vulnerabilityoccurrence.Occurrence{}, false, shared.ErrNotFound
+	}
+	return item, true, nil
+}
+
+func (runner *BackfillRunner) findJudgment(ctx context.Context, assessmentID, judgmentID shared.ID, cache *backfillCache) (judgment.Judgment, bool, error) {
+	if getter, ok := runner.judgments.(backfillJudgmentGetter); ok {
+		item, err := getter.GetByID(ctx, assessmentID, judgmentID)
+		if errors.Is(err, shared.ErrNotFound) {
+			return judgment.Judgment{}, false, nil
+		}
+		return item, err == nil, err
+	}
+	// Compatibility path for alternate stores. The production memory and
+	// PostgreSQL stores both implement the bounded direct lookup above.
+	items, err := runner.judgments.ListByEngagement(ctx, assessmentID)
+	if err != nil {
+		return judgment.Judgment{}, false, err
+	}
+	for _, item := range items {
+		if item.ID == judgmentID {
+			return item, true, nil
+		}
+	}
+	return judgment.Judgment{}, false, nil
+}
+
+func (runner *BackfillRunner) loadSnapshot(ctx context.Context, tenantID, snapshotID shared.ID, cache *backfillCache) (*snapshotdom.Snapshot, error) {
+	if snapshot := cache.snapshots[snapshotID]; snapshot != nil {
+		return snapshot, nil
+	}
+	snapshot, err := runner.snapshots.Get(ctx, tenantID, snapshotID)
+	if err != nil {
+		return nil, err
+	}
+	cache.snapshots[snapshotID] = snapshot
+	return snapshot, nil
+}
+
+func NormalizeFindingLineageProducerFilters(values []string) ([]string, error) {
+	set := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value == "" || value == "all" {
+			continue
+		}
+		var kinds []finding.Kind
+		switch value {
+		case "sca", "sast", "secret", "quality", "reliability", "manual", "dast", "threat", "hypothesis":
+			kinds = []finding.Kind{finding.Kind(value)}
+		case "iac", "misconfig":
+			kinds = []finding.Kind{finding.KindMisconfig}
+		case "cloud", "cloud_posture":
+			kinds = []finding.Kind{finding.KindCloudPosture}
+		case "offensive":
+			kinds = []finding.Kind{finding.KindRecon, finding.KindExploitation}
+		case "recon", "exploitation":
+			kinds = []finding.Kind{finding.Kind(value)}
+		default:
+			return nil, fmt.Errorf("%w: unsupported producer filter %q", shared.ErrValidation, value)
+		}
+		for _, kind := range kinds {
+			set[string(kind)] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func finalizeFindingLineageBackfillItem(item *ports.FindingLineageBackfillItem, snapshotContentHash string) {
+	if item.MatcherVersion <= 0 {
+		item.MatcherVersion = 1
+	}
+	payload := strings.Join([]string{item.SourceFindingID.String(), strconv.Itoa(item.MatcherVersion), snapshotContentHash}, "\x00")
+	sum := sha256.Sum256([]byte(payload))
+	item.SourceHash = hex.EncodeToString(sum[:])
+	key := sha256.Sum256([]byte("synapse:finding-lineage-backfill:v1\x00" + payload))
+	item.IdempotencyKey = hex.EncodeToString(key[:])
+}
+
+func legacyProducer(kind finding.Kind) (string, string) {
+	switch kind {
+	case "", finding.KindSCA:
+		return "sca", "vulnerability"
+	case finding.KindMisconfig:
+		return "iac", "misconfig"
+	case finding.KindManual:
+		return "manual_native", "manual"
+	case finding.KindRecon, finding.KindExploitation:
+		return "manual_import", "offensive"
+	default:
+		return string(kind), string(kind)
+	}
+}
+
+func legacySASTJudgmentID(dedupKey string) shared.ID {
+	const prefix = "sast:ai:"
+	if !strings.HasPrefix(strings.TrimSpace(dedupKey), prefix) {
+		return ""
+	}
+	return shared.ID(strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(dedupKey), prefix)))
+}
+
+func nativeManualSource(source ports.FindingLineageBackfillSourceRow) bool {
+	key := strings.TrimSpace(source.DedupKey)
+	for _, prefix := range []string{"manual:", "exploitation:", "recon:"} {
+		if strings.TrimPrefix(key, prefix) == source.FindingID.String() && strings.HasPrefix(key, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func legacyManualIdentityID(sourceFindingID shared.ID) shared.ID {
+	sum := sha256.Sum256([]byte("synapse:legacy-manual-identity:v1\x00" + sourceFindingID.String()))
+	return shared.ID("legacy-manual-v1-" + hex.EncodeToString(sum[:16]))
+}
+
+func sourcePath(source ports.FindingLineageBackfillSourceRow) string {
+	if source.SourceLocation != nil {
+		return source.SourceLocation.File
+	}
+	if location, ok := legacyFindingSourceLocation(source); ok {
+		return location.File
+	}
+	return ""
+}
+
+func sourceLocation(source ports.FindingLineageBackfillSourceRow) string {
+	location := source.SourceLocation
+	if location == nil {
+		legacy, ok := legacyFindingSourceLocation(source)
+		if !ok {
+			return ""
+		}
+		location = &legacy
+	}
+	return location.File + ":" + strconv.Itoa(location.StartLine)
+}
+
+func legacyFindingSourceLocation(source ports.FindingLineageBackfillSourceRow) (finding.SourceLocation, bool) {
+	var prefix string
+	switch source.Kind {
+	case finding.KindSAST:
+		if strings.HasPrefix(source.DedupKey, "cq:sast:") {
+			prefix = "cq:sast:"
+		}
+	case finding.KindQuality:
+		prefix = "cq:quality:"
+	case finding.KindReliability:
+		prefix = "cq:reliability:"
+	case finding.KindSecret:
+		prefix = "secret:"
+	case finding.KindMisconfig:
+		prefix = "misconfig:"
+	}
+	if prefix == "" || strings.TrimSpace(source.RuleKey) == "" {
+		return finding.SourceLocation{}, false
+	}
+	location := strings.TrimPrefix(source.DedupKey, prefix+source.RuleKey+":")
+	if location == source.DedupKey {
+		return finding.SourceLocation{}, false
+	}
+	return finding.SourceLocationFromLegacy(location)
+}
+
+func unsafeLegacySecretKey(value string) bool {
+	return strings.Contains(value, "://") || lineagedom.ContainsSensitiveAssignment(value)
+}
+
+func validBackfillSeverity(severity shared.Severity) shared.Severity {
+	if severity.Valid() {
+		return severity
+	}
+	return shared.SeverityUnknown
+}
+
+func (runner *BackfillRunner) finishBackfill(ctx context.Context, run ports.FindingLineageBackfillRun, leaseOwner string, state ports.FindingLineageBackfillState, actor string, cause error) (ports.FindingLineageBackfillRun, error) {
+	finishCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	finished, err := runner.store.FinishFindingLineageBackfillRun(finishCtx, run.TenantID, run.ID, leaseOwner, run.LeaseToken, state, runner.clock.Now().UTC())
+	if err != nil {
+		if cause != nil {
+			return run, errors.Join(cause, err)
+		}
+		return run, err
+	}
+	if runner.observer != nil {
+		runner.observer.ObserveFindingLineageBackfillRun(string(state))
+	}
+	auditErr := runner.record(finishCtx, actor, "finding_lineage.backfill_"+string(state), run.ID, map[string]string{
+		"tenant_id": run.TenantID.String(), "processed_count": strconv.Itoa(finished.ProcessedCount),
+		"observation_created_count": strconv.Itoa(finished.ObservationCreatedCount), "provisional_candidate_count": strconv.Itoa(finished.ProvisionalCandidateCount),
+		"skipped_count": strconv.Itoa(finished.SkippedCount),
+	})
+	if auditErr != nil {
+		partial := &ports.PartialWriteError{Operation: "finding lineage backfill terminal audit", IDs: []shared.ID{finished.ID}, Err: auditErr}
+		if cause != nil {
+			return finished, errors.Join(cause, partial)
+		}
+		return finished, partial
+	}
+	if cause != nil {
+		return finished, cause
+	}
+	return finished, nil
+}
+
+func (runner *BackfillRunner) record(ctx context.Context, actor, action string, target shared.ID, metadata map[string]string) error {
+	if runner.audit != nil {
+		return runner.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: action, Target: target.String(), Metadata: metadata, At: runner.clock.Now().UTC()})
+	}
+	return nil
+}
+
+func retryableFindingLineageBackfillError(err error) bool {
+	return !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, shared.ErrValidation) && !errors.Is(err, shared.ErrNotFound) && !errors.Is(err, shared.ErrConflict) && !errors.Is(err, lineagedom.ErrSensitiveInput) && !errors.Is(err, ErrSecretMaterialRejected)
+}
+
+func findingLineageBackfillTerminalState(err error) ports.FindingLineageBackfillState {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return ports.FindingLineageBackfillCancelled
+	}
+	return ports.FindingLineageBackfillFailed
+}

--- a/internal/usecase/findinglineage/backfill_internal_test.go
+++ b/internal/usecase/findinglineage/backfill_internal_test.go
@@ -1,0 +1,30 @@
+package findinglineage
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+)
+
+func TestSelectBackfillTargetRequiresProducerAndFindingKind(t *testing.T) {
+	snapshot := assessmentsnapshot.Snapshot{Dimensions: []assessmentsnapshot.Dimension{
+		{Producer: "sca", FindingKind: "misconfig", Target: assessmentsnapshot.Target{Canonical: "wrong-kind"}},
+		{Producer: "sast", FindingKind: "vulnerability", Target: assessmentsnapshot.Target{Canonical: "wrong-producer"}},
+		{Producer: "sca", FindingKind: "vulnerability", Target: assessmentsnapshot.Target{Canonical: "repo:expected"}},
+	}}
+	target := selectBackfillTarget(snapshot, "sca", "vulnerability", "assessment")
+	if target.canonical != "repo:expected" || target.reasonCode != "" {
+		t.Fatalf("target=%+v", target)
+	}
+}
+
+func TestSelectBackfillTargetRejectsHalfMatches(t *testing.T) {
+	snapshot := assessmentsnapshot.Snapshot{Dimensions: []assessmentsnapshot.Dimension{
+		{Producer: "sca", FindingKind: "misconfig", Target: assessmentsnapshot.Target{Canonical: "wrong-kind"}},
+		{Producer: "sast", FindingKind: "vulnerability", Target: assessmentsnapshot.Target{Canonical: "wrong-producer"}},
+	}}
+	target := selectBackfillTarget(snapshot, "sca", "vulnerability", "assessment")
+	if target.reasonCode != BackfillReasonMissingTarget || target.canonical != "assessment:assessment" {
+		t.Fatalf("target=%+v", target)
+	}
+}

--- a/internal/usecase/findinglineage/backfill_test.go
+++ b/internal/usecase/findinglineage/backfill_test.go
@@ -1,0 +1,474 @@
+package findinglineage_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	snapshotdom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerabilityoccurrence"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestFindingLineageBackfillFixtureMatrixReconcilesExactly(t *testing.T) {
+	now := time.Date(2026, 9, 1, 2, 0, 0, 0, time.UTC)
+	clock, ids, audit := fixedBackfillClock{now}, &backfillIDs{}, noOpBackfillAudit{}
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	snapshot := backfillSnapshot(t, now)
+	if _, _, err := snapshots.CreateLegacyProjection(context.Background(), snapshot); err != nil {
+		t.Fatal(err)
+	}
+	lineageRepository := memory.NewFindingLineageRepository()
+	lineage, err := lineageuc.NewService(lineageRepository, memory.NewTenantTransactionRunner(), audit, clock, ids, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	occurrence := vulnerabilityoccurrence.Occurrence{
+		TenantID: "tenant", ID: "occ-1", EngagementID: "assessment", AdvisoryID: "CVE-2026-1",
+		ComponentID: "component", SBOMID: "sbom", ComponentFingerprint: "dependency-instance-1",
+		Ecosystem: "npm", Package: "left-pad", ComponentVersion: "1.0.0",
+	}
+	backfillRepository := memory.NewFindingLineageBackfillRepository()
+	rows := []ports.FindingLineageBackfillSourceRow{
+		backfillSource("f01", finding.KindSCA, "vuln:CVE-2026-1:left-pad:1.0.0", "", "occ-1", now, snapshot),
+		backfillSource("f02", finding.KindSAST, "sast:ai:missing-judgment", "sast-rule", "", now, snapshot),
+		backfillSource("f03", finding.KindSAST, "cq:sast:go-sql:src/db.go:42", "go-sql", "", now, snapshot),
+		backfillSource("f04", finding.KindQuality, "cq:quality:quality-todo:src/app.go:7", "quality-todo", "", now, snapshot),
+		backfillSource("f05", finding.KindReliability, "cq:reliability:empty-catch:src/app.go:8", "empty-catch", "", now, snapshot),
+		backfillSource("f06", finding.KindSecret, "secret:generic-secret:config/app.env:9", "generic-secret", "", now, snapshot),
+		backfillSource("f07", finding.KindMisconfig, "misconfig:terraform-public-instance:main.tf:12", "terraform-public-instance", "", now, snapshot),
+		backfillSource("f08", finding.KindSCA, "", "", "", now, snapshot),
+		backfillSource("f09", finding.KindManual, "manual:f09", "", "", now, snapshot),
+		backfillSource("f10", finding.KindExploitation, "", "", "", now, snapshot),
+		backfillSource("f11", finding.KindDAST, "dast:legacy", "", "", now, snapshot),
+		backfillSource("f12", finding.KindCloudPosture, "cloud:legacy", "", "", now, snapshot),
+	}
+	rows[0].AdvisoryID, rows[0].ComponentFingerprint = occurrence.AdvisoryID, occurrence.ComponentFingerprint
+	backfillRepository.SetSources("tenant", rows)
+	runner, err := lineageuc.NewFindingLineageBackfillRunner(
+		lineage, backfillRepository, backfillRepository, snapshots, occurrenceBackfillStore{items: []vulnerabilityoccurrence.Occurrence{occurrence}}, emptyJudgmentStore{}, ids, clock, audit, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := runner.RunBackfill(context.Background(), lineageuc.FindingLineageBackfillRequest{
+		TenantID: "tenant", Actor: "operator", LeaseOwner: "worker-1", BatchSize: 3,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.ProcessedCount != len(rows) || run.ProcessedCount != run.ObservationCreatedCount+run.ProvisionalCandidateCount+run.SkippedCount {
+		t.Fatalf("counts do not reconcile: %+v", run)
+	}
+	if run.ObservationCreatedCount != 1 || run.ProvisionalCandidateCount != 9 || run.SkippedCount != 2 {
+		t.Fatalf("unexpected outcome matrix: %+v", run)
+	}
+	observations, err := lineageRepository.ListObservationsBySnapshot(context.Background(), "tenant", "cycle", snapshot.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidates, err := lineageRepository.ListOpenCandidatesBySnapshot(context.Background(), "tenant", "cycle", snapshot.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	skips, err := lineageRepository.ListSkipsBySnapshot(context.Background(), "tenant", "cycle", snapshot.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(observations) != 10 || len(candidates) != 9 || len(skips) != 2 {
+		t.Fatalf("persisted outcomes observations=%d candidates=%d skips=%d", len(observations), len(candidates), len(skips))
+	}
+	for _, observation := range observations {
+		if observation.ProducerKind == "secret" && observation.EvidenceDigest != "" {
+			t.Fatal("secret backfill persisted an evidence digest")
+		}
+		if observation.SourceFindingID == "f03" && observation.Location != "src/db.go:42" {
+			t.Fatalf("legacy line was not retained in Observation: %+v", observation)
+		}
+		if observation.SourceFindingID == "f01" && observation.ComponentVersion != "1.0.0" {
+			t.Fatalf("occurrence component version was not retained: %+v", observation)
+		}
+	}
+	item, err := backfillRepository.GetFindingLineageBackfillItem(context.Background(), "tenant", run.ID, "f02")
+	if err != nil || item.ReasonCode != lineageuc.BackfillReasonMissingTrustedJudgment {
+		t.Fatalf("missing Judgment outcome=%+v err=%v", item, err)
+	}
+	replayed, err := runner.RunBackfill(context.Background(), lineageuc.FindingLineageBackfillRequest{
+		TenantID: "tenant", Actor: "operator", LeaseOwner: "worker-2", BatchSize: 4,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if replayed.ObservationCreatedCount != run.ObservationCreatedCount || replayed.ProvisionalCandidateCount != run.ProvisionalCandidateCount || replayed.SkippedCount != run.SkippedCount {
+		t.Fatalf("idempotent replay changed outcomes first=%+v replay=%+v", run, replayed)
+	}
+	replayedObservations, _ := lineageRepository.ListObservationsBySnapshot(context.Background(), "tenant", "cycle", snapshot.ID)
+	replayedCandidates, _ := lineageRepository.ListOpenCandidatesBySnapshot(context.Background(), "tenant", "cycle", snapshot.ID)
+	replayedSkips, _ := lineageRepository.ListSkipsBySnapshot(context.Background(), "tenant", "cycle", snapshot.ID)
+	if len(replayedObservations) != len(observations) || len(replayedCandidates) != len(candidates) || len(replayedSkips) != len(skips) {
+		t.Fatalf("idempotent replay duplicated lineage objects observations=%d candidates=%d skips=%d", len(replayedObservations), len(replayedCandidates), len(replayedSkips))
+	}
+}
+
+func TestFindingLineageBackfillDryRunIsResumableAndWriteFree(t *testing.T) {
+	now := time.Date(2026, 9, 1, 3, 0, 0, 0, time.UTC)
+	clock, ids, audit := fixedBackfillClock{now}, &backfillIDs{}, noOpBackfillAudit{}
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	snapshot := backfillSnapshot(t, now)
+	if _, _, err := snapshots.CreateLegacyProjection(context.Background(), snapshot); err != nil {
+		t.Fatal(err)
+	}
+	lineageRepository := memory.NewFindingLineageRepository()
+	lineage, _ := lineageuc.NewService(lineageRepository, memory.NewTenantTransactionRunner(), audit, clock, ids, nil)
+	backfillRepository := memory.NewFindingLineageBackfillRepository()
+	backfillRepository.SetSources("tenant", []ports.FindingLineageBackfillSourceRow{
+		backfillSource("f01", finding.KindManual, "manual:f01", "", "", now, snapshot),
+		backfillSource("f02", finding.KindDAST, "dast:legacy", "", "", now, snapshot),
+	})
+	runner, err := lineageuc.NewFindingLineageBackfillRunner(lineage, backfillRepository, backfillRepository, snapshots, occurrenceBackfillStore{}, emptyJudgmentStore{}, ids, clock, audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := runner.RunBackfill(context.Background(), lineageuc.FindingLineageBackfillRequest{
+		TenantID: "tenant", Actor: "operator", LeaseOwner: "worker-1", DryRun: true, BatchSize: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.ProcessedCount != 2 || run.ObservationCreatedCount != 1 || run.SkippedCount != 1 {
+		t.Fatalf("unexpected dry-run counts: %+v", run)
+	}
+	observations, _ := lineageRepository.ListObservationsBySnapshot(context.Background(), "tenant", "cycle", snapshot.ID)
+	skips, _ := lineageRepository.ListSkipsBySnapshot(context.Background(), "tenant", "cycle", snapshot.ID)
+	if len(observations) != 0 || len(skips) != 0 {
+		t.Fatalf("dry run wrote lineage objects observations=%d skips=%d", len(observations), len(skips))
+	}
+}
+
+func TestFindingLineageBackfillRetainsAllNativeIaCFamiliesForReview(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 9, 8, 6, 0, 0, 0, time.UTC)
+	clock, ids, audit := fixedBackfillClock{now}, &backfillIDs{}, noOpBackfillAudit{}
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	snapshot := backfillSnapshot(t, now)
+	if _, _, err := snapshots.CreateLegacyProjection(ctx, snapshot); err != nil {
+		t.Fatal(err)
+	}
+	repository := memory.NewFindingLineageRepository()
+	lineage, err := lineageuc.NewService(repository, memory.NewTenantTransactionRunner(), audit, clock, ids, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := memory.NewFindingLineageBackfillRepository()
+	var rows []ports.FindingLineageBackfillSourceRow
+	for index, test := range []struct{ rule, path string }{
+		{"dockerfile-run-as-root", "Dockerfile"},
+		{"compose-privileged", "compose.yaml"},
+		{"gha-permissions-write-all", ".github/workflows/ci.yaml"},
+		{"arm-storage-https-only-off", "azure/template.json"},
+	} {
+		rows = append(rows, backfillSource(shared.ID(fmt.Sprintf("iac-%d", index)), finding.KindMisconfig,
+			"misconfig:"+test.rule+":"+test.path+":42", test.rule, "", now, snapshot))
+	}
+	store.SetSources("tenant", rows)
+	runner, err := lineageuc.NewFindingLineageBackfillRunner(lineage, store, store, snapshots, occurrenceBackfillStore{}, emptyJudgmentStore{}, ids, clock, audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := runner.RunBackfill(ctx, lineageuc.FindingLineageBackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "worker", BatchSize: 2})
+	if err != nil {
+		t.Fatalf("scanner-supported IaC findings aborted backfill: %v", err)
+	}
+	if run.State != ports.FindingLineageBackfillCompleted || run.ProcessedCount != len(rows) || run.ProvisionalCandidateCount != len(rows) || run.ObservationCreatedCount != 0 || run.SkippedCount != 0 {
+		t.Fatalf("scanner-supported findings were discarded or declared fully matched: %+v", run)
+	}
+	observations, err := repository.ListObservationsBySnapshot(ctx, "tenant", "cycle", snapshot.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidates, err := repository.ListOpenCandidatesBySnapshot(ctx, "tenant", "cycle", snapshot.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(observations) != len(rows) || len(candidates) != len(rows) {
+		t.Fatalf("provisional evidence was not retained: observations=%d candidates=%d", len(observations), len(candidates))
+	}
+	for _, row := range rows {
+		item, err := store.GetFindingLineageBackfillItem(ctx, "tenant", run.ID, row.FindingID)
+		if err != nil || item.Outcome != lineageuc.BackfillOutcomeProvisionalCandidate || item.ReasonCode != "resource_identity_unavailable" {
+			t.Fatalf("finding %s did not retain an explicit review outcome: item=%+v err=%v", row.FindingID, item, err)
+		}
+		found := false
+		for _, observation := range observations {
+			if observation.SourceFindingID == row.FindingID.String() {
+				found = true
+				if observation.ProducerKind != "iac" || observation.FindingKind != "misconfig" || !strings.HasSuffix(observation.Location, ":42") || observation.IdentityID.IsZero() {
+					t.Fatalf("wrong retained observation: %+v", observation)
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("finding %s lost its immutable observation", row.FindingID)
+		}
+	}
+	for _, candidate := range candidates {
+		if candidate.Reason != "insufficient_anchor" {
+			t.Fatalf("unsupported semantic matching must remain needs_review: %+v", candidate)
+		}
+	}
+	replayed, err := runner.RunBackfill(ctx, lineageuc.FindingLineageBackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "replay-worker", BatchSize: 3})
+	if err != nil || replayed.ProvisionalCandidateCount != len(rows) || replayed.SkippedCount != 0 {
+		t.Fatalf("replay changed backfill outcomes: %+v err=%v", replayed, err)
+	}
+	observations, err = repository.ListObservationsBySnapshot(ctx, "tenant", "cycle", snapshot.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	candidates, err = repository.ListOpenCandidatesBySnapshot(ctx, "tenant", "cycle", snapshot.ID)
+	if err != nil || len(observations) != len(rows) || len(candidates) != len(rows) {
+		t.Fatalf("replay duplicated lineage records: observations=%d candidates=%d err=%v", len(observations), len(candidates), err)
+	}
+}
+
+func TestFindingLineageBackfillRedactsMalformedSecretBeforePersistence(t *testing.T) {
+	now := time.Date(2026, 9, 1, 4, 0, 0, 0, time.UTC)
+	clock, ids, audit := fixedBackfillClock{now}, &backfillIDs{}, &recordingBackfillAudit{}
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	snapshot := backfillSnapshot(t, now)
+	if _, _, err := snapshots.CreateLegacyProjection(context.Background(), snapshot); err != nil {
+		t.Fatal(err)
+	}
+	lineageRepository := memory.NewFindingLineageRepository()
+	lineage, err := lineageuc.NewService(lineageRepository, memory.NewTenantTransactionRunner(), audit, clock, ids, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backfillRepository := memory.NewFindingLineageBackfillRepository()
+	const secret = "password-do-not-persist"
+	backfillRepository.SetSources("tenant", []ports.FindingLineageBackfillSourceRow{
+		backfillSource("secret-malformed", finding.KindSecret, "secret:generic:https://user:"+secret+"@example.test/repo:9", "generic", "", now, snapshot),
+	})
+	runner, err := lineageuc.NewFindingLineageBackfillRunner(lineage, backfillRepository, backfillRepository, snapshots, occurrenceBackfillStore{}, emptyJudgmentStore{}, ids, clock, audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := runner.RunBackfill(context.Background(), lineageuc.FindingLineageBackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "worker", BatchSize: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	item, err := backfillRepository.GetFindingLineageBackfillItem(context.Background(), "tenant", run.ID, "secret-malformed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	skips, err := lineageRepository.ListSkipsBySnapshot(context.Background(), "tenant", "cycle", snapshot.ID)
+	if err != nil || len(skips) != 1 {
+		t.Fatalf("skips=%+v err=%v", skips, err)
+	}
+	persisted := fmt.Sprint(item, skips, audit.entries)
+	if strings.Contains(persisted, secret) || item.Outcome != lineageuc.BackfillOutcomeSkipped || item.ReasonCode != lineageuc.BackfillReasonMalformedTrustBoundary {
+		t.Fatalf("secret redaction failed persisted=%s item=%+v", persisted, item)
+	}
+}
+
+func TestFindingLineageBackfillRetriesTransientOccurrenceRead(t *testing.T) {
+	now := time.Date(2026, 9, 1, 5, 0, 0, 0, time.UTC)
+	clock, ids, audit := fixedBackfillClock{now}, &backfillIDs{}, noOpBackfillAudit{}
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	snapshot := backfillSnapshot(t, now)
+	if _, _, err := snapshots.CreateLegacyProjection(context.Background(), snapshot); err != nil {
+		t.Fatal(err)
+	}
+	lineageRepository := memory.NewFindingLineageRepository()
+	lineage, _ := lineageuc.NewService(lineageRepository, memory.NewTenantTransactionRunner(), audit, clock, ids, nil)
+	backfillRepository := memory.NewFindingLineageBackfillRepository()
+	source := backfillSource("retry-source", finding.KindSCA, "vuln:CVE-2026-9:left-pad:1.0.0", "", "retry-occurrence", now, snapshot)
+	backfillRepository.SetSources("tenant", []ports.FindingLineageBackfillSourceRow{source})
+	occurrences := &retryOccurrenceStore{item: vulnerabilityoccurrence.Occurrence{
+		TenantID: "tenant", ID: "retry-occurrence", EngagementID: "assessment", AdvisoryID: "CVE-2026-9", ComponentID: "component", SBOMID: "sbom",
+		ComponentFingerprint: "dependency-instance", Ecosystem: "npm", Package: "left-pad", ComponentVersion: "1.0.0",
+	}}
+	runner, err := lineageuc.NewFindingLineageBackfillRunner(lineage, backfillRepository, backfillRepository, snapshots, occurrences, emptyJudgmentStore{}, ids, clock, audit, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, err := runner.RunBackfill(context.Background(), lineageuc.FindingLineageBackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "worker", BatchSize: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if occurrences.attempts != 3 || run.ProvisionalCandidateCount != 1 {
+		t.Fatalf("bounded retry attempts=%d run=%+v", occurrences.attempts, run)
+	}
+}
+
+func backfillSnapshot(t *testing.T, now time.Time) *snapshotdom.Snapshot {
+	t.Helper()
+	target, err := scanrun.CanonicalizeRepositoryTarget("https://example.com/repo.git", "0123456789abcdef0123456789abcdef01234567")
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := now.Add(-2 * time.Minute)
+	finished := now.Add(-time.Minute)
+	lane := scanrun.Lane{
+		TenantID: "tenant", EngagementID: "assessment", ScanRunID: "run", LaneKey: "sca",
+		Producer: "sca", TerminalStatus: scanrun.StatusSucceeded, Target: target,
+		AuthoritativeFindingKinds: []string{"vulnerability"}, StartedAt: now.Add(-2 * time.Minute), FinishedAt: &finished,
+		ResultRef: "result:run", EvidenceRef: "evidence:run", ResultSHA256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ManifestSchemaVersion: 1,
+		Versions: []scanrun.LaneVersion{{VersionKind: scanrun.VersionScanner, Name: "sca", Version: "1"}},
+		Stages:   []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSucceeded, StartedAt: started, FinishedAt: &finished}},
+		SealedAt: &now,
+	}
+	lane.ManifestHash, err = scanrun.ComputeManifestHash(lane)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lanes := []scanrun.Lane{lane}
+	snapshot, err := snapshotdom.NewFinalized("tenant", "snapshot", "cycle", "assessment", snapshotdom.Boundary{Kind: "standalone"}, "request", "operator", now, []snapshotdom.SelectedRun{{
+		ID: "run", ManifestHash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", Provenance: scanrun.ProvenanceLegacy, TerminalStatus: scanrun.StatusSucceeded, Lanes: lanes,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snapshot
+}
+
+func backfillSource(id shared.ID, kind finding.Kind, dedupKey, ruleKey string, occurrenceID shared.ID, now time.Time, snapshot *snapshotdom.Snapshot) ports.FindingLineageBackfillSourceRow {
+	return ports.FindingLineageBackfillSourceRow{
+		TenantID: "tenant", AssessmentID: "assessment", CycleID: "cycle", SnapshotID: snapshot.ID, SnapshotContentHash: snapshot.ContentHash, OwnershipValid: true,
+		FindingID: id, Kind: kind, RuleKey: ruleKey, DedupKey: dedupKey, OccurrenceID: occurrenceID,
+		Severity: shared.SeverityHigh, Reachability: "unknown", CreatedAt: now.Add(-time.Minute), ObservedAt: now.Add(-time.Minute),
+	}
+}
+
+type fixedBackfillClock struct{ now time.Time }
+
+func (clock fixedBackfillClock) Now() time.Time { return clock.now }
+
+type backfillIDs struct{ next int }
+
+func (ids *backfillIDs) NewID() shared.ID {
+	ids.next++
+	return shared.ID(fmt.Sprintf("generated-%03d", ids.next))
+}
+
+type noOpBackfillAudit struct{}
+
+func (noOpBackfillAudit) Record(context.Context, ports.AuditEntry) error { return nil }
+
+type recordingBackfillAudit struct{ entries []ports.AuditEntry }
+
+func (audit *recordingBackfillAudit) Record(_ context.Context, entry ports.AuditEntry) error {
+	audit.entries = append(audit.entries, entry)
+	return nil
+}
+
+type occurrenceBackfillStore struct {
+	items []vulnerabilityoccurrence.Occurrence
+}
+
+type retryOccurrenceStore struct {
+	attempts int
+	item     vulnerabilityoccurrence.Occurrence
+}
+
+func (store *retryOccurrenceStore) Upsert(context.Context, vulnerabilityoccurrence.Occurrence) (vulnerabilityoccurrence.UpsertResult, error) {
+	return vulnerabilityoccurrence.UpsertResult{}, nil
+}
+func (store *retryOccurrenceStore) Get(context.Context, shared.ID, shared.ID, string, string) (vulnerabilityoccurrence.Occurrence, error) {
+	store.attempts++
+	if store.attempts < 3 {
+		return vulnerabilityoccurrence.Occurrence{}, errors.New("temporary occurrence store outage")
+	}
+	return store.item, nil
+}
+func (store *retryOccurrenceStore) ListByEngagement(context.Context, shared.ID, shared.ID, []vulnerabilityoccurrence.State) ([]vulnerabilityoccurrence.Occurrence, error) {
+	return []vulnerabilityoccurrence.Occurrence{store.item}, nil
+}
+func (store *retryOccurrenceStore) ListEvents(context.Context, shared.ID, shared.ID) ([]vulnerabilityoccurrence.Event, error) {
+	return nil, nil
+}
+
+func (store occurrenceBackfillStore) Upsert(context.Context, vulnerabilityoccurrence.Occurrence) (vulnerabilityoccurrence.UpsertResult, error) {
+	return vulnerabilityoccurrence.UpsertResult{}, nil
+}
+func (store occurrenceBackfillStore) Get(_ context.Context, tenantID, engagementID shared.ID, advisoryID, componentFingerprint string) (vulnerabilityoccurrence.Occurrence, error) {
+	for _, item := range store.items {
+		if item.TenantID == tenantID && item.EngagementID == engagementID && item.AdvisoryID == advisoryID && item.ComponentFingerprint == componentFingerprint {
+			return item, nil
+		}
+	}
+	return vulnerabilityoccurrence.Occurrence{}, shared.ErrNotFound
+}
+func (store occurrenceBackfillStore) ListByEngagement(_ context.Context, tenantID, engagementID shared.ID, _ []vulnerabilityoccurrence.State) ([]vulnerabilityoccurrence.Occurrence, error) {
+	var out []vulnerabilityoccurrence.Occurrence
+	for _, item := range store.items {
+		if item.TenantID == tenantID && item.EngagementID == engagementID {
+			out = append(out, item)
+		}
+	}
+	return out, nil
+}
+func (store occurrenceBackfillStore) ListEvents(context.Context, shared.ID, shared.ID) ([]vulnerabilityoccurrence.Event, error) {
+	return nil, nil
+}
+
+type emptyJudgmentStore struct{}
+
+func (emptyJudgmentStore) Save(context.Context, judgment.Judgment) error { return nil }
+func (emptyJudgmentStore) ListByEngagement(context.Context, shared.ID) ([]judgment.Judgment, error) {
+	return nil, nil
+}
+func (emptyJudgmentStore) ListBySubject(context.Context, shared.ID, shared.ID) ([]judgment.Judgment, error) {
+	return nil, nil
+}
+
+type failedBackfillAudit struct{ action string }
+
+func (a failedBackfillAudit) Record(_ context.Context, entry ports.AuditEntry) error {
+	if entry.Action == a.action {
+		return errors.New("audit unavailable")
+	}
+	return nil
+}
+func TestBackfillAuditFailureStopsAndReportsRetainedCheckpoint(t *testing.T) {
+	for _, action := range []string{"finding_lineage.backfill_started", "finding_lineage.backfill_batch_committed", "finding_lineage.backfill_completed"} {
+		t.Run(action, func(t *testing.T) {
+			now := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+			ids, clock := &backfillIDs{}, fixedBackfillClock{now}
+			snapshots := memory.NewAssessmentSnapshotRepository()
+			snapshot := backfillSnapshot(t, now)
+			if _, _, err := snapshots.CreateLegacyProjection(context.Background(), snapshot); err != nil {
+				t.Fatal(err)
+			}
+			lineage, err := lineageuc.NewService(memory.NewFindingLineageRepository(), memory.NewTenantTransactionRunner(), noOpBackfillAudit{}, clock, ids, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			store := memory.NewFindingLineageBackfillRepository()
+			store.SetSources("tenant", []ports.FindingLineageBackfillSourceRow{backfillSource("manual", finding.KindManual, "manual:manual", "", "", now, snapshot)})
+			runner, err := lineageuc.NewFindingLineageBackfillRunner(lineage, store, store, snapshots, occurrenceBackfillStore{}, emptyJudgmentStore{}, ids, clock, failedBackfillAudit{action}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			run, err := runner.RunBackfill(context.Background(), lineageuc.FindingLineageBackfillRequest{TenantID: "tenant", Actor: "operator", LeaseOwner: "worker", BatchSize: 1})
+			var partial *ports.PartialWriteError
+			if !errors.As(err, &partial) || run.ID.IsZero() {
+				t.Fatalf("audit failure hidden: run=%+v err=%v", run, err)
+			}
+			if action == "finding_lineage.backfill_started" && run.ProcessedCount != 0 {
+				t.Fatal("backfill continued after start audit failure")
+			}
+			if action == "finding_lineage.backfill_batch_committed" && run.CheckpointFinding != "manual" {
+				t.Fatalf("durable checkpoint lost: %+v", run)
+			}
+		})
+	}
+}

--- a/internal/usecase/findinglineage/iac_matcher.go
+++ b/internal/usecase/findinglineage/iac_matcher.go
@@ -1,0 +1,509 @@
+package findinglineage
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	IaCMatcherVersionV1            = 1
+	IaCFingerprintSchemaVersionV1  = 1
+	IaCTargetIdentitySchemaVersion = 1
+)
+
+type IaCConfigKind string
+
+const (
+	IaCTerraform      IaCConfigKind = "terraform"
+	IaCCloudFormation IaCConfigKind = "cloudformation"
+	IaCKubernetes     IaCConfigKind = "kubernetes"
+	IaCDockerfile     IaCConfigKind = "dockerfile"
+	IaCCompose        IaCConfigKind = "compose"
+	IaCGitHubActions  IaCConfigKind = "github_actions"
+	IaCARM            IaCConfigKind = "arm"
+)
+
+func (kind IaCConfigKind) Valid() bool {
+	switch kind {
+	case IaCTerraform, IaCCloudFormation, IaCKubernetes, IaCDockerfile, IaCCompose, IaCGitHubActions, IaCARM:
+		return true
+	}
+	return false
+}
+
+type IaCRuleAliasSetV1 struct {
+	Primary string
+	Aliases []string
+}
+
+type IaCMatcherV1 struct {
+	rules SASTMatcherV1
+}
+
+func NewIaCMatcherV1(aliasSets []IaCRuleAliasSetV1) (IaCMatcherV1, error) {
+	sharedSets := make([]SASTRuleAliasSetV1, len(aliasSets))
+	for index, aliasSet := range aliasSets {
+		sharedSets[index] = SASTRuleAliasSetV1{Primary: aliasSet.Primary, Aliases: append([]string(nil), aliasSet.Aliases...)}
+	}
+	rules, err := NewSASTMatcherV1(sharedSets)
+	if err != nil {
+		return IaCMatcherV1{}, err
+	}
+	return IaCMatcherV1{rules: rules}, nil
+}
+
+type IaCFingerprintInputV1 struct {
+	TargetIdentityCanonical    string
+	ConfigKind                 IaCConfigKind
+	RuleKey                    string
+	RuleAliases                []string
+	RepoPath                   string
+	SemanticConfigAnchorDigest string
+	TerraformAddress           string
+	CloudFormationStackPath    []string
+	CloudFormationLogicalID    string
+	KubernetesAPIVersion       string
+	KubernetesKind             string
+	KubernetesNamespace        string
+	KubernetesName             string
+	KubernetesIdentityApproved bool
+	LegacyDedupKey             string
+	LegacySourceValidated      bool
+	RuntimeResourceID          string
+	RenderedValue              string
+	RawOffsets                 map[string]int
+}
+
+type IaCMatchPlanV1 struct {
+	FingerprintInput    domain.FingerprintCanonicalInputV1
+	Method              domain.MatchMethod
+	MatcherVersion      int
+	ReasonCode          string
+	ReviewReason        domain.CandidateReason
+	Ambiguous           bool
+	ProvisionalIdentity bool
+	SkipInput           bool
+}
+
+func (matcher IaCMatcherV1) Build(input IaCFingerprintInputV1) (IaCMatchPlanV1, error) {
+	if strings.TrimSpace(input.RuntimeResourceID) != "" || strings.TrimSpace(input.RenderedValue) != "" {
+		return IaCMatchPlanV1{}, fmt.Errorf("%w: IaC runtime identifiers and rendered values are observation-only", shared.ErrValidation)
+	}
+	if len(input.RawOffsets) > 0 {
+		return IaCMatchPlanV1{}, fmt.Errorf("%w: IaC identity cannot contain raw offsets", shared.ErrValidation)
+	}
+	target, err := normalizeSourceText("IaC", "target identity", input.TargetIdentityCanonical, 2048, false)
+	if err != nil {
+		return IaCMatchPlanV1{}, err
+	}
+	legacy := parseIaCLegacyKey(input.LegacyDedupKey)
+	ruleKey := input.RuleKey
+	repoPath := input.RepoPath
+	if legacy.kind == iacLegacyValid {
+		if strings.TrimSpace(ruleKey) == "" {
+			ruleKey = legacy.ruleKey
+		}
+		if strings.TrimSpace(repoPath) == "" {
+			repoPath = legacy.repoPath
+		}
+	}
+	configKind := input.ConfigKind
+	if configKind == "" {
+		configKind = inferIaCConfigKind(ruleKey)
+	}
+	if !configKind.Valid() {
+		return IaCMatchPlanV1{}, fmt.Errorf("%w: IaC config kind is unsupported", shared.ErrValidation)
+	}
+	normalizedPath, pathErr := normalizeSourceRepoPath("IaC", repoPath)
+	if pathErr != nil && strings.TrimSpace(repoPath) != "" {
+		return IaCMatchPlanV1{}, pathErr
+	}
+	primaryRule, normalizedRules, ruleConflict, ruleErr := matcher.rules.normalizeRule("IaC", ruleKey, input.RuleAliases)
+	if ruleErr != nil && strings.TrimSpace(ruleKey) != "" {
+		return IaCMatchPlanV1{}, ruleErr
+	}
+	semanticAnchor, semanticErr := normalizeSourceDigest("IaC", "semantic config anchor", input.SemanticConfigAnchorDigest)
+	if semanticErr != nil && strings.TrimSpace(input.SemanticConfigAnchorDigest) != "" {
+		return IaCMatchPlanV1{}, semanticErr
+	}
+	resourceAnchor, resourceReason, resourceErr := normalizeIaCResourceAnchor(configKind, input)
+	if resourceErr != nil {
+		return IaCMatchPlanV1{}, resourceErr
+	}
+
+	fields := map[string]domain.CanonicalValue{
+		"config_kind":              domain.Text(string(configKind)),
+		"producer_matcher_version": domain.Integer(IaCMatcherVersionV1),
+		"rule_alias_graph_version": domain.Integer(SASTRuleAliasSchemaVersionV1),
+	}
+	resourceIdentityUnavailable := resourceReason == "resource_identity_unavailable"
+	if !resourceIdentityUnavailable {
+		fields["resource_adapter_version"] = domain.Integer(1)
+		fields["resource_identity_grammar"] = domain.Text(string(configKind) + "_v1")
+	}
+	if normalizedPath != "" {
+		fields["repo_path"] = domain.Text(normalizedPath)
+	}
+	if primaryRule != "" {
+		fields["rule_key"] = domain.Text(primaryRule)
+	}
+	if semanticAnchor != "" {
+		fields["semantic_config_anchor"] = domain.Text(semanticAnchor)
+	}
+	if resourceReason == "" {
+		fields["resource_anchor"] = resourceAnchor
+	}
+	if ruleConflict {
+		fields["rule_candidates"] = domain.StringSet(normalizedRules...)
+		delete(fields, "rule_key")
+	}
+	plan := IaCMatchPlanV1{
+		FingerprintInput: domain.FingerprintCanonicalInputV1{
+			CanonicalizationVersion: domain.CanonicalizationVersionV1, ProducerKind: "iac",
+			TargetIdentitySchemaVersion: IaCTargetIdentitySchemaVersion, TargetIdentityCanonical: target, IdentityFields: fields,
+		},
+		Method: domain.MethodMatcher, MatcherVersion: IaCMatcherVersionV1, ReasonCode: "iac_identity_complete",
+	}
+	switch {
+	case input.LegacyDedupKey != "" && !input.LegacySourceValidated:
+		plan.SkipInput, plan.ReasonCode = true, "legacy_source_not_validated"
+	case ruleConflict:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous = domain.ReasonMerge, "rule_alias_conflict", true
+	case legacy.kind == iacLegacyMalformed:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonLegacyAmbiguous, "legacy_key_malformed", true, true
+	case normalizedPath == "":
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "missing_repo_path", true, true
+	case primaryRule == "":
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "missing_rule_key", true, true
+	case resourceIdentityUnavailable:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, resourceReason, true, true
+	case semanticAnchor == "":
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "missing_semantic_config_anchor", true, true
+	case resourceReason != "":
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, resourceReason, true, true
+	case legacy.kind == iacLegacyValid:
+		plan.ReasonCode = "legacy_iac_structured"
+	}
+	if resourceIdentityUnavailable && !plan.SkipInput {
+		// Even a caller-supplied semantic digest or alias conflict cannot promote
+		// an unadapted config family to a trusted cross-snapshot identity.
+		plan.ProvisionalIdentity, plan.Ambiguous = true, true
+	}
+	return plan, nil
+}
+
+func (plan IaCMatchPlanV1) Apply(input CorrelateInput) CorrelateInput {
+	input.ProducerKind = "iac"
+	input.FindingKind = "misconfig"
+	input.FingerprintSchemaVersion = IaCFingerprintSchemaVersionV1
+	input.FingerprintInput = plan.FingerprintInput
+	input.ReviewReason = plan.ReviewReason
+	input.ReviewDetailCode = plan.ReasonCode
+	input.ProvisionalIdentity = plan.ProvisionalIdentity
+	if plan.SkipInput {
+		input.InputTrusted = false
+	}
+	return input
+}
+
+func normalizeIaCResourceAnchor(kind IaCConfigKind, input IaCFingerprintInputV1) (domain.CanonicalValue, string, error) {
+	switch kind {
+	case IaCDockerfile, IaCCompose, IaCGitHubActions, IaCARM:
+		// These are supported scan producers, but their native findings do not yet
+		// expose approved semantic resource identities. Retain the redacted
+		// observation for review without inventing resource anchors or grammar.
+		return domain.CanonicalValue{}, "resource_identity_unavailable", nil
+	case IaCTerraform:
+		if strings.TrimSpace(input.TerraformAddress) == "" {
+			return domain.CanonicalValue{}, "missing_terraform_address", nil
+		}
+		modulePath, resourceAddress, err := normalizeTerraformAddress(input.TerraformAddress)
+		if err != nil {
+			return domain.CanonicalValue{}, "", err
+		}
+		if modulePath == "" {
+			modulePath = "root"
+		}
+		return domain.Object(map[string]domain.CanonicalValue{
+			"module_path":      domain.Text(modulePath),
+			"resource_address": domain.Text(resourceAddress),
+		}), "", nil
+	case IaCCloudFormation:
+		if strings.TrimSpace(input.CloudFormationLogicalID) == "" {
+			return domain.CanonicalValue{}, "missing_cloudformation_logical_id", nil
+		}
+		logicalID, err := normalizeCloudFormationLogicalID(input.CloudFormationLogicalID)
+		if err != nil {
+			return domain.CanonicalValue{}, "", err
+		}
+		if len(input.CloudFormationStackPath) > 32 {
+			return domain.CanonicalValue{}, "", fmt.Errorf("%w: CloudFormation nested stack path is too deep", shared.ErrValidation)
+		}
+		stackPath := make([]domain.CanonicalValue, len(input.CloudFormationStackPath))
+		for index, segment := range input.CloudFormationStackPath {
+			normalized, normalizeErr := normalizeCloudFormationLogicalID(segment)
+			if normalizeErr != nil {
+				return domain.CanonicalValue{}, "", normalizeErr
+			}
+			stackPath[index] = domain.Text(normalized)
+		}
+		anchor := map[string]domain.CanonicalValue{"logical_resource_id": domain.Text(logicalID)}
+		// The root stack has no nested path. Canonical arrays deliberately reject
+		// empty values, so absence is represented by omitting the optional field.
+		if len(stackPath) > 0 {
+			anchor["nested_stack_path"] = domain.OrderedArray(stackPath...)
+		}
+		return domain.Object(anchor), "", nil
+	case IaCKubernetes:
+		if !input.KubernetesIdentityApproved {
+			return domain.CanonicalValue{}, "kubernetes_source_identity_not_approved", nil
+		}
+		apiVersion, err := normalizeKubernetesIdentityPart("apiVersion", input.KubernetesAPIVersion, 253, true)
+		if err != nil {
+			return domain.CanonicalValue{}, "", err
+		}
+		objectKind, err := normalizeKubernetesIdentityPart("kind", input.KubernetesKind, 128, false)
+		if err != nil {
+			return domain.CanonicalValue{}, "", err
+		}
+		name, err := normalizeKubernetesIdentityPart("name", input.KubernetesName, 253, true)
+		if err != nil {
+			return domain.CanonicalValue{}, "", err
+		}
+		namespace := strings.TrimSpace(input.KubernetesNamespace)
+		if namespace == "" {
+			namespace = "default"
+		}
+		namespace, err = normalizeKubernetesIdentityPart("namespace", namespace, 253, true)
+		if err != nil {
+			return domain.CanonicalValue{}, "", err
+		}
+		return domain.Object(map[string]domain.CanonicalValue{
+			"api_version": domain.Text(apiVersion),
+			"kind":        domain.Text(objectKind),
+			"name":        domain.Text(name),
+			"namespace":   domain.Text(namespace),
+		}), "", nil
+	}
+	return domain.CanonicalValue{}, "", fmt.Errorf("%w: IaC config kind is unsupported", shared.ErrValidation)
+}
+
+func normalizeTerraformAddress(value string) (string, string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > 2048 || !utf8.ValidString(value) || domain.ContainsSensitiveAssignment(value) {
+		return "", "", fmt.Errorf("%w: Terraform address is invalid", shared.ErrValidation)
+	}
+	position := 0
+	modules := make([]string, 0, 8)
+	for strings.HasPrefix(value[position:], "module.") {
+		position += len("module.")
+		name, next, err := parseTerraformIdentifier(value, position)
+		if err != nil {
+			return "", "", err
+		}
+		position = next
+		index, next, err := parseTerraformIndex(value, position)
+		if err != nil {
+			return "", "", err
+		}
+		position = next
+		modules = append(modules, "module."+name+index)
+		if position >= len(value) || value[position] != '.' {
+			return "", "", fmt.Errorf("%w: Terraform module address must be followed by a resource", shared.ErrValidation)
+		}
+		position++
+	}
+	resourceType, next, err := parseTerraformIdentifier(value, position)
+	if err != nil {
+		return "", "", err
+	}
+	position = next
+	if position >= len(value) || value[position] != '.' {
+		return "", "", fmt.Errorf("%w: Terraform resource address needs type.name", shared.ErrValidation)
+	}
+	position++
+	resourceName, next, err := parseTerraformIdentifier(value, position)
+	if err != nil {
+		return "", "", err
+	}
+	position = next
+	index, next, err := parseTerraformIndex(value, position)
+	if err != nil {
+		return "", "", err
+	}
+	if next != len(value) {
+		return "", "", fmt.Errorf("%w: Terraform resource address has trailing content", shared.ErrValidation)
+	}
+	return strings.Join(modules, "."), resourceType + "." + resourceName + index, nil
+}
+
+func parseTerraformIdentifier(value string, start int) (string, int, error) {
+	if start >= len(value) || !isTerraformIdentifierStart(value[start]) {
+		return "", start, fmt.Errorf("%w: Terraform address identifier is invalid", shared.ErrValidation)
+	}
+	position := start + 1
+	for position < len(value) && isTerraformIdentifierContinue(value[position]) {
+		position++
+	}
+	return value[start:position], position, nil
+}
+
+func isTerraformIdentifierStart(value byte) bool {
+	return value == '_' || value >= 'A' && value <= 'Z' || value >= 'a' && value <= 'z'
+}
+
+func isTerraformIdentifierContinue(value byte) bool {
+	return isTerraformIdentifierStart(value) || value == '-' || value >= '0' && value <= '9'
+}
+
+func parseTerraformIndex(value string, start int) (string, int, error) {
+	if start >= len(value) || value[start] != '[' {
+		return "", start, nil
+	}
+	contentStart := start + 1
+	if contentStart >= len(value) {
+		return "", start, fmt.Errorf("%w: Terraform instance index is unterminated", shared.ErrValidation)
+	}
+	end := -1
+	if value[contentStart] == '"' {
+		escaped := false
+		for position := contentStart + 1; position < len(value); position++ {
+			switch {
+			case escaped:
+				escaped = false
+			case value[position] == '\\':
+				escaped = true
+			case value[position] == '"':
+				if position+1 < len(value) && value[position+1] == ']' {
+					end = position + 1
+				}
+				position = len(value)
+			}
+		}
+	} else if relativeEnd := strings.IndexByte(value[contentStart:], ']'); relativeEnd >= 0 {
+		end = contentStart + relativeEnd
+	}
+	if end < 0 {
+		return "", start, fmt.Errorf("%w: Terraform instance index is unterminated", shared.ErrValidation)
+	}
+	raw := value[contentStart:end]
+	if raw == "" {
+		return "", start, fmt.Errorf("%w: Terraform instance index is empty", shared.ErrValidation)
+	}
+	if raw[0] == '"' {
+		key, err := strconv.Unquote(raw)
+		if err != nil {
+			return "", start, fmt.Errorf("%w: Terraform for_each key is invalid", shared.ErrValidation)
+		}
+		key, err = normalizeSourceText("IaC", "Terraform for_each key", key, 512, false)
+		if err != nil {
+			return "", start, err
+		}
+		return "[" + strconv.Quote(key) + "]", end + 1, nil
+	}
+	for _, char := range raw {
+		if char < '0' || char > '9' {
+			return "", start, fmt.Errorf("%w: Terraform count index is invalid", shared.ErrValidation)
+		}
+	}
+	numeric, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		return "", start, fmt.Errorf("%w: Terraform count index is invalid", shared.ErrValidation)
+	}
+	return "[" + strconv.FormatUint(numeric, 10) + "]", end + 1, nil
+}
+
+func normalizeCloudFormationLogicalID(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > 255 || !isASCIILetter(value[0]) {
+		return "", fmt.Errorf("%w: CloudFormation logical ID is invalid", shared.ErrValidation)
+	}
+	for index := 1; index < len(value); index++ {
+		if !isASCIILetter(value[index]) && (value[index] < '0' || value[index] > '9') {
+			return "", fmt.Errorf("%w: CloudFormation logical ID is invalid", shared.ErrValidation)
+		}
+	}
+	return value, nil
+}
+
+func isASCIILetter(value byte) bool {
+	return value >= 'A' && value <= 'Z' || value >= 'a' && value <= 'z'
+}
+
+func normalizeKubernetesIdentityPart(name, value string, maximum int, lower bool) (string, error) {
+	value = strings.TrimSpace(value)
+	if lower {
+		value = strings.ToLower(value)
+	}
+	if value == "" || len(value) > maximum || !utf8.ValidString(value) || domain.ContainsSensitiveAssignment(value) {
+		return "", fmt.Errorf("%w: Kubernetes %s is invalid", shared.ErrValidation, name)
+	}
+	for _, char := range value {
+		if unicode.IsControl(char) || unicode.IsSpace(char) || char == '/' && name != "apiVersion" {
+			return "", fmt.Errorf("%w: Kubernetes %s is invalid", shared.ErrValidation, name)
+		}
+	}
+	return value, nil
+}
+
+func inferIaCConfigKind(rule string) IaCConfigKind {
+	rule = strings.ToLower(strings.TrimSpace(rule))
+	switch {
+	case strings.HasPrefix(rule, "terraform-"):
+		return IaCTerraform
+	case strings.HasPrefix(rule, "cloudformation-"):
+		return IaCCloudFormation
+	case strings.HasPrefix(rule, "kubernetes-"):
+		return IaCKubernetes
+	case strings.HasPrefix(rule, "dockerfile-"):
+		return IaCDockerfile
+	case strings.HasPrefix(rule, "compose-"):
+		return IaCCompose
+	case strings.HasPrefix(rule, "gha-"):
+		return IaCGitHubActions
+	case strings.HasPrefix(rule, "arm-"):
+		return IaCARM
+	}
+	return ""
+}
+
+type iacLegacyKind uint8
+
+const (
+	iacLegacyNone iacLegacyKind = iota
+	iacLegacyValid
+	iacLegacyMalformed
+)
+
+type iacLegacyKey struct {
+	kind     iacLegacyKind
+	ruleKey  string
+	repoPath string
+}
+
+func parseIaCLegacyKey(value string) iacLegacyKey {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return iacLegacyKey{}
+	}
+	if !strings.HasPrefix(value, "misconfig:") {
+		return iacLegacyKey{kind: iacLegacyMalformed}
+	}
+	rest := strings.TrimPrefix(value, "misconfig:")
+	lineSeparator := strings.LastIndexByte(rest, ':')
+	if lineSeparator <= 0 {
+		return iacLegacyKey{kind: iacLegacyMalformed}
+	}
+	line, err := strconv.Atoi(rest[lineSeparator+1:])
+	pathSeparator := strings.LastIndexByte(rest[:lineSeparator], ':')
+	if err != nil || line < 1 || pathSeparator <= 0 || pathSeparator == lineSeparator-1 {
+		return iacLegacyKey{kind: iacLegacyMalformed}
+	}
+	return iacLegacyKey{kind: iacLegacyValid, ruleKey: rest[:pathSeparator], repoPath: rest[pathSeparator+1 : lineSeparator]}
+}

--- a/internal/usecase/findinglineage/iac_matcher_test.go
+++ b/internal/usecase/findinglineage/iac_matcher_test.go
@@ -1,0 +1,393 @@
+package findinglineage
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+)
+
+func TestIaCMatcherV1GoldenTerraformAddressAndLineMovement(t *testing.T) {
+	matcher, err := NewIaCMatcherV1([]IaCRuleAliasSetV1{{Primary: "terraform-public-instance", Aliases: []string{"tf-public-instance"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := IaCFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", ConfigKind: IaCTerraform,
+		SemanticConfigAnchorDigest: strings.Repeat("a", 64),
+		TerraformAddress:           `module.network[0].module.service["blue]zone"].aws_instance.web[2]`,
+		LegacySourceValidated:      true,
+	}
+	first := base
+	first.LegacyDedupKey = "misconfig:tf-public-instance:infra/./Cafe\u0301.tf:42"
+	second := base
+	second.LegacyDedupKey = "misconfig:terraform-public-instance:infra/Café.tf:900"
+	firstPlan, err := matcher.Build(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondPlan, err := matcher.Build(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstFingerprint, err := domain.CanonicalizeFingerprintV1(firstPlan.FingerprintInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondFingerprint, err := domain.CanonicalizeFingerprintV1(secondPlan.FingerprintInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstFingerprint.Fingerprint != secondFingerprint.Fingerprint {
+		t.Fatalf("Terraform line movement changed identity: %s != %s", firstFingerprint.Fingerprint, secondFingerprint.Fingerprint)
+	}
+	const wantFingerprint = "601f24d6a4263f8c302c29241537b5c5a14f656f9e75d7b4687a46e5ac3773de"
+	if firstFingerprint.Fingerprint != wantFingerprint {
+		t.Fatalf("fingerprint=%s want=%s canonical=%s", firstFingerprint.Fingerprint, wantFingerprint, firstFingerprint.Bytes)
+	}
+	canonical := string(firstFingerprint.Bytes)
+	if !strings.Contains(canonical, `"module_path":"module.network[0].module.service[\"blue]zone\"]"`) ||
+		!strings.Contains(canonical, `"resource_address":"aws_instance.web[2]"`) {
+		t.Fatalf("Terraform address was not canonicalized: %s", canonical)
+	}
+	if strings.Contains(canonical, "42") || strings.Contains(canonical, "900") {
+		t.Fatalf("line leaked into IaC identity: %s", canonical)
+	}
+
+	differentModule := second
+	differentModule.LegacyDedupKey = ""
+	differentModule.RepoPath = "infra/Café.tf"
+	differentModule.RuleKey = "terraform-public-instance"
+	differentModule.TerraformAddress = `module.service["blue]zone"].module.network[0].aws_instance.web[2]`
+	differentPlan, err := matcher.Build(differentModule)
+	if err != nil {
+		t.Fatal(err)
+	}
+	differentFingerprint, _ := domain.CanonicalizeFingerprintV1(differentPlan.FingerprintInput)
+	if differentFingerprint.Fingerprint == firstFingerprint.Fingerprint {
+		t.Fatal("Terraform module order collapsed")
+	}
+
+	differentIndex := second
+	differentIndex.LegacyDedupKey = ""
+	differentIndex.RepoPath = "infra/Café.tf"
+	differentIndex.RuleKey = "terraform-public-instance"
+	differentIndex.TerraformAddress = `module.network[1].module.service["blue]zone"].aws_instance.web[2]`
+	differentIndexPlan, err := matcher.Build(differentIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	differentIndexFingerprint, _ := domain.CanonicalizeFingerprintV1(differentIndexPlan.FingerprintInput)
+	if differentIndexFingerprint.Fingerprint == firstFingerprint.Fingerprint {
+		t.Fatal("Terraform module instance keys collapsed")
+	}
+}
+
+func TestIaCMatcherV1CloudFormationKubernetesAndMissingAnchors(t *testing.T) {
+	matcher, err := NewIaCMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := strings.Repeat("b", 64)
+	cloudFormation, err := matcher.Build(IaCFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", ConfigKind: IaCCloudFormation, RuleKey: "cloudformation-rds-public", RepoPath: "infra/template.yaml",
+		SemanticConfigAnchorDigest: digest, CloudFormationStackPath: []string{"NetworkStack", "DataStack"}, CloudFormationLogicalID: "Database",
+	})
+	if err != nil || cloudFormation.ProvisionalIdentity {
+		t.Fatalf("CloudFormation plan=%+v err=%v", cloudFormation, err)
+	}
+	reversed, err := matcher.Build(IaCFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", ConfigKind: IaCCloudFormation, RuleKey: "cloudformation-rds-public", RepoPath: "infra/template.yaml",
+		SemanticConfigAnchorDigest: digest, CloudFormationStackPath: []string{"DataStack", "NetworkStack"}, CloudFormationLogicalID: "Database",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cloudFingerprint, _ := domain.CanonicalizeFingerprintV1(cloudFormation.FingerprintInput)
+	reversedFingerprint, _ := domain.CanonicalizeFingerprintV1(reversed.FingerprintInput)
+	if cloudFingerprint.Fingerprint == reversedFingerprint.Fingerprint {
+		t.Fatal("CloudFormation nested stack order collapsed")
+	}
+	rootStack, err := matcher.Build(IaCFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", ConfigKind: IaCCloudFormation, RuleKey: "cloudformation-rds-public", RepoPath: "infra/template.yaml",
+		SemanticConfigAnchorDigest: digest, CloudFormationLogicalID: "Database",
+	})
+	if err != nil || rootStack.ProvisionalIdentity {
+		t.Fatalf("root CloudFormation plan=%+v err=%v", rootStack, err)
+	}
+	rootFingerprint, err := domain.CanonicalizeFingerprintV1(rootStack.FingerprintInput)
+	if err != nil || strings.Contains(string(rootFingerprint.Bytes), "nested_stack_path") {
+		t.Fatalf("root CloudFormation canonical=%s err=%v", rootFingerprint.Bytes, err)
+	}
+
+	kubernetes, err := matcher.Build(IaCFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", ConfigKind: IaCKubernetes, RuleKey: "kubernetes-privileged", RepoPath: "deploy/app.yaml",
+		SemanticConfigAnchorDigest: digest, KubernetesIdentityApproved: true, KubernetesAPIVersion: "apps/v1", KubernetesKind: "Deployment", KubernetesName: "api",
+	})
+	if err != nil || kubernetes.ProvisionalIdentity {
+		t.Fatalf("Kubernetes plan=%+v err=%v", kubernetes, err)
+	}
+	explicitDefault, err := matcher.Build(IaCFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", ConfigKind: IaCKubernetes, RuleKey: "kubernetes-privileged", RepoPath: "deploy/app.yaml",
+		SemanticConfigAnchorDigest: digest, KubernetesIdentityApproved: true, KubernetesAPIVersion: "apps/v1", KubernetesKind: "Deployment", KubernetesNamespace: "default", KubernetesName: "api",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	kubernetesFingerprint, _ := domain.CanonicalizeFingerprintV1(kubernetes.FingerprintInput)
+	explicitFingerprint, _ := domain.CanonicalizeFingerprintV1(explicitDefault.FingerprintInput)
+	if kubernetesFingerprint.Fingerprint != explicitFingerprint.Fingerprint {
+		t.Fatal("implicit and explicit Kubernetes default namespace diverged")
+	}
+
+	unapproved, err := matcher.Build(IaCFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", ConfigKind: IaCKubernetes, RuleKey: "kubernetes-privileged", RepoPath: "deploy/app.yaml",
+		SemanticConfigAnchorDigest: digest, KubernetesAPIVersion: "apps/v1", KubernetesKind: "Deployment", KubernetesName: "api",
+	})
+	if err != nil || !unapproved.ProvisionalIdentity || unapproved.ReasonCode != "kubernetes_source_identity_not_approved" {
+		t.Fatalf("unapproved=%+v err=%v", unapproved, err)
+	}
+	missingSemantic, err := matcher.Build(IaCFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", ConfigKind: IaCTerraform, RuleKey: "terraform-public-instance", RepoPath: "main.tf", TerraformAddress: "aws_instance.web[0]",
+	})
+	if err != nil || !missingSemantic.ProvisionalIdentity || missingSemantic.ReasonCode != "missing_semantic_config_anchor" {
+		t.Fatalf("missing semantic=%+v err=%v", missingSemantic, err)
+	}
+	if _, err := matcher.Build(IaCFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", ConfigKind: IaCTerraform, RuleKey: "terraform-public-instance", RepoPath: "main.tf",
+		SemanticConfigAnchorDigest: digest, TerraformAddress: "aws_instance.web", RuntimeResourceID: "i-runtime-123",
+	}); !errors.Is(err, shared.ErrValidation) || strings.Contains(err.Error(), "i-runtime-123") {
+		t.Fatalf("runtime id error=%v", err)
+	}
+}
+
+func TestIaCMatcherV1TerraformGrammarCollisionAndPersistence(t *testing.T) {
+	matcher, err := NewIaCMatcherV1([]IaCRuleAliasSetV1{
+		{Primary: "terraform:a", Aliases: []string{"legacy:shared"}},
+		{Primary: "terraform:b", Aliases: []string{"legacy:shared"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := strings.Repeat("c", 64)
+	for _, address := range []string{
+		"module..aws_instance.web", "module.network", "aws_instance", "aws_instance.web[-1]", "aws_instance.web[key]", `aws_instance.web["unterminated]`,
+	} {
+		if _, err := matcher.Build(IaCFingerprintInputV1{
+			TargetIdentityCanonical: "repo:example", ConfigKind: IaCTerraform, RuleKey: "terraform:a", RepoPath: "main.tf",
+			SemanticConfigAnchorDigest: digest, TerraformAddress: address,
+		}); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("address=%q err=%v", address, err)
+		}
+	}
+	canonicalCount, err := matcher.Build(IaCFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", ConfigKind: IaCTerraform, RuleKey: "terraform:a", RepoPath: "main.tf",
+		SemanticConfigAnchorDigest: digest, TerraformAddress: "aws_instance.web[00]",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	countFingerprint, _ := domain.CanonicalizeFingerprintV1(canonicalCount.FingerprintInput)
+	if !strings.Contains(string(countFingerprint.Bytes), `"resource_address":"aws_instance.web[0]"`) {
+		t.Fatalf("count index was not canonicalized: %s", countFingerprint.Bytes)
+	}
+
+	conflict, err := matcher.Build(IaCFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", ConfigKind: IaCTerraform, RuleKey: "legacy:shared", RepoPath: "main.tf",
+		SemanticConfigAnchorDigest: digest, TerraformAddress: "aws_instance.web[0]",
+	})
+	if err != nil || !conflict.Ambiguous || conflict.ReasonCode != "rule_alias_conflict" {
+		t.Fatalf("conflict=%+v err=%v", conflict, err)
+	}
+	repository := memory.NewFindingLineageRepository()
+	clock := fixedClock{now: time.Date(2026, 9, 1, 15, 0, 0, 0, time.UTC)}
+	observer := &collectingObserver{}
+	service, err := NewService(repository, immediateTransactions{}, &collectingAudit{}, clock, &sequenceIDs{}, observer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := conflict.Apply(correlateInput("iac-conflict", "unused"))
+	input.Observation.SourceFindingID = "iac-source"
+	result, err := service.Correlate(context.Background(), input)
+	if err != nil || result.Outcome != OutcomeReview || result.Candidate == nil || result.Candidate.Reason != domain.ReasonMerge {
+		t.Fatalf("result=%+v err=%v", result, err)
+	}
+
+	legacy, err := matcher.Build(IaCFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", ConfigKind: IaCTerraform, LegacyDedupKey: "misconfig:terraform-public-instance:main.tf:42",
+		LegacySourceValidated: true,
+	})
+	if err != nil || !legacy.ProvisionalIdentity {
+		t.Fatalf("legacy=%+v err=%v", legacy, err)
+	}
+	legacyInput := legacy.Apply(correlateInput("iac-legacy", "unused"))
+	legacyInput.Observation.SourceFindingID = "iac-legacy-source"
+	legacyResult, err := service.Correlate(context.Background(), legacyInput)
+	if err != nil || legacyResult.Outcome != OutcomeReview || legacyResult.Identity == nil || legacyResult.Candidate == nil {
+		t.Fatalf("legacy result=%+v err=%v", legacyResult, err)
+	}
+	if len(observer.outcomes) != 2 {
+		t.Fatalf("metrics=%+v", observer.outcomes)
+	}
+
+	for _, repoPath := range []string{"../main.tf", "/tmp/main.tf", `infra\main.tf`} {
+		if _, err := matcher.Build(IaCFingerprintInputV1{
+			TargetIdentityCanonical: "repo:example", ConfigKind: IaCTerraform, RuleKey: "terraform:a", RepoPath: repoPath,
+			SemanticConfigAnchorDigest: digest, TerraformAddress: "aws_instance.web[0]",
+		}); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("path=%q err=%v", repoPath, err)
+		}
+	}
+}
+
+func TestIaCMatcherV1RecognizesEveryNativeConfigFamily(t *testing.T) {
+	matcher, err := NewIaCMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, scenario := range []struct {
+		rule string
+		kind IaCConfigKind
+	}{
+		{"terraform-public-instance", "terraform"},
+		{"cloudformation-rds-public", "cloudformation"},
+		{"kubernetes-privileged", "kubernetes"},
+		{"dockerfile-run-as-root", "dockerfile"},
+		{"compose-privileged", "compose"},
+		{"gha-pull-request-target", "github_actions"},
+		{"arm-storage-public-blob", "arm"},
+	} {
+		t.Run(string(scenario.kind), func(t *testing.T) {
+			for _, legacy := range []bool{false, true} {
+				input := IaCFingerprintInputV1{TargetIdentityCanonical: "repo:example", RuleKey: scenario.rule, RepoPath: "infra/config.yaml"}
+				if legacy {
+					input.RuleKey, input.RepoPath = "", ""
+					input.LegacyDedupKey = "misconfig:" + scenario.rule + ":infra/config.yaml:42"
+					input.LegacySourceValidated = true
+				}
+				plan, err := matcher.Build(input)
+				if err != nil {
+					t.Fatalf("legacy=%v: %v", legacy, err)
+				}
+				fingerprint, err := domain.CanonicalizeFingerprintV1(plan.FingerprintInput)
+				if err != nil || !strings.Contains(string(fingerprint.Bytes), `"config_kind":"`+string(scenario.kind)+`"`) {
+					t.Fatalf("canonical=%s err=%v", fingerprint.Bytes, err)
+				}
+				if !plan.ProvisionalIdentity || !plan.Ambiguous || plan.ReviewReason != domain.ReasonInsufficientAnchor || plan.SkipInput {
+					t.Fatalf("source-only input became trusted or was dropped: %+v", plan)
+				}
+			}
+		})
+	}
+}
+
+func TestIaCMatcherV1UnadaptedConfigFamiliesStayProvisional(t *testing.T) {
+	matcher, err := NewIaCMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fingerprints := map[string]IaCConfigKind{}
+	for _, kind := range []IaCConfigKind{"dockerfile", "compose", "github_actions", "arm"} {
+		t.Run(string(kind), func(t *testing.T) {
+			for _, digest := range []string{"", strings.Repeat("a", 64)} {
+				plan, err := matcher.Build(IaCFingerprintInputV1{
+					TargetIdentityCanonical: "repo:example", ConfigKind: kind, RuleKey: "shared-rule", RepoPath: "infra/config.yaml",
+					SemanticConfigAnchorDigest: digest,
+				})
+				if err != nil || !plan.ProvisionalIdentity || !plan.Ambiguous || plan.ReviewReason != domain.ReasonInsufficientAnchor || plan.ReasonCode != "resource_identity_unavailable" || plan.SkipInput {
+					t.Fatalf("unadapted config promoted or dropped: %+v err=%v", plan, err)
+				}
+				if _, exists := plan.FingerprintInput.IdentityFields["resource_anchor"]; exists {
+					t.Fatal("unadapted config invented a resource anchor")
+				}
+				for _, key := range []string{"resource_adapter_version", "resource_identity_grammar"} {
+					if _, exists := plan.FingerprintInput.IdentityFields[key]; exists {
+						t.Fatalf("unadapted config claimed %s", key)
+					}
+				}
+				if digest == "" {
+					if _, exists := plan.FingerprintInput.IdentityFields["semantic_config_anchor"]; exists {
+						t.Fatal("unadapted config invented a semantic anchor")
+					}
+				}
+				fingerprint, err := domain.CanonicalizeFingerprintV1(plan.FingerprintInput)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if previous, exists := fingerprints[fingerprint.Fingerprint]; exists {
+					t.Fatalf("same-file config kinds collapsed: %s and %s", previous, kind)
+				}
+				fingerprints[fingerprint.Fingerprint] = kind
+				applied := plan.Apply(CorrelateInput{InputTrusted: true})
+				if !applied.ProvisionalIdentity || applied.ReviewReason != domain.ReasonInsufficientAnchor || applied.ProducerKind != "iac" || applied.FindingKind != "misconfig" {
+					t.Fatalf("conservative plan lost at correlation boundary: %+v", applied)
+				}
+			}
+		})
+	}
+}
+
+func TestIaCMatcherV1UnadaptedConfigValidationStillFailsClosed(t *testing.T) {
+	matcher, err := NewIaCMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, kind := range []IaCConfigKind{"dockerfile", "compose", "github_actions", "arm"} {
+		for _, scenario := range []struct {
+			name string
+			edit func(*IaCFingerprintInputV1)
+		}{
+			{"parent-path", func(input *IaCFingerprintInputV1) { input.RepoPath = "../config.yaml" }},
+			{"absolute-path", func(input *IaCFingerprintInputV1) { input.RepoPath = "/tmp/config.yaml" }},
+			{"backslash-path", func(input *IaCFingerprintInputV1) { input.RepoPath = `infra\config.yaml` }},
+			{"sensitive-path", func(input *IaCFingerprintInputV1) { input.RepoPath = "token=never-retain-me/config.yaml" }},
+			{"sensitive-rule", func(input *IaCFingerprintInputV1) { input.RuleKey = "token=never-retain-me" }},
+			{"sensitive-target", func(input *IaCFingerprintInputV1) { input.TargetIdentityCanonical = "token=never-retain-me" }},
+			{"invalid-digest", func(input *IaCFingerprintInputV1) { input.SemanticConfigAnchorDigest = "token=never-retain-me" }},
+			{"raw-runtime", func(input *IaCFingerprintInputV1) { input.RuntimeResourceID = "never-retain-me" }},
+			{"raw-rendered", func(input *IaCFingerprintInputV1) { input.RenderedValue = "never-retain-me" }},
+			{"raw-offsets", func(input *IaCFingerprintInputV1) { input.RawOffsets = map[string]int{"line": 42} }},
+		} {
+			t.Run(string(kind)+"/"+scenario.name, func(t *testing.T) {
+				input := IaCFingerprintInputV1{TargetIdentityCanonical: "repo:example", ConfigKind: kind, RuleKey: "shared-rule", RepoPath: "infra/config.yaml"}
+				scenario.edit(&input)
+				if _, err := matcher.Build(input); (!errors.Is(err, shared.ErrValidation) && !errors.Is(err, domain.ErrSensitiveInput)) || strings.Contains(err.Error(), "never-retain-me") {
+					t.Fatalf("unsafe input accepted or leaked: %v", err)
+				}
+			})
+		}
+	}
+	for _, input := range []IaCFingerprintInputV1{
+		{TargetIdentityCanonical: "repo:example", RuleKey: "unknown-rule", RepoPath: "config.yaml"},
+		{TargetIdentityCanonical: "repo:example", ConfigKind: "unknown", RuleKey: "terraform-public-instance", RepoPath: "config.yaml"},
+		{TargetIdentityCanonical: "repo:example", ConfigKind: "unknown", RuleKey: "dockerfile-run-as-root", RepoPath: "config.yaml"},
+	} {
+		if _, err := matcher.Build(input); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("unsupported kind accepted: kind=%q rule=%q err=%v", input.ConfigKind, input.RuleKey, err)
+		}
+	}
+}
+
+func TestIaCMatcherV1UnadaptedConfigAliasConflictDoesNotPromoteIdentity(t *testing.T) {
+	matcher, err := NewIaCMatcherV1([]IaCRuleAliasSetV1{
+		{Primary: "config:a", Aliases: []string{"config:shared"}},
+		{Primary: "config:b", Aliases: []string{"config:shared"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, kind := range []IaCConfigKind{IaCDockerfile, IaCCompose, IaCGitHubActions, IaCARM} {
+		plan, err := matcher.Build(IaCFingerprintInputV1{
+			TargetIdentityCanonical: "repo:example", ConfigKind: kind, RuleKey: "config:shared", RepoPath: "infra/config.yaml",
+			SemanticConfigAnchorDigest: strings.Repeat("a", 64),
+		})
+		if err != nil || !plan.ProvisionalIdentity || !plan.Ambiguous || plan.ReviewReason != domain.ReasonMerge || plan.ReasonCode != "rule_alias_conflict" {
+			t.Fatalf("alias conflict lost conservative identity: kind=%s plan=%+v err=%v", kind, plan, err)
+		}
+	}
+}

--- a/internal/usecase/findinglineage/manual_workflow.go
+++ b/internal/usecase/findinglineage/manual_workflow.go
@@ -1,0 +1,228 @@
+package findinglineage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+)
+
+const (
+	ManualNativeFingerprintSchemaVersionV1 = 1
+	ManualImportFingerprintSchemaVersionV1 = 1
+	ManualTargetIdentitySchemaVersionV1    = 1
+)
+
+type ManualFindingClass string
+
+const (
+	ManualFindingNative    ManualFindingClass = "manual"
+	ManualFindingOffensive ManualFindingClass = "offensive"
+)
+
+func (class ManualFindingClass) Valid() bool {
+	return class == ManualFindingNative || class == ManualFindingOffensive
+}
+
+type NativeManualInput struct {
+	TenantID     shared.ID
+	CycleID      shared.ID
+	SnapshotID   shared.ID
+	AssessmentID shared.ID
+	IdentityID   shared.ID
+	FindingClass ManualFindingClass
+	Observation  ObservationInput
+	Actor        string
+}
+
+func (service *Service) CorrelateNativeManual(ctx context.Context, input NativeManualInput) (Result, error) {
+	input.TenantID = shared.TenantOrDefault(input.TenantID)
+	if input.TenantID.IsZero() || input.CycleID.IsZero() || input.SnapshotID.IsZero() || input.AssessmentID.IsZero() || !input.FindingClass.Valid() || strings.TrimSpace(input.Actor) == "" {
+		return Result{}, fmt.Errorf("%w: native manual lineage ownership and class are required", shared.ErrValidation)
+	}
+	if input.IdentityID.IsZero() {
+		input.IdentityID = service.ids.NewID()
+	}
+	target := "assessment:" + input.AssessmentID.String()
+	fingerprintInput := domain.FingerprintCanonicalInputV1{
+		CanonicalizationVersion: domain.CanonicalizationVersionV1, ProducerKind: "manual_native",
+		TargetIdentitySchemaVersion: ManualTargetIdentitySchemaVersionV1, TargetIdentityCanonical: target,
+		IdentityFields: map[string]domain.CanonicalValue{
+			"assessment_id":        domain.Text(input.AssessmentID.String()),
+			"explicit_identity_id": domain.Text(input.IdentityID.String()),
+			"finding_class":        domain.Text(string(input.FindingClass)),
+			"identity_schema":      domain.Integer(1),
+		},
+	}
+	fingerprint, err := domain.CanonicalizeFingerprintV1(fingerprintInput)
+	if err != nil {
+		return Result{}, err
+	}
+	if existing, getErr := service.repository.GetIdentity(ctx, input.TenantID, input.CycleID, input.IdentityID); getErr == nil {
+		if existing.ProducerKind != "manual_native" || existing.FindingKind != string(input.FindingClass) || existing.TargetIdentityCanonical != target || existing.LineageFingerprint != fingerprint.Fingerprint {
+			return Result{}, fmt.Errorf("%w: explicit native identity cannot be reused across Assessments or finding classes", shared.ErrConflict)
+		}
+	} else if getErr != nil && !errors.Is(getErr, shared.ErrNotFound) {
+		return Result{}, getErr
+	}
+	matches, err := service.repository.FindIdentitiesByFingerprint(ctx, input.TenantID, input.CycleID, "manual_native", string(input.FindingClass), ManualNativeFingerprintSchemaVersionV1, target, fingerprint.Fingerprint)
+	if err != nil {
+		return Result{}, err
+	}
+	for _, match := range matches {
+		if match.ID != input.IdentityID {
+			return Result{}, fmt.Errorf("%w: native manual fingerprint already belongs to another explicit identity", shared.ErrConflict)
+		}
+	}
+	if input.Observation.SourceFindingID == "" && input.Observation.SourceOccurrenceID == "" {
+		input.Observation.SourceFindingID = input.IdentityID.String()
+	}
+	if strings.TrimSpace(input.Observation.ScannerProvenance.ToolName) == "" {
+		input.Observation.ScannerProvenance.ToolName = "native-manual"
+	}
+	return service.Correlate(ctx, CorrelateInput{
+		TenantID: input.TenantID, CycleID: input.CycleID, SnapshotID: input.SnapshotID, IdentityID: input.IdentityID,
+		ProducerKind: "manual_native", FindingKind: string(input.FindingClass), FingerprintSchemaVersion: ManualNativeFingerprintSchemaVersionV1,
+		FingerprintInput: fingerprintInput, InputTrusted: true, OwnershipValidated: true, RedactionComplete: true,
+		Observation: input.Observation, Actor: input.Actor,
+	})
+}
+
+type ManualImportFingerprintInputV1 struct {
+	TargetIdentityCanonical string
+	AssessmentID            shared.ID
+	FindingClass            ManualFindingClass
+	ImporterNamespace       string
+	ImporterSchemaVersion   int
+	ExternalStableID        string
+	SourceValidated         bool
+	RedactionComplete       bool
+}
+
+type ManualImportMatchPlanV1 struct {
+	FingerprintInput    domain.FingerprintCanonicalInputV1
+	FindingClass        ManualFindingClass
+	ReasonCode          string
+	ReviewReason        domain.CandidateReason
+	ProvisionalIdentity bool
+	SkipInput           bool
+	SkipRedaction       bool
+}
+
+func BuildManualImportMatchPlanV1(input ManualImportFingerprintInputV1) (ManualImportMatchPlanV1, error) {
+	if input.AssessmentID.IsZero() || !input.FindingClass.Valid() || input.ImporterSchemaVersion <= 0 {
+		return ManualImportMatchPlanV1{}, fmt.Errorf("%w: manual import ownership, class, and schema are required", shared.ErrValidation)
+	}
+	target, err := normalizeSourceText("manual import", "target identity", input.TargetIdentityCanonical, 2048, false)
+	if err != nil {
+		return ManualImportMatchPlanV1{}, err
+	}
+	namespace, err := normalizeSourceText("manual import", "importer namespace", input.ImporterNamespace, 256, true)
+	if err != nil {
+		return ManualImportMatchPlanV1{}, err
+	}
+	fields := map[string]domain.CanonicalValue{
+		"assessment_id":           domain.Text(input.AssessmentID.String()),
+		"finding_class":           domain.Text(string(input.FindingClass)),
+		"importer_namespace":      domain.Text(namespace),
+		"importer_schema_version": domain.Integer(int64(input.ImporterSchemaVersion)),
+	}
+	externalID := strings.TrimSpace(input.ExternalStableID)
+	if externalID != "" {
+		externalID, err = normalizeSourceText("manual import", "external stable id", externalID, 512, false)
+		if err != nil {
+			return ManualImportMatchPlanV1{}, err
+		}
+		fields["external_stable_id"] = domain.Text(externalID)
+	}
+	plan := ManualImportMatchPlanV1{
+		FingerprintInput: domain.FingerprintCanonicalInputV1{
+			CanonicalizationVersion: domain.CanonicalizationVersionV1, ProducerKind: "manual_import",
+			TargetIdentitySchemaVersion: ManualTargetIdentitySchemaVersionV1, TargetIdentityCanonical: target, IdentityFields: fields,
+		},
+		FindingClass: input.FindingClass, ReviewReason: domain.ReasonLegacyAmbiguous, ProvisionalIdentity: true, ReasonCode: "imported_identity_requires_review",
+	}
+	switch {
+	case !input.RedactionComplete:
+		plan.SkipRedaction, plan.ReasonCode = true, "redaction_not_complete"
+	case !input.SourceValidated:
+		plan.SkipInput, plan.ReasonCode = true, "import_source_not_validated"
+	case externalID == "":
+		plan.ReviewReason, plan.ReasonCode = domain.ReasonInsufficientAnchor, "missing_external_stable_id"
+	}
+	return plan, nil
+}
+
+func (plan ManualImportMatchPlanV1) Apply(input CorrelateInput) CorrelateInput {
+	input.ProducerKind = "manual_import"
+	input.FindingKind = string(plan.FindingClass)
+	input.FingerprintSchemaVersion = ManualImportFingerprintSchemaVersionV1
+	input.FingerprintInput = plan.FingerprintInput
+	input.ReviewReason = plan.ReviewReason
+	input.ReviewDetailCode = plan.ReasonCode
+	input.ProvisionalIdentity = plan.ProvisionalIdentity
+	if plan.SkipInput {
+		input.InputTrusted = false
+	}
+	if plan.SkipRedaction {
+		input.RedactionComplete = false
+	}
+	return input
+}
+
+type ConfirmManualCrossAssessmentLinkInput struct {
+	TenantID            shared.ID
+	CycleID             shared.ID
+	EventID             shared.ID
+	SourceObservationID shared.ID
+	TargetIdentityID    shared.ID
+	TargetObservationID shared.ID
+	Actor               string
+	Role                userdom.Role
+	Reason              string
+	IfMatchProvided     bool
+	ExpectedVersion     int64
+	PriorEventID        shared.ID
+}
+
+func (service *Service) ConfirmManualCrossAssessmentLink(ctx context.Context, input ConfirmManualCrossAssessmentLinkInput) (domain.OverrideEvent, bool, error) {
+	input.TenantID = shared.TenantOrDefault(input.TenantID)
+	if !input.Role.Can(userdom.PermReview) {
+		return domain.OverrideEvent{}, false, shared.ErrForbidden
+	}
+	if input.EventID.IsZero() || input.SourceObservationID.IsZero() || input.TargetIdentityID.IsZero() || strings.TrimSpace(input.Actor) == "" || strings.TrimSpace(input.Reason) == "" || !input.IfMatchProvided || input.ExpectedVersion < 0 {
+		return domain.OverrideEvent{}, false, fmt.Errorf("%w: review event, references, reason, and If-Match are required", shared.ErrValidation)
+	}
+	sourceObservation, err := service.repository.GetObservation(ctx, input.TenantID, input.CycleID, input.SourceObservationID)
+	if err != nil {
+		return domain.OverrideEvent{}, false, err
+	}
+	sourceIdentity, err := service.repository.GetIdentity(ctx, input.TenantID, input.CycleID, sourceObservation.IdentityID)
+	if err != nil {
+		return domain.OverrideEvent{}, false, err
+	}
+	targetIdentity, err := service.repository.GetIdentity(ctx, input.TenantID, input.CycleID, input.TargetIdentityID)
+	if err != nil {
+		return domain.OverrideEvent{}, false, err
+	}
+	if !nativeManualIdentity(sourceIdentity) || !nativeManualIdentity(targetIdentity) || sourceIdentity.ID == targetIdentity.ID {
+		return domain.OverrideEvent{}, false, fmt.Errorf("%w: cross-Assessment manual link requires two native manual/offensive identities", shared.ErrValidation)
+	}
+	if sourceIdentity.TargetIdentityCanonical == targetIdentity.TargetIdentityCanonical {
+		return domain.OverrideEvent{}, false, fmt.Errorf("%w: identities already belong to the same Assessment", shared.ErrValidation)
+	}
+	return service.AppendOverride(ctx, OverrideInput{
+		TenantID: input.TenantID, CycleID: input.CycleID, EventID: input.EventID, Action: domain.OverrideConfirm,
+		SourceObservationID: input.SourceObservationID, SourceIdentityID: sourceIdentity.ID,
+		TargetObservationID: input.TargetObservationID, TargetIdentityID: input.TargetIdentityID,
+		Actor: input.Actor, Reason: input.Reason, ExpectedVersion: input.ExpectedVersion, PriorEventID: input.PriorEventID,
+	})
+}
+
+func nativeManualIdentity(identity domain.Identity) bool {
+	return identity.ProducerKind == "manual_native" && (identity.FindingKind == string(ManualFindingNative) || identity.FindingKind == string(ManualFindingOffensive))
+}

--- a/internal/usecase/findinglineage/manual_workflow_test.go
+++ b/internal/usecase/findinglineage/manual_workflow_test.go
@@ -1,0 +1,195 @@
+package findinglineage
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+)
+
+func TestNativeManualExplicitIdentityReuseAndCrossAssessmentIsolation(t *testing.T) {
+	repository := memory.NewFindingLineageRepository()
+	clock := fixedClock{now: time.Date(2026, 9, 1, 16, 0, 0, 0, time.UTC)}
+	service, err := NewService(repository, immediateTransactions{}, &collectingAudit{}, clock, &sequenceIDs{}, &collectingObserver{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := service.CorrelateNativeManual(context.Background(), NativeManualInput{
+		TenantID: "tenant", CycleID: "cycle", SnapshotID: "snapshot-a1", AssessmentID: "assessment-a", IdentityID: "manual-identity",
+		FindingClass: ManualFindingNative, Observation: manualObservation("manual-observation-a1", "native-finding-a1", shared.SeverityHigh, "endpoint:/admin"), Actor: "analyst",
+	})
+	if err != nil || first.Outcome != OutcomeCreated || first.Identity == nil || first.Identity.ID != "manual-identity" || first.Observation == nil {
+		t.Fatalf("first=%+v err=%v", first, err)
+	}
+	second, err := service.CorrelateNativeManual(context.Background(), NativeManualInput{
+		TenantID: "tenant", CycleID: "cycle", SnapshotID: "snapshot-a2", AssessmentID: "assessment-a", IdentityID: "manual-identity",
+		FindingClass: ManualFindingNative, Observation: manualObservation("manual-observation-a2", "native-finding-a2", shared.SeverityLow, "endpoint:/renamed"), Actor: "analyst",
+	})
+	if err != nil || second.Outcome != OutcomeMatched || second.Identity == nil || second.Identity.ID != first.Identity.ID {
+		t.Fatalf("second=%+v err=%v", second, err)
+	}
+	if _, err := service.CorrelateNativeManual(context.Background(), NativeManualInput{
+		TenantID: "tenant", CycleID: "cycle", SnapshotID: "snapshot-b1", AssessmentID: "assessment-b", IdentityID: "manual-identity",
+		FindingClass: ManualFindingNative, Observation: manualObservation("manual-observation-b1", "native-finding-b1", shared.SeverityHigh, "endpoint:/admin"), Actor: "analyst",
+	}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("cross-assessment explicit identity reuse error=%v", err)
+	}
+	observations, err := repository.ListObservationsBySnapshot(context.Background(), "tenant", "cycle", "snapshot-a2")
+	if err != nil || len(observations) != 1 || observations[0].IdentityID != "manual-identity" {
+		t.Fatalf("snapshot observations=%+v err=%v", observations, err)
+	}
+	if strings.Contains(string(first.Identity.CanonicalIdentityFields), "endpoint:/admin") || strings.Contains(string(second.Identity.CanonicalIdentityFields), "endpoint:/renamed") {
+		t.Fatal("manual endpoint observation leaked into identity")
+	}
+}
+
+func TestManualImportGoldenScopingCandidateAndReplayConflict(t *testing.T) {
+	firstPlan, err := BuildManualImportMatchPlanV1(ManualImportFingerprintInputV1{
+		TargetIdentityCanonical: "project:example", AssessmentID: "assessment-a", FindingClass: ManualFindingOffensive,
+		ImporterNamespace: "burp-enterprise", ImporterSchemaVersion: 2, ExternalStableID: "issue-123", SourceValidated: true, RedactionComplete: true,
+	})
+	if err != nil || !firstPlan.ProvisionalIdentity || firstPlan.ReasonCode != "imported_identity_requires_review" {
+		t.Fatalf("first plan=%+v err=%v", firstPlan, err)
+	}
+	fingerprint, err := domain.CanonicalizeFingerprintV1(firstPlan.FingerprintInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const wantFingerprint = "25795765d908c19d15e7d05b662c4919858af7a9936dcf97d11176f9cd347ce5"
+	if fingerprint.Fingerprint != wantFingerprint {
+		t.Fatalf("fingerprint=%s want=%s canonical=%s", fingerprint.Fingerprint, wantFingerprint, fingerprint.Bytes)
+	}
+	secondAssessment, err := BuildManualImportMatchPlanV1(ManualImportFingerprintInputV1{
+		TargetIdentityCanonical: "project:example", AssessmentID: "assessment-b", FindingClass: ManualFindingOffensive,
+		ImporterNamespace: "burp-enterprise", ImporterSchemaVersion: 2, ExternalStableID: "issue-123", SourceValidated: true, RedactionComplete: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondFingerprint, _ := domain.CanonicalizeFingerprintV1(secondAssessment.FingerprintInput)
+	if secondFingerprint.Fingerprint == fingerprint.Fingerprint {
+		t.Fatal("imported stable ID crossed Assessment scope")
+	}
+	missingID, err := BuildManualImportMatchPlanV1(ManualImportFingerprintInputV1{
+		TargetIdentityCanonical: "project:example", AssessmentID: "assessment-a", FindingClass: ManualFindingNative,
+		ImporterNamespace: "csv-import", ImporterSchemaVersion: 1, SourceValidated: true, RedactionComplete: true,
+	})
+	if err != nil || missingID.ReviewReason != domain.ReasonInsufficientAnchor || missingID.ReasonCode != "missing_external_stable_id" {
+		t.Fatalf("missing id=%+v err=%v", missingID, err)
+	}
+
+	repository := memory.NewFindingLineageRepository()
+	clock := fixedClock{now: time.Date(2026, 9, 1, 17, 0, 0, 0, time.UTC)}
+	observer := &collectingObserver{}
+	service, err := NewService(repository, immediateTransactions{}, &collectingAudit{}, clock, &sequenceIDs{}, observer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := firstPlan.Apply(correlateInput("manual-import", "unused"))
+	input.TenantID, input.CycleID, input.SnapshotID = "tenant", "cycle", "snapshot-import"
+	input.Observation.ID = "import-observation"
+	input.Observation.SourceFindingID = "import-source"
+	input.Observation.Location = "endpoint:/old-title-is-not-identity"
+	input.Observation.Severity = shared.SeverityHigh
+	result, err := service.Correlate(context.Background(), input)
+	if err != nil || result.Outcome != OutcomeReview || result.Identity == nil || result.Candidate == nil {
+		t.Fatalf("import result=%+v err=%v", result, err)
+	}
+	replay := input
+	replay.Observation.Severity = shared.SeverityLow
+	replay.Observation.Location = "endpoint:/different-body"
+	if _, err := service.Correlate(context.Background(), replay); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("same-key different-body replay error=%v", err)
+	}
+	if strings.Contains(string(result.Identity.CanonicalIdentityFields), input.Observation.Location) {
+		t.Fatalf("imported title/endpoint leaked into identity: %s", result.Identity.CanonicalIdentityFields)
+	}
+
+	redactionPlan, err := BuildManualImportMatchPlanV1(ManualImportFingerprintInputV1{
+		TargetIdentityCanonical: "project:example", AssessmentID: "assessment-a", FindingClass: ManualFindingNative,
+		ImporterNamespace: "csv-import", ImporterSchemaVersion: 1, ExternalStableID: "row-1", SourceValidated: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	redactionResult, err := service.Correlate(context.Background(), redactionPlan.Apply(correlateInput("manual-import-redaction", "unused")))
+	if err != nil || redactionResult.Outcome != OutcomeSkipped || redactionResult.Skip == nil || redactionResult.Skip.Reason != domain.SkipRedactionRequired {
+		t.Fatalf("redaction result=%+v err=%v", redactionResult, err)
+	}
+	if len(observer.outcomes) != 2 {
+		t.Fatalf("metrics=%+v", observer.outcomes)
+	}
+}
+
+func TestManualCrossAssessmentLinkRequiresReviewIfMatchAndIsIdempotent(t *testing.T) {
+	repository := memory.NewFindingLineageRepository()
+	clock := fixedClock{now: time.Date(2026, 9, 1, 18, 0, 0, 0, time.UTC)}
+	service, err := NewService(repository, immediateTransactions{}, &collectingAudit{}, clock, &sequenceIDs{}, &collectingObserver{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	source, err := service.CorrelateNativeManual(context.Background(), NativeManualInput{
+		TenantID: "tenant", CycleID: "cycle", SnapshotID: "snapshot-b", AssessmentID: "assessment-b", IdentityID: "manual-b",
+		FindingClass: ManualFindingOffensive, Observation: manualObservation("observation-b", "finding-b", shared.SeverityHigh, "endpoint:/b"), Actor: "analyst-b",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := service.CorrelateNativeManual(context.Background(), NativeManualInput{
+		TenantID: "tenant", CycleID: "cycle", SnapshotID: "snapshot-a", AssessmentID: "assessment-a", IdentityID: "manual-a",
+		FindingClass: ManualFindingOffensive, Observation: manualObservation("observation-a", "finding-a", shared.SeverityHigh, "endpoint:/a"), Actor: "analyst-a",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := ConfirmManualCrossAssessmentLinkInput{
+		TenantID: "tenant", CycleID: "cycle", EventID: "manual-link-event", SourceObservationID: source.Observation.ID,
+		TargetIdentityID: target.Identity.ID, Actor: "reviewer", Role: userdom.RoleReviewer, Reason: "same verified offensive issue",
+		IfMatchProvided: true, ExpectedVersion: 0,
+	}
+	denied := base
+	denied.Role = userdom.RoleConsultant
+	if _, _, err := service.ConfirmManualCrossAssessmentLink(context.Background(), denied); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("consultant link error=%v", err)
+	}
+	missingIfMatch := base
+	missingIfMatch.IfMatchProvided = false
+	if _, _, err := service.ConfirmManualCrossAssessmentLink(context.Background(), missingIfMatch); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing If-Match error=%v", err)
+	}
+	event, applied, err := service.ConfirmManualCrossAssessmentLink(context.Background(), base)
+	if err != nil || !applied || event.Action != domain.OverrideConfirm || event.Version != 1 {
+		t.Fatalf("event=%+v applied=%v err=%v", event, applied, err)
+	}
+	replayed, applied, err := service.ConfirmManualCrossAssessmentLink(context.Background(), base)
+	if err != nil || applied || replayed.ID != event.ID {
+		t.Fatalf("replay=%+v applied=%v err=%v", replayed, applied, err)
+	}
+	changedBody := base
+	changedBody.Reason = "different reason"
+	if _, _, err := service.ConfirmManualCrossAssessmentLink(context.Background(), changedBody); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("same event different body error=%v", err)
+	}
+	stale := base
+	stale.EventID = "manual-link-stale"
+	if _, _, err := service.ConfirmManualCrossAssessmentLink(context.Background(), stale); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale If-Match error=%v", err)
+	}
+	events, err := repository.ListOverrideEvents(context.Background(), "tenant", "cycle", source.Observation.ID)
+	if err != nil || len(events) != 1 || events[0].ID != event.ID {
+		t.Fatalf("events=%+v err=%v", events, err)
+	}
+}
+
+func manualObservation(id, source string, severity shared.Severity, location string) ObservationInput {
+	return ObservationInput{
+		ID: shared.ID(id), SourceFindingID: source, Severity: severity, Location: location,
+		ScannerProvenance: domain.ScannerProvenance{ToolName: "native-manual"},
+	}
+}

--- a/internal/usecase/findinglineage/native_evidence.go
+++ b/internal/usecase/findinglineage/native_evidence.go
@@ -1,0 +1,156 @@
+package findinglineage
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const NativeEvidenceVersion = 1
+const MaxNativeObservations = 100000
+
+// NativeEvidence contains only redacted matcher inputs and observed attributes.
+// No workflow status, raw finding description, source excerpt, or secret enters
+// this retained contract. Ownership is assigned from the selected sealed run.
+type NativeEvidence struct {
+	Version int
+	Records []CorrelateInput
+}
+
+func NativeNamespace(kind finding.Kind) (string, string) { return legacyProducer(kind) }
+
+func BuildNativeEvidenceRecord(item finding.Finding, target string, current *vulnerability.Vulnerability) (CorrelateInput, error) {
+	source := ports.FindingLineageBackfillSourceRow{
+		FindingID: item.ID, Kind: item.Kind, RuleKey: item.RuleKey, DedupKey: item.DedupKey,
+		Severity: item.Severity, RiskScore: item.RiskScore, Reachability: item.Reachability,
+		SourceLocation: item.SourceLocation, ObservedAt: item.Audit.CreatedAt,
+	}
+	observation, err := backfillObservation(source, backfillTarget{canonical: target})
+	if err != nil {
+		return CorrelateInput{}, err
+	}
+	base := CorrelateInput{InputTrusted: true, OwnershipValidated: true, RedactionComplete: true, Observation: observation}
+	switch item.Kind {
+	case "", finding.KindSCA:
+		matcher, _ := NewSCAMatcherV1(nil)
+		input := SCAFingerprintInputV1{TargetIdentityCanonical: target, AdvisoryID: item.AdvisoryID, LegacyDedupKey: item.DedupKey}
+		if current != nil {
+			input = SCAFingerprintInputFromVulnerabilityV1(target, *current, nil, item.DedupKey, "")
+			base.Observation.ComponentVersion = current.Version
+		}
+		plan, err := matcher.Build(input)
+		return plan.Apply(base), err
+	case finding.KindSAST:
+		matcher, _ := NewSASTMatcherV1(nil)
+		plan, err := matcher.Build(SASTFingerprintInputV1{TargetIdentityCanonical: target, RepoPath: sourcePath(source), RuleKey: item.RuleKey, LegacyDedupKey: item.DedupKey, LegacySourceValidated: true, LegacyOwnershipValid: true})
+		return plan.Apply(base), err
+	case finding.KindQuality, finding.KindReliability:
+		matcher, _ := NewQualityMatcherV1(nil)
+		plan, err := matcher.Build(QualityFingerprintInputV1{TargetIdentityCanonical: target, FindingClass: string(item.Kind), RepoPath: sourcePath(source), RuleKey: item.RuleKey, LegacyDedupKey: item.DedupKey, LegacySourceValidated: true})
+		return plan.Apply(base), err
+	case finding.KindSecret:
+		redacted, err := RedactSecretProducerInputV1(SecretProducerInputV1{TargetIdentityCanonical: target, DetectorKey: item.RuleKey, RepoPath: sourcePath(source), LegacyDedupKey: item.DedupKey, LegacySourceValidated: true})
+		if err != nil {
+			return CorrelateInput{}, err
+		}
+		matcher, _ := NewSecretMatcherV1(nil)
+		plan, err := matcher.Build(redacted)
+		return plan.Apply(base), err
+	case finding.KindMisconfig:
+		matcher, _ := NewIaCMatcherV1(nil)
+		plan, err := matcher.Build(IaCFingerprintInputV1{TargetIdentityCanonical: target, RepoPath: sourcePath(source), RuleKey: item.RuleKey, LegacyDedupKey: item.DedupKey, LegacySourceValidated: true})
+		return plan.Apply(base), err
+	default:
+		return CorrelateInput{}, fmt.Errorf("%w: unsupported native finding kind", shared.ErrValidation)
+	}
+}
+
+func (projector *ShadowProjector) SetNativeEvidence(store ports.ScanRunEvidenceStore, runs ports.AssessmentSnapshotRunReader) {
+	projector.nativeEvidence, projector.nativeRuns = store, runs
+}
+
+func (projector *ShadowProjector) projectNativeEvidence(ctx context.Context, snapshot *assessmentsnapshot.Snapshot, actor string) error {
+	if projector.nativeEvidence == nil || snapshot.Provenance != assessmentsnapshot.ProvenanceNative {
+		return nil
+	}
+	runs := make(map[string][]assessmentsnapshot.Dimension)
+	for _, dimension := range snapshot.Dimensions {
+		runs[dimension.RunID] = append(runs[dimension.RunID], dimension)
+	}
+	runIDs := make([]string, 0, len(runs))
+	for runID := range runs {
+		runIDs = append(runIDs, runID)
+	}
+	sort.Strings(runIDs)
+	total := 0
+	for _, runID := range runIDs {
+		dimensions := runs[runID]
+		evidence, err := projector.nativeEvidence.GetScanRunEvidence(ctx, snapshot.TenantID, runID)
+		if err != nil {
+			return fmt.Errorf("load immutable selected-run evidence: %w", err)
+		}
+		if err := evidence.Validate(); err != nil {
+			return err
+		}
+		if projector.nativeRuns == nil {
+			return fmt.Errorf("%w: native run verification is unavailable", shared.ErrValidation)
+		}
+		run, err := projector.nativeRuns.GetScanRun(ctx, snapshot.TenantID, runID)
+		if err != nil {
+			return err
+		}
+		if !run.IsSealed() || run.EngagementID != snapshot.AssessmentID {
+			return fmt.Errorf("%w: selected run evidence ownership mismatch", shared.ErrValidation)
+		}
+		for _, dimension := range dimensions {
+			bound := false
+			for _, lane := range run.Lanes {
+				if lane.LaneKey == dimension.LaneKey && lane.ManifestHash == dimension.LaneManifestHash && lane.ResultSHA256 == evidence.ContentHash {
+					bound = true
+					break
+				}
+			}
+			if !bound {
+				return fmt.Errorf("%w: evidence is not bound to the selected sealed lane", shared.ErrValidation)
+			}
+		}
+		var input NativeEvidence
+		if err := json.Unmarshal(evidence.Payload, &input); err != nil {
+			return fmt.Errorf("%w: invalid native evidence schema", shared.ErrValidation)
+		}
+		total += len(input.Records)
+		if input.Version != NativeEvidenceVersion || total > MaxNativeObservations {
+			return fmt.Errorf("%w: unsupported native evidence version or cardinality", shared.ErrValidation)
+		}
+		for _, record := range input.Records {
+			var selected *assessmentsnapshot.Dimension
+			for index := range dimensions {
+				dimension := &dimensions[index]
+				if dimension.Producer == record.ProducerKind && dimension.FindingKind == record.FindingKind && dimension.Target.Canonical == record.FingerprintInput.TargetIdentityCanonical {
+					selected = dimension
+					break
+				}
+			}
+			if selected == nil {
+				continue
+			} // A user may select only a subset of run lanes.
+			record.TenantID, record.CycleID, record.SnapshotID = snapshot.TenantID, snapshot.CycleID, snapshot.ID
+			record.Actor = actor
+			record.IdentityID, record.Observation.ID = "", ""
+			record.Observation.EvidenceDigest = evidence.ContentHash
+			record.Observation.ScannerProvenance = domain.ScannerProvenance{ScanRunID: runID, LaneKey: selected.LaneKey, ToolName: record.ProducerKind}
+			if _, err := projector.lineage.Correlate(ctx, record); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/internal/usecase/findinglineage/native_evidence_test.go
+++ b/internal/usecase/findinglineage/native_evidence_test.go
@@ -1,0 +1,145 @@
+package findinglineage_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
+)
+
+func TestBuildNativeEvidenceRecordIaCScannerFamilies(t *testing.T) {
+	for _, test := range []struct{ name, rule, path, configKind string }{
+		{"terraform", "terraform-public-instance", "infra/main.tf", "terraform"},
+		{"cloudformation", "cloudformation-rds-public", "infra/template.yaml", "cloudformation"},
+		{"kubernetes", "kubernetes-host-network", "deploy/pod.yaml", "kubernetes"},
+		{"helm", "kubernetes-host-network", "charts/service/Chart.yaml", "kubernetes"},
+		{"dockerfile", "dockerfile-run-as-root", "Dockerfile", "dockerfile"},
+		{"compose", "compose-privileged", "compose.yaml", "compose"},
+		{"github_actions", "gha-permissions-write-all", ".github/workflows/ci.yaml", "github_actions"},
+		{"arm", "arm-storage-https-only-off", "azure/template.json", "arm"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			now := time.Date(2026, 9, 8, 5, 0, 0, 0, time.UTC)
+			item := finding.Finding{
+				ID: "source-" + shared.ID(test.name), Kind: finding.KindMisconfig,
+				RuleKey: test.rule, DedupKey: "misconfig:" + test.rule + ":" + test.path + ":42",
+				Title: "private-source-title", Description: "private-source-description-and-rendered-value",
+				Status: finding.StatusRemediated, Assignee: "private-workflow-assignee",
+				Severity: shared.SeverityHigh, RiskScore: 7.5, Reachability: "unknown",
+				SourceLocation: &finding.SourceLocation{File: test.path, StartLine: 42, EndLine: 44},
+				Audit:          shared.Audit{CreatedAt: now},
+			}
+			record, err := lineageuc.BuildNativeEvidenceRecord(item, "repo:example", nil)
+			if err != nil {
+				t.Fatalf("scanner-supported %s finding aborted native evidence: %v", test.name, err)
+			}
+			if !record.InputTrusted || !record.OwnershipValidated || !record.RedactionComplete || record.ProducerKind != "iac" || record.FindingKind != "misconfig" {
+				t.Fatalf("invalid retained namespace or trust flags: %+v", record)
+			}
+			if !record.ProvisionalIdentity || record.ReviewReason != domain.ReasonInsufficientAnchor {
+				t.Fatalf("finding without semantic/resource anchors was treated as definitive: %+v", record)
+			}
+			fingerprint, err := domain.CanonicalizeFingerprintV1(record.FingerprintInput)
+			if err != nil {
+				t.Fatalf("native observation has no valid canonical identity: %v", err)
+			}
+			var fields map[string]any
+			if err := json.Unmarshal(fingerprint.IdentityFields, &fields); err != nil {
+				t.Fatal(err)
+			}
+			if fields["config_kind"] != test.configKind || fields["repo_path"] != test.path || fields["rule_key"] != test.rule {
+				t.Fatalf("wrong canonical scanner family: %s", fingerprint.IdentityFields)
+			}
+			for _, key := range []string{"resource_anchor", "semantic_config_anchor", "legacy_dedup_key", "raw_offsets", "start_line", "end_line"} {
+				if _, exists := fields[key]; exists {
+					t.Fatalf("invented or observation-only identity field %q: %s", key, fingerprint.IdentityFields)
+				}
+			}
+			if record.Observation.Location != test.path+":42" || record.Observation.SourceFindingID != item.ID.String() || record.Observation.Severity != shared.SeverityHigh || record.Observation.RiskScoreMilli == nil || *record.Observation.RiskScoreMilli != 7500 {
+				t.Fatalf("safe observed attributes were lost: %+v", record.Observation)
+			}
+			payload, err := json.Marshal(lineageuc.NativeEvidence{Version: lineageuc.NativeEvidenceVersion, Records: []lineageuc.CorrelateInput{record}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, forbidden := range []string{item.Title, item.Description, item.Assignee, item.DedupKey, string(item.Status)} {
+				if strings.Contains(string(payload), forbidden) {
+					t.Fatalf("raw finding or mutable workflow field leaked into evidence: %q", forbidden)
+				}
+			}
+
+			// A source-line move changes observed location, never the coarse identity.
+			moved := item
+			moved.DedupKey = "misconfig:" + test.rule + ":" + test.path + ":900"
+			moved.SourceLocation = &finding.SourceLocation{File: test.path, StartLine: 900, EndLine: 902}
+			movedRecord, err := lineageuc.BuildNativeEvidenceRecord(moved, "repo:example", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			movedFingerprint, err := domain.CanonicalizeFingerprintV1(movedRecord.FingerprintInput)
+			if err != nil || movedFingerprint.Fingerprint != fingerprint.Fingerprint || movedRecord.Observation.Location != test.path+":900" {
+				t.Fatalf("line movement polluted native identity: first=%s moved=%s err=%v", fingerprint.Fingerprint, movedFingerprint.Fingerprint, err)
+			}
+			legacy := item
+			legacy.SourceLocation = nil
+			legacyRecord, err := lineageuc.BuildNativeEvidenceRecord(legacy, "repo:example", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			legacyFingerprint, err := domain.CanonicalizeFingerprintV1(legacyRecord.FingerprintInput)
+			if err != nil || legacyFingerprint.Fingerprint != fingerprint.Fingerprint || legacyRecord.Observation.Location != record.Observation.Location {
+				t.Fatalf("legacy source range changed retained identity: first=%s legacy=%s err=%v", fingerprint.Fingerprint, legacyFingerprint.Fingerprint, err)
+			}
+
+			repository := memory.NewFindingLineageRepository()
+			service, err := lineageuc.NewService(repository, memory.NewTenantTransactionRunner(), noOpBackfillAudit{}, fixedBackfillClock{now}, &backfillIDs{}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			record.TenantID, record.CycleID, record.SnapshotID, record.Actor = "tenant", "cycle", "snapshot", "scanner"
+			// The projector binds scanner provenance only after selecting a sealed run.
+			record.Observation.ScannerProvenance = domain.ScannerProvenance{ToolName: "iac", ScanRunID: "run", LaneKey: "iac"}
+			result, err := service.Correlate(context.Background(), record)
+			if err != nil || result.Outcome != lineageuc.OutcomeReview || result.Observation == nil || result.Identity == nil || result.Candidate == nil || result.Skip != nil {
+				t.Fatalf("native finding was not retained for explicit review: result=%+v err=%v", result, err)
+			}
+			if result.Candidate.Reason != domain.ReasonInsufficientAnchor {
+				t.Fatalf("wrong review reason: %+v", result.Candidate)
+			}
+		})
+	}
+}
+
+func TestBuildNativeEvidenceRecordIaCUnknownOrUnsafeInputStillFails(t *testing.T) {
+	for _, test := range []struct{ name, rule, path string }{
+		{"unknown_family", "unknown-platform-rule", "config.yaml"},
+		{"traversal", "dockerfile-run-as-root", "../Dockerfile"},
+		{"absolute_path", "compose-privileged", "/private/compose.yaml"},
+		{"credential_locator", "gha-unpinned-action", "https://user:private-test-marker@example.test/ci.yaml"},
+		{"sensitive_rule", "arm-password=private-test-marker", "template.json"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			item := finding.Finding{
+				ID: "source", Kind: finding.KindMisconfig, RuleKey: test.rule,
+				DedupKey:       fmt.Sprintf("misconfig:%s:%s:1", test.rule, test.path),
+				SourceLocation: &finding.SourceLocation{File: test.path, StartLine: 1, EndLine: 1},
+			}
+			_, err := lineageuc.BuildNativeEvidenceRecord(item, "repo:example", nil)
+			if !errors.Is(err, shared.ErrValidation) && !errors.Is(err, domain.ErrSensitiveInput) {
+				t.Fatalf("unsafe/unknown input did not fail validation: %v", err)
+			}
+			if strings.Contains(err.Error(), "private-test-marker") {
+				t.Fatalf("validation error exposed untrusted source material: %v", err)
+			}
+		})
+	}
+}

--- a/internal/usecase/findinglineage/quality_matcher.go
+++ b/internal/usecase/findinglineage/quality_matcher.go
@@ -1,0 +1,292 @@
+package findinglineage
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	QualityMatcherVersionV1            = 1
+	QualityFingerprintSchemaVersionV1  = 1
+	QualityTargetIdentitySchemaVersion = 1
+)
+
+type QualityAnchorKind string
+
+const (
+	QualityAnchorSymbol QualityAnchorKind = "symbol"
+	QualityAnchorAST    QualityAnchorKind = "ast"
+	QualityAnchorFile   QualityAnchorKind = "file"
+)
+
+func (kind QualityAnchorKind) Valid() bool {
+	return kind == QualityAnchorSymbol || kind == QualityAnchorAST || kind == QualityAnchorFile
+}
+
+type QualityAnchorV1 struct {
+	Kind               QualityAnchorKind
+	SchemaVersion      int
+	LanguageID         string
+	QualifiedSymbol    string
+	NodeKind           string
+	AncestorNameDigest string
+	RawOffsets         map[string]int
+}
+
+type QualityRuleProfileV1 struct {
+	Primary           string
+	Aliases           []string
+	OneFindingPerFile bool
+}
+
+type QualityMatcherV1 struct {
+	rules           SASTMatcherV1
+	fileScopedRules map[string]struct{}
+}
+
+func NewQualityMatcherV1(profiles []QualityRuleProfileV1) (QualityMatcherV1, error) {
+	aliasSets := make([]SASTRuleAliasSetV1, len(profiles))
+	fileScoped := map[string]struct{}{}
+	for index, profile := range profiles {
+		primary, err := normalizeSourceRuleKey("code quality", profile.Primary)
+		if err != nil {
+			return QualityMatcherV1{}, err
+		}
+		aliasSets[index] = SASTRuleAliasSetV1{Primary: primary, Aliases: append([]string(nil), profile.Aliases...)}
+		if profile.OneFindingPerFile {
+			fileScoped[primary] = struct{}{}
+		}
+	}
+	rules, err := NewSASTMatcherV1(aliasSets)
+	if err != nil {
+		return QualityMatcherV1{}, err
+	}
+	return QualityMatcherV1{rules: rules, fileScopedRules: fileScoped}, nil
+}
+
+type QualityFingerprintInputV1 struct {
+	TargetIdentityCanonical string
+	FindingClass            string
+	RepoPath                string
+	RuleKey                 string
+	RuleAliases             []string
+	Anchor                  QualityAnchorV1
+	LegacyDedupKey          string
+	LegacySourceValidated   bool
+}
+
+type QualityMatchPlanV1 struct {
+	FingerprintInput    domain.FingerprintCanonicalInputV1
+	Method              domain.MatchMethod
+	MatcherVersion      int
+	ReasonCode          string
+	ReviewReason        domain.CandidateReason
+	Ambiguous           bool
+	ProvisionalIdentity bool
+	SkipInput           bool
+}
+
+func (matcher QualityMatcherV1) Build(input QualityFingerprintInputV1) (QualityMatchPlanV1, error) {
+	target, err := normalizeSourceText("code quality", "target identity", input.TargetIdentityCanonical, 2048, false)
+	if err != nil {
+		return QualityMatchPlanV1{}, err
+	}
+	legacy := parseQualityLegacyKey(input.LegacyDedupKey)
+	class := strings.ToLower(strings.TrimSpace(input.FindingClass))
+	repoPath := input.RepoPath
+	ruleKey := input.RuleKey
+	legacyClassMismatch := false
+	if legacy.kind == qualityLegacyValid {
+		if class == "" {
+			class = legacy.class
+		} else if class != legacy.class {
+			legacyClassMismatch = true
+		}
+		if strings.TrimSpace(repoPath) == "" {
+			repoPath = legacy.repoPath
+		}
+		if strings.TrimSpace(ruleKey) == "" {
+			ruleKey = legacy.ruleKey
+		}
+	}
+	if class != "quality" && class != "reliability" {
+		return QualityMatchPlanV1{}, fmt.Errorf("%w: finding class must be quality or reliability", shared.ErrValidation)
+	}
+	normalizedPath, pathErr := normalizeSourceRepoPath("code quality", repoPath)
+	if pathErr != nil && strings.TrimSpace(repoPath) != "" {
+		return QualityMatchPlanV1{}, pathErr
+	}
+	primaryRule, normalizedRules, ruleConflict, ruleErr := matcher.rules.normalizeRule("code quality", ruleKey, input.RuleAliases)
+	if ruleErr != nil && strings.TrimSpace(ruleKey) != "" {
+		return QualityMatchPlanV1{}, ruleErr
+	}
+	anchorValue, anchorErr := matcher.normalizeAnchor(primaryRule, input.Anchor)
+	if input.Anchor.Kind != "" && !input.Anchor.Kind.Valid() {
+		return QualityMatchPlanV1{}, fmt.Errorf("%w: code quality anchor kind is invalid", shared.ErrValidation)
+	}
+	if len(input.Anchor.RawOffsets) > 0 {
+		return QualityMatchPlanV1{}, fmt.Errorf("%w: code quality anchors cannot contain raw offsets", shared.ErrValidation)
+	}
+	if anchorErr != nil && input.Anchor.Kind.Valid() && input.Anchor.Kind != QualityAnchorFile {
+		return QualityMatchPlanV1{}, anchorErr
+	}
+
+	fields := map[string]domain.CanonicalValue{
+		"finding_class":            domain.Text(class),
+		"producer_matcher_version": domain.Integer(QualityMatcherVersionV1),
+		"rule_alias_graph_version": domain.Integer(SASTRuleAliasSchemaVersionV1),
+	}
+	if normalizedPath != "" {
+		fields["repo_path"] = domain.Text(normalizedPath)
+	}
+	if primaryRule != "" {
+		fields["rule_key"] = domain.Text(primaryRule)
+	}
+	if anchorErr == nil && input.Anchor.Kind.Valid() {
+		fields["anchor_kind"] = domain.Text(string(input.Anchor.Kind))
+		fields["anchor_schema_version"] = domain.Integer(int64(input.Anchor.SchemaVersion))
+		fields["anchor_value"] = anchorValue
+	}
+	if ruleConflict {
+		fields["rule_candidates"] = domain.StringSet(normalizedRules...)
+		delete(fields, "rule_key")
+	}
+	plan := QualityMatchPlanV1{
+		FingerprintInput: domain.FingerprintCanonicalInputV1{
+			CanonicalizationVersion: domain.CanonicalizationVersionV1, ProducerKind: class,
+			TargetIdentitySchemaVersion: QualityTargetIdentitySchemaVersion, TargetIdentityCanonical: target, IdentityFields: fields,
+		},
+		Method: domain.MethodMatcher, MatcherVersion: QualityMatcherVersionV1, ReasonCode: "quality_identity_complete",
+	}
+	switch {
+	case input.LegacyDedupKey != "" && !input.LegacySourceValidated:
+		plan.SkipInput, plan.ReasonCode = true, "legacy_source_not_validated"
+	case ruleConflict:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous = domain.ReasonMerge, "rule_alias_conflict", true
+	case legacyClassMismatch:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonLegacyAmbiguous, "legacy_class_mismatch", true, true
+	case legacy.kind == qualityLegacyMalformed:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonLegacyAmbiguous, "legacy_key_malformed", true, true
+	case normalizedPath == "":
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "missing_repo_path", true, true
+	case primaryRule == "":
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "missing_rule_key", true, true
+	case input.Anchor.Kind == QualityAnchorFile && anchorErr != nil:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "file_anchor_not_declared", true, true
+	case !input.Anchor.Kind.Valid():
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "missing_semantic_anchor", true, true
+	case legacy.kind == qualityLegacyValid:
+		plan.ReasonCode = "legacy_quality_structured"
+	}
+	return plan, nil
+}
+
+func (plan QualityMatchPlanV1) Apply(input CorrelateInput) CorrelateInput {
+	producer := plan.FingerprintInput.ProducerKind
+	input.ProducerKind = producer
+	input.FindingKind = producer
+	input.FingerprintSchemaVersion = QualityFingerprintSchemaVersionV1
+	input.FingerprintInput = plan.FingerprintInput
+	input.ReviewReason = plan.ReviewReason
+	input.ReviewDetailCode = plan.ReasonCode
+	input.ProvisionalIdentity = plan.ProvisionalIdentity
+	if plan.SkipInput {
+		input.InputTrusted = false
+	}
+	return input
+}
+
+func (matcher QualityMatcherV1) normalizeAnchor(primaryRule string, anchor QualityAnchorV1) (domain.CanonicalValue, error) {
+	if !anchor.Kind.Valid() || anchor.SchemaVersion <= 0 {
+		return domain.CanonicalValue{}, fmt.Errorf("%w: code quality semantic anchor is required", shared.ErrValidation)
+	}
+	value := map[string]domain.CanonicalValue{}
+	switch anchor.Kind {
+	case QualityAnchorSymbol:
+		language, err := normalizeSourceToken("code quality", "language id", anchor.LanguageID)
+		if err != nil {
+			return domain.CanonicalValue{}, err
+		}
+		symbol, err := normalizeSourceText("code quality", "qualified symbol", anchor.QualifiedSymbol, 1024, false)
+		if err != nil {
+			return domain.CanonicalValue{}, err
+		}
+		if anchor.NodeKind != "" || anchor.AncestorNameDigest != "" {
+			return domain.CanonicalValue{}, fmt.Errorf("%w: symbol anchor contains AST fields", shared.ErrValidation)
+		}
+		value["language_id"] = domain.Text(language)
+		value["qualified_symbol"] = domain.Text(symbol)
+	case QualityAnchorAST:
+		nodeKind, err := normalizeSourceToken("code quality", "AST node kind", anchor.NodeKind)
+		if err != nil {
+			return domain.CanonicalValue{}, err
+		}
+		digest, err := normalizeSourceDigest("code quality", "AST ancestor/name digest", anchor.AncestorNameDigest)
+		if err != nil {
+			return domain.CanonicalValue{}, err
+		}
+		if anchor.LanguageID != "" || anchor.QualifiedSymbol != "" {
+			return domain.CanonicalValue{}, fmt.Errorf("%w: AST anchor contains symbol fields", shared.ErrValidation)
+		}
+		value["ancestor_name_digest"] = domain.Text(digest)
+		value["node_kind"] = domain.Text(nodeKind)
+	case QualityAnchorFile:
+		if _, allowed := matcher.fileScopedRules[primaryRule]; !allowed {
+			return domain.CanonicalValue{}, fmt.Errorf("%w: rule does not declare one Finding per file", shared.ErrValidation)
+		}
+		if anchor.LanguageID != "" || anchor.QualifiedSymbol != "" || anchor.NodeKind != "" || anchor.AncestorNameDigest != "" {
+			return domain.CanonicalValue{}, fmt.Errorf("%w: file anchor cannot carry symbol or AST fields", shared.ErrValidation)
+		}
+		value["scope"] = domain.Text("file")
+	}
+	return domain.Object(value), nil
+}
+
+type qualityLegacyKind uint8
+
+const (
+	qualityLegacyNone qualityLegacyKind = iota
+	qualityLegacyValid
+	qualityLegacyMalformed
+)
+
+type qualityLegacyKey struct {
+	kind     qualityLegacyKind
+	class    string
+	ruleKey  string
+	repoPath string
+}
+
+func parseQualityLegacyKey(value string) qualityLegacyKey {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return qualityLegacyKey{}
+	}
+	if !strings.HasPrefix(value, "cq:") {
+		return qualityLegacyKey{kind: qualityLegacyMalformed}
+	}
+	rest := strings.TrimPrefix(value, "cq:")
+	classEnd := strings.IndexByte(rest, ':')
+	if classEnd <= 0 {
+		return qualityLegacyKey{kind: qualityLegacyMalformed}
+	}
+	class := rest[:classEnd]
+	if class != "quality" && class != "reliability" {
+		return qualityLegacyKey{kind: qualityLegacyMalformed}
+	}
+	rest = rest[classEnd+1:]
+	lineSeparator := strings.LastIndexByte(rest, ':')
+	if lineSeparator <= 0 {
+		return qualityLegacyKey{kind: qualityLegacyMalformed}
+	}
+	line, err := strconv.Atoi(rest[lineSeparator+1:])
+	pathSeparator := strings.LastIndexByte(rest[:lineSeparator], ':')
+	if err != nil || line < 1 || pathSeparator <= 0 || pathSeparator == lineSeparator-1 {
+		return qualityLegacyKey{kind: qualityLegacyMalformed}
+	}
+	return qualityLegacyKey{kind: qualityLegacyValid, class: class, ruleKey: rest[:pathSeparator], repoPath: rest[pathSeparator+1 : lineSeparator]}
+}

--- a/internal/usecase/findinglineage/quality_matcher_test.go
+++ b/internal/usecase/findinglineage/quality_matcher_test.go
@@ -1,0 +1,179 @@
+package findinglineage
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+)
+
+func TestQualityMatcherV1GoldenLegacyLineMovementAliasAndClassSeparation(t *testing.T) {
+	matcher, err := NewQualityMatcherV1([]QualityRuleProfileV1{
+		{Primary: "quality:cognitive-complexity", Aliases: []string{"legacy:complexity"}},
+		{Primary: "quality:file-license", OneFindingPerFile: true},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := QualityFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", FindingClass: "quality",
+		Anchor:                QualityAnchorV1{Kind: QualityAnchorSymbol, SchemaVersion: 1, LanguageID: "Go", QualifiedSymbol: "example.Handler.Serve"},
+		LegacySourceValidated: true,
+	}
+	first := base
+	first.LegacyDedupKey = "cq:quality:legacy:complexity:src/./Cafe\u0301.go:42"
+	second := base
+	second.LegacyDedupKey = "cq:quality:quality:cognitive-complexity:src/Café.go:900"
+	firstPlan, err := matcher.Build(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondPlan, err := matcher.Build(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstFingerprint, err := domain.CanonicalizeFingerprintV1(firstPlan.FingerprintInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondFingerprint, err := domain.CanonicalizeFingerprintV1(secondPlan.FingerprintInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstFingerprint.Fingerprint != secondFingerprint.Fingerprint {
+		t.Fatalf("quality line movement changed identity: %s != %s", firstFingerprint.Fingerprint, secondFingerprint.Fingerprint)
+	}
+	const wantFingerprint = "f6f8fc7b1c9a0dd2692fce3f835aea2b0a95e4bd4be34fd668aec5d97d380965"
+	if firstFingerprint.Fingerprint != wantFingerprint {
+		t.Fatalf("fingerprint=%s want=%s canonical=%s", firstFingerprint.Fingerprint, wantFingerprint, firstFingerprint.Bytes)
+	}
+	if strings.Contains(string(firstFingerprint.Bytes), "42") || strings.Contains(string(firstFingerprint.Bytes), "900") {
+		t.Fatalf("line leaked into quality identity: %s", firstFingerprint.Bytes)
+	}
+
+	reliability := second
+	reliability.FindingClass = "reliability"
+	reliability.LegacyDedupKey = ""
+	reliability.RepoPath = "src/Café.go"
+	reliability.RuleKey = "quality:cognitive-complexity"
+	reliabilityPlan, err := matcher.Build(reliability)
+	if err != nil {
+		t.Fatal(err)
+	}
+	reliabilityFingerprint, _ := domain.CanonicalizeFingerprintV1(reliabilityPlan.FingerprintInput)
+	if reliabilityFingerprint.Fingerprint == firstFingerprint.Fingerprint || reliabilityPlan.FingerprintInput.ProducerKind != "reliability" {
+		t.Fatal("quality and reliability identities collapsed")
+	}
+}
+
+func TestQualityMatcherV1AnchorPoliciesLegacyAndUnsafePaths(t *testing.T) {
+	matcher, err := NewQualityMatcherV1([]QualityRuleProfileV1{
+		{Primary: "quality:file-license", OneFindingPerFile: true},
+		{Primary: "quality:symbol"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := strings.Repeat("a", 64)
+	for _, testCase := range []struct {
+		name   string
+		rule   string
+		anchor QualityAnchorV1
+	}{
+		{name: "symbol", rule: "quality:symbol", anchor: QualityAnchorV1{Kind: QualityAnchorSymbol, SchemaVersion: 1, LanguageID: "go", QualifiedSymbol: "example.Run"}},
+		{name: "ast", rule: "quality:symbol", anchor: QualityAnchorV1{Kind: QualityAnchorAST, SchemaVersion: 1, NodeKind: "function_declaration", AncestorNameDigest: digest}},
+		{name: "file", rule: "quality:file-license", anchor: QualityAnchorV1{Kind: QualityAnchorFile, SchemaVersion: 1}},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			plan, buildErr := matcher.Build(QualityFingerprintInputV1{
+				TargetIdentityCanonical: "repo:example", FindingClass: "quality", RepoPath: "src/app.go", RuleKey: testCase.rule, Anchor: testCase.anchor,
+			})
+			if buildErr != nil || plan.ProvisionalIdentity {
+				t.Fatalf("plan=%+v err=%v", plan, buildErr)
+			}
+		})
+	}
+
+	undeclared, err := matcher.Build(QualityFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", FindingClass: "quality", RepoPath: "src/app.go", RuleKey: "quality:symbol",
+		Anchor: QualityAnchorV1{Kind: QualityAnchorFile, SchemaVersion: 1},
+	})
+	if err != nil || !undeclared.ProvisionalIdentity || undeclared.ReasonCode != "file_anchor_not_declared" {
+		t.Fatalf("undeclared file anchor=%+v err=%v", undeclared, err)
+	}
+	anchorless, err := matcher.Build(QualityFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", FindingClass: "quality", LegacyDedupKey: "cq:quality:quality:symbol:src/app.go:42", LegacySourceValidated: true,
+	})
+	if err != nil || !anchorless.ProvisionalIdentity || anchorless.ReasonCode != "missing_semantic_anchor" {
+		t.Fatalf("anchorless=%+v err=%v", anchorless, err)
+	}
+	malformed, err := matcher.Build(QualityFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", FindingClass: "reliability", LegacyDedupKey: "cq:reliability:broken", LegacySourceValidated: true,
+	})
+	if err != nil || !malformed.ProvisionalIdentity || malformed.ReasonCode != "legacy_key_malformed" {
+		t.Fatalf("malformed=%+v err=%v", malformed, err)
+	}
+	for _, repoPath := range []string{"../outside.go", "/tmp/app.go", `src\app.go`} {
+		if _, err := matcher.Build(QualityFingerprintInputV1{
+			TargetIdentityCanonical: "repo:example", FindingClass: "quality", RepoPath: repoPath, RuleKey: "quality:symbol",
+			Anchor: QualityAnchorV1{Kind: QualityAnchorSymbol, SchemaVersion: 1, LanguageID: "go", QualifiedSymbol: "example.Run"},
+		}); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("path=%q err=%v", repoPath, err)
+		}
+	}
+}
+
+func TestQualityMatcherV1AliasConflictAndMemoryCandidatePersistence(t *testing.T) {
+	matcher, err := NewQualityMatcherV1([]QualityRuleProfileV1{
+		{Primary: "quality:a", Aliases: []string{"legacy:shared"}},
+		{Primary: "quality:b", Aliases: []string{"legacy:shared"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	conflict, err := matcher.Build(QualityFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", FindingClass: "quality", RepoPath: "src/app.go", RuleKey: "legacy:shared",
+		Anchor: QualityAnchorV1{Kind: QualityAnchorSymbol, SchemaVersion: 1, LanguageID: "go", QualifiedSymbol: "example.Run"},
+	})
+	if err != nil || !conflict.Ambiguous || conflict.ReviewReason != domain.ReasonMerge || conflict.ReasonCode != "rule_alias_conflict" {
+		t.Fatalf("conflict=%+v err=%v", conflict, err)
+	}
+
+	repository := memory.NewFindingLineageRepository()
+	clock := fixedClock{now: time.Date(2026, 9, 1, 13, 0, 0, 0, time.UTC)}
+	observer := &collectingObserver{}
+	service, err := NewService(repository, immediateTransactions{}, &collectingAudit{}, clock, &sequenceIDs{}, observer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := conflict.Apply(correlateInput("quality-conflict", "unused"))
+	input.Observation.SourceFindingID = "quality-source"
+	result, err := service.Correlate(context.Background(), input)
+	if err != nil || result.Outcome != OutcomeReview || result.Candidate == nil || result.Candidate.Reason != domain.ReasonMerge {
+		t.Fatalf("result=%+v err=%v", result, err)
+	}
+	if len(observer.outcomes) != 1 || observer.outcomes[0] != "needs_review:matcher:rule_alias_conflict" {
+		t.Fatalf("metrics=%+v", observer.outcomes)
+	}
+
+	provisional, err := matcher.Build(QualityFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", FindingClass: "reliability", RepoPath: "src/app.go", RuleKey: "quality:a",
+	})
+	if err != nil || !provisional.ProvisionalIdentity {
+		t.Fatalf("provisional=%+v err=%v", provisional, err)
+	}
+	provisionalInput := provisional.Apply(correlateInput("quality-provisional", "unused"))
+	provisionalInput.Observation.SourceFindingID = "reliability-source"
+	provisionalResult, err := service.Correlate(context.Background(), provisionalInput)
+	if err != nil || provisionalResult.Outcome != OutcomeReview || provisionalResult.Identity == nil || provisionalResult.Candidate == nil {
+		t.Fatalf("provisional result=%+v err=%v", provisionalResult, err)
+	}
+	if strings.Contains(string(provisionalResult.Identity.CanonicalIdentityFields), provisionalInput.Observation.SourceFindingID) {
+		t.Fatalf("raw source id leaked into provisional identity: %s", provisionalResult.Identity.CanonicalIdentityFields)
+	}
+}

--- a/internal/usecase/findinglineage/sast_matcher.go
+++ b/internal/usecase/findinglineage/sast_matcher.go
@@ -1,0 +1,544 @@
+package findinglineage
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"golang.org/x/text/unicode/norm"
+)
+
+const (
+	SASTMatcherVersionV1             = 1
+	SASTFingerprintSchemaVersionV1   = 1
+	SASTTargetIdentitySchemaVersion  = 1
+	SASTRuleAliasSchemaVersionV1     = 1
+	SASTIdentityAliasSchemaVersionV1 = 1
+)
+
+type SASTAnchorKind string
+
+const (
+	SASTAnchorSymbol   SASTAnchorKind = "symbol"
+	SASTAnchorAST      SASTAnchorKind = "ast"
+	SASTAnchorDataflow SASTAnchorKind = "dataflow"
+	SASTAnchorJudgment SASTAnchorKind = "judgment"
+)
+
+func (kind SASTAnchorKind) Valid() bool {
+	switch kind {
+	case SASTAnchorSymbol, SASTAnchorAST, SASTAnchorDataflow, SASTAnchorJudgment:
+		return true
+	}
+	return false
+}
+
+type SASTAnchorV1 struct {
+	Kind                   SASTAnchorKind
+	SchemaVersion          int
+	LanguageID             string
+	QualifiedSymbol        string
+	NodeKind               string
+	AncestorNameDigest     string
+	SourceRuleClass        string
+	SinkRuleClass          string
+	GraphAnchorDigest      string
+	JudgmentID             shared.ID
+	JudgmentSemanticDigest string
+	RawOffsets             map[string]int
+}
+
+type SASTRuleAliasSetV1 struct {
+	Primary string
+	Aliases []string
+}
+
+type SASTMatcherV1 struct {
+	rulePrimaries map[string]map[string]struct{}
+}
+
+func NewSASTMatcherV1(aliasSets []SASTRuleAliasSetV1) (SASTMatcherV1, error) {
+	matcher := SASTMatcherV1{rulePrimaries: map[string]map[string]struct{}{}}
+	for _, aliasSet := range aliasSets {
+		primary, err := normalizeSourceRuleKey("SAST", aliasSet.Primary)
+		if err != nil {
+			return SASTMatcherV1{}, err
+		}
+		for _, raw := range append([]string{primary}, aliasSet.Aliases...) {
+			alias, err := normalizeSourceRuleKey("SAST", raw)
+			if err != nil {
+				return SASTMatcherV1{}, err
+			}
+			if matcher.rulePrimaries[alias] == nil {
+				matcher.rulePrimaries[alias] = map[string]struct{}{}
+			}
+			matcher.rulePrimaries[alias][primary] = struct{}{}
+		}
+	}
+	return matcher, nil
+}
+
+func (SASTMatcherV1) Descriptor() domain.MatcherDescriptor {
+	return domain.MatcherDescriptor{
+		ProducerKind: "sast", FindingKind: "sast", Method: domain.MethodMatcher,
+		MethodVersion: SASTMatcherVersionV1, CanonicalizationVersion: domain.CanonicalizationVersionV1,
+		FingerprintSchemaVersion: SASTFingerprintSchemaVersionV1, TargetIdentitySchemaVersion: SASTTargetIdentitySchemaVersion,
+	}
+}
+
+type SASTFingerprintInputV1 struct {
+	TargetIdentityCanonical string
+	RepoPath                string
+	PriorRepoPath           string
+	RuleKey                 string
+	RuleAliases             []string
+	Anchor                  SASTAnchorV1
+	LegacyDedupKey          string
+	LegacySourceValidated   bool
+	LegacyOwnershipValid    bool
+	JudgmentAnchor          *SASTAnchorV1
+	TrustedProducerIdentity bool
+	ApprovedIdentityAliases []string
+}
+
+type SASTMatchPlanV1 struct {
+	FingerprintInput    domain.FingerprintCanonicalInputV1
+	Aliases             []AliasInput
+	Method              domain.MatchMethod
+	MatcherVersion      int
+	ReasonCode          string
+	ReviewReason        domain.CandidateReason
+	Ambiguous           bool
+	ProvisionalIdentity bool
+	TrustedProducerID   bool
+	PathChanged         bool
+	SkipInput           bool
+	SkipOwnership       bool
+}
+
+func (matcher SASTMatcherV1) Build(input SASTFingerprintInputV1) (SASTMatchPlanV1, error) {
+	target, err := normalizeSourceText("SAST", "target identity", input.TargetIdentityCanonical, 2048, false)
+	if err != nil {
+		return SASTMatchPlanV1{}, err
+	}
+
+	legacy := parseSASTLegacyKey(input.LegacyDedupKey)
+	repoPath := input.RepoPath
+	ruleKey := input.RuleKey
+	anchor := input.Anchor
+	if legacy.kind == sastLegacyCodeQuality {
+		if strings.TrimSpace(repoPath) == "" {
+			repoPath = legacy.repoPath
+		}
+		if strings.TrimSpace(ruleKey) == "" {
+			ruleKey = legacy.ruleKey
+		}
+	}
+	if legacy.kind == sastLegacyJudgment {
+		switch {
+		case input.JudgmentAnchor == nil:
+			anchor = SASTAnchorV1{}
+		case input.JudgmentAnchor.Kind != SASTAnchorJudgment || input.JudgmentAnchor.JudgmentID.String() != legacy.judgmentID:
+			anchor = SASTAnchorV1{}
+		default:
+			anchor = *input.JudgmentAnchor
+		}
+	}
+
+	normalizedPath, pathErr := normalizeSourceRepoPath("SAST", repoPath)
+	primaryRule, normalizedRules, ruleConflict, ruleErr := matcher.normalizeRule("SAST", ruleKey, input.RuleAliases)
+	if anchor.Kind != "" && !anchor.Kind.Valid() {
+		return SASTMatchPlanV1{}, fmt.Errorf("%w: SAST semantic anchor kind is invalid", shared.ErrValidation)
+	}
+	if len(anchor.RawOffsets) > 0 && !anchor.Kind.Valid() {
+		return SASTMatchPlanV1{}, fmt.Errorf("%w: SAST semantic anchors cannot contain raw offsets", shared.ErrValidation)
+	}
+	anchorValue, anchorErr := normalizeSASTAnchor(anchor)
+	if pathErr != nil && strings.TrimSpace(repoPath) != "" {
+		return SASTMatchPlanV1{}, pathErr
+	}
+	if ruleErr != nil && strings.TrimSpace(ruleKey) != "" {
+		return SASTMatchPlanV1{}, ruleErr
+	}
+	if anchorErr != nil && anchor.Kind.Valid() {
+		return SASTMatchPlanV1{}, anchorErr
+	}
+
+	fields := map[string]domain.CanonicalValue{
+		"producer_matcher_version": domain.Integer(SASTMatcherVersionV1),
+		"rule_alias_graph_version": domain.Integer(SASTRuleAliasSchemaVersionV1),
+	}
+	if normalizedPath != "" {
+		fields["repo_path"] = domain.Text(normalizedPath)
+	}
+	if primaryRule != "" {
+		fields["rule_key"] = domain.Text(primaryRule)
+	}
+	if anchorErr == nil && anchor.Kind.Valid() {
+		fields["anchor_kind"] = domain.Text(string(anchor.Kind))
+		fields["anchor_schema_version"] = domain.Integer(int64(anchor.SchemaVersion))
+		fields["anchor_value"] = anchorValue
+	}
+	if ruleConflict {
+		fields["rule_candidates"] = domain.StringSet(normalizedRules...)
+		delete(fields, "rule_key")
+	}
+
+	plan := SASTMatchPlanV1{
+		FingerprintInput: domain.FingerprintCanonicalInputV1{
+			CanonicalizationVersion: domain.CanonicalizationVersionV1,
+			ProducerKind:            "sast", TargetIdentitySchemaVersion: SASTTargetIdentitySchemaVersion,
+			TargetIdentityCanonical: target, IdentityFields: fields,
+		},
+		Method: domain.MethodMatcher, MatcherVersion: SASTMatcherVersionV1, ReasonCode: "sast_identity_complete",
+		TrustedProducerID: input.TrustedProducerIdentity,
+	}
+	approvedAliases := append([]string(nil), input.ApprovedIdentityAliases...)
+	sort.Strings(approvedAliases)
+	lastAlias := ""
+	for _, alias := range approvedAliases {
+		normalized, normalizeErr := normalizeSourceText("SAST", "approved identity alias", alias, 2048, false)
+		if normalizeErr != nil {
+			return SASTMatchPlanV1{}, normalizeErr
+		}
+		if normalized == lastAlias {
+			continue
+		}
+		lastAlias = normalized
+		plan.Aliases = append(plan.Aliases, AliasInput{SchemaVersion: SASTIdentityAliasSchemaVersionV1, Value: normalized})
+	}
+
+	if strings.TrimSpace(input.PriorRepoPath) != "" {
+		prior, priorErr := normalizeSourceRepoPath("SAST", input.PriorRepoPath)
+		if priorErr != nil {
+			return SASTMatchPlanV1{}, priorErr
+		}
+		plan.PathChanged = normalizedPath != "" && prior != normalizedPath
+	}
+
+	switch {
+	case input.LegacyDedupKey != "" && !input.LegacySourceValidated:
+		plan.SkipInput, plan.ReasonCode = true, "legacy_source_not_validated"
+	case input.LegacyDedupKey != "" && !input.LegacyOwnershipValid:
+		plan.SkipOwnership, plan.ReasonCode = true, "legacy_ownership_not_validated"
+	case ruleConflict:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous = domain.ReasonMerge, "rule_alias_conflict", true
+	case legacy.kind == sastLegacyJudgment && input.JudgmentAnchor == nil:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonLegacyAmbiguous, "legacy_judgment_missing", true, true
+	case legacy.kind == sastLegacyJudgment && (input.JudgmentAnchor.Kind != SASTAnchorJudgment || input.JudgmentAnchor.JudgmentID.String() != legacy.judgmentID):
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonLegacyAmbiguous, "legacy_judgment_mismatch", true, true
+	case legacy.kind == sastLegacyMalformed:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonLegacyAmbiguous, "legacy_key_malformed", true, true
+	case pathErr != nil || normalizedPath == "":
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "missing_repo_path", true, true
+	case ruleErr != nil || primaryRule == "":
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "missing_rule_key", true, true
+	case anchorErr != nil || !anchor.Kind.Valid():
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "missing_semantic_anchor", true, true
+	case legacy.kind == sastLegacyCodeQuality:
+		plan.ReasonCode = "legacy_code_quality_structured"
+	case legacy.kind == sastLegacyJudgment:
+		plan.ReasonCode = "legacy_judgment_resolved"
+	}
+	return plan, nil
+}
+
+func (plan SASTMatchPlanV1) Apply(input CorrelateInput) CorrelateInput {
+	input.ProducerKind = "sast"
+	input.FindingKind = "sast"
+	input.FingerprintSchemaVersion = SASTFingerprintSchemaVersionV1
+	input.FingerprintInput = plan.FingerprintInput
+	input.Aliases = append([]AliasInput(nil), plan.Aliases...)
+	input.TrustedProducerID = input.TrustedProducerID || plan.TrustedProducerID
+	input.ReviewReason = plan.ReviewReason
+	input.ReviewDetailCode = plan.ReasonCode
+	input.ProvisionalIdentity = plan.ProvisionalIdentity
+	if plan.PathChanged && input.OverrideSourceObservationID.IsZero() && !input.TrustedProducerID && len(input.Aliases) == 0 {
+		input.ReviewReason = domain.ReasonLegacyAmbiguous
+		input.ReviewDetailCode = "unapproved_path_change"
+	}
+	if plan.SkipInput {
+		input.InputTrusted = false
+	}
+	if plan.SkipOwnership {
+		input.OwnershipValidated = false
+	}
+	return input
+}
+
+func SASTJudgmentAnchorV1(expectedEngagementID shared.ID, current judgment.Judgment) (SASTAnchorV1, error) {
+	if expectedEngagementID.IsZero() || current.ID.IsZero() || current.EngagementID != expectedEngagementID {
+		return SASTAnchorV1{}, fmt.Errorf("%w: SAST judgment ownership does not match the Assessment", shared.ErrForbidden)
+	}
+	if current.Capability != judgment.CapSAST || !current.Publishable() {
+		return SASTAnchorV1{}, fmt.Errorf("%w: SAST judgment must be confirmed and publishable", shared.ErrValidation)
+	}
+	if !current.SubjectKind.Valid() || current.SubjectID.IsZero() {
+		return SASTAnchorV1{}, fmt.Errorf("%w: SAST judgment subject is invalid", shared.ErrValidation)
+	}
+	claim, ok := current.Claim.(judgment.SASTClaim)
+	if !ok {
+		return SASTAnchorV1{}, fmt.Errorf("%w: SAST judgment claim type is invalid", shared.ErrValidation)
+	}
+	if err := claim.Validate(); err != nil {
+		return SASTAnchorV1{}, err
+	}
+	canonical, err := json.Marshal(struct {
+		Capability  judgment.Capability  `json:"capability"`
+		SubjectKind judgment.SubjectKind `json:"subject_kind"`
+		SubjectID   shared.ID            `json:"subject_id"`
+		CWE         string               `json:"cwe"`
+		Rule        string               `json:"rule"`
+		AssetID     shared.ID            `json:"asset_id"`
+	}{current.Capability, current.SubjectKind, current.SubjectID, claim.CWE, claim.Rule, claim.AssetID})
+	if err != nil {
+		return SASTAnchorV1{}, fmt.Errorf("marshal SAST judgment semantic anchor: %w", err)
+	}
+	digest := sha256.Sum256(append([]byte("synapse:sast-judgment-anchor:v1\x00"), canonical...))
+	return SASTAnchorV1{
+		Kind: SASTAnchorJudgment, SchemaVersion: 1, JudgmentID: current.ID,
+		JudgmentSemanticDigest: hex.EncodeToString(digest[:]),
+	}, nil
+}
+
+func (matcher SASTMatcherV1) normalizeRule(producer, rule string, aliases []string) (string, []string, bool, error) {
+	observed := make([]string, 0, len(aliases)+1)
+	for _, raw := range append([]string{rule}, aliases...) {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		normalized, err := normalizeSourceRuleKey(producer, raw)
+		if err != nil {
+			return "", nil, false, err
+		}
+		observed = append(observed, normalized)
+	}
+	if len(observed) == 0 {
+		return "", nil, false, fmt.Errorf("%w: SAST rule key is required", shared.ErrValidation)
+	}
+	primaries := map[string]struct{}{}
+	for _, observedRule := range observed {
+		mapped := matcher.rulePrimaries[observedRule]
+		if len(mapped) == 0 {
+			primaries[observedRule] = struct{}{}
+			continue
+		}
+		for primary := range mapped {
+			primaries[primary] = struct{}{}
+		}
+	}
+	values := make([]string, 0, len(primaries))
+	for primary := range primaries {
+		values = append(values, primary)
+	}
+	sort.Strings(values)
+	if len(values) != 1 {
+		return "", values, true, nil
+	}
+	return values[0], values, false, nil
+}
+
+func normalizeSASTAnchor(anchor SASTAnchorV1) (domain.CanonicalValue, error) {
+	if !anchor.Kind.Valid() || anchor.SchemaVersion <= 0 {
+		return domain.CanonicalValue{}, fmt.Errorf("%w: SAST semantic anchor is required", shared.ErrValidation)
+	}
+	if len(anchor.RawOffsets) > 0 {
+		return domain.CanonicalValue{}, fmt.Errorf("%w: SAST semantic anchors cannot contain raw offsets", shared.ErrValidation)
+	}
+	value := map[string]domain.CanonicalValue{}
+	switch anchor.Kind {
+	case SASTAnchorSymbol:
+		language, err := normalizeSourceToken("SAST", "language id", anchor.LanguageID)
+		if err != nil {
+			return domain.CanonicalValue{}, err
+		}
+		symbol, err := normalizeSourceText("SAST", "qualified symbol", anchor.QualifiedSymbol, 1024, false)
+		if err != nil {
+			return domain.CanonicalValue{}, err
+		}
+		if anchor.NodeKind != "" || anchor.AncestorNameDigest != "" || anchor.SourceRuleClass != "" || anchor.SinkRuleClass != "" || anchor.GraphAnchorDigest != "" || !anchor.JudgmentID.IsZero() || anchor.JudgmentSemanticDigest != "" {
+			return domain.CanonicalValue{}, fmt.Errorf("%w: symbol anchor contains fields from another anchor kind", shared.ErrValidation)
+		}
+		value["language_id"] = domain.Text(language)
+		value["qualified_symbol"] = domain.Text(symbol)
+	case SASTAnchorAST:
+		nodeKind, err := normalizeSourceToken("SAST", "AST node kind", anchor.NodeKind)
+		if err != nil {
+			return domain.CanonicalValue{}, err
+		}
+		digest, err := normalizeSourceDigest("SAST", "AST ancestor/name digest", anchor.AncestorNameDigest)
+		if err != nil {
+			return domain.CanonicalValue{}, err
+		}
+		if anchor.LanguageID != "" || anchor.QualifiedSymbol != "" || anchor.SourceRuleClass != "" || anchor.SinkRuleClass != "" || anchor.GraphAnchorDigest != "" || !anchor.JudgmentID.IsZero() || anchor.JudgmentSemanticDigest != "" {
+			return domain.CanonicalValue{}, fmt.Errorf("%w: AST anchor contains fields from another anchor kind", shared.ErrValidation)
+		}
+		value["ancestor_name_digest"] = domain.Text(digest)
+		value["node_kind"] = domain.Text(nodeKind)
+	case SASTAnchorDataflow:
+		sourceClass, err := normalizeSourceToken("SAST", "dataflow source rule class", anchor.SourceRuleClass)
+		if err != nil {
+			return domain.CanonicalValue{}, err
+		}
+		sinkClass, err := normalizeSourceToken("SAST", "dataflow sink rule class", anchor.SinkRuleClass)
+		if err != nil {
+			return domain.CanonicalValue{}, err
+		}
+		graphDigest, err := normalizeSourceDigest("SAST", "dataflow graph anchor", anchor.GraphAnchorDigest)
+		if err != nil {
+			return domain.CanonicalValue{}, err
+		}
+		if anchor.LanguageID != "" || anchor.QualifiedSymbol != "" || anchor.NodeKind != "" || anchor.AncestorNameDigest != "" || !anchor.JudgmentID.IsZero() || anchor.JudgmentSemanticDigest != "" {
+			return domain.CanonicalValue{}, fmt.Errorf("%w: dataflow anchor contains fields from another anchor kind", shared.ErrValidation)
+		}
+		value["graph_anchor_digest"] = domain.Text(graphDigest)
+		value["sink_rule_class"] = domain.Text(sinkClass)
+		value["source_rule_class"] = domain.Text(sourceClass)
+	case SASTAnchorJudgment:
+		judgmentID, err := normalizeSourceText("SAST", "judgment id", anchor.JudgmentID.String(), 512, false)
+		if err != nil {
+			return domain.CanonicalValue{}, err
+		}
+		digest, err := normalizeSourceDigest("SAST", "judgment semantic digest", anchor.JudgmentSemanticDigest)
+		if err != nil {
+			return domain.CanonicalValue{}, err
+		}
+		if anchor.LanguageID != "" || anchor.QualifiedSymbol != "" || anchor.NodeKind != "" || anchor.AncestorNameDigest != "" || anchor.SourceRuleClass != "" || anchor.SinkRuleClass != "" || anchor.GraphAnchorDigest != "" {
+			return domain.CanonicalValue{}, fmt.Errorf("%w: judgment anchor contains fields from another anchor kind", shared.ErrValidation)
+		}
+		value["judgment_id"] = domain.Text(judgmentID)
+		value["semantic_digest"] = domain.Text(digest)
+	}
+	return domain.Object(value), nil
+}
+
+func normalizeSourceRepoPath(producer, value string) (string, error) {
+	value = norm.NFC.String(strings.TrimSpace(value))
+	if value == "" {
+		return "", fmt.Errorf("%w: %s repository path is required", shared.ErrValidation, producer)
+	}
+	// Reject URL locators before path.Clean collapses the scheme separator and
+	// obscures URL userinfo. Source identities accept repository-relative paths.
+	if !utf8.ValidString(value) || len(value) > 2048 || strings.Contains(value, "\\") || strings.Contains(value, "://") || path.IsAbs(value) || len(value) >= 2 && value[1] == ':' {
+		return "", fmt.Errorf("%w: %s repository path must be a bounded relative slash path", shared.ErrValidation, producer)
+	}
+	for _, part := range strings.Split(value, "/") {
+		if part == ".." {
+			return "", fmt.Errorf("%w: %s repository path traversal is forbidden", shared.ErrValidation, producer)
+		}
+	}
+	cleaned := path.Clean(value)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("%w: %s repository path is invalid", shared.ErrValidation, producer)
+	}
+	for _, char := range cleaned {
+		if unicode.IsControl(char) {
+			return "", fmt.Errorf("%w: %s repository path contains control characters", shared.ErrValidation, producer)
+		}
+	}
+	if domain.ContainsSensitiveAssignment(cleaned) {
+		return "", fmt.Errorf("%w: %s repository path contains sensitive input", domain.ErrSensitiveInput, producer)
+	}
+	return cleaned, nil
+}
+
+func normalizeSourceRuleKey(producer, value string) (string, error) {
+	return normalizeSourceText(producer, "rule key", value, 256, true)
+}
+
+func normalizeSourceToken(producer, name, value string) (string, error) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" || len(value) > 128 {
+		return "", fmt.Errorf("%w: %s %s is required", shared.ErrValidation, producer, name)
+	}
+	for index, char := range value {
+		if (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9' && index > 0) || index > 0 && strings.ContainsRune("+._-/", char) {
+			continue
+		}
+		return "", fmt.Errorf("%w: %s %s is not a stable token", shared.ErrValidation, producer, name)
+	}
+	return value, nil
+}
+
+func normalizeSourceDigest(producer, name, value string) (string, error) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if len(value) != sha256.Size*2 {
+		return "", fmt.Errorf("%w: %s %s must be a SHA-256 digest", shared.ErrValidation, producer, name)
+	}
+	if _, err := hex.DecodeString(value); err != nil {
+		return "", fmt.Errorf("%w: %s %s must be a SHA-256 digest", shared.ErrValidation, producer, name)
+	}
+	return value, nil
+}
+
+func normalizeSourceText(producer, name, value string, maximum int, rejectWhitespace bool) (string, error) {
+	value = norm.NFC.String(strings.TrimSpace(value))
+	if value == "" || !utf8.ValidString(value) || len(value) > maximum {
+		return "", fmt.Errorf("%w: %s %s is required and must not exceed %d bytes", shared.ErrValidation, producer, name, maximum)
+	}
+	for _, char := range value {
+		if unicode.IsControl(char) || rejectWhitespace && unicode.IsSpace(char) {
+			return "", fmt.Errorf("%w: %s %s contains invalid characters", shared.ErrValidation, producer, name)
+		}
+	}
+	if domain.ContainsSensitiveAssignment(value) {
+		return "", fmt.Errorf("%w: %s %s contains sensitive input", domain.ErrSensitiveInput, producer, name)
+	}
+	return value, nil
+}
+
+type sastLegacyKind uint8
+
+const (
+	sastLegacyNone sastLegacyKind = iota
+	sastLegacyJudgment
+	sastLegacyCodeQuality
+	sastLegacyMalformed
+)
+
+type sastLegacyKey struct {
+	kind       sastLegacyKind
+	judgmentID string
+	ruleKey    string
+	repoPath   string
+}
+
+func parseSASTLegacyKey(value string) sastLegacyKey {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return sastLegacyKey{}
+	}
+	if strings.HasPrefix(value, "sast:ai:") {
+		judgmentID := strings.TrimSpace(strings.TrimPrefix(value, "sast:ai:"))
+		if judgmentID == "" || strings.ContainsAny(judgmentID, "\x00\r\n") {
+			return sastLegacyKey{kind: sastLegacyMalformed}
+		}
+		return sastLegacyKey{kind: sastLegacyJudgment, judgmentID: judgmentID}
+	}
+	if strings.HasPrefix(value, "cq:sast:") {
+		rest := strings.TrimPrefix(value, "cq:sast:")
+		lineSeparator := strings.LastIndexByte(rest, ':')
+		if lineSeparator <= 0 {
+			return sastLegacyKey{kind: sastLegacyMalformed}
+		}
+		line, err := strconv.Atoi(rest[lineSeparator+1:])
+		pathSeparator := strings.LastIndexByte(rest[:lineSeparator], ':')
+		if err != nil || line < 1 || pathSeparator <= 0 || pathSeparator == lineSeparator-1 {
+			return sastLegacyKey{kind: sastLegacyMalformed}
+		}
+		return sastLegacyKey{
+			kind: sastLegacyCodeQuality, ruleKey: rest[:pathSeparator], repoPath: rest[pathSeparator+1 : lineSeparator],
+		}
+	}
+	return sastLegacyKey{kind: sastLegacyMalformed}
+}

--- a/internal/usecase/findinglineage/sast_matcher_test.go
+++ b/internal/usecase/findinglineage/sast_matcher_test.go
@@ -1,0 +1,263 @@
+package findinglineage
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+)
+
+func TestSASTMatcherV1GoldenCanonicalProfilesAndLineMovement(t *testing.T) {
+	matcher, err := NewSASTMatcherV1([]SASTRuleAliasSetV1{{Primary: "go:sql-injection", Aliases: []string{"legacy:sqli"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := matcher.Descriptor().Validate(); err != nil {
+		t.Fatal(err)
+	}
+
+	base := SASTFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example",
+		Anchor: SASTAnchorV1{
+			Kind: SASTAnchorSymbol, SchemaVersion: 1, LanguageID: "Go", QualifiedSymbol: "example.Handler.Serve",
+		},
+		LegacySourceValidated: true, LegacyOwnershipValid: true,
+	}
+	first := base
+	first.LegacyDedupKey = "cq:sast:legacy:sqli:src/./Cafe\u0301.go:42"
+	second := base
+	second.LegacyDedupKey = "cq:sast:go:sql-injection:src/Café.go:900"
+
+	firstPlan, err := matcher.Build(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondPlan, err := matcher.Build(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstFingerprint, err := domain.CanonicalizeFingerprintV1(firstPlan.FingerprintInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondFingerprint, err := domain.CanonicalizeFingerprintV1(secondPlan.FingerprintInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstFingerprint.Fingerprint != secondFingerprint.Fingerprint {
+		t.Fatalf("line movement or approved rule alias changed identity: %s != %s", firstFingerprint.Fingerprint, secondFingerprint.Fingerprint)
+	}
+	const wantFingerprint = "a1a68cbafe4ec3186633549a1f4253ac8b46007cca1698fb1a6308bf6d982b54"
+	if firstFingerprint.Fingerprint != wantFingerprint {
+		t.Fatalf("fingerprint=%s want=%s canonical=%s", firstFingerprint.Fingerprint, wantFingerprint, firstFingerprint.Bytes)
+	}
+	canonical := string(firstFingerprint.Bytes)
+	if strings.Contains(canonical, `"line"`) || strings.Contains(canonical, "42") || strings.Contains(canonical, "900") {
+		t.Fatalf("raw line leaked into identity: %s", canonical)
+	}
+	if !strings.Contains(canonical, `"repo_path":"src/Café.go"`) || !strings.Contains(canonical, `"qualified_symbol":"example.Handler.Serve"`) {
+		t.Fatalf("path or symbol normalization missing: %s", canonical)
+	}
+
+	caseChanged := second
+	caseChanged.LegacyDedupKey = "cq:sast:go:sql-injection:src/café.go:900"
+	casePlan, err := matcher.Build(caseChanged)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caseFingerprint, _ := domain.CanonicalizeFingerprintV1(casePlan.FingerprintInput)
+	if caseFingerprint.Fingerprint == firstFingerprint.Fingerprint {
+		t.Fatal("repository path case must be preserved")
+	}
+}
+
+func TestSASTMatcherV1AnchorProfilesAndUnsafeInputs(t *testing.T) {
+	matcher, err := NewSASTMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digestA := strings.Repeat("a", 64)
+	digestB := strings.Repeat("b", 64)
+	anchors := []SASTAnchorV1{
+		{Kind: SASTAnchorSymbol, SchemaVersion: 1, LanguageID: "typescript", QualifiedSymbol: "api.UserController.create"},
+		{Kind: SASTAnchorAST, SchemaVersion: 1, NodeKind: "Call_Expression", AncestorNameDigest: digestA},
+		{Kind: SASTAnchorDataflow, SchemaVersion: 2, SourceRuleClass: "http.request", SinkRuleClass: "sql.execute", GraphAnchorDigest: digestB},
+		{Kind: SASTAnchorJudgment, SchemaVersion: 1, JudgmentID: "judgment-1", JudgmentSemanticDigest: digestA},
+	}
+	seen := map[string]struct{}{}
+	for _, anchor := range anchors {
+		plan, buildErr := matcher.Build(SASTFingerprintInputV1{
+			TargetIdentityCanonical: "repo:example", RepoPath: "src/app.ts", RuleKey: "ts:rule", Anchor: anchor,
+		})
+		if buildErr != nil {
+			t.Fatalf("anchor=%s err=%v", anchor.Kind, buildErr)
+		}
+		fingerprint, canonicalErr := domain.CanonicalizeFingerprintV1(plan.FingerprintInput)
+		if canonicalErr != nil {
+			t.Fatal(canonicalErr)
+		}
+		if _, exists := seen[fingerprint.Fingerprint]; exists {
+			t.Fatalf("anchor profile collapsed: %s", anchor.Kind)
+		}
+		seen[fingerprint.Fingerprint] = struct{}{}
+	}
+
+	for _, input := range []SASTFingerprintInputV1{
+		{TargetIdentityCanonical: "repo:example", RepoPath: "../outside.go", RuleKey: "go:rule", Anchor: anchors[0]},
+		{TargetIdentityCanonical: "repo:example", RepoPath: "/tmp/app.go", RuleKey: "go:rule", Anchor: anchors[0]},
+		{TargetIdentityCanonical: "repo:example", RepoPath: `src\app.go`, RuleKey: "go:rule", Anchor: anchors[0]},
+		{TargetIdentityCanonical: "repo:example", RepoPath: "src/app.go", RuleKey: "go:rule", Anchor: SASTAnchorV1{Kind: SASTAnchorSymbol, SchemaVersion: 1, LanguageID: "go", QualifiedSymbol: "main.run", RawOffsets: map[string]int{"line": 42}}},
+	} {
+		if _, buildErr := matcher.Build(input); !errors.Is(buildErr, shared.ErrValidation) {
+			t.Fatalf("unsafe input err=%v input=%+v", buildErr, input)
+		}
+	}
+}
+
+func TestSASTMatcherV1LegacyJudgmentAndRuleConflictOutcomes(t *testing.T) {
+	matcher, err := NewSASTMatcherV1([]SASTRuleAliasSetV1{
+		{Primary: "go:sql", Aliases: []string{"legacy:sql"}},
+		{Primary: "go:command", Aliases: []string{"legacy:sql"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	current := judgment.Judgment{
+		ID: "judgment-1", EngagementID: "assessment-1", Capability: judgment.CapSAST,
+		SubjectKind: judgment.SubjectFinding, SubjectID: "finding-1",
+		Claim: judgment.SASTClaim{CWE: "CWE-89", Location: "src/db.go:42", Rule: "go:sql", AssetID: "asset-1"},
+		State: judgment.StateConfirmed, EvidenceScore: 100,
+	}
+	anchor, err := SASTJudgmentAnchorV1("assessment-1", current)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := SASTJudgmentAnchorV1("assessment-2", current); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("ownership error=%v", err)
+	}
+	moved := current
+	moved.Claim = judgment.SASTClaim{CWE: "CWE-89", Location: "src/db.go:900", Rule: "go:sql", AssetID: "asset-1"}
+	movedAnchor, err := SASTJudgmentAnchorV1("assessment-1", moved)
+	if err != nil || movedAnchor.JudgmentSemanticDigest != anchor.JudgmentSemanticDigest {
+		t.Fatalf("judgment line movement changed semantic digest: %+v err=%v", movedAnchor, err)
+	}
+
+	resolved, err := matcher.Build(SASTFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", RepoPath: "src/db.go", RuleKey: "go:sql",
+		LegacyDedupKey: "sast:ai:judgment-1", LegacySourceValidated: true, LegacyOwnershipValid: true, JudgmentAnchor: &anchor,
+	})
+	if err != nil || resolved.ProvisionalIdentity || resolved.ReasonCode != "legacy_judgment_resolved" {
+		t.Fatalf("resolved=%+v err=%v", resolved, err)
+	}
+	missing, err := matcher.Build(SASTFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", RepoPath: "src/db.go", RuleKey: "go:sql",
+		LegacyDedupKey: "sast:ai:judgment-1", LegacySourceValidated: true, LegacyOwnershipValid: true,
+	})
+	if err != nil || !missing.ProvisionalIdentity || missing.ReviewReason != domain.ReasonLegacyAmbiguous || missing.ReasonCode != "legacy_judgment_missing" {
+		t.Fatalf("missing=%+v err=%v", missing, err)
+	}
+	mismatchAnchor := anchor
+	mismatchAnchor.JudgmentID = "judgment-2"
+	mismatch, err := matcher.Build(SASTFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", RepoPath: "src/db.go", RuleKey: "go:sql",
+		LegacyDedupKey: "sast:ai:judgment-1", LegacySourceValidated: true, LegacyOwnershipValid: true, JudgmentAnchor: &mismatchAnchor,
+	})
+	if err != nil || !mismatch.ProvisionalIdentity || mismatch.ReasonCode != "legacy_judgment_mismatch" {
+		t.Fatalf("mismatch=%+v err=%v", mismatch, err)
+	}
+	conflict, err := matcher.Build(SASTFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", RepoPath: "src/db.go", RuleKey: "legacy:sql", Anchor: anchor,
+	})
+	if err != nil || !conflict.Ambiguous || conflict.ReviewReason != domain.ReasonMerge || conflict.ReasonCode != "rule_alias_conflict" {
+		t.Fatalf("conflict=%+v err=%v", conflict, err)
+	}
+}
+
+func TestSASTMatcherV1MemoryCorrelationProvisionalSkipAndRename(t *testing.T) {
+	matcher, err := NewSASTMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repository := memory.NewFindingLineageRepository()
+	clock := fixedClock{now: time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)}
+	observer := &collectingObserver{}
+	service, err := NewService(repository, immediateTransactions{}, &collectingAudit{}, clock, &sequenceIDs{}, observer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	anchor := SASTAnchorV1{Kind: SASTAnchorSymbol, SchemaVersion: 1, LanguageID: "go", QualifiedSymbol: "example.Handler.Serve"}
+
+	correlate := func(snapshot, source, location string) Result {
+		plan, buildErr := matcher.Build(SASTFingerprintInputV1{
+			TargetIdentityCanonical: "repo:example", RepoPath: "src/handler.go", RuleKey: "go:sqli", Anchor: anchor,
+		})
+		if buildErr != nil {
+			t.Fatal(buildErr)
+		}
+		input := plan.Apply(correlateInput(snapshot, "unused"))
+		input.SnapshotID = shared.ID(snapshot)
+		input.Observation.ID = shared.ID("observation-" + snapshot)
+		input.Observation.SourceFindingID = source
+		input.Observation.Location = location
+		result, correlateErr := service.Correlate(context.Background(), input)
+		if correlateErr != nil {
+			t.Fatal(correlateErr)
+		}
+		return result
+	}
+	first := correlate("snapshot-1", "source-1", "src/handler.go:42")
+	second := correlate("snapshot-2", "source-2", "src/handler.go:900")
+	if first.Outcome != OutcomeCreated || second.Outcome != OutcomeMatched || first.Identity.ID != second.Identity.ID {
+		t.Fatalf("line movement first=%+v second=%+v", first, second)
+	}
+
+	malformed, err := matcher.Build(SASTFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", LegacyDedupKey: "cq:sast:broken",
+		LegacySourceValidated: true, LegacyOwnershipValid: true,
+	})
+	if err != nil || !malformed.ProvisionalIdentity || malformed.ReasonCode != "legacy_key_malformed" {
+		t.Fatalf("malformed=%+v err=%v", malformed, err)
+	}
+	malformedInput := malformed.Apply(correlateInput("malformed", "unused"))
+	malformedResult, err := service.Correlate(context.Background(), malformedInput)
+	if err != nil || malformedResult.Outcome != OutcomeReview || malformedResult.Identity == nil || malformedResult.Candidate == nil {
+		t.Fatalf("malformed result=%+v err=%v", malformedResult, err)
+	}
+
+	invalidOwnership, err := matcher.Build(SASTFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", RepoPath: "src/db.go", RuleKey: "go:sql", Anchor: anchor,
+		LegacyDedupKey: "sast:ai:foreign", LegacySourceValidated: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	skipResult, err := service.Correlate(context.Background(), invalidOwnership.Apply(correlateInput("skip", "unused")))
+	if err != nil || skipResult.Outcome != OutcomeSkipped || skipResult.Skip == nil || skipResult.Skip.Reason != domain.SkipInvalidOwnership {
+		t.Fatalf("skip=%+v err=%v", skipResult, err)
+	}
+
+	rename, err := matcher.Build(SASTFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", RepoPath: "src/new.go", PriorRepoPath: "src/old.go", RuleKey: "go:sqli", Anchor: anchor,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	renameResult, err := service.Correlate(context.Background(), rename.Apply(correlateInput("rename", "unused")))
+	if err != nil || renameResult.Outcome != OutcomeReview || renameResult.Candidate == nil || renameResult.Reason != "unapproved_path_change" {
+		t.Fatalf("rename=%+v err=%v", renameResult, err)
+	}
+	if len(observer.outcomes) != 5 {
+		t.Fatalf("metrics outcomes=%+v", observer.outcomes)
+	}
+	if _, err := matcher.Build(SASTFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example?api_token=must-not-hash", RepoPath: "src/app.go", RuleKey: "go:rule", Anchor: anchor,
+	}); !errors.Is(err, domain.ErrSensitiveInput) {
+		t.Fatalf("sensitive target error=%v", err)
+	}
+}

--- a/internal/usecase/findinglineage/sca_matcher.go
+++ b/internal/usecase/findinglineage/sca_matcher.go
@@ -1,0 +1,494 @@
+package findinglineage
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"sort"
+	"strings"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+)
+
+const (
+	SCAMatcherVersionV1            = 1
+	SCAFingerprintSchemaVersionV1  = 1
+	SCATargetIdentitySchemaVersion = 1
+	SCAAdvisoryAliasSchemaVersion  = 1
+)
+
+var pypiNameSeparators = regexp.MustCompile(`[-_.]+`)
+
+type SCAAdvisoryAliasSetV1 struct {
+	Primary string
+	Aliases []string
+}
+
+type SCAMatcherV1 struct {
+	advisoryPrimaries map[string]string
+}
+
+func NewSCAMatcherV1(aliasSets []SCAAdvisoryAliasSetV1) (SCAMatcherV1, error) {
+	matcher := SCAMatcherV1{advisoryPrimaries: map[string]string{}}
+	for _, aliasSet := range aliasSets {
+		primary, err := normalizeSCAAdvisoryID(aliasSet.Primary)
+		if err != nil {
+			return SCAMatcherV1{}, err
+		}
+		for _, raw := range append([]string{primary}, aliasSet.Aliases...) {
+			alias, err := normalizeSCAAdvisoryID(raw)
+			if err != nil {
+				return SCAMatcherV1{}, err
+			}
+			if existing := matcher.advisoryPrimaries[alias]; existing != "" && existing != primary {
+				return SCAMatcherV1{}, fmt.Errorf("%w: advisory alias %q maps to multiple primaries", shared.ErrValidation, alias)
+			}
+			matcher.advisoryPrimaries[alias] = primary
+		}
+	}
+	return matcher, nil
+}
+
+func (SCAMatcherV1) Descriptor() domain.MatcherDescriptor {
+	return domain.MatcherDescriptor{
+		ProducerKind: "sca", FindingKind: "vulnerability", Method: domain.MethodMatcher,
+		MethodVersion: SCAMatcherVersionV1, CanonicalizationVersion: domain.CanonicalizationVersionV1,
+		FingerprintSchemaVersion: SCAFingerprintSchemaVersionV1, TargetIdentitySchemaVersion: SCATargetIdentitySchemaVersion,
+	}
+}
+
+type SCAFingerprintInputV1 struct {
+	TargetIdentityCanonical string
+	AdvisoryID              string
+	AdvisoryAliases         []string
+	PackagePURL             string
+	PackageEcosystem        string
+	PackageName             string
+	// StableDependencyAnchor identifies a lockfile/dependency-graph position and
+	// MUST NOT contain the resolved component version. Version-bearing component
+	// fingerprints belong on Observation.ComponentVersion, never in identity.
+	StableDependencyAnchor string
+	DependencyPath         []string
+	LegacyDedupKey         string
+}
+
+func SCAFingerprintInputFromVulnerabilityV1(target string, current vulnerability.Vulnerability, aliases []string, legacyDedupKey, stableDependencyAnchor string) SCAFingerprintInputV1 {
+	return SCAFingerprintInputV1{
+		TargetIdentityCanonical: target,
+		AdvisoryID:              current.ID,
+		AdvisoryAliases:         append([]string(nil), aliases...),
+		PackagePURL:             current.PackagePURL,
+		PackageEcosystem:        current.Ecosystem,
+		PackageName:             current.Component,
+		StableDependencyAnchor:  stableDependencyAnchor,
+		DependencyPath:          append([]string(nil), current.Path...),
+		LegacyDedupKey:          legacyDedupKey,
+	}
+}
+
+type SCAMatchPlanV1 struct {
+	FingerprintInput    domain.FingerprintCanonicalInputV1
+	Aliases             []AliasInput
+	Method              domain.MatchMethod
+	MatcherVersion      int
+	ReasonCode          string
+	ReviewReason        domain.CandidateReason
+	Ambiguous           bool
+	ProvisionalIdentity bool
+}
+
+func (matcher SCAMatcherV1) Build(input SCAFingerprintInputV1) (SCAMatchPlanV1, error) {
+	target := strings.TrimSpace(input.TargetIdentityCanonical)
+	if target == "" || len(target) > 2048 {
+		return SCAMatchPlanV1{}, fmt.Errorf("%w: SCA target identity is required", shared.ErrValidation)
+	}
+	if err := validateSCASafeText(target); err != nil {
+		return SCAMatchPlanV1{}, err
+	}
+
+	advisoryID := input.AdvisoryID
+	packageName := input.PackageName
+	legacyAdvisory, legacyPackage, _, legacyOK := vulnerability.ParseDedupKey(input.LegacyDedupKey)
+	legacyMalformed := input.LegacyDedupKey != "" && (!legacyOK || strings.TrimSpace(legacyAdvisory) == "" || strings.TrimSpace(legacyPackage) == "")
+	if strings.TrimSpace(advisoryID) == "" && legacyOK {
+		advisoryID = legacyAdvisory
+	}
+	if strings.TrimSpace(input.PackagePURL) == "" && strings.TrimSpace(packageName) == "" && legacyOK {
+		packageName = legacyPackage
+	}
+
+	primary, normalizedIDs, conflict, advisoryErr := matcher.normalizeAdvisory(advisoryID, input.AdvisoryAliases)
+	packageCoordinate, packageErr := normalizeSCAPackageCoordinate(input.PackagePURL, input.PackageEcosystem, packageName)
+	dependencyPath, pathErr := normalizeSCADependencyPath(input.DependencyPath)
+	stableAnchor := strings.TrimSpace(input.StableDependencyAnchor)
+	if stableAnchor != "" {
+		if err := validateSCASafeText(stableAnchor); err != nil {
+			return SCAMatchPlanV1{}, err
+		}
+	}
+	if errors.Is(packageErr, domain.ErrSensitiveInput) {
+		return SCAMatchPlanV1{}, packageErr
+	}
+	if errors.Is(pathErr, domain.ErrSensitiveInput) {
+		return SCAMatchPlanV1{}, pathErr
+	}
+
+	fields := map[string]domain.CanonicalValue{
+		"advisory_alias_graph_version": domain.Integer(SCAAdvisoryAliasSchemaVersion),
+		"producer_matcher_version":     domain.Integer(SCAMatcherVersionV1),
+	}
+	if primary != "" {
+		fields["advisory_id"] = domain.Text(primary)
+	}
+	if packageErr == nil {
+		fields["package_coordinate"] = domain.Text(packageCoordinate)
+	}
+	if pathErr == nil && len(dependencyPath) > 0 {
+		values := make([]domain.CanonicalValue, len(dependencyPath))
+		for index, coordinate := range dependencyPath {
+			values[index] = domain.Text(coordinate)
+		}
+		fields["dependency_path"] = domain.OrderedArray(values...)
+	} else if stableAnchor != "" {
+		fields["stable_dependency_anchor"] = domain.Text(stableAnchor)
+	}
+	if conflict {
+		fields["advisory_candidates"] = domain.StringSet(normalizedIDs...)
+		delete(fields, "advisory_id")
+	}
+
+	plan := SCAMatchPlanV1{
+		FingerprintInput: domain.FingerprintCanonicalInputV1{
+			CanonicalizationVersion: domain.CanonicalizationVersionV1,
+			ProducerKind:            "sca", TargetIdentitySchemaVersion: SCATargetIdentitySchemaVersion,
+			TargetIdentityCanonical: target, IdentityFields: fields,
+		},
+		Method: domain.MethodMatcher, MatcherVersion: SCAMatcherVersionV1, ReasonCode: "sca_identity_complete",
+	}
+	switch {
+	case conflict:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous = domain.ReasonMerge, "advisory_alias_conflict", true
+	case advisoryErr != nil:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonLegacyAmbiguous, "missing_advisory_identity", true, true
+	case packageErr != nil:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "invalid_package_coordinate", true, true
+	case pathErr != nil:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "invalid_dependency_path", true, true
+	case len(dependencyPath) == 0 && stableAnchor == "":
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "insufficient_dependency_instance", true, true
+	case legacyMalformed:
+		plan.ReasonCode = "structured_fields_preferred"
+	}
+	if !plan.Ambiguous {
+		plan.Aliases = make([]AliasInput, len(normalizedIDs))
+		for index, alias := range normalizedIDs {
+			plan.Aliases[index] = AliasInput{SchemaVersion: SCAAdvisoryAliasSchemaVersion, Value: alias}
+		}
+	}
+	return plan, nil
+}
+
+func (plan SCAMatchPlanV1) Apply(input CorrelateInput) CorrelateInput {
+	input.ProducerKind = "sca"
+	input.FindingKind = "vulnerability"
+	input.FingerprintSchemaVersion = SCAFingerprintSchemaVersionV1
+	input.FingerprintInput = plan.FingerprintInput
+	input.Aliases = append([]AliasInput(nil), plan.Aliases...)
+	input.ReviewReason = plan.ReviewReason
+	input.ReviewDetailCode = plan.ReasonCode
+	input.ProvisionalIdentity = plan.ProvisionalIdentity
+	return input
+}
+
+func (matcher SCAMatcherV1) normalizeAdvisory(primary string, aliases []string) (string, []string, bool, error) {
+	seen := map[string]struct{}{}
+	for _, raw := range append([]string{primary}, aliases...) {
+		if strings.TrimSpace(raw) == "" {
+			continue
+		}
+		id, err := normalizeSCAAdvisoryID(raw)
+		if err != nil {
+			return "", nil, false, err
+		}
+		seen[id] = struct{}{}
+	}
+	if len(seen) == 0 {
+		return "", nil, false, fmt.Errorf("%w: SCA advisory identity is required", shared.ErrValidation)
+	}
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	knownPrimaries := map[string]struct{}{}
+	for _, id := range ids {
+		if resolved := matcher.advisoryPrimaries[id]; resolved != "" {
+			knownPrimaries[resolved] = struct{}{}
+		}
+	}
+	if len(knownPrimaries) > 1 {
+		return "", ids, true, nil
+	}
+	if len(knownPrimaries) == 1 {
+		var resolved string
+		for resolved = range knownPrimaries {
+		}
+		if strings.HasPrefix(resolved, "CVE-") {
+			for _, id := range ids {
+				if strings.HasPrefix(id, "CVE-") && id != resolved {
+					return "", ids, true, nil
+				}
+			}
+		}
+		return resolved, ids, false, nil
+	}
+
+	cves := 0
+	for _, id := range ids {
+		if strings.HasPrefix(id, "CVE-") {
+			cves++
+		}
+	}
+	if cves > 1 {
+		return "", ids, true, nil
+	}
+	return preferredSCAAdvisoryID(ids), ids, false, nil
+}
+
+func normalizeSCAAdvisoryID(value string) (string, error) {
+	value = strings.ToUpper(strings.TrimSpace(value))
+	if value == "" || len(value) > 256 {
+		return "", fmt.Errorf("%w: SCA advisory id is required", shared.ErrValidation)
+	}
+	for _, char := range value {
+		if char != '-' && char != '_' && char != '.' && char != ':' && (char < 'A' || char > 'Z') && (char < '0' || char > '9') {
+			return "", fmt.Errorf("%w: SCA advisory id contains invalid characters", shared.ErrValidation)
+		}
+	}
+	return value, nil
+}
+
+func preferredSCAAdvisoryID(ids []string) string {
+	best, bestRank := "", 0
+	for _, id := range ids {
+		rank := 1
+		if strings.HasPrefix(id, "GHSA-") {
+			rank = 2
+		}
+		if strings.HasPrefix(id, "CVE-") {
+			rank = 3
+		}
+		if rank > bestRank || rank == bestRank && (best == "" || id < best) {
+			best, bestRank = id, rank
+		}
+	}
+	return best
+}
+
+func normalizeSCADependencyPath(values []string) ([]string, error) {
+	if len(values) > 256 {
+		return nil, fmt.Errorf("%w: SCA dependency path is too long", shared.ErrValidation)
+	}
+	path := make([]string, len(values))
+	for index, value := range values {
+		coordinate, err := normalizeSCAPackageCoordinate(value, "", "")
+		if err != nil {
+			return nil, err
+		}
+		path[index] = coordinate
+	}
+	return path, nil
+}
+
+func normalizeSCAPackageCoordinate(purl, ecosystem, packageName string) (string, error) {
+	purl = strings.TrimSpace(purl)
+	if purl == "" {
+		var err error
+		purl, err = scaPURLFromPackage(ecosystem, packageName)
+		if err != nil {
+			return "", err
+		}
+	}
+	if len(purl) > 2048 || len(purl) < 5 || !strings.EqualFold(purl[:4], "pkg:") {
+		return "", fmt.Errorf("%w: SCA package purl is malformed", shared.ErrValidation)
+	}
+	rest := purl[4:]
+	if fragment := strings.IndexByte(rest, '#'); fragment >= 0 {
+		rest = rest[:fragment]
+	}
+	qualifiers := ""
+	if query := strings.IndexByte(rest, '?'); query >= 0 {
+		qualifiers, rest = rest[query+1:], rest[:query]
+	}
+	typeEnd := strings.IndexByte(rest, '/')
+	if typeEnd <= 0 || typeEnd == len(rest)-1 {
+		return "", fmt.Errorf("%w: SCA package purl is incomplete", shared.ErrValidation)
+	}
+	typ := strings.ToLower(rest[:typeEnd])
+	if typ[0] < 'a' || typ[0] > 'z' {
+		return "", fmt.Errorf("%w: SCA package purl type is invalid", shared.ErrValidation)
+	}
+	for _, char := range typ {
+		if char != '.' && char != '-' && (char < 'a' || char > 'z') && (char < '0' || char > '9') {
+			return "", fmt.Errorf("%w: SCA package purl type is invalid", shared.ErrValidation)
+		}
+	}
+	rawPath := strings.Trim(rest[typeEnd+1:], "/")
+	if slash := strings.LastIndexByte(rawPath, '/'); slash >= 0 {
+		if version := strings.LastIndexByte(rawPath, '@'); version > slash {
+			rawPath = rawPath[:version]
+		}
+	} else if version := strings.LastIndexByte(rawPath, '@'); version > 0 {
+		rawPath = rawPath[:version]
+	}
+	path, err := normalizeSCAPackagePath(typ, rawPath)
+	if err != nil {
+		return "", err
+	}
+	coordinate := "pkg:" + typ + "/" + path
+	if qualifiers != "" {
+		normalized, err := normalizeSCAPURLQualifiers(qualifiers)
+		if err != nil {
+			return "", err
+		}
+		if normalized != "" {
+			coordinate += "?" + normalized
+		}
+	}
+	return coordinate, nil
+}
+
+func scaPURLFromPackage(ecosystem, packageName string) (string, error) {
+	name := strings.TrimSpace(packageName)
+	if name == "" {
+		return "", fmt.Errorf("%w: SCA package identity is required", shared.ErrValidation)
+	}
+	switch strings.ToLower(strings.TrimSpace(ecosystem)) {
+	case "go", "golang":
+		return "pkg:golang/" + name, nil
+	case "npm":
+		return "pkg:npm/" + name, nil
+	case "pypi":
+		return "pkg:pypi/" + name, nil
+	case "maven":
+		group, artifact, ok := strings.Cut(name, ":")
+		if !ok || group == "" || artifact == "" {
+			return "", fmt.Errorf("%w: Maven package must use group:artifact", shared.ErrValidation)
+		}
+		return "pkg:maven/" + group + "/" + artifact, nil
+	case "crates.io", "cargo":
+		return "pkg:cargo/" + name, nil
+	case "rubygems", "gem":
+		return "pkg:gem/" + name, nil
+	case "nuget":
+		return "pkg:nuget/" + name, nil
+	default:
+		return "", fmt.Errorf("%w: SCA package ecosystem is unsupported", shared.ErrValidation)
+	}
+}
+
+func normalizeSCAPackagePath(typ, rawPath string) (string, error) {
+	parts := strings.Split(rawPath, "/")
+	if len(parts) == 0 || len(parts) > 64 {
+		return "", fmt.Errorf("%w: SCA package path is invalid", shared.ErrValidation)
+	}
+	for index, raw := range parts {
+		part, err := url.PathUnescape(raw)
+		if err != nil || strings.TrimSpace(part) == "" || part == "." || part == ".." || strings.ContainsAny(part, "\x00\r\n") {
+			return "", fmt.Errorf("%w: SCA package path is invalid", shared.ErrValidation)
+		}
+		switch typ {
+		case "pypi", "cargo", "gem", "nuget", "deb", "apk", "rpm":
+			part = strings.ToLower(part)
+		}
+		if typ == "pypi" {
+			part = pypiNameSeparators.ReplaceAllString(part, "-")
+		}
+		parts[index] = escapePURLComponent(part)
+	}
+	if typ == "maven" && len(parts) < 2 {
+		return "", fmt.Errorf("%w: Maven package path is incomplete", shared.ErrValidation)
+	}
+	return strings.Join(parts, "/"), nil
+}
+
+func normalizeSCAPURLQualifiers(raw string) (string, error) {
+	values := map[string]string{}
+	for _, entry := range strings.Split(raw, "&") {
+		rawKey, rawValue, ok := strings.Cut(entry, "=")
+		if !ok || strings.Contains(rawKey, "%") {
+			return "", fmt.Errorf("%w: SCA package qualifiers are invalid", shared.ErrValidation)
+		}
+		key := strings.ToLower(strings.TrimSpace(rawKey))
+		value, err := url.PathUnescape(rawValue)
+		if err != nil || key == "" || strings.TrimSpace(value) == "" {
+			return "", fmt.Errorf("%w: SCA package qualifiers are invalid", shared.ErrValidation)
+		}
+		for _, char := range key {
+			if char != '.' && char != '_' && char != '-' && (char < 'a' || char > 'z') && (char < '0' || char > '9') {
+				return "", fmt.Errorf("%w: SCA package qualifier key is invalid", shared.ErrValidation)
+			}
+		}
+		if sensitiveSCAQualifierKey(key) {
+			return "", fmt.Errorf("%w: SCA package qualifier %q is not allowed", domain.ErrSensitiveInput, key)
+		}
+		if err := validateSCASafeText(value); err != nil {
+			return "", err
+		}
+		if _, duplicate := values[key]; duplicate {
+			return "", fmt.Errorf("%w: SCA package qualifier keys must be unique", shared.ErrValidation)
+		}
+		values[key] = strings.TrimSpace(value)
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	qualifiers := make([]string, len(keys))
+	for index, key := range keys {
+		qualifiers[index] = key + "=" + escapePURLComponent(values[key])
+	}
+	return strings.Join(qualifiers, "&"), nil
+}
+
+func escapePURLComponent(value string) string {
+	const hexDigits = "0123456789ABCDEF"
+	var output strings.Builder
+	for _, current := range []byte(value) {
+		if current >= 'a' && current <= 'z' || current >= 'A' && current <= 'Z' || current >= '0' && current <= '9' || strings.ContainsRune(".-_~:", rune(current)) {
+			output.WriteByte(current)
+			continue
+		}
+		output.WriteByte('%')
+		output.WriteByte(hexDigits[current>>4])
+		output.WriteByte(hexDigits[current&0x0f])
+	}
+	return output.String()
+}
+
+func sensitiveSCAQualifierKey(value string) bool {
+	return domain.SensitiveIdentityQualifier(value)
+}
+
+func validateSCASafeText(value string) error {
+	if len(value) > 2048 || strings.ContainsAny(value, "\x00\r\n") {
+		return fmt.Errorf("%w: SCA identity text is invalid", shared.ErrValidation)
+	}
+	parsed, err := url.Parse(value)
+	if err == nil && parsed.User != nil {
+		return fmt.Errorf("%w: credentials are not allowed in SCA identity text", domain.ErrSensitiveInput)
+	}
+	if err == nil {
+		for key := range parsed.Query() {
+			if sensitiveSCAQualifierKey(key) {
+				return fmt.Errorf("%w: credentials are not allowed in SCA identity text", domain.ErrSensitiveInput)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/usecase/findinglineage/sca_matcher_test.go
+++ b/internal/usecase/findinglineage/sca_matcher_test.go
@@ -1,0 +1,233 @@
+package findinglineage
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+)
+
+func TestSCAMatcherV1GoldenAliasVersionAndPackageNormalization(t *testing.T) {
+	matcher, err := NewSCAMatcherV1([]SCAAdvisoryAliasSetV1{{
+		Primary: "CVE-2026-1234", Aliases: []string{"GHSA-AAAA-BBBB-CCCC", "OSV-2026-1"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := matcher.Descriptor().Validate(); err != nil {
+		t.Fatal(err)
+	}
+	first, err := matcher.Build(SCAFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", AdvisoryID: "cve-2026-1234",
+		PackagePURL:    "pkg:NPM/%40scope/package@1.0.0?B=2&a=1#src",
+		DependencyPath: []string{"pkg:npm/root@1.0.0", "pkg:npm/%40scope/package@1.0.0?b=2&a=1"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := matcher.Build(SCAFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", AdvisoryID: "ghsa-aaaa-bbbb-cccc",
+		PackagePURL:    "pkg:npm/%40scope/package@9.9.9?a=1&b=2",
+		DependencyPath: []string{"pkg:npm/root@2.0.0", "pkg:npm/%40scope/package@9.9.9?a=1&b=2"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstFingerprint, err := domain.CanonicalizeFingerprintV1(first.FingerprintInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondFingerprint, err := domain.CanonicalizeFingerprintV1(second.FingerprintInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstFingerprint.Fingerprint != secondFingerprint.Fingerprint {
+		t.Fatalf("alias or package version changed lineage: %s != %s", firstFingerprint.Fingerprint, secondFingerprint.Fingerprint)
+	}
+	const wantFingerprint = "e5d98c5ff678117dc71f9dabb82b23603ae42d9bd3daa3a7e41e22d736ad690c"
+	if firstFingerprint.Fingerprint != wantFingerprint {
+		t.Fatalf("fingerprint=%s want=%s canonical=%s", firstFingerprint.Fingerprint, wantFingerprint, firstFingerprint.Bytes)
+	}
+	if strings.Contains(string(firstFingerprint.Bytes), "1.0.0") || strings.Contains(string(firstFingerprint.Bytes), "9.9.9") {
+		t.Fatalf("component version leaked into identity: %s", firstFingerprint.Bytes)
+	}
+
+	reversed := first
+	reversed.FingerprintInput.IdentityFields = cloneCanonicalFields(first.FingerprintInput.IdentityFields)
+	reversed.FingerprintInput.IdentityFields["dependency_path"] = domain.OrderedArray(
+		domain.Text("pkg:npm/%40scope/package?a=1&b=2"), domain.Text("pkg:npm/root"),
+	)
+	reversedFingerprint, err := domain.CanonicalizeFingerprintV1(reversed.FingerprintInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reversedFingerprint.Fingerprint == firstFingerprint.Fingerprint {
+		t.Fatal("dependency path order must be semantic")
+	}
+}
+
+func TestSCAMatcherV1InstancesConflictAndLegacyFallback(t *testing.T) {
+	matcher, err := NewSCAMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := SCAFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", AdvisoryID: "CVE-2026-44",
+		PackageEcosystem: "PyPI", PackageName: "Django.rest_framework", StableDependencyAnchor: "lock:1",
+	}
+	first, err := matcher.Build(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base.StableDependencyAnchor = "lock:2"
+	second, err := matcher.Build(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstFingerprint, _ := domain.CanonicalizeFingerprintV1(first.FingerprintInput)
+	secondFingerprint, _ := domain.CanonicalizeFingerprintV1(second.FingerprintInput)
+	if firstFingerprint.Fingerprint == secondFingerprint.Fingerprint {
+		t.Fatal("distinct dependency instances collapsed")
+	}
+	if !strings.Contains(string(firstFingerprint.Bytes), `"package_coordinate":"pkg:pypi/django-rest-framework"`) {
+		t.Fatalf("PyPI coordinate was not normalized: %s", firstFingerprint.Bytes)
+	}
+
+	conflict, err := matcher.Build(SCAFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", AdvisoryID: "CVE-2026-1", AdvisoryAliases: []string{"CVE-2026-2"},
+		PackagePURL: "pkg:golang/example.com/mod@v1.0.0", StableDependencyAnchor: "go.mod:example.com/mod",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !conflict.Ambiguous || conflict.ReviewReason != domain.ReasonMerge || conflict.ReasonCode != "advisory_alias_conflict" {
+		t.Fatalf("conflict plan=%+v", conflict)
+	}
+
+	legacy, err := matcher.Build(SCAFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", PackageEcosystem: "npm", PackageName: "left-pad",
+		StableDependencyAnchor: "package-lock:17", LegacyDedupKey: "vuln:CVE-2026-9:left-pad:1.0.0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if legacy.Ambiguous || legacy.ReasonCode != "sca_identity_complete" {
+		t.Fatalf("legacy plan=%+v", legacy)
+	}
+	legacyFingerprint, err := domain.CanonicalizeFingerprintV1(legacy.FingerprintInput)
+	if err != nil || strings.Contains(string(legacyFingerprint.Bytes), "1.0.0") {
+		t.Fatalf("legacy fingerprint=%s err=%v", legacyFingerprint.Bytes, err)
+	}
+
+	mapped := SCAFingerprintInputFromVulnerabilityV1("repo:example", vulnerability.Vulnerability{
+		ID: "CVE-2026-10", Ecosystem: "npm", Component: "left-pad", Version: "4.0.0",
+		PackagePURL: "pkg:npm/left-pad@4.0.0", Path: []string{"pkg:npm/root@1", "pkg:npm/left-pad@4"},
+	}, []string{"GHSA-AAAA-BBBB-DDDD"}, "vuln:CVE-2026-10:left-pad:4.0.0", "")
+	if mapped.AdvisoryID != "CVE-2026-10" || mapped.PackagePURL == "" || len(mapped.DependencyPath) != 2 || mapped.LegacyDedupKey == "" {
+		t.Fatalf("mapped vulnerability=%+v", mapped)
+	}
+}
+
+func TestSCAMatcherV1CorrelatesUpgradeAndPersistsProvisionalReview(t *testing.T) {
+	matcher, err := NewSCAMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repository := memory.NewFindingLineageRepository()
+	clock := fixedClock{now: time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)}
+	service, err := NewService(repository, immediateTransactions{}, &collectingAudit{}, clock, &sequenceIDs{}, &collectingObserver{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	build := func(version, snapshot, source string) Result {
+		plan, err := matcher.Build(SCAFingerprintInputV1{
+			TargetIdentityCanonical: "repo:example", AdvisoryID: "CVE-2026-77",
+			PackagePURL: "pkg:npm/left-pad@" + version, StableDependencyAnchor: "package-lock:17",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		input := plan.Apply(correlateInput(snapshot, "unused"))
+		input.SnapshotID = shared.ID(snapshot)
+		input.Observation.ID = shared.ID("observation-" + snapshot)
+		input.Observation.SourceFindingID = source
+		input.Observation.ComponentVersion = version
+		result, err := service.Correlate(context.Background(), input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return result
+	}
+	first := build("1.0.0", "snapshot-1", "source-1")
+	second := build("2.0.0", "snapshot-2", "source-2")
+	if first.Outcome != OutcomeCreated || second.Outcome != OutcomeMatched || first.Identity.ID != second.Identity.ID {
+		t.Fatalf("upgrade correlation first=%+v second=%+v", first, second)
+	}
+
+	plan, err := matcher.Build(SCAFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", AdvisoryID: "CVE-2026-88", PackagePURL: "pkg:npm/other@1.0.0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !plan.ProvisionalIdentity || plan.ReasonCode != "insufficient_dependency_instance" {
+		t.Fatalf("provisional plan=%+v", plan)
+	}
+	input := plan.Apply(correlateInput("provisional", "unused"))
+	input.Observation.SourceFindingID = "producer-secret-free-id"
+	result, err := service.Correlate(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Outcome != OutcomeReview || result.Identity == nil || result.Observation == nil || result.Candidate == nil || result.Reason != "insufficient_dependency_instance" {
+		t.Fatalf("provisional result=%+v", result)
+	}
+	if len(result.Candidate.Refs) != 2 || result.Candidate.Refs[1].IdentityID != result.Identity.ID {
+		t.Fatalf("provisional refs=%+v", result.Candidate.Refs)
+	}
+	if strings.Contains(string(result.Identity.CanonicalIdentityFields), input.Observation.SourceFindingID) {
+		t.Fatalf("raw source id leaked into provisional identity: %s", result.Identity.CanonicalIdentityFields)
+	}
+}
+
+func TestSCAMatcherV1RejectsMissingTargetAndServiceOwnedField(t *testing.T) {
+	matcher, err := NewSCAMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := matcher.Build(SCAFingerprintInputV1{}); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("missing target error=%v", err)
+	}
+	if _, err := matcher.Build(SCAFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", AdvisoryID: "CVE-2026-1",
+		PackagePURL: "pkg:npm/left-pad@1?api_token=must-not-hash", StableDependencyAnchor: "lock:1",
+	}); !errors.Is(err, domain.ErrSensitiveInput) {
+		t.Fatalf("sensitive qualifier error=%v", err)
+	}
+	if _, err := matcher.Build(SCAFingerprintInputV1{
+		TargetIdentityCanonical: "https://user:password@example.test/repo", AdvisoryID: "CVE-2026-1",
+		PackagePURL: "pkg:npm/left-pad@1", StableDependencyAnchor: "lock:1",
+	}); !errors.Is(err, domain.ErrSensitiveInput) {
+		t.Fatalf("sensitive target error=%v", err)
+	}
+	input := correlateInput("reserved", "rule")
+	input.FingerprintInput.IdentityFields["provisional_source_reference_hash"] = domain.Text("caller-controlled")
+	if _, err := (&Service{}).Correlate(context.Background(), input); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("reserved field error=%v", err)
+	}
+}
+
+func cloneCanonicalFields(input map[string]domain.CanonicalValue) map[string]domain.CanonicalValue {
+	output := make(map[string]domain.CanonicalValue, len(input))
+	for key, value := range input {
+		output[key] = value
+	}
+	return output
+}

--- a/internal/usecase/findinglineage/secret_matcher.go
+++ b/internal/usecase/findinglineage/secret_matcher.go
@@ -1,0 +1,335 @@
+package findinglineage
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	SecretMatcherVersionV1            = 1
+	SecretFingerprintSchemaVersionV1  = 1
+	SecretTargetIdentitySchemaVersion = 1
+)
+
+var ErrSecretMaterialRejected = errors.New("secret material rejected before lineage matching")
+
+type SecretAnchorKind string
+
+const (
+	SecretAnchorSymbol         SecretAnchorKind = "symbol"
+	SecretAnchorConfigKey      SecretAnchorKind = "config_key"
+	SecretAnchorEnvName        SecretAnchorKind = "env_name"
+	SecretAnchorStructuredSlot SecretAnchorKind = "structured_slot"
+)
+
+func (kind SecretAnchorKind) Valid() bool {
+	switch kind {
+	case SecretAnchorSymbol, SecretAnchorConfigKey, SecretAnchorEnvName, SecretAnchorStructuredSlot:
+		return true
+	}
+	return false
+}
+
+type SecretAnchorV1 struct {
+	Kind              SecretAnchorKind
+	SchemaVersion     int
+	LanguageID        string
+	QualifiedSymbol   string
+	ContainerName     string
+	ContainerApproved bool
+	RawOffsets        map[string]int
+}
+
+type SecretDetectorAliasSetV1 struct {
+	Primary string
+	Aliases []string
+}
+
+type SecretMatcherV1 struct {
+	detectors SASTMatcherV1
+}
+
+func NewSecretMatcherV1(aliasSets []SecretDetectorAliasSetV1) (SecretMatcherV1, error) {
+	sharedSets := make([]SASTRuleAliasSetV1, len(aliasSets))
+	for index, aliasSet := range aliasSets {
+		sharedSets[index] = SASTRuleAliasSetV1{Primary: aliasSet.Primary, Aliases: append([]string(nil), aliasSet.Aliases...)}
+	}
+	detectors, err := NewSASTMatcherV1(sharedSets)
+	if err != nil {
+		return SecretMatcherV1{}, err
+	}
+	return SecretMatcherV1{detectors: detectors}, nil
+}
+
+type SecretProducerInputV1 struct {
+	TargetIdentityCanonical string
+	DetectorKey             string
+	DetectorAliases         []string
+	SecretClass             string
+	RepoPath                string
+	Anchor                  SecretAnchorV1
+	LegacyDedupKey          string
+	LegacySourceValidated   bool
+	TrustedProducerIdentity bool
+	RawSecret               string
+	ReversibleDigest        string
+	EntropySample           string
+	MatchedSubstring        string
+	RequestValue            string
+	ResponseValue           string
+	Evidence                string
+}
+
+type SecretFingerprintInputV1 struct {
+	TargetIdentityCanonical string
+	DetectorKey             string
+	DetectorAliases         []string
+	SecretClass             string
+	RepoPath                string
+	Anchor                  SecretAnchorV1
+	LegacyDedupKey          string
+	LegacySourceValidated   bool
+	TrustedProducerIdentity bool
+	RedactionComplete       bool
+}
+
+func RedactSecretProducerInputV1(raw SecretProducerInputV1) (SecretFingerprintInputV1, error) {
+	anchor := raw.Anchor
+	if !anchor.ContainerApproved {
+		anchor.ContainerName = ""
+	}
+	sanitized := SecretFingerprintInputV1{
+		TargetIdentityCanonical: raw.TargetIdentityCanonical,
+		DetectorKey:             raw.DetectorKey,
+		DetectorAliases:         append([]string(nil), raw.DetectorAliases...),
+		SecretClass:             raw.SecretClass,
+		RepoPath:                raw.RepoPath,
+		Anchor:                  anchor,
+		LegacyDedupKey:          raw.LegacyDedupKey,
+		LegacySourceValidated:   raw.LegacySourceValidated,
+		TrustedProducerIdentity: raw.TrustedProducerIdentity,
+		RedactionComplete:       true,
+	}
+	forbidden := make([]string, 0, 7)
+	for _, field := range []struct {
+		name  string
+		value string
+	}{
+		{"raw_secret", raw.RawSecret},
+		{"reversible_digest", raw.ReversibleDigest},
+		{"entropy_sample", raw.EntropySample},
+		{"matched_substring", raw.MatchedSubstring},
+		{"request_value", raw.RequestValue},
+		{"response_value", raw.ResponseValue},
+		{"evidence", raw.Evidence},
+	} {
+		if field.value != "" {
+			forbidden = append(forbidden, field.name)
+		}
+	}
+	if len(forbidden) > 0 {
+		sort.Strings(forbidden)
+		return sanitized, fmt.Errorf("%w: forbidden fields: %s", ErrSecretMaterialRejected, strings.Join(forbidden, ","))
+	}
+	return sanitized, nil
+}
+
+type SecretMatchPlanV1 struct {
+	FingerprintInput    domain.FingerprintCanonicalInputV1
+	Method              domain.MatchMethod
+	MatcherVersion      int
+	ReasonCode          string
+	ReviewReason        domain.CandidateReason
+	Ambiguous           bool
+	ProvisionalIdentity bool
+	TrustedProducerID   bool
+	SkipInput           bool
+	SkipRedaction       bool
+}
+
+func (matcher SecretMatcherV1) Build(input SecretFingerprintInputV1) (SecretMatchPlanV1, error) {
+	target, err := normalizeSourceText("secret", "target identity", input.TargetIdentityCanonical, 2048, false)
+	if err != nil {
+		return SecretMatchPlanV1{}, err
+	}
+	legacy := parseSecretLegacyKey(input.LegacyDedupKey)
+	detectorKey := input.DetectorKey
+	repoPath := input.RepoPath
+	if legacy.kind == secretLegacyValid {
+		if strings.TrimSpace(detectorKey) == "" {
+			detectorKey = legacy.detectorKey
+		}
+		if strings.TrimSpace(repoPath) == "" {
+			repoPath = legacy.repoPath
+		}
+	}
+	normalizedPath, pathErr := normalizeSourceRepoPath("secret", repoPath)
+	if pathErr != nil && strings.TrimSpace(repoPath) != "" {
+		return SecretMatchPlanV1{}, pathErr
+	}
+	primaryDetector, normalizedDetectors, detectorConflict, detectorErr := matcher.detectors.normalizeRule("secret", detectorKey, input.DetectorAliases)
+	if detectorErr != nil && strings.TrimSpace(detectorKey) != "" {
+		return SecretMatchPlanV1{}, detectorErr
+	}
+	secretClass, classErr := normalizeSourceToken("secret", "class", input.SecretClass)
+	if classErr != nil && strings.TrimSpace(input.SecretClass) != "" {
+		return SecretMatchPlanV1{}, classErr
+	}
+	anchorValue, anchorErr := normalizeSecretAnchor(input.Anchor)
+	if input.Anchor.Kind != "" && !input.Anchor.Kind.Valid() {
+		return SecretMatchPlanV1{}, fmt.Errorf("%w: secret container anchor kind is invalid", shared.ErrValidation)
+	}
+	if len(input.Anchor.RawOffsets) > 0 {
+		return SecretMatchPlanV1{}, fmt.Errorf("%w: secret container anchors cannot contain raw offsets", shared.ErrValidation)
+	}
+	if anchorErr != nil && input.Anchor.Kind.Valid() {
+		return SecretMatchPlanV1{}, anchorErr
+	}
+
+	fields := map[string]domain.CanonicalValue{
+		"detector_alias_graph_version": domain.Integer(SASTRuleAliasSchemaVersionV1),
+		"producer_matcher_version":     domain.Integer(SecretMatcherVersionV1),
+	}
+	if primaryDetector != "" {
+		fields["detector_id"] = domain.Text(primaryDetector)
+	}
+	if secretClass != "" {
+		fields["secret_class"] = domain.Text(secretClass)
+	}
+	if normalizedPath != "" {
+		fields["repo_path"] = domain.Text(normalizedPath)
+	}
+	if anchorErr == nil && input.Anchor.Kind.Valid() {
+		fields["anchor_kind"] = domain.Text(string(input.Anchor.Kind))
+		fields["anchor_schema_version"] = domain.Integer(int64(input.Anchor.SchemaVersion))
+		fields["anchor_value"] = anchorValue
+	}
+	if detectorConflict {
+		fields["detector_candidates"] = domain.StringSet(normalizedDetectors...)
+		delete(fields, "detector_id")
+	}
+	plan := SecretMatchPlanV1{
+		FingerprintInput: domain.FingerprintCanonicalInputV1{
+			CanonicalizationVersion: domain.CanonicalizationVersionV1, ProducerKind: "secret",
+			TargetIdentitySchemaVersion: SecretTargetIdentitySchemaVersion, TargetIdentityCanonical: target, IdentityFields: fields,
+		},
+		Method: domain.MethodMatcher, MatcherVersion: SecretMatcherVersionV1, ReasonCode: "secret_identity_complete",
+		TrustedProducerID: input.TrustedProducerIdentity,
+	}
+	switch {
+	case !input.RedactionComplete:
+		plan.SkipRedaction, plan.ReasonCode = true, "redaction_not_complete"
+	case input.LegacyDedupKey != "" && !input.LegacySourceValidated:
+		plan.SkipInput, plan.ReasonCode = true, "legacy_source_not_validated"
+	case detectorConflict:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous = domain.ReasonMerge, "detector_alias_conflict", true
+	case legacy.kind == secretLegacyMalformed:
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonLegacyAmbiguous, "legacy_key_malformed", true, true
+	case normalizedPath == "":
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "missing_repo_path", true, true
+	case primaryDetector == "":
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "missing_detector_id", true, true
+	case secretClass == "":
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "missing_secret_class", true, true
+	case !input.Anchor.Kind.Valid():
+		plan.ReviewReason, plan.ReasonCode, plan.Ambiguous, plan.ProvisionalIdentity = domain.ReasonInsufficientAnchor, "missing_container_anchor", true, true
+	case legacy.kind == secretLegacyValid:
+		plan.ReasonCode = "legacy_secret_structured"
+	}
+	return plan, nil
+}
+
+func (plan SecretMatchPlanV1) Apply(input CorrelateInput) CorrelateInput {
+	input.ProducerKind = "secret"
+	input.FindingKind = "secret"
+	input.FingerprintSchemaVersion = SecretFingerprintSchemaVersionV1
+	input.FingerprintInput = plan.FingerprintInput
+	input.TrustedProducerID = input.TrustedProducerID || plan.TrustedProducerID
+	input.ReviewReason = plan.ReviewReason
+	input.ReviewDetailCode = plan.ReasonCode
+	input.ProvisionalIdentity = plan.ProvisionalIdentity
+	if plan.SkipInput {
+		input.InputTrusted = false
+	}
+	if plan.SkipRedaction {
+		input.RedactionComplete = false
+	}
+	return input
+}
+
+func normalizeSecretAnchor(anchor SecretAnchorV1) (domain.CanonicalValue, error) {
+	if !anchor.Kind.Valid() || anchor.SchemaVersion <= 0 {
+		return domain.CanonicalValue{}, fmt.Errorf("%w: secret container anchor is required", shared.ErrValidation)
+	}
+	value := map[string]domain.CanonicalValue{}
+	switch anchor.Kind {
+	case SecretAnchorSymbol:
+		language, err := normalizeSourceToken("secret", "language id", anchor.LanguageID)
+		if err != nil {
+			return domain.CanonicalValue{}, err
+		}
+		symbol, err := normalizeSourceText("secret", "qualified symbol", anchor.QualifiedSymbol, 1024, false)
+		if err != nil {
+			return domain.CanonicalValue{}, err
+		}
+		if anchor.ContainerName != "" {
+			return domain.CanonicalValue{}, fmt.Errorf("%w: symbol anchor cannot carry a container name", shared.ErrValidation)
+		}
+		value["language_id"] = domain.Text(language)
+		value["qualified_symbol"] = domain.Text(symbol)
+	default:
+		if !anchor.ContainerApproved {
+			return domain.CanonicalValue{}, fmt.Errorf("%w: secret container name is not approved for identity", shared.ErrValidation)
+		}
+		container, err := normalizeSourceText("secret", "container name", anchor.ContainerName, 1024, false)
+		if err != nil {
+			return domain.CanonicalValue{}, err
+		}
+		if anchor.LanguageID != "" || anchor.QualifiedSymbol != "" {
+			return domain.CanonicalValue{}, fmt.Errorf("%w: container anchor cannot carry symbol fields", shared.ErrValidation)
+		}
+		value["container_name"] = domain.Text(container)
+	}
+	return domain.Object(value), nil
+}
+
+type secretLegacyKind uint8
+
+const (
+	secretLegacyNone secretLegacyKind = iota
+	secretLegacyValid
+	secretLegacyMalformed
+)
+
+type secretLegacyKey struct {
+	kind        secretLegacyKind
+	detectorKey string
+	repoPath    string
+}
+
+func parseSecretLegacyKey(value string) secretLegacyKey {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return secretLegacyKey{}
+	}
+	if !strings.HasPrefix(value, "secret:") {
+		return secretLegacyKey{kind: secretLegacyMalformed}
+	}
+	rest := strings.TrimPrefix(value, "secret:")
+	lineSeparator := strings.LastIndexByte(rest, ':')
+	if lineSeparator <= 0 {
+		return secretLegacyKey{kind: secretLegacyMalformed}
+	}
+	line, err := strconv.Atoi(rest[lineSeparator+1:])
+	pathSeparator := strings.LastIndexByte(rest[:lineSeparator], ':')
+	if err != nil || line < 1 || pathSeparator <= 0 || pathSeparator == lineSeparator-1 {
+		return secretLegacyKey{kind: secretLegacyMalformed}
+	}
+	return secretLegacyKey{kind: secretLegacyValid, detectorKey: rest[:pathSeparator], repoPath: rest[pathSeparator+1 : lineSeparator]}
+}

--- a/internal/usecase/findinglineage/secret_matcher_test.go
+++ b/internal/usecase/findinglineage/secret_matcher_test.go
@@ -1,0 +1,177 @@
+package findinglineage
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+)
+
+func TestSecretMatcherV1RedactsBeforeErrorAndRejectsRawMaterial(t *testing.T) {
+	rawSecret := "AKIA" + "Z2K7QMN4TJ5VWXY9"
+	sanitized, err := RedactSecretProducerInputV1(SecretProducerInputV1{
+		TargetIdentityCanonical: "repo:example", DetectorKey: "aws-access-key-id", SecretClass: "aws_access_key",
+		RepoPath: "config/app.env", Anchor: SecretAnchorV1{Kind: SecretAnchorEnvName, SchemaVersion: 1, ContainerName: "AWS_ACCESS_KEY_ID", ContainerApproved: true},
+		RawSecret: rawSecret, Evidence: "assignment=" + rawSecret,
+	})
+	if !errors.Is(err, ErrSecretMaterialRejected) {
+		t.Fatalf("raw secret error=%v", err)
+	}
+	if strings.Contains(err.Error(), rawSecret) || strings.Contains(err.Error(), "assignment=") {
+		t.Fatalf("raw material leaked into error: %v", err)
+	}
+	if !sanitized.RedactionComplete || sanitized.DetectorKey != "aws-access-key-id" || sanitized.Anchor.ContainerName != "AWS_ACCESS_KEY_ID" {
+		t.Fatalf("sanitized=%+v", sanitized)
+	}
+
+	unapproved, err := RedactSecretProducerInputV1(SecretProducerInputV1{
+		TargetIdentityCanonical: "repo:example", DetectorKey: "generic-secret", SecretClass: "credential",
+		RepoPath: "config/app.env", Anchor: SecretAnchorV1{Kind: SecretAnchorConfigKey, SchemaVersion: 1, ContainerName: "password"},
+	})
+	if err != nil || unapproved.Anchor.Kind != SecretAnchorConfigKey || unapproved.Anchor.ContainerName != "" {
+		t.Fatalf("unapproved sanitized=%+v err=%v", unapproved, err)
+	}
+	matcher, err := NewSecretMatcherV1(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := matcher.Build(unapproved)
+	if err == nil || plan.ProvisionalIdentity {
+		t.Fatalf("direct unapproved container must fail closed plan=%+v err=%v", plan, err)
+	}
+}
+
+func TestSecretMatcherV1GoldenAliasLineMovementAndClassSeparation(t *testing.T) {
+	matcher, err := NewSecretMatcherV1([]SecretDetectorAliasSetV1{{Primary: "aws-access-key-id", Aliases: []string{"aws-key"}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	build := func(legacy, class string) SecretMatchPlanV1 {
+		input, redactErr := RedactSecretProducerInputV1(SecretProducerInputV1{
+			TargetIdentityCanonical: "repo:example", SecretClass: class, LegacyDedupKey: legacy, LegacySourceValidated: true,
+			Anchor: SecretAnchorV1{Kind: SecretAnchorEnvName, SchemaVersion: 1, ContainerName: "AWS_ACCESS_KEY_ID", ContainerApproved: true},
+		})
+		if redactErr != nil {
+			t.Fatal(redactErr)
+		}
+		plan, buildErr := matcher.Build(input)
+		if buildErr != nil {
+			t.Fatal(buildErr)
+		}
+		return plan
+	}
+	first := build("secret:aws-key:config/./Cafe\u0301.env:4", "aws_access_key")
+	second := build("secret:aws-access-key-id:config/Café.env:900", "aws_access_key")
+	firstFingerprint, err := domain.CanonicalizeFingerprintV1(first.FingerprintInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondFingerprint, err := domain.CanonicalizeFingerprintV1(second.FingerprintInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if firstFingerprint.Fingerprint != secondFingerprint.Fingerprint {
+		t.Fatalf("secret line movement changed identity: %s != %s", firstFingerprint.Fingerprint, secondFingerprint.Fingerprint)
+	}
+	const wantFingerprint = "345422cc846a454e8eb024f58cadc0dc0d32d0f728916cf5370eb30accf2ec6e"
+	if firstFingerprint.Fingerprint != wantFingerprint {
+		t.Fatalf("fingerprint=%s want=%s canonical=%s", firstFingerprint.Fingerprint, wantFingerprint, firstFingerprint.Bytes)
+	}
+	canonical := string(firstFingerprint.Bytes)
+	if strings.Contains(canonical, "900") || strings.Contains(canonical, `"line"`) || strings.Contains(canonical, "AKIA") {
+		t.Fatalf("observation or secret material leaked: %s", canonical)
+	}
+
+	differentClass := build("secret:aws-access-key-id:config/Café.env:900", "cloud_api_token")
+	differentFingerprint, _ := domain.CanonicalizeFingerprintV1(differentClass.FingerprintInput)
+	if differentFingerprint.Fingerprint == firstFingerprint.Fingerprint {
+		t.Fatal("different secret classes collapsed")
+	}
+	duplicate := build("secret:aws-access-key-id:config/Café.env:1", "aws_access_key")
+	duplicateFingerprint, _ := domain.CanonicalizeFingerprintV1(duplicate.FingerprintInput)
+	if duplicateFingerprint.Fingerprint != firstFingerprint.Fingerprint {
+		t.Fatal("duplicate class and container should retain identity")
+	}
+}
+
+func TestSecretMatcherV1AnchorProfilesProvisionalSkipAndCollision(t *testing.T) {
+	matcher, err := NewSecretMatcherV1([]SecretDetectorAliasSetV1{
+		{Primary: "detector:a", Aliases: []string{"legacy:shared"}},
+		{Primary: "detector:b", Aliases: []string{"legacy:shared"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	anchors := []SecretAnchorV1{
+		{Kind: SecretAnchorSymbol, SchemaVersion: 1, LanguageID: "go", QualifiedSymbol: "example.Config.Load"},
+		{Kind: SecretAnchorConfigKey, SchemaVersion: 1, ContainerName: "database.password", ContainerApproved: true},
+		{Kind: SecretAnchorEnvName, SchemaVersion: 1, ContainerName: "DATABASE_PASSWORD", ContainerApproved: true},
+		{Kind: SecretAnchorStructuredSlot, SchemaVersion: 1, ContainerName: "spec.template.secretKeyRef", ContainerApproved: true},
+	}
+	for _, anchor := range anchors {
+		plan, buildErr := matcher.Build(SecretFingerprintInputV1{
+			TargetIdentityCanonical: "repo:example", DetectorKey: "detector:a", SecretClass: "credential", RepoPath: "config/app.yaml",
+			Anchor: anchor, RedactionComplete: true,
+		})
+		if buildErr != nil || plan.ProvisionalIdentity {
+			t.Fatalf("anchor=%s plan=%+v err=%v", anchor.Kind, plan, buildErr)
+		}
+	}
+
+	legacy, err := matcher.Build(SecretFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", SecretClass: "credential", LegacyDedupKey: "secret:detector:a:config/app.yaml:42",
+		LegacySourceValidated: true, RedactionComplete: true,
+	})
+	if err != nil || !legacy.ProvisionalIdentity || legacy.ReasonCode != "missing_container_anchor" {
+		t.Fatalf("legacy=%+v err=%v", legacy, err)
+	}
+	conflict, err := matcher.Build(SecretFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", DetectorKey: "legacy:shared", SecretClass: "credential", RepoPath: "config/app.yaml",
+		Anchor: anchors[1], RedactionComplete: true,
+	})
+	if err != nil || !conflict.Ambiguous || conflict.ReasonCode != "detector_alias_conflict" {
+		t.Fatalf("conflict=%+v err=%v", conflict, err)
+	}
+
+	repository := memory.NewFindingLineageRepository()
+	clock := fixedClock{now: time.Date(2026, 9, 1, 14, 0, 0, 0, time.UTC)}
+	observer := &collectingObserver{}
+	service, err := NewService(repository, immediateTransactions{}, &collectingAudit{}, clock, &sequenceIDs{}, observer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	conflictInput := conflict.Apply(correlateInput("secret-conflict", "unused"))
+	conflictInput.Observation.SourceFindingID = "secret-source"
+	conflictResult, err := service.Correlate(context.Background(), conflictInput)
+	if err != nil || conflictResult.Outcome != OutcomeReview || conflictResult.Candidate == nil || conflictResult.Candidate.Reason != domain.ReasonMerge {
+		t.Fatalf("conflict result=%+v err=%v", conflictResult, err)
+	}
+
+	redactionPlan, err := matcher.Build(SecretFingerprintInputV1{
+		TargetIdentityCanonical: "repo:example", DetectorKey: "detector:a", SecretClass: "credential", RepoPath: "config/app.yaml", Anchor: anchors[1],
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	redactionResult, err := service.Correlate(context.Background(), redactionPlan.Apply(correlateInput("secret-redaction", "unused")))
+	if err != nil || redactionResult.Outcome != OutcomeSkipped || redactionResult.Skip == nil || redactionResult.Skip.Reason != domain.SkipRedactionRequired {
+		t.Fatalf("redaction result=%+v err=%v", redactionResult, err)
+	}
+	if len(observer.outcomes) != 2 {
+		t.Fatalf("metrics=%+v", observer.outcomes)
+	}
+
+	for _, repoPath := range []string{"../secret.env", "/tmp/secret.env", `config\secret.env`} {
+		if _, err := matcher.Build(SecretFingerprintInputV1{
+			TargetIdentityCanonical: "repo:example", DetectorKey: "detector:a", SecretClass: "credential", RepoPath: repoPath,
+			Anchor: anchors[1], RedactionComplete: true,
+		}); !errors.Is(err, shared.ErrValidation) {
+			t.Fatalf("path=%q err=%v", repoPath, err)
+		}
+	}
+}

--- a/internal/usecase/findinglineage/service.go
+++ b/internal/usecase/findinglineage/service.go
@@ -1,0 +1,712 @@
+package findinglineage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type Outcome string
+
+const (
+	OutcomeMatched Outcome = "matched"
+	OutcomeCreated Outcome = "created"
+	OutcomeReview  Outcome = "needs_review"
+	OutcomeSkipped Outcome = "skipped"
+)
+
+type ObservationInput struct {
+	ID                 shared.ID
+	SourceFindingID    string
+	SourceOccurrenceID string
+	Severity           shared.Severity
+	RiskScoreMilli     *int
+	ComponentVersion   string
+	Location           string
+	Reachability       string
+	EvidenceDigest     string
+	ScannerProvenance  domain.ScannerProvenance
+	ObservedAt         time.Time
+}
+
+type AliasInput struct {
+	SchemaVersion int
+	Value         string
+}
+
+type CorrelateInput struct {
+	TenantID                    shared.ID
+	CycleID                     shared.ID
+	SnapshotID                  shared.ID
+	IdentityID                  shared.ID
+	ProducerKind                string
+	FindingKind                 string
+	FingerprintSchemaVersion    int
+	FingerprintInput            domain.FingerprintCanonicalInputV1
+	InputTrusted                bool
+	OwnershipValidated          bool
+	RedactionComplete           bool
+	TrustedProducerID           bool
+	OverrideSourceObservationID shared.ID
+	Aliases                     []AliasInput
+	ReviewReason                domain.CandidateReason
+	ReviewDetailCode            string
+	SkipDetailCode              string
+	ReviewRefs                  []domain.CandidateRef
+	ProvisionalIdentity         bool
+	Observation                 ObservationInput
+	Actor                       string
+}
+
+type Result struct {
+	Outcome     Outcome
+	Method      domain.MatchMethod
+	Reason      string
+	Identity    *domain.Identity
+	Observation *domain.Observation
+	Candidate   *domain.MatchCandidate
+	Skip        *domain.SkipRecord
+}
+
+type ResolveInput struct {
+	TenantID             shared.ID
+	CycleID              shared.ID
+	CandidateID          shared.ID
+	EventID              shared.ID
+	Action               domain.ResolutionAction
+	Actor                string
+	Reason               string
+	AfterRefs            []domain.CandidateRef
+	SuccessorCandidateID shared.ID
+	ExpectedVersion      int64
+	PriorEventID         shared.ID
+}
+
+type OverrideInput struct {
+	TenantID            shared.ID
+	CycleID             shared.ID
+	EventID             shared.ID
+	Action              domain.OverrideAction
+	SourceObservationID shared.ID
+	SourceIdentityID    shared.ID
+	TargetObservationID shared.ID
+	TargetIdentityID    shared.ID
+	Actor               string
+	Reason              string
+	ExpectedVersion     int64
+	PriorEventID        shared.ID
+}
+
+type ApproveAliasInput struct {
+	TenantID        shared.ID
+	CycleID         shared.ID
+	IdentityID      shared.ID
+	AliasID         shared.ID
+	ProducerKind    string
+	FindingKind     string
+	TargetCanonical string
+	SchemaVersion   int
+	Value           string
+	Actor           string
+}
+
+type Service struct {
+	repository   ports.FindingLineageRepository
+	transactions ports.TenantTransactionRunner
+	audit        ports.AuditLogger
+	clock        ports.Clock
+	ids          ports.IDGenerator
+	observer     ports.FindingLineageObserver
+}
+
+func NewService(repository ports.FindingLineageRepository, transactions ports.TenantTransactionRunner, audit ports.AuditLogger, clock ports.Clock, ids ports.IDGenerator, observer ports.FindingLineageObserver) (*Service, error) {
+	if repository == nil || transactions == nil || audit == nil || clock == nil || ids == nil {
+		return nil, fmt.Errorf("%w: finding lineage dependencies are required", shared.ErrValidation)
+	}
+	if observer == nil {
+		observer = noopObserver{}
+	}
+	return &Service{repository: repository, transactions: transactions, audit: audit, clock: clock, ids: ids, observer: observer}, nil
+}
+
+func (service *Service) Correlate(ctx context.Context, input CorrelateInput) (Result, error) {
+	input.TenantID = shared.TenantOrDefault(input.TenantID)
+	input.Actor = strings.TrimSpace(input.Actor)
+	producer, kind, target, err := domain.NormalizeIdentityNamespace(input.ProducerKind, input.FindingKind, input.FingerprintInput.TargetIdentityCanonical)
+	if err != nil {
+		return Result{}, err
+	}
+	input.ProducerKind, input.FindingKind = producer, kind
+	input.FingerprintInput.ProducerKind, input.FingerprintInput.TargetIdentityCanonical = producer, target
+	if err := validateCorrelateInput(input); err != nil {
+		return Result{}, err
+	}
+	sourceHash, err := domain.SourceReferenceHash(input.ProducerKind, input.FindingKind, input.FingerprintInput.TargetIdentityCanonical,
+		input.Observation.SourceFindingID, input.Observation.SourceOccurrenceID)
+	if err != nil {
+		return Result{}, err
+	}
+	if input.ProvisionalIdentity {
+		fields := make(map[string]domain.CanonicalValue, len(input.FingerprintInput.IdentityFields)+1)
+		for key, value := range input.FingerprintInput.IdentityFields {
+			fields[key] = value
+		}
+		fields["provisional_source_reference_hash"] = domain.Text(sourceHash)
+		input.FingerprintInput.IdentityFields = fields
+	}
+	var result Result
+	err = service.transactions.Run(ctx, input.TenantID, func(txCtx context.Context) error {
+		var err error
+		switch {
+		case !input.InputTrusted:
+			result, err = service.skip(txCtx, input, sourceHash, domain.SkipInvalidTrust, skipDetailCode(input.SkipDetailCode, "input_not_trusted"))
+			return err
+		case !input.OwnershipValidated:
+			result, err = service.skip(txCtx, input, sourceHash, domain.SkipInvalidOwnership, skipDetailCode(input.SkipDetailCode, "ownership_not_validated"))
+			return err
+		case !input.RedactionComplete:
+			result, err = service.skip(txCtx, input, sourceHash, domain.SkipRedactionRequired, skipDetailCode(input.SkipDetailCode, "redaction_not_complete"))
+			return err
+		}
+
+		fingerprint, canonicalErr := domain.CanonicalizeFingerprintV1(input.FingerprintInput)
+		discriminator := sourceHash
+		if canonicalErr == nil {
+			discriminator = fingerprint.Fingerprint
+		}
+		if err := service.repository.LockCorrelationNamespace(txCtx, input.TenantID, input.CycleID,
+			input.ProducerKind, input.FindingKind, input.FingerprintInput.TargetIdentityCanonical, discriminator); err != nil {
+			return err
+		}
+		// Source replay is independent of fingerprint completeness. In particular,
+		// trusted producer-id imports with a provisional fingerprint must still return
+		// the exact persisted observation instead of attempting a duplicate append.
+		existing, lookupErr := service.repository.GetObservationBySource(txCtx, input.TenantID, input.CycleID, input.SnapshotID,
+			input.ProducerKind, input.FindingKind, input.FingerprintInput.TargetIdentityCanonical,
+			input.Observation.SourceFindingID, input.Observation.SourceOccurrenceID)
+		if lookupErr == nil {
+			if !observationReplayMatches(existing, input.Observation) {
+				return fmt.Errorf("%w: source observation replay body differs", shared.ErrConflict)
+			}
+			identity, getErr := service.repository.GetIdentity(txCtx, input.TenantID, input.CycleID, existing.IdentityID)
+			if getErr != nil {
+				return getErr
+			}
+			result = matchedResult(identity, existing, domain.MethodProducerID, "observation_replay")
+			return service.auditResult(txCtx, input, result, sourceHash)
+		}
+		if !errors.Is(lookupErr, shared.ErrNotFound) {
+			return lookupErr
+		}
+		if errors.Is(canonicalErr, domain.ErrSensitiveInput) {
+			result, err = service.skip(txCtx, input, sourceHash, domain.SkipRedactionRequired, "sensitive_canonical_field")
+			return err
+		}
+		if canonicalErr != nil && !errors.Is(canonicalErr, domain.ErrIncompleteIdentity) {
+			return canonicalErr
+		}
+		excluded := map[shared.ID]struct{}{}
+		if !input.OverrideSourceObservationID.IsZero() {
+			override, lookupErr := service.repository.GetActiveOverride(txCtx, input.TenantID, input.CycleID, input.OverrideSourceObservationID)
+			if lookupErr == nil {
+				if override.Action == domain.OverrideUnlink {
+					excluded[override.TargetIdentityID] = struct{}{}
+				} else {
+					identity, getErr := service.repository.GetIdentity(txCtx, input.TenantID, input.CycleID, override.TargetIdentityID)
+					if getErr != nil {
+						return getErr
+					}
+					result, err = service.link(txCtx, input, identity, domain.MethodOverride, "active_override", sourceHash)
+					return err
+				}
+			} else if !errors.Is(lookupErr, shared.ErrNotFound) {
+				return lookupErr
+			}
+		}
+
+		if input.TrustedProducerID {
+			sourceID := input.Observation.SourceFindingID
+			if sourceID == "" {
+				sourceID = input.Observation.SourceOccurrenceID
+			}
+			identities, lookupErr := service.repository.FindIdentitiesByProducerID(txCtx, input.TenantID, input.CycleID,
+				input.ProducerKind, input.FindingKind, input.FingerprintInput.TargetIdentityCanonical, sourceID)
+			if lookupErr != nil {
+				return lookupErr
+			}
+			identities = withoutExcluded(identities, excluded)
+			switch len(identities) {
+			case 1:
+				result, err = service.link(txCtx, input, identities[0], domain.MethodProducerID, "trusted_producer_id", sourceHash)
+				return err
+			case 2:
+				fallthrough
+			default:
+				if len(identities) > 1 {
+					result, err = service.review(txCtx, input, sourceHash, fingerprint, domain.ReasonLegacyAmbiguous, domain.MethodProducerID, identities, nil)
+					return err
+				}
+			}
+		}
+
+		if canonicalErr == nil {
+			identities, lookupErr := service.repository.FindIdentitiesByFingerprint(txCtx, input.TenantID, input.CycleID,
+				input.ProducerKind, input.FindingKind, input.FingerprintSchemaVersion,
+				input.FingerprintInput.TargetIdentityCanonical, fingerprint.Fingerprint)
+			if lookupErr != nil {
+				return lookupErr
+			}
+			identities = withoutExcluded(identities, excluded)
+			if len(identities) == 1 {
+				if input.ProvisionalIdentity {
+					// A repeated source finding can reuse its provisional identity,
+					// but an exact coarse fingerprint does not supply a missing
+					// resource anchor. Keep review visible in every new snapshot.
+					observation, observationErr := service.observation(input, identities[0].ID)
+					if observationErr != nil {
+						return observationErr
+					}
+					if appendErr := service.repository.AppendObservation(txCtx, observation); appendErr != nil {
+						return appendErr
+					}
+					result, err = service.review(txCtx, input, sourceHash, fingerprint, input.ReviewReason, domain.MethodFingerprint, identities, input.ReviewRefs)
+					if err == nil {
+						result.Identity, result.Observation = &identities[0], &observation
+					}
+					return err
+				}
+				result, err = service.link(txCtx, input, identities[0], domain.MethodFingerprint, "exact_fingerprint", sourceHash)
+				return err
+			}
+			if len(identities) > 1 {
+				result, err = service.review(txCtx, input, sourceHash, fingerprint, domain.ReasonFingerprintCollision, domain.MethodFingerprint, identities, nil)
+				return err
+			}
+		}
+
+		aliasIdentities := make([]domain.Identity, 0)
+		seenAliases := map[shared.ID]struct{}{}
+		for _, alias := range input.Aliases {
+			aliasFingerprint, hashErr := domain.HashAlias(input.ProducerKind, input.FindingKind,
+				input.FingerprintInput.TargetIdentityCanonical, alias.SchemaVersion, alias.Value)
+			if hashErr != nil {
+				return hashErr
+			}
+			matches, lookupErr := service.repository.FindIdentitiesByAlias(txCtx, input.TenantID, input.CycleID,
+				input.ProducerKind, input.FindingKind, alias.SchemaVersion,
+				input.FingerprintInput.TargetIdentityCanonical, aliasFingerprint)
+			if lookupErr != nil {
+				return lookupErr
+			}
+			for _, identity := range withoutExcluded(matches, excluded) {
+				if _, exists := seenAliases[identity.ID]; exists {
+					continue
+				}
+				seenAliases[identity.ID] = struct{}{}
+				aliasIdentities = append(aliasIdentities, identity)
+			}
+		}
+		if len(aliasIdentities) == 1 {
+			result, err = service.link(txCtx, input, aliasIdentities[0], domain.MethodAlias, "approved_alias", sourceHash)
+			return err
+		}
+		if len(aliasIdentities) > 1 {
+			result, err = service.review(txCtx, input, sourceHash, fingerprint, domain.ReasonMerge, domain.MethodAlias, aliasIdentities, nil)
+			return err
+		}
+
+		if canonicalErr == nil && input.ProvisionalIdentity {
+			identity, observation, createErr := service.createIdentityObservation(txCtx, input, fingerprint)
+			if createErr != nil {
+				return createErr
+			}
+			result, err = service.review(txCtx, input, sourceHash, fingerprint, input.ReviewReason, domain.MethodMatcher, []domain.Identity{identity}, input.ReviewRefs)
+			if err == nil {
+				result.Identity, result.Observation = &identity, &observation
+			}
+			return err
+		}
+		if canonicalErr != nil {
+			result, err = service.review(txCtx, input, sourceHash, domain.CanonicalFingerprint{}, domain.ReasonInsufficientAnchor, domain.MethodMatcher, nil, input.ReviewRefs)
+			return err
+		}
+		if len(input.ReviewRefs) > 0 || input.ReviewReason.Valid() {
+			if !input.ReviewReason.Valid() {
+				return fmt.Errorf("%w: review reason is required", shared.ErrValidation)
+			}
+			result, err = service.review(txCtx, input, sourceHash, fingerprint, input.ReviewReason, domain.MethodMatcher, nil, input.ReviewRefs)
+			return err
+		}
+
+		identity, observation, createErr := service.createIdentityObservation(txCtx, input, fingerprint)
+		if createErr != nil {
+			return createErr
+		}
+		result = Result{Outcome: OutcomeCreated, Method: domain.MethodNewIdentity, Reason: "new_identity", Identity: &identity, Observation: &observation}
+		return service.auditResult(txCtx, input, result, sourceHash)
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	service.observer.ObserveFindingLineage(string(result.Outcome), string(result.Method), result.Reason)
+	return result, nil
+}
+
+func (service *Service) ResolveCandidate(ctx context.Context, input ResolveInput) (domain.MatchCandidate, domain.ResolutionEvent, bool, error) {
+	input.TenantID = shared.TenantOrDefault(input.TenantID)
+	if input.TenantID.IsZero() || input.CycleID.IsZero() || input.CandidateID.IsZero() || input.ExpectedVersion <= 0 || strings.TrimSpace(input.Actor) == "" {
+		return domain.MatchCandidate{}, domain.ResolutionEvent{}, false, fmt.Errorf("%w: resolution ownership and version are required", shared.ErrValidation)
+	}
+	if input.EventID.IsZero() {
+		input.EventID = service.ids.NewID()
+	}
+	var candidate domain.MatchCandidate
+	var event domain.ResolutionEvent
+	var applied bool
+	err := service.transactions.Run(ctx, input.TenantID, func(txCtx context.Context) error {
+		if !input.EventID.IsZero() {
+			events, err := service.repository.ListCandidateResolutions(txCtx, input.TenantID, input.CycleID, input.CandidateID)
+			if err != nil {
+				return err
+			}
+			for _, existing := range events {
+				if existing.ID != input.EventID {
+					continue
+				}
+				candidate, err = service.repository.GetCandidate(txCtx, input.TenantID, input.CycleID, input.CandidateID)
+				if err != nil {
+					return err
+				}
+				event, applied = existing, false
+				return service.audit.Record(txCtx, ports.AuditEntry{
+					Actor: strings.TrimSpace(input.Actor), Action: "finding_lineage.candidate_resolved", Target: candidate.ID.String(), At: event.CreatedAt,
+					Metadata: map[string]string{"tenant_id": input.TenantID.String(), "cycle_id": input.CycleID.String(), "action": string(existing.Action), "applied": "false", "version": fmt.Sprintf("%d", event.Version)},
+				})
+			}
+		}
+		current, err := service.repository.GetCandidate(txCtx, input.TenantID, input.CycleID, input.CandidateID)
+		if err != nil {
+			return err
+		}
+		updated, resolution, err := domain.ResolveCandidate(current, input.EventID, input.Action, input.Actor, input.Reason,
+			input.AfterRefs, input.SuccessorCandidateID, input.ExpectedVersion, input.PriorEventID, service.clock.Now().UTC())
+		if err != nil {
+			return err
+		}
+		candidate, event, applied, err = service.repository.ResolveCandidateCAS(txCtx, updated, resolution)
+		if err != nil {
+			return err
+		}
+		return service.audit.Record(txCtx, ports.AuditEntry{
+			Actor: strings.TrimSpace(input.Actor), Action: "finding_lineage.candidate_resolved", Target: candidate.ID.String(), At: event.CreatedAt,
+			Metadata: map[string]string{"tenant_id": input.TenantID.String(), "cycle_id": input.CycleID.String(), "action": string(input.Action), "applied": fmt.Sprintf("%t", applied), "version": fmt.Sprintf("%d", event.Version)},
+		})
+	})
+	if err == nil {
+		service.observer.ObserveFindingLineage("resolved", string(domain.MethodManual), string(input.Action))
+	}
+	return candidate, event, applied, err
+}
+
+func (service *Service) AppendOverride(ctx context.Context, input OverrideInput) (domain.OverrideEvent, bool, error) {
+	input.TenantID = shared.TenantOrDefault(input.TenantID)
+	if input.EventID.IsZero() {
+		input.EventID = service.ids.NewID()
+	}
+	event, err := domain.NewOverrideEvent(domain.OverrideEvent{
+		TenantID: input.TenantID, CycleID: input.CycleID, ID: input.EventID, Action: input.Action,
+		SourceObservationID: input.SourceObservationID, SourceIdentityID: input.SourceIdentityID,
+		TargetObservationID: input.TargetObservationID, TargetIdentityID: input.TargetIdentityID,
+		Actor: input.Actor, Reason: input.Reason, ExpectedVersion: input.ExpectedVersion, Version: input.ExpectedVersion + 1,
+		PriorEventID: input.PriorEventID, CreatedAt: service.clock.Now().UTC(),
+	})
+	if err != nil {
+		return domain.OverrideEvent{}, false, err
+	}
+	var stored domain.OverrideEvent
+	var applied bool
+	err = service.transactions.Run(ctx, input.TenantID, func(txCtx context.Context) error {
+		var appendErr error
+		stored, applied, appendErr = service.repository.AppendOverrideCAS(txCtx, event)
+		if appendErr != nil {
+			return appendErr
+		}
+		return service.audit.Record(txCtx, ports.AuditEntry{
+			Actor: stored.Actor, Action: "finding_lineage.override_appended", Target: stored.ID.String(), At: stored.CreatedAt,
+			Metadata: map[string]string{"tenant_id": stored.TenantID.String(), "cycle_id": stored.CycleID.String(), "action": string(stored.Action), "applied": fmt.Sprintf("%t", applied), "version": fmt.Sprintf("%d", stored.Version)},
+		})
+	})
+	if err == nil {
+		service.observer.ObserveFindingLineage("override", string(domain.MethodOverride), string(stored.Action))
+	}
+	return stored, applied, err
+}
+
+func (service *Service) ApproveAlias(ctx context.Context, input ApproveAliasInput) (domain.Alias, bool, error) {
+	input.TenantID = shared.TenantOrDefault(input.TenantID)
+	producer, kind, target, err := domain.NormalizeIdentityNamespace(input.ProducerKind, input.FindingKind, input.TargetCanonical)
+	if err != nil {
+		return domain.Alias{}, false, err
+	}
+	input.ProducerKind, input.FindingKind, input.TargetCanonical = producer, kind, target
+	if input.AliasID.IsZero() {
+		input.AliasID = service.ids.NewID()
+	}
+	fingerprint, err := domain.HashAlias(input.ProducerKind, input.FindingKind, input.TargetCanonical, input.SchemaVersion, input.Value)
+	if err != nil {
+		return domain.Alias{}, false, err
+	}
+	alias := domain.Alias{
+		TenantID: input.TenantID, CycleID: input.CycleID, ID: input.AliasID, IdentityID: input.IdentityID,
+		ProducerKind: input.ProducerKind, FindingKind: input.FindingKind, TargetCanonical: input.TargetCanonical,
+		SchemaVersion: input.SchemaVersion, Fingerprint: fingerprint, ApprovedBy: strings.TrimSpace(input.Actor), ApprovedAt: service.clock.Now().UTC(),
+	}
+	if err := alias.Validate(); err != nil {
+		return domain.Alias{}, false, err
+	}
+	created := false
+	err = service.transactions.Run(ctx, input.TenantID, func(txCtx context.Context) error {
+		identity, getErr := service.repository.GetIdentity(txCtx, input.TenantID, input.CycleID, input.IdentityID)
+		if getErr != nil {
+			return getErr
+		}
+		if identity.ProducerKind != input.ProducerKind || identity.FindingKind != input.FindingKind || identity.TargetIdentityCanonical != input.TargetCanonical {
+			return fmt.Errorf("%w: alias namespace does not match identity", shared.ErrValidation)
+		}
+		var appendErr error
+		created, appendErr = service.repository.AppendAlias(txCtx, alias)
+		if appendErr != nil {
+			return appendErr
+		}
+		return service.audit.Record(txCtx, ports.AuditEntry{
+			Actor: alias.ApprovedBy, Action: "finding_lineage.alias_approved", Target: alias.IdentityID.String(), At: alias.ApprovedAt,
+			Metadata: map[string]string{"tenant_id": alias.TenantID.String(), "cycle_id": alias.CycleID.String(), "alias_id": alias.ID.String(), "created": fmt.Sprintf("%t", created), "schema_version": fmt.Sprintf("%d", alias.SchemaVersion)},
+		})
+	})
+	return alias, created, err
+}
+
+func (service *Service) link(ctx context.Context, input CorrelateInput, identity domain.Identity, method domain.MatchMethod, reason, sourceHash string) (Result, error) {
+	observation, err := service.observation(input, identity.ID)
+	if err != nil {
+		return Result{}, err
+	}
+	if err := service.repository.AppendObservation(ctx, observation); err != nil {
+		return Result{}, err
+	}
+	result := matchedResult(identity, observation, method, reason)
+	return result, service.auditResult(ctx, input, result, sourceHash)
+}
+
+func (service *Service) review(ctx context.Context, input CorrelateInput, sourceHash string, fingerprint domain.CanonicalFingerprint, reason domain.CandidateReason, method domain.MatchMethod, identities []domain.Identity, extraRefs []domain.CandidateRef) (Result, error) {
+	reasonCode := string(reason)
+	if input.ReviewDetailCode != "" {
+		reasonCode = input.ReviewDetailCode
+	}
+	refs := []domain.CandidateRef{{Position: 0, Role: domain.RoleSource, ExternalReferenceHash: sourceHash, Method: method, ScoreMilli: 1000, Confidence: domain.ConfidenceHigh, ReasonPayload: map[string]string{"reason_code": reasonCode}}}
+	for _, identity := range identities {
+		refs = append(refs, domain.CandidateRef{Position: len(refs), Role: domain.RoleCandidate, IdentityID: identity.ID, Method: method, ScoreMilli: 1000, Confidence: domain.ConfidenceHigh, ReasonPayload: map[string]string{"reason_code": reasonCode}})
+	}
+	for _, reference := range extraRefs {
+		reference.Position = len(refs)
+		if reference.Role == domain.RoleSource {
+			reference.Role = domain.RoleCandidate
+		}
+		refs = append(refs, reference)
+	}
+	candidate, err := domain.NewMatchCandidate(domain.MatchCandidate{
+		TenantID: input.TenantID, CycleID: input.CycleID, SnapshotID: input.SnapshotID, ID: service.ids.NewID(),
+		ProducerKind: input.ProducerKind, FindingKind: input.FindingKind, Reason: reason,
+		FingerprintSchemaVersion: input.FingerprintSchemaVersion, Fingerprint: fingerprint.Fingerprint,
+		SourceReferenceHash: sourceHash, Refs: refs, CreatedAt: service.clock.Now().UTC(),
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	stored, _, err := service.repository.CreateCandidate(ctx, candidate, service.ids.NewID())
+	if err != nil {
+		return Result{}, err
+	}
+	result := Result{Outcome: OutcomeReview, Method: method, Reason: reasonCode, Candidate: &stored}
+	if err := service.auditResult(ctx, input, result, sourceHash); err != nil {
+		return Result{}, err
+	}
+	return result, nil
+}
+
+func (service *Service) skip(ctx context.Context, input CorrelateInput, sourceHash string, reason domain.SkipReason, detailCode string) (Result, error) {
+	record := domain.SkipRecord{
+		TenantID: input.TenantID, CycleID: input.CycleID, SnapshotID: input.SnapshotID, ID: service.ids.NewID(),
+		ProducerKind: input.ProducerKind, FindingKind: input.FindingKind, Reason: reason,
+		SourceReferenceHash: sourceHash, DetailCode: detailCode, CreatedAt: service.clock.Now().UTC(),
+	}
+	stored, _, err := service.repository.AppendSkip(ctx, record)
+	if err != nil {
+		return Result{}, err
+	}
+	result := Result{Outcome: OutcomeSkipped, Reason: string(reason), Skip: &stored}
+	return result, service.auditResult(ctx, input, result, sourceHash)
+}
+
+func (service *Service) observation(input CorrelateInput, identityID shared.ID) (domain.Observation, error) {
+	id := input.Observation.ID
+	if id.IsZero() {
+		id = service.ids.NewID()
+	}
+	observedAt := input.Observation.ObservedAt
+	if observedAt.IsZero() {
+		observedAt = service.clock.Now().UTC()
+	}
+	observation := domain.Observation{
+		TenantID: input.TenantID, CycleID: input.CycleID, ID: id, SnapshotID: input.SnapshotID, IdentityID: identityID,
+		ProducerKind: input.ProducerKind, FindingKind: input.FindingKind, TargetCanonical: input.FingerprintInput.TargetIdentityCanonical,
+		SourceFindingID: input.Observation.SourceFindingID, SourceOccurrenceID: input.Observation.SourceOccurrenceID,
+		Severity: input.Observation.Severity, RiskScoreMilli: input.Observation.RiskScoreMilli,
+		ComponentVersion: input.Observation.ComponentVersion, Location: input.Observation.Location,
+		Reachability: input.Observation.Reachability, EvidenceDigest: input.Observation.EvidenceDigest,
+		ScannerProvenance: input.Observation.ScannerProvenance, ObservedAt: observedAt,
+	}
+	return observation, observation.Validate()
+}
+
+func (service *Service) createIdentityObservation(ctx context.Context, input CorrelateInput, fingerprint domain.CanonicalFingerprint) (domain.Identity, domain.Observation, error) {
+	identityID := input.IdentityID
+	if identityID.IsZero() {
+		identityID = service.ids.NewID()
+	}
+	identity := domain.Identity{
+		TenantID: input.TenantID, CycleID: input.CycleID, ID: identityID, ProducerKind: input.ProducerKind,
+		FindingKind: input.FindingKind, CanonicalizationVersion: domain.CanonicalizationVersionV1,
+		FingerprintSchemaVersion: input.FingerprintSchemaVersion, LineageFingerprint: fingerprint.Fingerprint,
+		TargetIdentitySchemaVersion: input.FingerprintInput.TargetIdentitySchemaVersion,
+		TargetIdentityCanonical:     input.FingerprintInput.TargetIdentityCanonical,
+		CanonicalIdentityFields:     fingerprint.IdentityFields, FirstSeenSnapshotID: input.SnapshotID, CreatedAt: service.clock.Now().UTC(),
+	}
+	observation, err := service.observation(input, identity.ID)
+	if err != nil {
+		return domain.Identity{}, domain.Observation{}, err
+	}
+	if err := service.repository.CreateIdentityWithObservation(ctx, identity, observation); err != nil {
+		return domain.Identity{}, domain.Observation{}, err
+	}
+	return identity, observation, nil
+}
+
+func observationReplayMatches(existing domain.Observation, incoming ObservationInput) bool {
+	if !incoming.ID.IsZero() && incoming.ID != existing.ID {
+		return false
+	}
+	if incoming.SourceFindingID != existing.SourceFindingID || incoming.SourceOccurrenceID != existing.SourceOccurrenceID ||
+		incoming.Severity != existing.Severity || !sameOptionalRiskScore(incoming.RiskScoreMilli, existing.RiskScoreMilli) ||
+		incoming.ComponentVersion != existing.ComponentVersion || incoming.Location != existing.Location || incoming.Reachability != existing.Reachability ||
+		incoming.EvidenceDigest != existing.EvidenceDigest || incoming.ScannerProvenance != existing.ScannerProvenance {
+		return false
+	}
+	return incoming.ObservedAt.IsZero() || incoming.ObservedAt.Equal(existing.ObservedAt)
+}
+
+func sameOptionalRiskScore(left, right *int) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return *left == *right
+}
+
+func (service *Service) auditResult(ctx context.Context, input CorrelateInput, result Result, sourceHash string) error {
+	target := sourceHash
+	if result.Identity != nil {
+		target = result.Identity.ID.String()
+	}
+	if result.Candidate != nil {
+		target = result.Candidate.ID.String()
+	}
+	if result.Skip != nil {
+		target = result.Skip.ID.String()
+	}
+	return service.audit.Record(ctx, ports.AuditEntry{
+		Actor: input.Actor, Action: "finding_lineage.correlated", Target: target, At: service.clock.Now().UTC(),
+		Metadata: map[string]string{
+			"tenant_id": input.TenantID.String(), "cycle_id": input.CycleID.String(), "snapshot_id": input.SnapshotID.String(),
+			"outcome": string(result.Outcome), "method": string(result.Method), "reason": result.Reason, "source_reference_hash": sourceHash,
+		},
+	})
+}
+
+func validateCorrelateInput(input CorrelateInput) error {
+	if input.TenantID.IsZero() || input.CycleID.IsZero() || input.SnapshotID.IsZero() || input.FingerprintSchemaVersion <= 0 || input.Actor == "" || len(input.Actor) > 256 {
+		return fmt.Errorf("%w: correlation ownership, actor, and fingerprint version are required", shared.ErrValidation)
+	}
+	if strings.TrimSpace(input.ProducerKind) == "" || strings.TrimSpace(input.FindingKind) == "" || len(input.ProducerKind) > 256 || len(input.FindingKind) > 256 {
+		return fmt.Errorf("%w: producer and finding kind are required", shared.ErrValidation)
+	}
+	if input.FingerprintInput.ProducerKind != input.ProducerKind || input.FingerprintInput.CanonicalizationVersion != domain.CanonicalizationVersionV1 || input.FingerprintInput.TargetIdentitySchemaVersion <= 0 || strings.TrimSpace(input.FingerprintInput.TargetIdentityCanonical) == "" {
+		return fmt.Errorf("%w: fingerprint metadata does not match correlation input", shared.ErrValidation)
+	}
+	if input.Observation.SourceFindingID == "" && input.Observation.SourceOccurrenceID == "" {
+		return fmt.Errorf("%w: source finding or occurrence id is required", shared.ErrValidation)
+	}
+	if len(input.Observation.SourceFindingID) > 512 || len(input.Observation.SourceOccurrenceID) > 512 {
+		return fmt.Errorf("%w: source finding identifiers exceed 512 bytes", shared.ErrValidation)
+	}
+	for _, alias := range input.Aliases {
+		if alias.SchemaVersion <= 0 || strings.TrimSpace(alias.Value) == "" {
+			return fmt.Errorf("%w: alias schema and value are required", shared.ErrValidation)
+		}
+	}
+	if input.ProvisionalIdentity && !input.ReviewReason.Valid() {
+		return fmt.Errorf("%w: provisional identity review reason is required", shared.ErrValidation)
+	}
+	if input.ReviewDetailCode != "" && !validReasonCode(input.ReviewDetailCode) {
+		return fmt.Errorf("%w: review detail code is invalid", shared.ErrValidation)
+	}
+	if input.SkipDetailCode != "" && !validReasonCode(input.SkipDetailCode) {
+		return fmt.Errorf("%w: skip detail code is invalid", shared.ErrValidation)
+	}
+	if _, reserved := input.FingerprintInput.IdentityFields["provisional_source_reference_hash"]; reserved {
+		return fmt.Errorf("%w: provisional source hash is service-owned", shared.ErrValidation)
+	}
+	return nil
+}
+
+func skipDetailCode(value, fallback string) string {
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func validReasonCode(value string) bool {
+	if len(value) == 0 || len(value) > 64 {
+		return false
+	}
+	for _, char := range value {
+		if char != '_' && (char < 'a' || char > 'z') && (char < '0' || char > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func matchedResult(identity domain.Identity, observation domain.Observation, method domain.MatchMethod, reason string) Result {
+	return Result{Outcome: OutcomeMatched, Method: method, Reason: reason, Identity: &identity, Observation: &observation}
+}
+
+func withoutExcluded(identities []domain.Identity, excluded map[shared.ID]struct{}) []domain.Identity {
+	filtered := make([]domain.Identity, 0, len(identities))
+	for _, identity := range identities {
+		if _, exists := excluded[identity.ID]; !exists {
+			filtered = append(filtered, identity)
+		}
+	}
+	return filtered
+}
+
+type noopObserver struct{}
+
+func (noopObserver) ObserveFindingLineage(string, string, string) {}

--- a/internal/usecase/findinglineage/service_test.go
+++ b/internal/usecase/findinglineage/service_test.go
@@ -1,0 +1,409 @@
+package findinglineage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestCorrelatePrecedenceTable(t *testing.T) {
+	for _, testCase := range []struct {
+		name          string
+		withOverride  bool
+		trustedSource bool
+		fingerprint   string
+		alias         bool
+		provisional   bool
+		wantMethod    domain.MatchMethod
+		wantIdentity  shared.ID
+		wantOutcome   Outcome
+	}{
+		{name: "override", withOverride: true, trustedSource: true, fingerprint: "fingerprint", alias: true, wantMethod: domain.MethodOverride, wantIdentity: "identity-override", wantOutcome: OutcomeMatched},
+		{name: "producer id", trustedSource: true, fingerprint: "fingerprint", alias: true, wantMethod: domain.MethodProducerID, wantIdentity: "identity-producer", wantOutcome: OutcomeMatched},
+		{name: "fingerprint", fingerprint: "fingerprint", alias: true, wantMethod: domain.MethodFingerprint, wantIdentity: "identity-fingerprint", wantOutcome: OutcomeMatched},
+		{name: "alias", fingerprint: "unique-alias", alias: true, wantMethod: domain.MethodAlias, wantIdentity: "identity-alias", wantOutcome: OutcomeMatched},
+		{name: "new identity", fingerprint: "unique-new", wantMethod: domain.MethodNewIdentity, wantOutcome: OutcomeCreated},
+		{name: "provisional override", withOverride: true, trustedSource: true, fingerprint: "fingerprint", alias: true, provisional: true, wantMethod: domain.MethodOverride, wantIdentity: "identity-override", wantOutcome: OutcomeMatched},
+		{name: "provisional trusted producer", trustedSource: true, fingerprint: "fingerprint", alias: true, provisional: true, wantMethod: domain.MethodProducerID, wantIdentity: "identity-producer", wantOutcome: OutcomeMatched},
+		{name: "provisional approved alias", fingerprint: "unique-alias", alias: true, provisional: true, wantMethod: domain.MethodAlias, wantIdentity: "identity-alias", wantOutcome: OutcomeMatched},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			repository := memory.NewFindingLineageRepository()
+			clock := fixedClock{now: time.Date(2026, 8, 31, 8, 0, 0, 0, time.UTC)}
+			ids := &sequenceIDs{}
+			audit := &collectingAudit{}
+			service, err := NewService(repository, immediateTransactions{}, audit, clock, ids, &collectingObserver{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			seedIdentity(t, repository, clock.now, "identity-override", "observation-override", "override-source", "override")
+			seedIdentity(t, repository, clock.now, "identity-producer", "observation-producer", "trusted-source", "producer")
+			seedIdentity(t, repository, clock.now, "identity-fingerprint", "observation-fingerprint", "fingerprint-source", "fingerprint")
+			seedIdentity(t, repository, clock.now, "identity-alias", "observation-alias", "alias-source", "alias-target")
+			aliasFingerprint, err := domain.HashAlias("sca", "vulnerability", "repo:example", 1, "legacy-alias")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := repository.AppendAlias(context.Background(), domain.Alias{
+				TenantID: "tenant", CycleID: "cycle", ID: "alias", IdentityID: "identity-alias", ProducerKind: "sca",
+				FindingKind: "vulnerability", TargetCanonical: "repo:example", SchemaVersion: 1, Fingerprint: aliasFingerprint,
+				ApprovedBy: "reviewer", ApprovedAt: clock.now,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if testCase.withOverride {
+				override, err := domain.NewOverrideEvent(domain.OverrideEvent{
+					TenantID: "tenant", CycleID: "cycle", ID: "override-event", Action: domain.OverrideConfirm,
+					SourceObservationID: "observation-producer", TargetIdentityID: "identity-override",
+					Actor: "reviewer", Reason: "manual confirmation", Version: 1, CreatedAt: clock.now,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, _, err := repository.AppendOverrideCAS(context.Background(), override); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			input := correlateInput(testCase.name, testCase.fingerprint)
+			if testCase.provisional {
+				input.ProvisionalIdentity = true
+				input.ReviewReason = domain.ReasonInsufficientAnchor
+			}
+			if testCase.trustedSource {
+				input.Observation.SourceFindingID = "trusted-source"
+				input.TrustedProducerID = true
+			}
+			if testCase.withOverride {
+				input.OverrideSourceObservationID = "observation-producer"
+			}
+			if testCase.alias {
+				input.Aliases = []AliasInput{{SchemaVersion: 1, Value: "legacy-alias"}}
+			}
+			result, err := service.Correlate(context.Background(), input)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.Outcome != testCase.wantOutcome || result.Method != testCase.wantMethod {
+				t.Fatalf("result=%+v", result)
+			}
+			if !testCase.wantIdentity.IsZero() && (result.Identity == nil || result.Identity.ID != testCase.wantIdentity) {
+				t.Fatalf("identity=%+v want=%s", result.Identity, testCase.wantIdentity)
+			}
+			if len(audit.entries) != 1 {
+				t.Fatalf("audit entries=%d", len(audit.entries))
+			}
+		})
+	}
+}
+
+func TestCorrelateProvisionalIaCRemainsInReviewAcrossSnapshots(t *testing.T) {
+	for _, rule := range []string{"dockerfile-run-as-root", "compose-privileged", "gha-permissions-write-all", "arm-storage-public-blob"} {
+		t.Run(rule, func(t *testing.T) {
+			ctx := context.Background()
+			repository := memory.NewFindingLineageRepository()
+			clock := fixedClock{now: time.Date(2026, 9, 8, 14, 0, 0, 0, time.UTC)}
+			service, err := NewService(repository, memory.NewTenantTransactionRunner(), &collectingAudit{}, clock, &sequenceIDs{}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			matcher, err := NewIaCMatcherV1(nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			plan, err := matcher.Build(IaCFingerprintInputV1{TargetIdentityCanonical: "repo:example", RuleKey: rule, RepoPath: "infra/config.yaml"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			var identityID shared.ID
+			var lastInput CorrelateInput
+			var lastCandidate domain.MatchCandidate
+			for index := 1; index <= 3; index++ {
+				input := plan.Apply(correlateInput(fmt.Sprintf("provisional-%d", index), "unused"))
+				input.Observation.SourceFindingID = "same-source-finding"
+				input.Observation.Location = "infra/config.yaml:42"
+				input.Observation.ObservedAt = clock.now.Add(time.Duration(index) * time.Minute)
+				result, err := service.Correlate(ctx, input)
+				if err != nil || result.Outcome != OutcomeReview || result.Identity == nil || result.Observation == nil || result.Candidate == nil {
+					t.Fatalf("snapshot %d promoted provisional evidence: result=%+v err=%v", index, result, err)
+				}
+				if identityID.IsZero() {
+					identityID = result.Identity.ID
+				}
+				if result.Identity.ID != identityID || result.Candidate.SnapshotID != input.SnapshotID || result.Candidate.Reason != domain.ReasonInsufficientAnchor || result.Reason != "resource_identity_unavailable" {
+					t.Fatalf("snapshot %d lost stable identity or explicit review: %+v", index, result)
+				}
+				replayed, err := service.Correlate(ctx, input)
+				if err != nil || replayed.Observation == nil || replayed.Observation.ID != result.Observation.ID || replayed.Identity == nil || replayed.Identity.ID != identityID {
+					t.Fatalf("snapshot %d source replay changed evidence: %+v err=%v", index, replayed, err)
+				}
+				observations, err := repository.ListObservationsBySnapshot(ctx, "tenant", "cycle", input.SnapshotID)
+				if err != nil || len(observations) != 1 {
+					t.Fatalf("snapshot %d replay duplicated observations: count=%d err=%v", index, len(observations), err)
+				}
+				candidates, err := repository.ListOpenCandidatesBySnapshot(ctx, "tenant", "cycle", input.SnapshotID)
+				if err != nil || len(candidates) != 1 || candidates[0].ID != result.Candidate.ID {
+					t.Fatalf("snapshot %d replay lost or duplicated review: %+v err=%v", index, candidates, err)
+				}
+				lastInput, lastCandidate = input, *result.Candidate
+			}
+			// A source replay must not reopen a candidate explicitly resolved by a
+			// reviewer. Future snapshots are independent evidence boundaries.
+			if _, _, _, err := service.ResolveCandidate(ctx, ResolveInput{
+				TenantID: "tenant", CycleID: "cycle", CandidateID: lastCandidate.ID,
+				EventID: "dismiss-provisional", Action: domain.ResolutionDismiss,
+				Actor: "reviewer", Reason: "review completed", ExpectedVersion: lastCandidate.Version,
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := service.Correlate(ctx, lastInput); err != nil {
+				t.Fatal(err)
+			}
+			candidates, err := repository.ListOpenCandidatesBySnapshot(ctx, "tenant", "cycle", lastInput.SnapshotID)
+			if err != nil || len(candidates) != 0 {
+				t.Fatalf("source replay reopened a resolved candidate: %+v err=%v", candidates, err)
+			}
+		})
+	}
+}
+
+func TestCorrelateCollisionReplayAndChangedSetSupersession(t *testing.T) {
+	repository := memory.NewFindingLineageRepository()
+	clock := fixedClock{now: time.Date(2026, 8, 31, 9, 0, 0, 0, time.UTC)}
+	service, err := NewService(repository, immediateTransactions{}, &collectingAudit{}, clock, &sequenceIDs{}, &collectingObserver{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedIdentity(t, repository, clock.now, "identity-one", "observation-one", "source-one", "collision")
+	seedIdentity(t, repository, clock.now, "identity-two", "observation-two", "source-two", "collision")
+
+	input := correlateInput("collision", "collision")
+	first, err := service.Correlate(context.Background(), input)
+	if err != nil || first.Outcome != OutcomeReview || first.Candidate == nil || first.Candidate.Reason != domain.ReasonFingerprintCollision {
+		t.Fatalf("first=%+v err=%v", first, err)
+	}
+	replay, err := service.Correlate(context.Background(), input)
+	if err != nil || replay.Candidate == nil || replay.Candidate.ID != first.Candidate.ID {
+		t.Fatalf("replay=%+v err=%v", replay, err)
+	}
+
+	seedIdentity(t, repository, clock.now, "identity-three", "observation-three", "source-three", "collision")
+	changed, err := service.Correlate(context.Background(), input)
+	if err != nil || changed.Candidate == nil || changed.Candidate.ID == first.Candidate.ID {
+		t.Fatalf("changed=%+v err=%v", changed, err)
+	}
+	prior, err := repository.GetCandidate(context.Background(), "tenant", "cycle", first.Candidate.ID)
+	if err != nil || prior.Status != domain.CandidateSuperseded || prior.SupersededByCandidateID != changed.Candidate.ID {
+		t.Fatalf("prior=%+v err=%v", prior, err)
+	}
+	events, err := repository.ListCandidateResolutions(context.Background(), "tenant", "cycle", first.Candidate.ID)
+	if err != nil || len(events) != 1 || events[0].Action != domain.ResolutionSupersede {
+		t.Fatalf("events=%+v err=%v", events, err)
+	}
+}
+
+func TestCorrelateSensitiveInputCreatesSecretSafeSkip(t *testing.T) {
+	repository := memory.NewFindingLineageRepository()
+	clock := fixedClock{now: time.Date(2026, 8, 31, 10, 0, 0, 0, time.UTC)}
+	service, err := NewService(repository, immediateTransactions{}, &collectingAudit{}, clock, &sequenceIDs{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := correlateInput("sensitive", "unused")
+	input.FingerprintInput.IdentityFields = map[string]domain.CanonicalValue{"api_token": domain.Text("must-not-persist")}
+	result, err := service.Correlate(context.Background(), input)
+	if err != nil || result.Outcome != OutcomeSkipped || result.Skip == nil || result.Skip.Reason != domain.SkipRedactionRequired {
+		t.Fatalf("result=%+v err=%v", result, err)
+	}
+	if result.Skip.DetailCode != "sensitive_canonical_field" || result.Skip.SourceReferenceHash == "" {
+		t.Fatalf("skip=%+v", result.Skip)
+	}
+	replayed, err := service.Correlate(context.Background(), input)
+	if err != nil || replayed.Skip == nil || replayed.Skip.ID != result.Skip.ID {
+		t.Fatalf("skip replay=%+v err=%v want persisted id=%s", replayed, err, result.Skip.ID)
+	}
+	records, err := repository.ListSkipsBySnapshot(context.Background(), "tenant", "cycle", input.SnapshotID)
+	if err != nil || len(records) != 1 || strings.Contains(fmt.Sprintf("%+v", records[0]), "must-not-persist") {
+		t.Fatalf("records=%+v err=%v", records, err)
+	}
+}
+
+func TestTrustedProducerReplayWorksWithIncompleteFingerprint(t *testing.T) {
+	repository := memory.NewFindingLineageRepository()
+	clock := fixedClock{now: time.Date(2026, 8, 31, 10, 30, 0, 0, time.UTC)}
+	service, err := NewService(repository, memory.NewTenantTransactionRunner(), &collectingAudit{}, clock, &sequenceIDs{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedIdentity(t, repository, clock.now, "trusted-identity", "trusted-old-observation", "stable-producer-id", "seed")
+	input := correlateInput("trusted-incomplete", "unused")
+	input.SnapshotID = "snapshot-new"
+	input.Observation.ID = "trusted-new-observation"
+	input.Observation.SourceFindingID = "stable-producer-id"
+	input.Observation.Severity = shared.SeverityUnknown
+	input.Observation.ObservedAt = clock.now
+	input.FingerprintInput.IdentityFields = nil
+	input.TrustedProducerID = true
+	first, err := service.Correlate(context.Background(), input)
+	if err != nil || first.Outcome != OutcomeMatched || first.Identity == nil || first.Identity.ID != "trusted-identity" {
+		t.Fatalf("first=%+v err=%v", first, err)
+	}
+	replay, err := service.Correlate(context.Background(), input)
+	if err != nil || replay.Observation == nil || replay.Observation.ID != first.Observation.ID || replay.Identity.ID != first.Identity.ID {
+		t.Fatalf("replay=%+v err=%v", replay, err)
+	}
+}
+
+func TestApproveAliasValidatesIdentityNamespace(t *testing.T) {
+	repository := memory.NewFindingLineageRepository()
+	clock := fixedClock{now: time.Date(2026, 8, 31, 10, 45, 0, 0, time.UTC)}
+	service, err := NewService(repository, memory.NewTenantTransactionRunner(), &collectingAudit{}, clock, &sequenceIDs{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedIdentity(t, repository, clock.now, "alias-identity", "alias-observation", "alias-source", "alias-rule")
+	_, _, err = service.ApproveAlias(context.Background(), ApproveAliasInput{
+		TenantID: "tenant", CycleID: "cycle", IdentityID: "alias-identity", ProducerKind: "sca",
+		FindingKind: "vulnerability", TargetCanonical: "repo:other", SchemaVersion: 1, Value: "legacy-alias", Actor: "reviewer",
+	})
+	if !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("cross-namespace alias error=%v", err)
+	}
+}
+
+func TestCorrelateUsesNormalizedTargetForRepositoryNamespace(t *testing.T) {
+	repository := memory.NewFindingLineageRepository()
+	clock := fixedClock{now: time.Date(2026, 8, 31, 10, 50, 0, 0, time.UTC)}
+	service, err := NewService(repository, immediateTransactions{}, &collectingAudit{}, clock, &sequenceIDs{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstInput := correlateInput("nfc-first", "same-rule")
+	firstInput.FingerprintInput.TargetIdentityCanonical = "repo:Café"
+	first, err := service.Correlate(context.Background(), firstInput)
+	if err != nil || first.Identity == nil {
+		t.Fatalf("first=%+v err=%v", first, err)
+	}
+	secondInput := correlateInput("nfc-second", "same-rule")
+	secondInput.FingerprintInput.TargetIdentityCanonical = "repo:Cafe\u0301"
+	second, err := service.Correlate(context.Background(), secondInput)
+	if err != nil || second.Identity == nil {
+		t.Fatalf("second=%+v err=%v", second, err)
+	}
+	if second.Identity.ID != first.Identity.ID || second.Identity.TargetIdentityCanonical != "repo:Café" {
+		t.Fatalf("NFC-equivalent targets split repository namespace: first=%+v second=%+v", first.Identity, second.Identity)
+	}
+}
+
+func TestResolveCandidateIsCASAndEventIdempotent(t *testing.T) {
+	repository := memory.NewFindingLineageRepository()
+	clock := fixedClock{now: time.Date(2026, 8, 31, 11, 0, 0, 0, time.UTC)}
+	service, err := NewService(repository, immediateTransactions{}, &collectingAudit{}, clock, &sequenceIDs{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedIdentity(t, repository, clock.now, "identity-one", "observation-one", "source-one", "resolve")
+	seedIdentity(t, repository, clock.now, "identity-two", "observation-two", "source-two", "resolve")
+	match, err := service.Correlate(context.Background(), correlateInput("resolve", "resolve"))
+	if err != nil || match.Candidate == nil {
+		t.Fatalf("match=%+v err=%v", match, err)
+	}
+	input := ResolveInput{
+		TenantID: "tenant", CycleID: "cycle", CandidateID: match.Candidate.ID, EventID: "resolution-event",
+		Action: domain.ResolutionDismiss, Actor: "reviewer", Reason: "not actionable", ExpectedVersion: 1,
+	}
+	resolved, event, applied, err := service.ResolveCandidate(context.Background(), input)
+	if err != nil || !applied || resolved.Status != domain.CandidateResolved || event.Version != 2 {
+		t.Fatalf("resolved=%+v event=%+v applied=%v err=%v", resolved, event, applied, err)
+	}
+	replayed, replayEvent, applied, err := service.ResolveCandidate(context.Background(), input)
+	if err != nil || applied || replayed.ID != resolved.ID || replayEvent.ID != event.ID {
+		t.Fatalf("replay=%+v event=%+v applied=%v err=%v", replayed, replayEvent, applied, err)
+	}
+	stale := input
+	stale.EventID = "stale-event"
+	if _, _, _, err := service.ResolveCandidate(context.Background(), stale); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale error=%v", err)
+	}
+}
+
+func correlateInput(name, rule string) CorrelateInput {
+	return CorrelateInput{
+		TenantID: "tenant", CycleID: "cycle", SnapshotID: shared.ID("snapshot-new-" + name),
+		ProducerKind: "sca", FindingKind: "vulnerability", FingerprintSchemaVersion: 1,
+		FingerprintInput: domain.FingerprintCanonicalInputV1{
+			CanonicalizationVersion: domain.CanonicalizationVersionV1, ProducerKind: "sca", TargetIdentitySchemaVersion: 1,
+			TargetIdentityCanonical: "repo:example", IdentityFields: map[string]domain.CanonicalValue{"rule_id": domain.Text(rule)},
+		},
+		InputTrusted: true, OwnershipValidated: true, RedactionComplete: true,
+		Observation: ObservationInput{
+			ID: shared.ID("incoming-" + name), SourceFindingID: "incoming-source-" + name, Severity: shared.SeverityHigh,
+			ScannerProvenance: domain.ScannerProvenance{ToolName: "scanner"},
+		},
+		Actor: "operator",
+	}
+}
+
+func seedIdentity(t *testing.T, repository *memory.FindingLineageRepository, now time.Time, identityID, observationID, sourceID, rule string) {
+	t.Helper()
+	fingerprint, err := domain.CanonicalizeFingerprintV1(domain.FingerprintCanonicalInputV1{
+		CanonicalizationVersion: domain.CanonicalizationVersionV1, ProducerKind: "sca", TargetIdentitySchemaVersion: 1,
+		TargetIdentityCanonical: "repo:example", IdentityFields: map[string]domain.CanonicalValue{"rule_id": domain.Text(rule)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := domain.Identity{
+		TenantID: "tenant", CycleID: "cycle", ID: shared.ID(identityID), ProducerKind: "sca", FindingKind: "vulnerability",
+		CanonicalizationVersion: 1, FingerprintSchemaVersion: 1, LineageFingerprint: fingerprint.Fingerprint,
+		TargetIdentitySchemaVersion: 1, TargetIdentityCanonical: "repo:example", CanonicalIdentityFields: fingerprint.IdentityFields,
+		FirstSeenSnapshotID: "snapshot-old", CreatedAt: now,
+	}
+	observation := domain.Observation{
+		TenantID: "tenant", CycleID: "cycle", ID: shared.ID(observationID), SnapshotID: "snapshot-old", IdentityID: identity.ID,
+		ProducerKind: "sca", FindingKind: "vulnerability", TargetCanonical: "repo:example", SourceFindingID: sourceID,
+		Severity: shared.SeverityUnknown, ScannerProvenance: domain.ScannerProvenance{ToolName: "scanner"}, ObservedAt: now,
+	}
+	if err := repository.CreateIdentityWithObservation(context.Background(), identity, observation); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type immediateTransactions struct{}
+
+func (immediateTransactions) Run(ctx context.Context, _ shared.ID, fn func(context.Context) error) error {
+	return fn(ctx)
+}
+
+type fixedClock struct{ now time.Time }
+
+func (clock fixedClock) Now() time.Time { return clock.now }
+
+type sequenceIDs struct{ next int }
+
+func (ids *sequenceIDs) NewID() shared.ID {
+	ids.next++
+	return shared.ID(fmt.Sprintf("generated-%d", ids.next))
+}
+
+type collectingAudit struct{ entries []ports.AuditEntry }
+
+func (audit *collectingAudit) Record(_ context.Context, entry ports.AuditEntry) error {
+	audit.entries = append(audit.entries, entry)
+	return nil
+}
+
+type collectingObserver struct{ outcomes []string }
+
+func (observer *collectingObserver) ObserveFindingLineage(outcome, method, reason string) {
+	observer.outcomes = append(observer.outcomes, outcome+":"+method+":"+reason)
+}

--- a/internal/usecase/findinglineage/shadow.go
+++ b/internal/usecase/findinglineage/shadow.go
@@ -1,0 +1,110 @@
+package findinglineage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// ShadowProjector freezes manual/offensive observations at Snapshot finalization.
+// Findings created later belong to the next Snapshot, never an existing default.
+type ShadowProjector struct {
+	nativeEvidence ports.ScanRunEvidenceStore
+	nativeRuns     ports.AssessmentSnapshotRunReader
+	lineage        *Service
+	cycles         ports.AssessmentCycleRepository
+	snapshots      ports.AssessmentSnapshotRepository
+	findings       ports.FindingRepository
+	enabled        func(string) bool
+}
+
+func NewShadowProjector(lineage *Service, cycles ports.AssessmentCycleRepository, snapshots ports.AssessmentSnapshotRepository, findings ports.FindingRepository, enabled func(string) bool) (*ShadowProjector, error) {
+	if lineage == nil || cycles == nil || snapshots == nil || findings == nil || enabled == nil {
+		return nil, fmt.Errorf("%w: finding lineage shadow dependencies are required", shared.ErrValidation)
+	}
+	return &ShadowProjector{lineage: lineage, cycles: cycles, snapshots: snapshots, findings: findings, enabled: enabled}, nil
+}
+
+// ProjectCreatedFinding intentionally defers projection until the next Snapshot.
+// Retaining this hook keeps the Finding workflow independent during cutover.
+func (projector *ShadowProjector) ProjectCreatedFinding(context.Context, shared.ID, finding.Finding, string) error {
+	return nil
+}
+
+func (projector *ShadowProjector) AssessmentSnapshotFinalized(ctx context.Context, snapshot *assessmentsnapshot.Snapshot, actor string) error {
+	if snapshot == nil || !projector.enabled(snapshot.TenantID.String()) {
+		return nil
+	}
+	if err := projector.projectNativeEvidence(ctx, snapshot, actor); err != nil {
+		return err
+	}
+	items, err := projector.findings.ListByEngagement(ctx, snapshot.AssessmentID)
+	if err != nil {
+		return err
+	}
+	for _, item := range items {
+		// Scanner Findings are mutable projections and are not authoritative for a
+		// finalized Snapshot. They are projected only by the backfill/native producer
+		// path that can prove the selected immutable run and lane. Finalization merely
+		// closes the gap for native human/offensive findings created before a Snapshot.
+		if !manualOrOffensive(item.Kind) || item.EngagementID != snapshot.AssessmentID {
+			continue
+		}
+		if err := projector.project(ctx, snapshot.TenantID, snapshot.CycleID, snapshot, item, actor); err != nil {
+			// One malformed legacy manual Finding must not roll back an otherwise valid
+			// finalized Snapshot. Infrastructure/audit failures remain fatal and preserve
+			// the shared transaction's all-or-nothing guarantee.
+			if nonRetryableProjectionError(err) {
+				continue
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func (projector *ShadowProjector) project(ctx context.Context, tenantID, cycleID shared.ID, snapshot *assessmentsnapshot.Snapshot, item finding.Finding, actor string) error {
+	if snapshot == nil || snapshot.TenantID != tenantID || snapshot.CycleID != cycleID || snapshot.AssessmentID != item.EngagementID {
+		return fmt.Errorf("%w: shadow Finding/Snapshot ownership mismatch", shared.ErrValidation)
+	}
+	source := ports.FindingLineageBackfillSourceRow{
+		TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshot.ID, SnapshotContentHash: snapshot.ContentHash,
+		AssessmentID: item.EngagementID, OwnershipValid: true, FindingID: item.ID, Kind: item.Kind,
+		RuleKey: item.RuleKey, DedupKey: item.DedupKey, AdvisoryID: item.AdvisoryID,
+		ComponentFingerprint: item.ComponentFingerprint, Severity: item.Severity, RiskScore: item.RiskScore,
+		Reachability: item.Reachability, SourceLocation: item.SourceLocation, ObservedAt: item.Audit.CreatedAt,
+	}
+	producer, findingKind := legacyProducer(item.Kind)
+	target := selectBackfillTarget(*snapshot, producer, findingKind, item.EngagementID)
+	observation, err := backfillObservation(source, target)
+	if err != nil {
+		return err
+	}
+	class := ManualFindingNative
+	if item.Kind != finding.KindManual {
+		class = ManualFindingOffensive
+	}
+	_, err = projector.lineage.CorrelateNativeManual(ctx, NativeManualInput{
+		TenantID: tenantID, CycleID: cycleID, SnapshotID: snapshot.ID, AssessmentID: item.EngagementID,
+		IdentityID: legacyManualIdentityID(item.ID), FindingClass: class, Actor: actor, Observation: observation,
+	})
+	return err
+}
+
+func nonRetryableProjectionError(err error) bool {
+	return errors.Is(err, shared.ErrValidation) || errors.Is(err, shared.ErrNotFound) || errors.Is(err, shared.ErrConflict) ||
+		errors.Is(err, ErrSecretMaterialRejected)
+}
+
+func manualOrOffensive(kind finding.Kind) bool {
+	return kind == finding.KindManual || kind == finding.KindRecon || kind == finding.KindExploitation
+}
+
+var _ interface {
+	AssessmentSnapshotFinalized(context.Context, *assessmentsnapshot.Snapshot, string) error
+} = (*ShadowProjector)(nil)

--- a/internal/usecase/findinglineage/shadow_test.go
+++ b/internal/usecase/findinglineage/shadow_test.go
@@ -1,0 +1,72 @@
+package findinglineage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+)
+
+func TestShadowProjectorProjectsManualFindingOnSnapshotWithReadsIndependent(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 9, 4, 9, 0, 0, 0, time.UTC)
+	lineageRepository := memory.NewFindingLineageRepository()
+	lineage, err := NewService(lineageRepository, memory.NewTenantTransactionRunner(), &collectingAudit{}, fixedClock{now: now}, &sequenceIDs{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	findings := memory.NewFindingRepository()
+	item, err := finding.NewManual("finding-shadow", "assessment-shadow", finding.ManualInput{Title: "manual issue", Severity: shared.SeverityHigh}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := findings.Upsert(shared.WithTenant(ctx, "tenant-shadow"), []finding.Finding{item}); err != nil {
+		t.Fatal(err)
+	}
+	scaFinding := finding.Finding{
+		ID: "finding-sca-shadow", EngagementID: item.EngagementID, Title: "dependency issue", Severity: shared.SeverityHigh,
+		Status: finding.StatusOpen, Kind: finding.KindSCA, AdvisoryID: "CVE-2026-1234", ComponentFingerprint: "pkg:npm/example@1.0.0",
+		DedupKey: "CVE-2026-1234|example@1.0.0", Version: 1, Audit: shared.Audit{CreatedAt: now, UpdatedAt: now},
+	}
+	if err := findings.Upsert(shared.WithTenant(ctx, "tenant-shadow"), []finding.Finding{scaFinding}); err != nil {
+		t.Fatal(err)
+	}
+	projector, err := NewShadowProjector(lineage, memory.NewAssessmentCycleRepository(), memory.NewAssessmentSnapshotRepository(), findings, func(tenant string) bool {
+		return tenant == "tenant-shadow"
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := &assessmentsnapshot.Snapshot{TenantID: "tenant-shadow", ID: "snapshot-shadow", CycleID: "cycle-shadow", AssessmentID: item.EngagementID}
+	if err := projector.AssessmentSnapshotFinalized(ctx, snapshot, "system:shadow"); err != nil {
+		t.Fatal(err)
+	}
+	if err := projector.AssessmentSnapshotFinalized(ctx, snapshot, "system:shadow"); err != nil {
+		t.Fatalf("idempotent replay: %v", err)
+	}
+	observations, err := lineageRepository.ListObservationsBySnapshot(ctx, "tenant-shadow", "cycle-shadow", "snapshot-shadow")
+	if err != nil || len(observations) != 1 {
+		t.Fatalf("observations=%+v err=%v", observations, err)
+	}
+	bySource := map[string]string{}
+	for _, observation := range observations {
+		bySource[observation.SourceFindingID] = observation.FindingKind
+	}
+	if bySource[item.ID.String()] != string(ManualFindingNative) || bySource[scaFinding.ID.String()] != "" {
+		t.Fatalf("unexpected shadow kinds: %+v", bySource)
+	}
+
+	disabled := *snapshot
+	disabled.TenantID, disabled.ID = "tenant-read-disabled", "snapshot-disabled"
+	if err := projector.AssessmentSnapshotFinalized(ctx, &disabled, "system:shadow"); err != nil {
+		t.Fatal(err)
+	}
+	disabledObservations, err := lineageRepository.ListObservationsBySnapshot(ctx, disabled.TenantID, disabled.CycleID, disabled.ID)
+	if err != nil || len(disabledObservations) != 0 {
+		t.Fatalf("disabled observations=%+v err=%v", disabledObservations, err)
+	}
+}

--- a/internal/usecase/findinglineage/source_repo_path_test.go
+++ b/internal/usecase/findinglineage/source_repo_path_test.go
@@ -1,0 +1,45 @@
+package findinglineage
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestNormalizeSourceRepoPathRejectsURLsBeforeCleaning(t *testing.T) {
+	for _, input := range []string{
+		"https://user:private-test-marker@example.test/ci.yaml",
+		"http://example.test/ci.yaml",
+		"ssh://git@example.test/repo/config.yaml",
+		"file:///private/config.yaml",
+		"custom://example.test/config.yaml",
+	} {
+		t.Run(strings.SplitN(input, ":", 2)[0], func(t *testing.T) {
+			got, err := normalizeSourceRepoPath("IaC", input)
+			if !errors.Is(err, shared.ErrValidation) || got != "" {
+				t.Fatalf("URL accepted as a repository path: got=%q err=%v", got, err)
+			}
+			if strings.Contains(err.Error(), input) || strings.Contains(err.Error(), "private-test-marker") {
+				t.Fatal("validation error exposed the rejected locator")
+			}
+		})
+	}
+}
+
+func TestNormalizeSourceRepoPathPreservesRelativePathNormalization(t *testing.T) {
+	for _, test := range []struct{ input, want string }{
+		{" ./infra//main.tf ", "infra/main.tf"},
+		{"src/Cafe\u0301.yaml", "src/Café.yaml"},
+		{".github/workflows/CI.yaml", ".github/workflows/CI.yaml"},
+		{"infra/a:b.yaml", "infra/a:b.yaml"},
+	} {
+		t.Run(test.want, func(t *testing.T) {
+			got, err := normalizeSourceRepoPath("IaC", test.input)
+			if err != nil || got != test.want {
+				t.Fatalf("relative path normalization changed: got=%q want=%q err=%v", got, test.want, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Persist finding identity, observations, aliases and review history across assessment snapshots. Add deterministic matchers and resumable lineage backfill, including supported IaC retention. Extend existing ScanRun storage only with comparison evidence.

Phase 4/10. Base: `codex/868-phase-04-snapshot-history`. Keep #868 as tracking/reference only; do not merge it.

## Review follow-up: migration 0145 collision

Addressed the new review on #884 and the dependent holds on #885–#893. Main `9a7bae2d` includes #921's `0145_advisory_alias_index.sql`; the entire unmerged assessment block moves from 0145–0159 to **0146–0160**. #884 adds only 0146; #885 adds 0147–0160. All 15 assessment SQL bodies and their relative order are preserved. Existing main migrations (including 0145), core ScanRun and governed response/correlation code remain unchanged.

Updated migration test filenames and embedded-file references, Goose UpTo/DownTo targets, upgrade fixtures from main version 0145, diagnostics, and operational documentation. The complete payload is preserved through an explicit old/new filename map; runtime assessment code is unchanged by renumbering. Each PR still contains one capability commit against its immediate predecessor.

## Validation

Local validation after this update: all 10 phases passed scoped tests and repository-wide Go builds; the final stack passed repository-wide Go tests and vet. Isolated PostgreSQL 17 tests passed for duplicate migration inventory, authoritative main migrations, assessment upgrade/rollback paths, tenant isolation, immutable evidence and source bindings. Frontend typecheck, 116 test files / 694 tests, production build and lint passed (0 errors, 10 existing warnings); Helm lint/render assertions passed. CI is disabled, so these are explicitly local results. Final GitHub heads, bases and incremental file diffs are checked against the tested commits.

## Stack merge order

#884 → #885 → #886 → #887 → #888 → #889 → #890 → #891 → #892 → #893

Merge #884 first, then proceed in order. Prefer merge commits to retain ancestry; after each predecessor merges, retarget the next PR to `main` and inspect its remaining diff. Branch names remain stable. See the [preservation and migration audit](https://github.com/KKloudTarus/synapse-ce/blob/codex/868-phase-11-operations-docs/docs/architecture/assessment-stack-868-audit.md).
