### PR TITLE
feat(assessment): [5/10] compare snapshots and govern review state

### DIFF
--- a/internal/infrastructure/persistence/memory/assessment_comparison_repo.go
+++ b/internal/infrastructure/persistence/memory/assessment_comparison_repo.go
@@ -1,0 +1,372 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AssessmentComparisonRepository struct {
+	mu          sync.RWMutex
+	comparisons map[comparisonKey]assessmentcomparison.Comparison
+	byInputHash map[string]comparisonKey
+}
+
+type comparisonKey struct {
+	tenantID shared.ID
+	cycleID  shared.ID
+	id       shared.ID
+}
+
+func NewAssessmentComparisonRepository() *AssessmentComparisonRepository {
+	return &AssessmentComparisonRepository{
+		comparisons: map[comparisonKey]assessmentcomparison.Comparison{},
+		byInputHash: map[string]comparisonKey{},
+	}
+}
+
+var _ ports.AssessmentComparisonRepository = (*AssessmentComparisonRepository)(nil)
+
+func (repository *AssessmentComparisonRepository) CreateQueued(ctx context.Context, comparison assessmentcomparison.Comparison) (assessmentcomparison.Comparison, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return assessmentcomparison.Comparison{}, false, err
+	}
+	comparison.TenantID = shared.TenantOrDefault(comparison.TenantID)
+	if err := comparison.Validate(); err != nil {
+		return assessmentcomparison.Comparison{}, false, err
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	repository.registerRollback(ctx)
+	hashKey := comparison.TenantID.String() + "\x00" + comparison.InputHash
+	if existingKey, exists := repository.byInputHash[hashKey]; exists {
+		existing := repository.comparisons[existingKey]
+		if !sameComparisonRequest(existing, comparison) {
+			return assessmentcomparison.Comparison{}, false, fmt.Errorf("%w: comparison input hash was reused with different content", shared.ErrConflict)
+		}
+		return cloneAssessmentComparison(existing), false, nil
+	}
+	key := comparisonKey{tenantID: comparison.TenantID, cycleID: comparison.CycleID, id: comparison.ID}
+	if _, exists := repository.comparisons[key]; exists {
+		return assessmentcomparison.Comparison{}, false, fmt.Errorf("%w: comparison id was reused", shared.ErrConflict)
+	}
+	repository.comparisons[key] = cloneAssessmentComparison(comparison)
+	repository.byInputHash[hashKey] = key
+	return cloneAssessmentComparison(comparison), true, nil
+}
+
+func (repository *AssessmentComparisonRepository) Get(ctx context.Context, tenantID, comparisonID shared.ID) (assessmentcomparison.Comparison, error) {
+	if err := ctx.Err(); err != nil {
+		return assessmentcomparison.Comparison{}, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	for key, comparison := range repository.comparisons {
+		if key.tenantID == tenantID && key.id == comparisonID {
+			return cloneAssessmentComparison(comparison), nil
+		}
+	}
+	return assessmentcomparison.Comparison{}, shared.ErrNotFound
+}
+
+func (repository *AssessmentComparisonRepository) GetMetadata(ctx context.Context, tenantID, comparisonID shared.ID) (assessmentcomparison.Comparison, error) {
+	comparison, err := repository.Get(ctx, tenantID, comparisonID)
+	comparison.Items = nil
+	return comparison, err
+}
+
+func (repository *AssessmentComparisonRepository) GetByInputHash(ctx context.Context, tenantID shared.ID, inputHash string) (assessmentcomparison.Comparison, error) {
+	if err := ctx.Err(); err != nil {
+		return assessmentcomparison.Comparison{}, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	key, exists := repository.byInputHash[tenantID.String()+"\x00"+inputHash]
+	if !exists {
+		return assessmentcomparison.Comparison{}, shared.ErrNotFound
+	}
+	return cloneAssessmentComparison(repository.comparisons[key]), nil
+}
+
+func (repository *AssessmentComparisonRepository) ListMetadataByCycle(ctx context.Context, tenantID, cycleID shared.ID) ([]assessmentcomparison.Comparison, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	result := make([]assessmentcomparison.Comparison, 0)
+	for key, comparison := range repository.comparisons {
+		if key.tenantID != tenantID || comparison.CycleID != cycleID {
+			continue
+		}
+		value := cloneAssessmentComparison(comparison)
+		value.Items = nil
+		result = append(result, value)
+	}
+	sort.Slice(result, func(left, right int) bool {
+		if result[left].CreatedAt.Equal(result[right].CreatedAt) {
+			return result[left].ID < result[right].ID
+		}
+		return result[left].CreatedAt.Before(result[right].CreatedAt)
+	})
+	return result, nil
+}
+
+func (repository *AssessmentComparisonRepository) GetAssessmentComparisonBacklog(ctx context.Context, tenantID shared.ID) (ports.AssessmentComparisonBacklog, error) {
+	if err := ctx.Err(); err != nil {
+		return ports.AssessmentComparisonBacklog{}, err
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	var backlog ports.AssessmentComparisonBacklog
+	for key, comparison := range repository.comparisons {
+		if key.tenantID != tenantID {
+			continue
+		}
+		switch comparison.Status {
+		case assessmentcomparison.StatusQueued:
+			backlog.Queued++
+			setOldestAssessmentComparison(&backlog, comparison.CreatedAt)
+		case assessmentcomparison.StatusGenerating:
+			backlog.Generating++
+			setOldestAssessmentComparison(&backlog, comparison.UpdatedAt)
+		case assessmentcomparison.StatusFailed:
+			backlog.Failed++
+			if comparison.FailureCode == "dead_lettered" {
+				backlog.DeadLettered++
+			}
+		}
+	}
+	return backlog, nil
+}
+
+func (repository *AssessmentComparisonRepository) ListFailedAssessmentComparisons(ctx context.Context, tenantID shared.ID, limit int) ([]assessmentcomparison.Comparison, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if limit < 1 || limit > 2000 {
+		return nil, fmt.Errorf("%w: failed comparison limit must be between 1 and 2000", shared.ErrValidation)
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	repository.mu.RLock()
+	defer repository.mu.RUnlock()
+	result := make([]assessmentcomparison.Comparison, 0)
+	for key, comparison := range repository.comparisons {
+		if key.tenantID == tenantID && comparison.Status == assessmentcomparison.StatusFailed {
+			comparison.Items = nil
+			result = append(result, cloneAssessmentComparison(comparison))
+		}
+	}
+	sort.Slice(result, func(left, right int) bool {
+		if result[left].UpdatedAt.Equal(result[right].UpdatedAt) {
+			return result[left].ID < result[right].ID
+		}
+		return result[left].UpdatedAt.Before(result[right].UpdatedAt)
+	})
+	if len(result) > limit {
+		result = result[:limit]
+	}
+	return result, nil
+}
+
+func (repository *AssessmentComparisonRepository) GetItem(ctx context.Context, tenantID, comparisonID, itemID shared.ID) (assessmentcomparison.Item, error) {
+	comparison, err := repository.Get(ctx, tenantID, comparisonID)
+	if err != nil {
+		return assessmentcomparison.Item{}, err
+	}
+	for _, item := range comparison.Items {
+		if item.ID == itemID {
+			return cloneAssessmentComparisonItem(item), nil
+		}
+	}
+	return assessmentcomparison.Item{}, shared.ErrNotFound
+}
+
+func (repository *AssessmentComparisonRepository) SummarizeItems(ctx context.Context, tenantID, comparisonID shared.ID, scope assessmentcomparison.Scope) (assessmentcomparison.Summary, error) {
+	if !scope.Valid() {
+		return assessmentcomparison.Summary{}, fmt.Errorf("%w: comparison summary scope is invalid", shared.ErrValidation)
+	}
+	comparison, err := repository.Get(ctx, tenantID, comparisonID)
+	if err != nil {
+		return assessmentcomparison.Summary{}, err
+	}
+	items := make([]assessmentcomparison.Item, 0, len(comparison.Items))
+	for _, item := range comparison.Items {
+		if scope.Matches(item) {
+			items = append(items, item)
+		}
+	}
+	return assessmentcomparison.Summarize(items), nil
+}
+
+func (repository *AssessmentComparisonRepository) ListItems(ctx context.Context, tenantID, comparisonID shared.ID, filter ports.AssessmentComparisonItemFilter) (ports.AssessmentComparisonItemPage, error) {
+	comparison, err := repository.Get(ctx, tenantID, comparisonID)
+	if err != nil {
+		return ports.AssessmentComparisonItemPage{}, err
+	}
+	if filter.Scope == "" {
+		filter.Scope = assessmentcomparison.ScopeAll
+	}
+	items := make([]assessmentcomparison.Item, 0, filter.Limit)
+	for _, item := range comparison.Items {
+		severity := item.CurrentObservation.Severity
+		if item.CurrentObservationID.IsZero() {
+			severity = item.BaselineObservation.Severity
+		}
+		if !filter.Scope.Matches(item) || item.Position <= filter.AfterPosition || filter.Presence != "" && filter.Presence != string(item.Presence) && filter.Presence != string(item.NeutralPresence) ||
+			filter.ChangeFlag != "" && !comparisonItemHasFlag(item, filter.ChangeFlag) || filter.Severity != "" && filter.Severity != severity ||
+			filter.ProducerKind != "" && filter.ProducerKind != item.ProducerKind || filter.FindingKind != "" && filter.FindingKind != item.FindingKind ||
+			filter.Disposition != "" && filter.Disposition != comparisonItemDisposition(item) || filter.ReviewState != "" && filter.ReviewState != comparisonItemReviewState(item) {
+			continue
+		}
+		if len(items) == filter.Limit {
+			return ports.AssessmentComparisonItemPage{Items: items, NextPosition: items[len(items)-1].Position, HasMore: true}, nil
+		}
+		items = append(items, cloneAssessmentComparisonItem(item))
+	}
+	next := filter.AfterPosition
+	if len(items) > 0 {
+		next = items[len(items)-1].Position
+	}
+	return ports.AssessmentComparisonItemPage{Items: items, NextPosition: next}, nil
+}
+
+func (repository *AssessmentComparisonRepository) UpdateCAS(ctx context.Context, comparison assessmentcomparison.Comparison, expectedVersion int64) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	comparison.TenantID = shared.TenantOrDefault(comparison.TenantID)
+	if err := comparison.Validate(); err != nil {
+		return err
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	repository.registerRollback(ctx)
+	key := comparisonKey{tenantID: comparison.TenantID, cycleID: comparison.CycleID, id: comparison.ID}
+	existing, exists := repository.comparisons[key]
+	if !exists {
+		return shared.ErrNotFound
+	}
+	if existing.Version != expectedVersion || comparison.Version != expectedVersion+1 {
+		return fmt.Errorf("%w: comparison version mismatch", shared.ErrConflict)
+	}
+	if !sameComparisonImmutable(existing, comparison) || !validComparisonTransition(existing.Status, comparison.Status) || terminalComparisonChanged(existing, comparison) {
+		return fmt.Errorf("%w: immutable comparison input or output changed", shared.ErrConflict)
+	}
+	repository.comparisons[key] = cloneAssessmentComparison(comparison)
+	return nil
+}
+
+func sameComparisonRequest(left, right assessmentcomparison.Comparison) bool {
+	return left.TenantID == right.TenantID && left.CycleID == right.CycleID &&
+		left.BaselineSnapshotID == right.BaselineSnapshotID && left.CurrentSnapshotID == right.CurrentSnapshotID &&
+		left.Mode == right.Mode && left.InputHash == right.InputHash && reflect.DeepEqual(left.InputPayload, right.InputPayload) &&
+		left.AlgorithmVersion == right.AlgorithmVersion && left.FingerprintVersion == right.FingerprintVersion &&
+		left.RiskModelVersion == right.RiskModelVersion && left.CoveragePolicyVersion == right.CoveragePolicyVersion
+}
+
+func sameComparisonImmutable(left, right assessmentcomparison.Comparison) bool {
+	return sameComparisonRequest(left, right) && left.ID == right.ID && left.CreatedAt.Equal(right.CreatedAt)
+}
+
+func validComparisonTransition(from, to assessmentcomparison.Status) bool {
+	switch from {
+	case assessmentcomparison.StatusQueued:
+		return to == assessmentcomparison.StatusGenerating
+	case assessmentcomparison.StatusGenerating:
+		return to == assessmentcomparison.StatusQueued || to == assessmentcomparison.StatusComplete || to == assessmentcomparison.StatusNeedsReview || to == assessmentcomparison.StatusFailed
+	case assessmentcomparison.StatusFailed:
+		return to == assessmentcomparison.StatusGenerating
+	case assessmentcomparison.StatusComplete, assessmentcomparison.StatusNeedsReview:
+		return to == assessmentcomparison.StatusSuperseded
+	}
+	return false
+}
+
+func terminalComparisonChanged(existing, updated assessmentcomparison.Comparison) bool {
+	if existing.Status != assessmentcomparison.StatusComplete && existing.Status != assessmentcomparison.StatusNeedsReview && existing.Status != assessmentcomparison.StatusSuperseded {
+		return false
+	}
+	return existing.ContentHash != updated.ContentHash || !reflect.DeepEqual(existing.Items, updated.Items) || !reflect.DeepEqual(existing.Summary, updated.Summary) ||
+		!sameTime(existing.CompletedAt, updated.CompletedAt)
+}
+
+func cloneAssessmentComparison(comparison assessmentcomparison.Comparison) assessmentcomparison.Comparison {
+	comparison.InputPayload = append([]byte(nil), comparison.InputPayload...)
+	comparison.Items = append([]assessmentcomparison.Item(nil), comparison.Items...)
+	for index := range comparison.Items {
+		comparison.Items[index] = cloneAssessmentComparisonItem(comparison.Items[index])
+	}
+	if comparison.CompletedAt != nil {
+		value := *comparison.CompletedAt
+		comparison.CompletedAt = &value
+	}
+	if comparison.SupersededAt != nil {
+		value := *comparison.SupersededAt
+		comparison.SupersededAt = &value
+	}
+	return comparison
+}
+
+func setOldestAssessmentComparison(backlog *ports.AssessmentComparisonBacklog, candidate time.Time) {
+	if candidate.IsZero() || backlog.OldestActiveAt != nil && !candidate.Before(*backlog.OldestActiveAt) {
+		return
+	}
+	oldest := candidate.UTC()
+	backlog.OldestActiveAt = &oldest
+}
+
+func cloneAssessmentComparisonItem(item assessmentcomparison.Item) assessmentcomparison.Item {
+	item.ChangeFlags = append([]assessmentcomparison.ChangeFlag(nil), item.ChangeFlags...)
+	item.ReviewCandidateIDs = append([]shared.ID(nil), item.ReviewCandidateIDs...)
+	item.MatchMethods = append([]findinglineage.MatchMethod(nil), item.MatchMethods...)
+	return item
+}
+
+func comparisonItemDisposition(item assessmentcomparison.Item) string {
+	if item.CurrentActionable {
+		return "current_actionable"
+	}
+	if item.BaselineActionable {
+		return "baseline_only"
+	}
+	return "non_actionable"
+}
+
+func comparisonItemReviewState(item assessmentcomparison.Item) string {
+	if item.Presence == assessmentcomparison.PresenceNeedsReview || item.NeutralPresence == assessmentcomparison.NeutralNeedsReview || len(item.ReviewCandidateIDs) > 0 {
+		return "needs_review"
+	}
+	if !item.VerificationID.IsZero() {
+		return "verified"
+	}
+	return "clear"
+}
+
+func comparisonItemHasFlag(item assessmentcomparison.Item, flag assessmentcomparison.ChangeFlag) bool {
+	for _, candidate := range item.ChangeFlags {
+		if candidate == flag {
+			return true
+		}
+	}
+	return false
+}
+
+func sameTime(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return left.Equal(*right)
+}

--- a/internal/infrastructure/persistence/memory/assessment_comparison_repo_test.go
+++ b/internal/infrastructure/persistence/memory/assessment_comparison_repo_test.go
@@ -1,0 +1,88 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestAssessmentComparisonRepositoryIdempotencyCASAndIsolation(t *testing.T) {
+	repository := NewAssessmentComparisonRepository()
+	now := time.Date(2026, 8, 31, 14, 0, 0, 0, time.UTC)
+	comparison := queuedMemoryComparison(t, "tenant-a", "comparison-a", now)
+	stored, created, err := repository.CreateQueued(context.Background(), comparison)
+	if err != nil || !created || stored.ID != comparison.ID {
+		t.Fatalf("create stored=%+v created=%v err=%v", stored, created, err)
+	}
+	replay := comparison
+	replay.ID, replay.CreatedAt, replay.UpdatedAt = "different-candidate-id", now.Add(time.Minute), now.Add(time.Minute)
+	stored, created, err = repository.CreateQueued(context.Background(), replay)
+	if err != nil || created || stored.ID != comparison.ID {
+		t.Fatalf("replay stored=%+v created=%v err=%v", stored, created, err)
+	}
+	if _, err := repository.Get(context.Background(), "tenant-b", comparison.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant get error=%v", err)
+	}
+
+	updated := comparison
+	if err := updated.Start(updated.Version, now.Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.UpdateCAS(context.Background(), updated, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.UpdateCAS(context.Background(), updated, 1); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale update error=%v", err)
+	}
+	loaded, err := repository.GetByInputHash(context.Background(), "tenant-a", comparison.InputHash)
+	if err != nil || loaded.Status != assessmentcomparison.StatusGenerating || loaded.Version != 2 {
+		t.Fatalf("loaded=%+v err=%v", loaded, err)
+	}
+	metadata, err := repository.GetMetadata(context.Background(), "tenant-a", comparison.ID)
+	if err != nil || len(metadata.Items) != 0 || metadata.ID != comparison.ID {
+		t.Fatalf("metadata=%+v err=%v", metadata, err)
+	}
+	backlog, err := repository.GetAssessmentComparisonBacklog(context.Background(), "tenant-a")
+	if err != nil || backlog.Generating != 1 || backlog.OldestActiveAt == nil {
+		t.Fatalf("generating backlog=%+v err=%v", backlog, err)
+	}
+	failed := updated
+	if err := failed.Fail("dead_lettered", false, 3, failed.Version, now.Add(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.UpdateCAS(context.Background(), failed, 2); err != nil {
+		t.Fatal(err)
+	}
+	backlog, err = repository.GetAssessmentComparisonBacklog(context.Background(), "tenant-a")
+	if err != nil || backlog.Active() != 0 || backlog.Failed != 1 || backlog.DeadLettered != 1 {
+		t.Fatalf("failed backlog=%+v err=%v", backlog, err)
+	}
+	failedRows, err := repository.ListFailedAssessmentComparisons(context.Background(), "tenant-a", 10)
+	if err != nil || len(failedRows) != 1 || failedRows[0].ID != comparison.ID {
+		t.Fatalf("failed rows=%+v err=%v", failedRows, err)
+	}
+}
+
+func queuedMemoryComparison(t *testing.T, tenantID, comparisonID string, now time.Time) assessmentcomparison.Comparison {
+	t.Helper()
+	input := assessmentcomparison.GenerationInput{
+		Mode:             assessmentcomparison.ModeLifecycle,
+		Baseline:         assessmentcomparison.SnapshotHashRef{ID: "baseline", ContentHash: strings.Repeat("a", 64)},
+		Current:          assessmentcomparison.SnapshotHashRef{ID: "current", ContentHash: strings.Repeat("b", 64)},
+		AlgorithmVersion: 1, FingerprintVersion: 1, RiskModelVersion: 1, CoveragePolicyVersion: 1,
+	}
+	payload, inputHash, err := assessmentcomparison.HashGenerationInput(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	comparison, err := assessmentcomparison.NewQueued(shared.ID(tenantID), "cycle", shared.ID(comparisonID), input, payload, inputHash, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return comparison
+}

--- a/internal/infrastructure/persistence/memory/assessment_cycle_request_repo.go
+++ b/internal/infrastructure/persistence/memory/assessment_cycle_request_repo.go
@@ -1,0 +1,107 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AssessmentCycleRequestRepository struct {
+	mu       sync.Mutex
+	requests map[string]ports.AssessmentCycleRequest
+}
+
+func NewAssessmentCycleRequestRepository() *AssessmentCycleRequestRepository {
+	return &AssessmentCycleRequestRepository{requests: map[string]ports.AssessmentCycleRequest{}}
+}
+
+var _ ports.AssessmentCycleRequestStore = (*AssessmentCycleRequestRepository)(nil)
+
+func (repository *AssessmentCycleRequestRepository) BeginAssessmentCycleRequest(ctx context.Context, request ports.AssessmentCycleRequest) (ports.AssessmentCycleRequest, bool, error) {
+	if request.ExpiresAt.IsZero() {
+		request.ExpiresAt = request.CreatedAt.Add(24 * time.Hour)
+	}
+	if err := validateAssessmentCycleRequest(request); err != nil {
+		return ports.AssessmentCycleRequest{}, false, err
+	}
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	repository.registerRollback(ctx)
+	for storedKey, stored := range repository.requests {
+		if !stored.ExpiresAt.After(request.CreatedAt) {
+			delete(repository.requests, storedKey)
+		}
+	}
+	key := assessmentCycleRequestKey(request.Scope)
+	if stored, exists := repository.requests[key]; exists {
+		return cloneAssessmentCycleRequest(stored), false, nil
+	}
+	repository.requests[key] = cloneAssessmentCycleRequest(request)
+	return cloneAssessmentCycleRequest(request), true, nil
+}
+
+func (repository *AssessmentCycleRequestRepository) CompleteAssessmentCycleRequest(ctx context.Context, scope ports.AssessmentCycleRequestScope, requestHash string, statusCode int, responseBody []byte, completedAt time.Time) error {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	key := assessmentCycleRequestKey(scope)
+	stored, exists := repository.requests[key]
+	if !exists {
+		return fmt.Errorf("%w: assessment cycle request reservation not found", shared.ErrNotFound)
+	}
+	if stored.RequestHash != requestHash || stored.CompletedAt != nil {
+		return fmt.Errorf("%w: assessment cycle request completion conflict", shared.ErrConflict)
+	}
+	repository.registerRollback(ctx)
+	completedAt = completedAt.UTC()
+	stored.StatusCode, stored.ResponseBody, stored.CompletedAt = statusCode, append([]byte(nil), responseBody...), &completedAt
+	repository.requests[key] = stored
+	return nil
+}
+
+func (repository *AssessmentCycleRequestRepository) AbortAssessmentCycleRequest(ctx context.Context, scope ports.AssessmentCycleRequestScope, requestHash string) error {
+	repository.mu.Lock()
+	defer repository.mu.Unlock()
+	key := assessmentCycleRequestKey(scope)
+	stored, exists := repository.requests[key]
+	if exists && stored.RequestHash == requestHash && stored.CompletedAt == nil {
+		repository.registerRollback(ctx)
+		delete(repository.requests, key)
+	}
+	return nil
+}
+
+func validateAssessmentCycleRequest(request ports.AssessmentCycleRequest) error {
+	if shared.TenantOrDefault(request.Scope.TenantID).IsZero() || strings.TrimSpace(request.Scope.Actor) == "" || strings.TrimSpace(request.Scope.Route) == "" || strings.TrimSpace(request.Scope.IdempotencyKey) == "" || len(request.Scope.IdempotencyKey) > 128 || len(request.RequestHash) != 64 || request.CreatedAt.IsZero() || !request.ExpiresAt.After(request.CreatedAt) {
+		return fmt.Errorf("%w: assessment cycle idempotency request is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (repository *AssessmentCycleRequestRepository) registerRollback(ctx context.Context) {
+	registerTenantCheckpoint(ctx, repository, func(tenantID shared.ID) func() {
+		restore := captureTenantEntries(repository.requests, func(_ string, request ports.AssessmentCycleRequest) bool { return request.Scope.TenantID == tenantID })
+		return func() {
+			repository.mu.Lock()
+			defer repository.mu.Unlock()
+			restore()
+		}
+	})
+}
+
+func assessmentCycleRequestKey(scope ports.AssessmentCycleRequestScope) string {
+	return strings.Join([]string{shared.TenantOrDefault(scope.TenantID).String(), scope.Actor, scope.Route, scope.IdempotencyKey}, "\x00")
+}
+
+func cloneAssessmentCycleRequest(request ports.AssessmentCycleRequest) ports.AssessmentCycleRequest {
+	request.ResponseBody = append([]byte(nil), request.ResponseBody...)
+	if request.CompletedAt != nil {
+		completedAt := *request.CompletedAt
+		request.CompletedAt = &completedAt
+	}
+	return request
+}

--- a/internal/infrastructure/persistence/memory/assessment_evidence_tx.go
+++ b/internal/infrastructure/persistence/memory/assessment_evidence_tx.go
@@ -2,6 +2,7 @@ package memory
 
 import (
 	"context"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 )
@@ -25,6 +26,19 @@ func (repository *FindingLineageRepository) registerRollback(ctx context.Context
 			resolutions()
 			overrides()
 			skips()
+		}
+	})
+}
+
+func (repository *AssessmentComparisonRepository) registerRollback(ctx context.Context) {
+	registerTenantCheckpoint(ctx, repository, func(tenantID shared.ID) func() {
+		comparisons := captureTenantEntries(repository.comparisons, func(k comparisonKey, _ assessmentcomparison.Comparison) bool { return k.tenantID == tenantID })
+		hashes := captureTenantEntries(repository.byInputHash, func(_ string, k comparisonKey) bool { return k.tenantID == tenantID })
+		return func() {
+			repository.mu.Lock()
+			defer repository.mu.Unlock()
+			comparisons()
+			hashes()
 		}
 	})
 }

--- a/internal/infrastructure/persistence/postgres/assessment_comparison_repo.go
+++ b/internal/infrastructure/persistence/postgres/assessment_comparison_repo.go
@@ -1,0 +1,516 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type AssessmentComparisonRepository struct{ pool *pgxpool.Pool }
+
+func NewAssessmentComparisonRepository(pool *pgxpool.Pool) *AssessmentComparisonRepository {
+	return &AssessmentComparisonRepository{pool: pool}
+}
+
+var _ ports.AssessmentComparisonRepository = (*AssessmentComparisonRepository)(nil)
+
+const assessmentComparisonColumns = `tenant_id,cycle_id,id,baseline_snapshot_id,current_snapshot_id,mode,input_hash,input_payload,
+ algorithm_version,fingerprint_version,risk_model_version,coverage_policy_version,status,version,attempts,failure_code,content_hash,summary,
+ created_at,updated_at,completed_at,superseded_at,superseded_by`
+
+func (repository *AssessmentComparisonRepository) CreateQueued(ctx context.Context, comparison assessmentcomparison.Comparison) (assessmentcomparison.Comparison, bool, error) {
+	comparison.TenantID = shared.TenantOrDefault(comparison.TenantID)
+	if err := comparison.Validate(); err != nil {
+		return assessmentcomparison.Comparison{}, false, err
+	}
+	var stored assessmentcomparison.Comparison
+	created := false
+	err := WithTenant(ctx, repository.pool, comparison.TenantID.String(), func(tx pgx.Tx) error {
+		summary, err := marshalAssessmentComparisonSummary(comparison)
+		if err != nil {
+			return err
+		}
+		result, err := tx.Exec(ctx, `INSERT INTO assessment_comparisons (
+ tenant_id,cycle_id,id,baseline_snapshot_id,current_snapshot_id,mode,input_hash,input_payload,
+ algorithm_version,fingerprint_version,risk_model_version,coverage_policy_version,status,version,attempts,failure_code,content_hash,summary,
+ created_at,updated_at,completed_at,superseded_at,superseded_by)
+ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23)
+ ON CONFLICT (tenant_id,input_hash) DO NOTHING`,
+			comparison.TenantID.String(), comparison.CycleID.String(), comparison.ID.String(), comparison.BaselineSnapshotID.String(), comparison.CurrentSnapshotID.String(), string(comparison.Mode), comparison.InputHash, comparison.InputPayload,
+			comparison.AlgorithmVersion, comparison.FingerprintVersion, comparison.RiskModelVersion, comparison.CoveragePolicyVersion, string(comparison.Status), comparison.Version, comparison.Attempts, comparison.FailureCode, comparison.ContentHash, summary,
+			comparison.CreatedAt, comparison.UpdatedAt, comparison.CompletedAt, comparison.SupersededAt, nullableComparisonID(comparison.SupersededBy))
+		if err != nil {
+			return mapPostgresError(err, "create assessment comparison")
+		}
+		if result.RowsAffected() == 1 {
+			stored, created = comparison, true
+			return nil
+		}
+		existing, err := loadAssessmentComparisonByInputHash(ctx, tx, comparison.TenantID, comparison.InputHash, false)
+		if err != nil {
+			return err
+		}
+		if !samePostgresComparisonRequest(existing, comparison) {
+			return fmt.Errorf("%w: comparison input hash was reused with different content", shared.ErrConflict)
+		}
+		stored = existing
+		return nil
+	})
+	return stored, created, err
+}
+
+func (repository *AssessmentComparisonRepository) Get(ctx context.Context, tenantID, comparisonID shared.ID) (assessmentcomparison.Comparison, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var comparison assessmentcomparison.Comparison
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var err error
+		comparison, err = loadAssessmentComparison(ctx, tx, tenantID, comparisonID, false)
+		return err
+	})
+	return comparison, err
+}
+
+func (repository *AssessmentComparisonRepository) GetMetadata(ctx context.Context, tenantID, comparisonID shared.ID) (assessmentcomparison.Comparison, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var comparison assessmentcomparison.Comparison
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var err error
+		comparison, err = loadAssessmentComparisonMetadata(ctx, tx, tenantID, comparisonID, false)
+		return err
+	})
+	return comparison, err
+}
+
+func (repository *AssessmentComparisonRepository) GetByInputHash(ctx context.Context, tenantID shared.ID, inputHash string) (assessmentcomparison.Comparison, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var comparison assessmentcomparison.Comparison
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var err error
+		comparison, err = loadAssessmentComparisonByInputHash(ctx, tx, tenantID, inputHash, false)
+		return err
+	})
+	return comparison, err
+}
+
+func (repository *AssessmentComparisonRepository) ListMetadataByCycle(ctx context.Context, tenantID, cycleID shared.ID) ([]assessmentcomparison.Comparison, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var result []assessmentcomparison.Comparison
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT `+assessmentComparisonColumns+` FROM assessment_comparisons WHERE tenant_id=$1 AND cycle_id=$2 ORDER BY created_at,id`, tenantID.String(), cycleID.String())
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			comparison, err := scanAssessmentComparison(rows)
+			if err != nil {
+				return err
+			}
+			result = append(result, comparison)
+		}
+		return rows.Err()
+	})
+	return result, err
+}
+
+func (repository *AssessmentComparisonRepository) GetAssessmentComparisonBacklog(ctx context.Context, tenantID shared.ID) (ports.AssessmentComparisonBacklog, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var backlog ports.AssessmentComparisonBacklog
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var oldest pgtype.Timestamptz
+		if err := tx.QueryRow(ctx, `SELECT
+			count(*) FILTER (WHERE status='queued'),
+			count(*) FILTER (WHERE status='generating'),
+			count(*) FILTER (WHERE status='failed'),
+			count(*) FILTER (WHERE status='failed' AND failure_code='dead_lettered'),
+			min(CASE WHEN status='queued' THEN created_at WHEN status='generating' THEN updated_at END)
+			FROM assessment_comparisons WHERE tenant_id=$1`, tenantID.String()).Scan(
+			&backlog.Queued, &backlog.Generating, &backlog.Failed, &backlog.DeadLettered, &oldest,
+		); err != nil {
+			return fmt.Errorf("read assessment comparison backlog: %w", err)
+		}
+		if oldest.Valid {
+			value := oldest.Time.UTC()
+			backlog.OldestActiveAt = &value
+		}
+		return nil
+	})
+	return backlog, err
+}
+
+func (repository *AssessmentComparisonRepository) ListFailedAssessmentComparisons(ctx context.Context, tenantID shared.ID, limit int) ([]assessmentcomparison.Comparison, error) {
+	if limit < 1 || limit > 2000 {
+		return nil, fmt.Errorf("%w: failed comparison limit must be between 1 and 2000", shared.ErrValidation)
+	}
+	tenantID = shared.TenantOrDefault(tenantID)
+	result := make([]assessmentcomparison.Comparison, 0)
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		rows, err := tx.Query(ctx, `SELECT `+assessmentComparisonColumns+` FROM assessment_comparisons
+			WHERE tenant_id=$1 AND status='failed' ORDER BY updated_at,id LIMIT $2`, tenantID.String(), limit)
+		if err != nil {
+			return fmt.Errorf("list failed assessment comparisons: %w", err)
+		}
+		defer rows.Close()
+		for rows.Next() {
+			comparison, err := scanAssessmentComparison(rows)
+			if err != nil {
+				return err
+			}
+			result = append(result, comparison)
+		}
+		return rows.Err()
+	})
+	return result, err
+}
+
+func (repository *AssessmentComparisonRepository) GetItem(ctx context.Context, tenantID, comparisonID, itemID shared.ID) (assessmentcomparison.Item, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	var item assessmentcomparison.Item
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var err error
+		item, err = scanAssessmentComparisonItem(tx.QueryRow(ctx, `SELECT id,position,identity_id,producer_kind,finding_kind,target_canonical,baseline_observation_id,current_observation_id,baseline_observation,current_observation,presence,neutral_presence,change_flags,coverage_decision,match_methods,verification_id,verification_state,fixed_basis,
+ baseline_actionable,current_actionable,comparable_baseline,baseline_risk_milli,current_risk_milli,review_candidate_ids,review_candidates
+ FROM assessment_comparison_items WHERE tenant_id=$1 AND comparison_id=$2 AND id=$3`, tenantID.String(), comparisonID.String(), itemID.String()))
+		if errors.Is(err, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		return err
+	})
+	return item, err
+}
+
+func (repository *AssessmentComparisonRepository) SummarizeItems(ctx context.Context, tenantID, comparisonID shared.ID, scope assessmentcomparison.Scope) (assessmentcomparison.Summary, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	if !scope.Valid() {
+		return assessmentcomparison.Summary{}, fmt.Errorf("%w: comparison summary scope is invalid", shared.ErrValidation)
+	}
+	var summary assessmentcomparison.Summary
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		if _, err := loadAssessmentComparisonMetadata(ctx, tx, tenantID, comparisonID, false); err != nil {
+			return err
+		}
+		rows, err := tx.Query(ctx, `SELECT presence,neutral_presence,baseline_actionable,current_actionable,comparable_baseline,
+ baseline_risk_milli,current_risk_milli,
+ COALESCE(NULLIF(baseline_observation->>'severity',''),'unknown'),
+ COALESCE(NULLIF(current_observation->>'severity',''),'unknown'),
+ jsonb_array_length(review_candidate_ids)>0
+ FROM assessment_comparison_items
+ WHERE tenant_id=$1 AND comparison_id=$2
+   AND ($3='all'
+        OR ($3='vulnerability' AND finding_kind='vulnerability')
+        OR ($3='security' AND finding_kind IN ('vulnerability','sast','secret','misconfig')))
+ ORDER BY position`, tenantID.String(), comparisonID.String(), string(scope))
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		items := make([]assessmentcomparison.Item, 0)
+		for rows.Next() {
+			var item assessmentcomparison.Item
+			var presence, neutral string
+			var baselineSeverity, currentSeverity shared.Severity
+			var hasReviewCandidates bool
+			if err := rows.Scan(
+				&presence, &neutral, &item.BaselineActionable, &item.CurrentActionable, &item.ComparableBaseline,
+				&item.BaselineRiskMilli, &item.CurrentRiskMilli, &baselineSeverity, &currentSeverity, &hasReviewCandidates,
+			); err != nil {
+				return err
+			}
+			item.Presence, item.NeutralPresence = assessmentcomparison.Presence(presence), assessmentcomparison.NeutralPresence(neutral)
+			item.BaselineObservation.Severity, item.CurrentObservation.Severity = baselineSeverity, currentSeverity
+			if hasReviewCandidates {
+				item.ReviewCandidateIDs = []shared.ID{"scoped-summary-review"}
+			}
+			items = append(items, item)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		summary = assessmentcomparison.Summarize(items)
+		return nil
+	})
+	return summary, err
+}
+
+func (repository *AssessmentComparisonRepository) ListItems(ctx context.Context, tenantID, comparisonID shared.ID, filter ports.AssessmentComparisonItemFilter) (ports.AssessmentComparisonItemPage, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	if filter.Scope == "" {
+		filter.Scope = assessmentcomparison.ScopeAll
+	}
+	var page ports.AssessmentComparisonItemPage
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		if _, err := loadAssessmentComparisonMetadata(ctx, tx, tenantID, comparisonID, false); err != nil {
+			return err
+		}
+		rows, err := tx.Query(ctx, `SELECT id,position,identity_id,producer_kind,finding_kind,target_canonical,baseline_observation_id,current_observation_id,baseline_observation,current_observation,presence,neutral_presence,change_flags,coverage_decision,match_methods,verification_id,verification_state,fixed_basis,
+ baseline_actionable,current_actionable,comparable_baseline,baseline_risk_milli,current_risk_milli,review_candidate_ids,review_candidates
+ FROM assessment_comparison_items
+ WHERE tenant_id=$1 AND comparison_id=$2 AND position>$3
+	   AND ($4='' OR presence=$4 OR neutral_presence=$4)
+	   AND ($5='' OR change_flags ? $5)
+	   AND ($6='' OR COALESCE(NULLIF(current_observation->>'severity',''),baseline_observation->>'severity')=$6)
+	   AND ($7='' OR producer_kind=$7)
+	   AND ($8='' OR finding_kind=$8)
+	   AND ($9='' OR CASE WHEN current_actionable THEN 'current_actionable' WHEN baseline_actionable THEN 'baseline_only' ELSE 'non_actionable' END=$9)
+	   AND ($10='' OR CASE WHEN presence='needs_review' OR neutral_presence='needs_review' OR jsonb_array_length(review_candidate_ids)>0 THEN 'needs_review' WHEN verification_id IS NOT NULL THEN 'verified' ELSE 'clear' END=$10)
+	   AND ($11='all'
+	        OR ($11='vulnerability' AND finding_kind='vulnerability')
+	        OR ($11='security' AND finding_kind IN ('vulnerability','sast','secret','misconfig')))
+	 ORDER BY position LIMIT $12`, tenantID.String(), comparisonID.String(), filter.AfterPosition, filter.Presence, string(filter.ChangeFlag), string(filter.Severity), filter.ProducerKind, filter.FindingKind, filter.Disposition, filter.ReviewState, string(filter.Scope), filter.Limit+1)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+		for rows.Next() {
+			item, err := scanAssessmentComparisonItem(rows)
+			if err != nil {
+				return err
+			}
+			page.Items = append(page.Items, item)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		if len(page.Items) > filter.Limit {
+			page.Items, page.HasMore = page.Items[:filter.Limit], true
+		}
+		if len(page.Items) > 0 {
+			page.NextPosition = page.Items[len(page.Items)-1].Position
+		} else {
+			page.NextPosition = filter.AfterPosition
+		}
+		return nil
+	})
+	return page, err
+}
+
+func (repository *AssessmentComparisonRepository) UpdateCAS(ctx context.Context, comparison assessmentcomparison.Comparison, expectedVersion int64) error {
+	comparison.TenantID = shared.TenantOrDefault(comparison.TenantID)
+	if err := comparison.Validate(); err != nil {
+		return err
+	}
+	return WithTenant(ctx, repository.pool, comparison.TenantID.String(), func(tx pgx.Tx) error {
+		existing, err := loadAssessmentComparison(ctx, tx, comparison.TenantID, comparison.ID, true)
+		if err != nil {
+			return err
+		}
+		if existing.Version != expectedVersion || comparison.Version != expectedVersion+1 || !samePostgresComparisonImmutable(existing, comparison) || !postgresComparisonTransition(existing.Status, comparison.Status) {
+			return fmt.Errorf("%w: comparison version or transition mismatch", shared.ErrConflict)
+		}
+		if comparison.Status == assessmentcomparison.StatusComplete || comparison.Status == assessmentcomparison.StatusNeedsReview {
+			for _, item := range comparison.Items {
+				flags, err := json.Marshal(item.ChangeFlags)
+				if err != nil {
+					return err
+				}
+				candidateIDs, err := json.Marshal(item.ReviewCandidateIDs)
+				if err != nil {
+					return err
+				}
+				reviewCandidates, err := json.Marshal(item.ReviewCandidates)
+				if err != nil {
+					return err
+				}
+				baselineObservation, err := json.Marshal(item.BaselineObservation)
+				if err != nil {
+					return err
+				}
+				currentObservation, err := json.Marshal(item.CurrentObservation)
+				if err != nil {
+					return err
+				}
+				matchMethods, err := json.Marshal(item.MatchMethods)
+				if err != nil {
+					return err
+				}
+				if _, err := tx.Exec(ctx, `INSERT INTO assessment_comparison_items (
+	 tenant_id,cycle_id,comparison_id,id,position,identity_id,producer_kind,finding_kind,target_canonical,baseline_observation_id,current_observation_id,baseline_observation,current_observation,presence,neutral_presence,change_flags,coverage_decision,match_methods,
+	 verification_id,verification_state,fixed_basis,baseline_actionable,current_actionable,comparable_baseline,baseline_risk_milli,current_risk_milli,review_candidate_ids,review_candidates)
+	 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28)`,
+					comparison.TenantID.String(), comparison.CycleID.String(), comparison.ID.String(), item.ID.String(), item.Position, item.IdentityID.String(), item.ProducerKind, item.FindingKind, item.TargetCanonical, nullableComparisonID(item.BaselineObservationID), nullableComparisonID(item.CurrentObservationID), baselineObservation, currentObservation, string(item.Presence), string(item.NeutralPresence), flags, string(item.CoverageDecision), matchMethods,
+					nullableComparisonID(item.VerificationID), item.VerificationState, string(item.FixedBasis), item.BaselineActionable, item.CurrentActionable, item.ComparableBaseline, item.BaselineRiskMilli, item.CurrentRiskMilli, candidateIDs, reviewCandidates); err != nil {
+					return err
+				}
+			}
+		}
+		summary, err := marshalAssessmentComparisonSummary(comparison)
+		if err != nil {
+			return err
+		}
+		result, err := tx.Exec(ctx, `UPDATE assessment_comparisons SET status=$1,version=$2,attempts=$3,failure_code=$4,content_hash=$5,summary=$6,
+ updated_at=$7,completed_at=$8,superseded_at=$9,superseded_by=$10 WHERE tenant_id=$11 AND cycle_id=$12 AND id=$13 AND version=$14`,
+			string(comparison.Status), comparison.Version, comparison.Attempts, comparison.FailureCode, comparison.ContentHash, summary,
+			comparison.UpdatedAt, comparison.CompletedAt, comparison.SupersededAt, nullableComparisonID(comparison.SupersededBy),
+			comparison.TenantID.String(), comparison.CycleID.String(), comparison.ID.String(), expectedVersion)
+		if err != nil {
+			return err
+		}
+		if result.RowsAffected() != 1 {
+			return fmt.Errorf("%w: comparison version mismatch", shared.ErrConflict)
+		}
+		return nil
+	})
+}
+
+func loadAssessmentComparison(ctx context.Context, tx pgx.Tx, tenantID, comparisonID shared.ID, lock bool) (assessmentcomparison.Comparison, error) {
+	comparison, err := loadAssessmentComparisonMetadata(ctx, tx, tenantID, comparisonID, lock)
+	if err != nil {
+		return assessmentcomparison.Comparison{}, err
+	}
+	return loadAssessmentComparisonItems(ctx, tx, comparison)
+}
+
+func loadAssessmentComparisonMetadata(ctx context.Context, tx pgx.Tx, tenantID, comparisonID shared.ID, lock bool) (assessmentcomparison.Comparison, error) {
+	query := `SELECT ` + assessmentComparisonColumns + ` FROM assessment_comparisons WHERE tenant_id=$1 AND id=$2`
+	if lock {
+		query += ` FOR UPDATE`
+	}
+	return scanAssessmentComparison(tx.QueryRow(ctx, query, tenantID.String(), comparisonID.String()))
+}
+
+func loadAssessmentComparisonByInputHash(ctx context.Context, tx pgx.Tx, tenantID shared.ID, inputHash string, lock bool) (assessmentcomparison.Comparison, error) {
+	query := `SELECT ` + assessmentComparisonColumns + ` FROM assessment_comparisons WHERE tenant_id=$1 AND input_hash=$2`
+	if lock {
+		query += ` FOR UPDATE`
+	}
+	comparison, err := scanAssessmentComparison(tx.QueryRow(ctx, query, tenantID.String(), inputHash))
+	if err != nil {
+		return assessmentcomparison.Comparison{}, err
+	}
+	return loadAssessmentComparisonItems(ctx, tx, comparison)
+}
+
+func scanAssessmentComparison(row rowScanner) (assessmentcomparison.Comparison, error) {
+	var comparison assessmentcomparison.Comparison
+	var mode, status string
+	var summary []byte
+	var supersededBy *string
+	if err := row.Scan(&comparison.TenantID, &comparison.CycleID, &comparison.ID, &comparison.BaselineSnapshotID, &comparison.CurrentSnapshotID, &mode, &comparison.InputHash, &comparison.InputPayload,
+		&comparison.AlgorithmVersion, &comparison.FingerprintVersion, &comparison.RiskModelVersion, &comparison.CoveragePolicyVersion, &status, &comparison.Version, &comparison.Attempts, &comparison.FailureCode, &comparison.ContentHash, &summary,
+		&comparison.CreatedAt, &comparison.UpdatedAt, &comparison.CompletedAt, &comparison.SupersededAt, &supersededBy); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return assessmentcomparison.Comparison{}, shared.ErrNotFound
+		}
+		return assessmentcomparison.Comparison{}, err
+	}
+	comparison.Mode, comparison.Status = assessmentcomparison.Mode(mode), assessmentcomparison.Status(status)
+	if supersededBy != nil {
+		comparison.SupersededBy = shared.ID(*supersededBy)
+	}
+	if err := json.Unmarshal(summary, &comparison.Summary); err != nil {
+		return assessmentcomparison.Comparison{}, err
+	}
+	return comparison, nil
+}
+
+func loadAssessmentComparisonItems(ctx context.Context, tx pgx.Tx, comparison assessmentcomparison.Comparison) (assessmentcomparison.Comparison, error) {
+	rows, err := tx.Query(ctx, `SELECT id,position,identity_id,producer_kind,finding_kind,target_canonical,baseline_observation_id,current_observation_id,baseline_observation,current_observation,presence,neutral_presence,change_flags,coverage_decision,match_methods,verification_id,verification_state,fixed_basis,
+ baseline_actionable,current_actionable,comparable_baseline,baseline_risk_milli,current_risk_milli,review_candidate_ids,review_candidates
+ FROM assessment_comparison_items WHERE tenant_id=$1 AND cycle_id=$2 AND comparison_id=$3 ORDER BY position`, comparison.TenantID.String(), comparison.CycleID.String(), comparison.ID.String())
+	if err != nil {
+		return assessmentcomparison.Comparison{}, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		item, err := scanAssessmentComparisonItem(rows)
+		if err != nil {
+			return assessmentcomparison.Comparison{}, err
+		}
+		comparison.Items = append(comparison.Items, item)
+	}
+	return comparison, rows.Err()
+}
+
+func scanAssessmentComparisonItem(row rowScanner) (assessmentcomparison.Item, error) {
+	var item assessmentcomparison.Item
+	var baselineID, currentID, verificationID *string
+	var presence, neutral, coverage string
+	var flags, candidateIDs, reviewCandidates, baselineObservation, currentObservation, matchMethods []byte
+	if err := row.Scan(&item.ID, &item.Position, &item.IdentityID, &item.ProducerKind, &item.FindingKind, &item.TargetCanonical, &baselineID, &currentID, &baselineObservation, &currentObservation, &presence, &neutral, &flags, &coverage, &matchMethods, &verificationID, &item.VerificationState, &item.FixedBasis,
+		&item.BaselineActionable, &item.CurrentActionable, &item.ComparableBaseline, &item.BaselineRiskMilli, &item.CurrentRiskMilli, &candidateIDs, &reviewCandidates); err != nil {
+		return assessmentcomparison.Item{}, err
+	}
+	item.Presence, item.NeutralPresence, item.CoverageDecision = assessmentcomparison.Presence(presence), assessmentcomparison.NeutralPresence(neutral), assessmentsnapshot.Comparability(coverage)
+	if baselineID != nil {
+		item.BaselineObservationID = shared.ID(*baselineID)
+	}
+	if currentID != nil {
+		item.CurrentObservationID = shared.ID(*currentID)
+	}
+	if verificationID != nil {
+		item.VerificationID = shared.ID(*verificationID)
+	}
+	if err := json.Unmarshal(flags, &item.ChangeFlags); err != nil {
+		return assessmentcomparison.Item{}, err
+	}
+	if err := json.Unmarshal(baselineObservation, &item.BaselineObservation); err != nil {
+		return assessmentcomparison.Item{}, err
+	}
+	if err := json.Unmarshal(currentObservation, &item.CurrentObservation); err != nil {
+		return assessmentcomparison.Item{}, err
+	}
+	if err := json.Unmarshal(matchMethods, &item.MatchMethods); err != nil {
+		return assessmentcomparison.Item{}, err
+	}
+	if err := json.Unmarshal(candidateIDs, &item.ReviewCandidateIDs); err != nil {
+		return assessmentcomparison.Item{}, err
+	}
+	if err := json.Unmarshal(reviewCandidates, &item.ReviewCandidates); err != nil {
+		return assessmentcomparison.Item{}, err
+	}
+	return item, nil
+}
+
+func samePostgresComparisonRequest(left, right assessmentcomparison.Comparison) bool {
+	return left.TenantID == right.TenantID && left.CycleID == right.CycleID && left.BaselineSnapshotID == right.BaselineSnapshotID && left.CurrentSnapshotID == right.CurrentSnapshotID &&
+		left.Mode == right.Mode && left.InputHash == right.InputHash && jsonPayloadEqual(left.InputPayload, right.InputPayload) && left.AlgorithmVersion == right.AlgorithmVersion &&
+		left.FingerprintVersion == right.FingerprintVersion && left.RiskModelVersion == right.RiskModelVersion && left.CoveragePolicyVersion == right.CoveragePolicyVersion
+}
+
+func samePostgresComparisonImmutable(left, right assessmentcomparison.Comparison) bool {
+	return samePostgresComparisonRequest(left, right) && left.ID == right.ID && left.CreatedAt.Equal(right.CreatedAt)
+}
+
+func postgresComparisonTransition(from, to assessmentcomparison.Status) bool {
+	switch from {
+	case assessmentcomparison.StatusQueued:
+		return to == assessmentcomparison.StatusGenerating
+	case assessmentcomparison.StatusGenerating:
+		return to == assessmentcomparison.StatusQueued || to == assessmentcomparison.StatusComplete || to == assessmentcomparison.StatusNeedsReview || to == assessmentcomparison.StatusFailed
+	case assessmentcomparison.StatusFailed:
+		return to == assessmentcomparison.StatusGenerating
+	case assessmentcomparison.StatusComplete, assessmentcomparison.StatusNeedsReview:
+		return to == assessmentcomparison.StatusSuperseded
+	}
+	return false
+}
+
+func jsonPayloadEqual(left, right []byte) bool {
+	var a, b any
+	return json.Unmarshal(left, &a) == nil && json.Unmarshal(right, &b) == nil && reflect.DeepEqual(a, b)
+}
+
+func nullableComparisonID(id shared.ID) any {
+	if id.IsZero() {
+		return nil
+	}
+	return id.String()
+}
+
+func marshalAssessmentComparisonSummary(comparison assessmentcomparison.Comparison) ([]byte, error) {
+	if comparison.Status == assessmentcomparison.StatusQueued || comparison.Status == assessmentcomparison.StatusGenerating || comparison.Status == assessmentcomparison.StatusFailed {
+		return []byte("{}"), nil
+	}
+	return json.Marshal(comparison.Summary)
+}

--- a/internal/infrastructure/persistence/postgres/assessment_comparison_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_comparison_repo_test.go
@@ -1,0 +1,426 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	comparisonuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestPostgresAssessmentComparisonRepositoryLifecycle(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := fmt.Sprintf("comparison-%d", time.Now().UnixNano())
+	tenantID := shared.ID("tenant-" + suffix)
+	cycleID, baseline, current := createAssessmentComparisonSnapshots(t, ctx, pool, tenantID, suffix)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	identity, baselineObservation := postgresFindingLineagePair(t, tenantID, cycleID, baseline.ID, "comparison-identity-"+suffix, "comparison-baseline-observation-"+suffix, "baseline-source-"+suffix, "CVE-2026-1", now)
+	baselineRisk := 8000
+	baselineObservation.RiskScoreMilli = &baselineRisk
+	lineageRepository := NewFindingLineageRepository(pool)
+	if err := lineageRepository.CreateIdentityWithObservation(ctx, identity, baselineObservation); err != nil {
+		t.Fatal(err)
+	}
+	currentObservation := baselineObservation
+	currentRisk := 5000
+	currentObservation.ID = shared.ID("comparison-current-observation-" + suffix)
+	currentObservation.SnapshotID = current.ID
+	currentObservation.SourceFindingID = "current-source-" + suffix
+	currentObservation.Severity = shared.SeverityMedium
+	currentObservation.RiskScoreMilli = &currentRisk
+	currentObservation.ObservedAt = now.Add(time.Second)
+	if err := lineageRepository.AppendObservation(ctx, currentObservation); err != nil {
+		t.Fatal(err)
+	}
+	fixedIdentity, fixedObservation := postgresFindingLineagePair(t, tenantID, cycleID, baseline.ID, "comparison-fixed-identity-"+suffix, "comparison-fixed-observation-"+suffix, "fixed-source-"+suffix, "CVE-2026-3", now)
+	if err := lineageRepository.CreateIdentityWithObservation(ctx, fixedIdentity, fixedObservation); err != nil {
+		t.Fatal(err)
+	}
+
+	queued := postgresQueuedComparison(t, tenantID, cycleID, shared.ID("comparison-"+suffix), baseline, current, 1, now)
+	repository := NewAssessmentComparisonRepository(pool)
+	stored, created, err := repository.CreateQueued(ctx, queued)
+	if err != nil || !created {
+		t.Fatalf("create stored=%+v created=%v err=%v", stored, created, err)
+	}
+	backlog, err := repository.GetAssessmentComparisonBacklog(ctx, tenantID)
+	if err != nil || backlog.Queued != 1 || backlog.OldestActiveAt == nil {
+		t.Fatalf("queued backlog=%+v err=%v", backlog, err)
+	}
+	replay := queued
+	replay.ID = "different-id"
+	stored, created, err = repository.CreateQueued(ctx, replay)
+	if err != nil || created || stored.ID != queued.ID {
+		t.Fatalf("replay stored=%+v created=%v err=%v", stored, created, err)
+	}
+	bodyMismatch := replay
+	bodyMismatch.InputPayload = []byte(`{"different":true}`)
+	if _, _, err := repository.CreateQueued(ctx, bodyMismatch); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("input hash body mismatch error=%v", err)
+	}
+	if err := queued.Start(1, now.Add(2*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.UpdateCAS(ctx, queued, 1); err != nil {
+		t.Fatal(err)
+	}
+	backlog, err = repository.GetAssessmentComparisonBacklog(ctx, tenantID)
+	if err != nil || backlog.Generating != 1 || backlog.Queued != 0 {
+		t.Fatalf("generating backlog=%+v err=%v", backlog, err)
+	}
+	if err := repository.UpdateCAS(ctx, queued, 1); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale CAS error=%v", err)
+	}
+	item, err := assessmentcomparison.ClassifyLifecycle(assessmentcomparison.ClassifyInput{
+		IdentityID: identity.ID, Baseline: &baselineObservation, Current: &currentObservation,
+		BaselineActionable: true, CurrentActionable: true, BaselineRiskMilli: int64(baselineRisk), CurrentRiskMilli: int64(currentRisk),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	item.ReviewCandidateIDs = []shared.ID{"candidate-a-" + shared.ID(suffix), "candidate-b-" + shared.ID(suffix)}
+	fixedItem, err := assessmentcomparison.ClassifyLifecycle(assessmentcomparison.ClassifyInput{
+		IdentityID: fixedIdentity.ID, Baseline: &fixedObservation, CurrentCoverage: assessmentsnapshot.Comparable,
+		BaselineActionable: true, BaselineRiskMilli: 8000,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := queued.Complete([]assessmentcomparison.Item{item, fixedItem}, 2, now.Add(3*time.Second)); err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.UpdateCAS(ctx, queued, 2); err != nil {
+		t.Fatal(err)
+	}
+	backlog, err = repository.GetAssessmentComparisonBacklog(ctx, tenantID)
+	if err != nil || backlog.Active() != 0 {
+		t.Fatalf("completed backlog=%+v err=%v", backlog, err)
+	}
+	failedRows, err := repository.ListFailedAssessmentComparisons(ctx, tenantID, 10)
+	if err != nil || len(failedRows) != 0 {
+		t.Fatalf("failed rows=%+v err=%v", failedRows, err)
+	}
+	loaded, err := repository.Get(ctx, tenantID, queued.ID)
+	if err != nil || loaded.Status != assessmentcomparison.StatusComplete || loaded.ContentHash == "" || len(loaded.Items) != 2 {
+		t.Fatalf("loaded=%+v err=%v", loaded, err)
+	}
+	var detected, fixed assessmentcomparison.Item
+	for _, loadedItem := range loaded.Items {
+		if loadedItem.IdentityID == identity.ID {
+			detected = loadedItem
+		}
+		if loadedItem.IdentityID == fixedIdentity.ID {
+			fixed = loadedItem
+		}
+	}
+	if detected.BaselineObservationID != baselineObservation.ID || detected.CurrentObservationID != currentObservation.ID || fixed.FixedBasis != assessmentcomparison.FixedByComparableAbsence {
+		t.Fatalf("loaded detected=%+v fixed=%+v", detected, fixed)
+	}
+	if loaded.Summary.ComparisonID != loaded.ID || loaded.Summary.BaselineSnapshotID != baseline.ID || loaded.Summary.CurrentSnapshotID != current.ID || loaded.Summary.RiskModelVersion != 1 {
+		t.Fatalf("loaded summary=%+v", loaded.Summary)
+	}
+	metadata, err := repository.GetMetadata(ctx, tenantID, queued.ID)
+	if err != nil || len(metadata.Items) != 0 || metadata.ContentHash != loaded.ContentHash {
+		t.Fatalf("metadata=%+v err=%v", metadata, err)
+	}
+	storedItem, err := repository.GetItem(ctx, tenantID, queued.ID, detected.ID)
+	if err != nil || storedItem.ID != detected.ID || storedItem.Position != detected.Position || len(storedItem.ReviewCandidateIDs) != 2 || storedItem.ReviewCandidateIDs[0] != item.ReviewCandidateIDs[0] || storedItem.CurrentObservation.Severity != shared.SeverityMedium || storedItem.ProducerKind != "sca" {
+		t.Fatalf("stored item=%+v err=%v", storedItem, err)
+	}
+	firstPage, err := repository.ListItems(ctx, tenantID, queued.ID, ports.AssessmentComparisonItemFilter{AfterPosition: -1, Limit: 1})
+	if err != nil || len(firstPage.Items) != 1 || !firstPage.HasMore || firstPage.NextPosition != firstPage.Items[0].Position {
+		t.Fatalf("first page=%+v err=%v", firstPage, err)
+	}
+	secondPage, err := repository.ListItems(ctx, tenantID, queued.ID, ports.AssessmentComparisonItemFilter{AfterPosition: firstPage.NextPosition, Limit: 1})
+	if err != nil || len(secondPage.Items) != 1 || secondPage.HasMore || secondPage.Items[0].ID == firstPage.Items[0].ID {
+		t.Fatalf("second page=%+v err=%v", secondPage, err)
+	}
+	presencePage, err := repository.ListItems(ctx, tenantID, queued.ID, ports.AssessmentComparisonItemFilter{AfterPosition: -1, Limit: 10, Presence: string(assessmentcomparison.PresenceNotDetected)})
+	if err != nil || len(presencePage.Items) != 1 || presencePage.Items[0].ID != fixed.ID {
+		t.Fatalf("presence page=%+v err=%v", presencePage, err)
+	}
+	changePage, err := repository.ListItems(ctx, tenantID, queued.ID, ports.AssessmentComparisonItemFilter{AfterPosition: -1, Limit: 10, ChangeFlag: assessmentcomparison.SeverityDecreased})
+	if err != nil || len(changePage.Items) != 1 || changePage.Items[0].ID != detected.ID {
+		t.Fatalf("change page=%+v err=%v", changePage, err)
+	}
+	severityPage, err := repository.ListItems(ctx, tenantID, queued.ID, ports.AssessmentComparisonItemFilter{AfterPosition: -1, Limit: 10, Severity: shared.SeverityMedium, ProducerKind: "sca", FindingKind: "vulnerability", ReviewState: "needs_review"})
+	if err != nil || len(severityPage.Items) != 1 || severityPage.Items[0].ID != detected.ID {
+		t.Fatalf("severity/review page=%+v err=%v", severityPage, err)
+	}
+	dispositionPage, err := repository.ListItems(ctx, tenantID, queued.ID, ports.AssessmentComparisonItemFilter{AfterPosition: -1, Limit: 10, Disposition: "baseline_only"})
+	if err != nil || len(dispositionPage.Items) != 1 || dispositionPage.Items[0].ID != fixed.ID {
+		t.Fatalf("disposition page=%+v err=%v", dispositionPage, err)
+	}
+	if _, err := repository.Get(ctx, "different-tenant", queued.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant get error=%v", err)
+	}
+	if _, err := repository.GetMetadata(ctx, "different-tenant", queued.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant metadata error=%v", err)
+	}
+	if _, err := repository.GetItem(ctx, "different-tenant", queued.ID, detected.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant item error=%v", err)
+	}
+	if _, err := repository.ListItems(ctx, "different-tenant", queued.ID, ports.AssessmentComparisonItemFilter{AfterPosition: -1, Limit: 10}); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant list error=%v", err)
+	}
+
+	assertAssessmentComparisonImmutable(t, ctx, pool, tenantID, cycleID, queued.ID)
+	assertAssessmentComparisonRLS(t, ctx, pool, tenantID, queued.ID)
+	for _, table := range []string{"assessment_comparisons", "assessment_comparison_items"} {
+		var forced bool
+		if err := pool.QueryRow(ctx, `SELECT relforcerowsecurity FROM pg_class WHERE oid=$1::regclass`, table).Scan(&forced); err != nil || !forced {
+			t.Fatalf("FORCE RLS %s=%v err=%v", table, forced, err)
+		}
+	}
+}
+
+func TestPostgresAssessmentComparisonRepositoryConcurrentInputReplay(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := fmt.Sprintf("comparison-race-%d", time.Now().UnixNano())
+	tenantID := shared.ID("tenant-" + suffix)
+	cycleID, baseline, current := createAssessmentComparisonSnapshots(t, ctx, pool, tenantID, suffix)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	comparisons := []assessmentcomparison.Comparison{
+		postgresQueuedComparison(t, tenantID, cycleID, shared.ID("comparison-race-a-"+suffix), baseline, current, 2, now),
+		postgresQueuedComparison(t, tenantID, cycleID, shared.ID("comparison-race-b-"+suffix), baseline, current, 2, now),
+	}
+	type result struct {
+		stored  assessmentcomparison.Comparison
+		created bool
+		err     error
+	}
+	results := make(chan result, len(comparisons))
+	start := make(chan struct{})
+	var wait sync.WaitGroup
+	for _, comparison := range comparisons {
+		comparison := comparison
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			<-start
+			stored, created, err := NewAssessmentComparisonRepository(pool).CreateQueued(ctx, comparison)
+			results <- result{stored: stored, created: created, err: err}
+		}()
+	}
+	close(start)
+	wait.Wait()
+	close(results)
+	createdCount := 0
+	var retainedID shared.ID
+	for result := range results {
+		if result.err != nil {
+			t.Fatal(result.err)
+		}
+		if result.created {
+			createdCount++
+		}
+		if retainedID.IsZero() {
+			retainedID = result.stored.ID
+		} else if result.stored.ID != retainedID {
+			t.Fatalf("concurrent replay retained different IDs: %s and %s", retainedID, result.stored.ID)
+		}
+	}
+	if createdCount != 1 {
+		t.Fatalf("concurrent replay created=%d want=1", createdCount)
+	}
+}
+
+func TestPostgresAssessmentComparisonRepositoryRejectsCrossCycleSnapshots(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := fmt.Sprintf("comparison-fk-%d", time.Now().UnixNano())
+	tenantID := shared.ID("tenant-" + suffix)
+	cycleA, baselineA, _ := createAssessmentComparisonSnapshots(t, ctx, pool, tenantID, suffix+"-a")
+	_, _, currentB := createAssessmentComparisonSnapshots(t, ctx, pool, tenantID, suffix+"-b")
+	comparison := postgresQueuedComparison(t, tenantID, cycleA, shared.ID("comparison-cross-cycle-"+suffix), baselineA, currentB, 1, time.Now().UTC())
+	if _, _, err := NewAssessmentComparisonRepository(pool).CreateQueued(ctx, comparison); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-cycle snapshot ownership error=%v", err)
+	}
+}
+
+func TestPostgresAssessmentComparisonServiceParity(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	suffix := fmt.Sprintf("comparison-service-%d", time.Now().UnixNano())
+	tenantID := shared.ID("tenant-" + suffix)
+	cycleID, baseline, current := createAssessmentComparisonSnapshots(t, ctx, pool, tenantID, suffix)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	identity, baselineObservation := postgresFindingLineagePair(t, tenantID, cycleID, baseline.ID, "service-identity-"+suffix, "service-baseline-observation-"+suffix, "service-baseline-source-"+suffix, "CVE-2026-2", now)
+	lineageRepository := NewFindingLineageRepository(pool)
+	if err := lineageRepository.CreateIdentityWithObservation(ctx, identity, baselineObservation); err != nil {
+		t.Fatal(err)
+	}
+	currentObservation := baselineObservation
+	currentObservation.ID = shared.ID("service-current-observation-" + suffix)
+	currentObservation.SnapshotID = current.ID
+	currentObservation.SourceFindingID = "service-current-source-" + suffix
+	currentObservation.Severity = shared.SeverityMedium
+	currentObservation.ObservedAt = now.Add(time.Second)
+	if err := lineageRepository.AppendObservation(ctx, currentObservation); err != nil {
+		t.Fatal(err)
+	}
+	verification, err := comparisonuc.NewRetestVerificationReader(lineageRepository, NewAssessmentSnapshotRepository(pool), NewRetestRepository(pool))
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := comparisonuc.NewService(
+		NewAssessmentComparisonRepository(pool), NewAssessmentSnapshotRepository(pool), NewAssessmentCycleRepository(pool), lineageRepository,
+		NewTenantTransactionRunner(pool), postgresLineageAudit{}, postgresLineageClock{now: now.Add(2 * time.Second)}, &postgresLineageIDs{prefix: "comparison-service-id"}, verification, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	queued, created, decision, err := service.Queue(ctx, comparisonuc.QueueInput{
+		TenantID: tenantID, BaselineSnapshotID: baseline.ID, CurrentSnapshotID: current.ID,
+		Mode: assessmentcomparison.ModeLifecycle, FingerprintVersion: 1, RiskModelVersion: 1, Actor: "integration-test",
+	})
+	if err != nil || !created || !decision.Allowed {
+		t.Fatalf("queue=%+v created=%v decision=%+v err=%v", queued, created, decision, err)
+	}
+	completed, err := service.Generate(ctx, comparisonuc.WorkInput{TenantID: tenantID, ComparisonID: queued.ID, Actor: "worker", MaxAttempts: 3})
+	if err != nil || completed.Status != assessmentcomparison.StatusComplete || len(completed.Items) != 1 || completed.Items[0].Presence != assessmentcomparison.PresenceDetected {
+		t.Fatalf("completed=%+v err=%v", completed, err)
+	}
+	loaded, err := NewAssessmentComparisonRepository(pool).Get(ctx, tenantID, completed.ID)
+	if err != nil || loaded.ContentHash != completed.ContentHash || loaded.Summary.ComparisonID != completed.ID {
+		t.Fatalf("loaded=%+v err=%v", loaded, err)
+	}
+}
+
+func TestMigration0153RollbackGuard(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 153); err != nil {
+		t.Fatalf("up to 0153: %v", err)
+	}
+	pool, err := Connect(context.Background(), dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	suffix := fmt.Sprintf("comparison-rollback-%d", time.Now().UnixNano())
+	tenantID := shared.ID("tenant-" + suffix)
+	assessmentID := shared.ID("lineage-assessment-" + suffix)
+	if _, err := pool.Exec(context.Background(), `INSERT INTO tenants (id,name) VALUES ($1,$2)`, tenantID.String(), "Rollback tenant"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(context.Background(), `INSERT INTO engagements (id,tenant_id,name,status) VALUES ($1,$2,$3,'draft')`, assessmentID.String(), tenantID.String(), "Rollback assessment"); err != nil {
+		t.Fatal(err)
+	}
+	cycleID, baseline, current := createAssessmentComparisonSnapshots(t, context.Background(), pool, tenantID, suffix)
+	comparison := postgresQueuedComparison(t, tenantID, cycleID, shared.ID("comparison-rollback-row-"+suffix), baseline, current, 1, time.Now().UTC())
+	if _, created, err := NewAssessmentComparisonRepository(pool).CreateQueued(context.Background(), comparison); err != nil || !created {
+		pool.Close()
+		t.Fatalf("create rollback guard row created=%v err=%v", created, err)
+	}
+	pool.Close()
+	if err := goose.DownTo(db, ".", 152); err == nil || !strings.Contains(err.Error(), "cannot roll back assessment comparisons") {
+		t.Fatalf("rollback guard error=%v", err)
+	}
+	var exists bool
+	if err := db.QueryRowContext(context.Background(), `SELECT to_regclass('public.assessment_comparisons') IS NOT NULL`).Scan(&exists); err != nil || !exists {
+		t.Fatalf("assessment comparisons after blocked rollback exists=%v err=%v", exists, err)
+	}
+}
+
+func createAssessmentComparisonSnapshots(t *testing.T, ctx context.Context, pool *pgxpool.Pool, tenantID shared.ID, suffix string) (shared.ID, *assessmentsnapshot.Snapshot, *assessmentsnapshot.Snapshot) {
+	t.Helper()
+	cycleID, baselineID := createFindingLineageSnapshot(t, ctx, pool, tenantID, suffix)
+	assessmentID := shared.ID("lineage-assessment-" + suffix)
+	runID := shared.ID("comparison-run-" + suffix)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	run := postgresNativeRun(t, tenantID, assessmentID, runID, strings.Repeat("c", 64))
+	runRepository := NewScanRunStore(pool)
+	sealPostgresNativeRun(t, ctx, runRepository, &run, now)
+	snapshot := postgresAssessmentSnapshot(t, tenantID, cycleID, assessmentID, "comparison-current-"+suffix, "comparison-request-"+suffix, run)
+	current, created, err := NewAssessmentSnapshotRepository(pool).CreateFinalizedCAS(ctx, snapshot, 1)
+	if err != nil || !created {
+		t.Fatalf("current snapshot=%+v created=%v err=%v", current, created, err)
+	}
+	baseline, err := NewAssessmentSnapshotRepository(pool).Get(ctx, tenantID, baselineID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cycleID, baseline, current
+}
+
+func postgresQueuedComparison(t *testing.T, tenantID, cycleID, comparisonID shared.ID, baseline, current *assessmentsnapshot.Snapshot, riskModelVersion int, now time.Time) assessmentcomparison.Comparison {
+	t.Helper()
+	input := assessmentcomparison.GenerationInput{
+		Mode:             assessmentcomparison.ModeLifecycle,
+		Baseline:         assessmentcomparison.SnapshotHashRef{ID: baseline.ID, ContentHash: baseline.ContentHash},
+		Current:          assessmentcomparison.SnapshotHashRef{ID: current.ID, ContentHash: current.ContentHash},
+		AlgorithmVersion: 1, FingerprintVersion: 1, RiskModelVersion: riskModelVersion, CoveragePolicyVersion: 1,
+	}
+	payload, inputHash, err := assessmentcomparison.HashGenerationInput(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	comparison, err := assessmentcomparison.NewQueued(tenantID, cycleID, comparisonID, input, payload, inputHash, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return comparison
+}
+
+func assertAssessmentComparisonImmutable(t *testing.T, ctx context.Context, pool *pgxpool.Pool, tenantID, cycleID, comparisonID shared.ID) {
+	t.Helper()
+	for name, statement := range map[string]string{
+		"comparison":  `UPDATE assessment_comparisons SET version=version+1,updated_at=clock_timestamp() WHERE tenant_id=$1 AND cycle_id=$2 AND id=$3`,
+		"item update": `UPDATE assessment_comparison_items SET current_risk_milli=current_risk_milli+1 WHERE tenant_id=$1 AND cycle_id=$2 AND comparison_id=$3`,
+		"item delete": `DELETE FROM assessment_comparison_items WHERE tenant_id=$1 AND cycle_id=$2 AND comparison_id=$3`,
+	} {
+		err := WithTenant(ctx, pool, tenantID.String(), func(tx pgx.Tx) error {
+			_, err := tx.Exec(ctx, statement, tenantID.String(), cycleID.String(), comparisonID.String())
+			return err
+		})
+		if err == nil {
+			t.Fatalf("completed %s accepted mutation", name)
+		}
+	}
+}
+
+func assertAssessmentComparisonRLS(t *testing.T, ctx context.Context, pool *pgxpool.Pool, tenantID, comparisonID shared.ID) {
+	t.Helper()
+	role := fmt.Sprintf("synapse_comparison_rls_%d", time.Now().UnixNano())
+	quotedRole := pgx.Identifier{role}.Sanitize()
+	if _, err := pool.Exec(ctx, `CREATE ROLE `+quotedRole+` NOLOGIN NOSUPERUSER NOBYPASSRLS`); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DROP OWNED BY `+quotedRole)
+		_, _ = pool.Exec(context.Background(), `DROP ROLE IF EXISTS `+quotedRole)
+	})
+	if _, err := pool.Exec(ctx, `GRANT USAGE ON SCHEMA public TO `+quotedRole); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `GRANT SELECT ON assessment_comparisons,assessment_comparison_items TO `+quotedRole); err != nil {
+		t.Fatal(err)
+	}
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, `SET LOCAL ROLE `+quotedRole); err != nil {
+		t.Fatal(err)
+	}
+	for tenant, want := range map[string]int64{"different-tenant": 0, tenantID.String(): 1} {
+		if _, err := tx.Exec(ctx, `SELECT set_config('app.current_tenant',$1,true)`, tenant); err != nil {
+			t.Fatal(err)
+		}
+		var count int64
+		if err := tx.QueryRow(ctx, `SELECT count(*) FROM assessment_comparisons WHERE id=$1`, comparisonID.String()).Scan(&count); err != nil || count != want {
+			t.Fatalf("RLS tenant=%s count=%d want=%d err=%v", tenant, count, want, err)
+		}
+	}
+}

--- a/internal/infrastructure/persistence/postgres/assessment_cycle_request_repo.go
+++ b/internal/infrastructure/persistence/postgres/assessment_cycle_request_repo.go
@@ -1,0 +1,130 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const maxAssessmentCycleResponseBytes = 2 << 20
+
+type AssessmentCycleRequestRepository struct{ pool *pgxpool.Pool }
+
+func NewAssessmentCycleRequestRepository(pool *pgxpool.Pool) *AssessmentCycleRequestRepository {
+	return &AssessmentCycleRequestRepository{pool: pool}
+}
+
+var _ ports.AssessmentCycleRequestStore = (*AssessmentCycleRequestRepository)(nil)
+
+func (repository *AssessmentCycleRequestRepository) BeginAssessmentCycleRequest(ctx context.Context, request ports.AssessmentCycleRequest) (ports.AssessmentCycleRequest, bool, error) {
+	if request.ExpiresAt.IsZero() {
+		request.ExpiresAt = request.CreatedAt.Add(24 * time.Hour)
+	}
+	if err := validatePostgresAssessmentCycleRequest(request); err != nil {
+		return ports.AssessmentCycleRequest{}, false, err
+	}
+	tenantID := shared.TenantOrDefault(request.Scope.TenantID)
+	var stored ports.AssessmentCycleRequest
+	created := false
+	err := WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `DELETE FROM assessment_cycle_api_requests WHERE tenant_id=$1 AND expires_at <= $2`, tenantID.String(), request.CreatedAt.UTC()); err != nil {
+			return fmt.Errorf("prune expired assessment cycle requests: %w", err)
+		}
+		tag, err := tx.Exec(ctx, `INSERT INTO assessment_cycle_api_requests
+			(tenant_id, actor, route, idempotency_key, request_hash, created_at, expires_at)
+			VALUES ($1,$2,$3,$4,$5,$6,$7)
+			ON CONFLICT (tenant_id, actor, route, idempotency_key) DO NOTHING`,
+			tenantID.String(), request.Scope.Actor, request.Scope.Route, request.Scope.IdempotencyKey, request.RequestHash, request.CreatedAt.UTC(), request.ExpiresAt.UTC())
+		if err != nil {
+			return fmt.Errorf("reserve assessment cycle request: %w", err)
+		}
+		if tag.RowsAffected() == 1 {
+			stored, created = clonePostgresAssessmentCycleRequest(request), true
+			return nil
+		}
+		loaded, err := scanAssessmentCycleRequest(tx.QueryRow(ctx, `SELECT tenant_id, actor, route, idempotency_key, request_hash,
+			status_code, response_body, created_at, expires_at, completed_at
+			FROM assessment_cycle_api_requests
+			WHERE tenant_id=$1 AND actor=$2 AND route=$3 AND idempotency_key=$4`,
+			tenantID.String(), request.Scope.Actor, request.Scope.Route, request.Scope.IdempotencyKey))
+		if err != nil {
+			return err
+		}
+		stored = loaded
+		return nil
+	})
+	return stored, created, err
+}
+
+func (repository *AssessmentCycleRequestRepository) CompleteAssessmentCycleRequest(ctx context.Context, scope ports.AssessmentCycleRequestScope, requestHash string, statusCode int, responseBody []byte, completedAt time.Time) error {
+	if err := validatePostgresAssessmentCycleRequest(ports.AssessmentCycleRequest{Scope: scope, RequestHash: requestHash, CreatedAt: completedAt, ExpiresAt: completedAt.Add(24 * time.Hour)}); err != nil || statusCode < 200 || statusCode > 599 || len(responseBody) == 0 || len(responseBody) > maxAssessmentCycleResponseBytes {
+		return fmt.Errorf("%w: assessment cycle request completion is invalid", shared.ErrValidation)
+	}
+	tenantID := shared.TenantOrDefault(scope.TenantID)
+	return WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		tag, err := tx.Exec(ctx, `UPDATE assessment_cycle_api_requests
+			SET status_code=$6, response_body=$7, completed_at=$8
+			WHERE tenant_id=$1 AND actor=$2 AND route=$3 AND idempotency_key=$4
+			  AND request_hash=$5 AND completed_at IS NULL`, tenantID.String(), scope.Actor, scope.Route, scope.IdempotencyKey, requestHash, statusCode, responseBody, completedAt.UTC())
+		if err != nil {
+			return fmt.Errorf("complete assessment cycle request: %w", err)
+		}
+		if tag.RowsAffected() == 0 {
+			return fmt.Errorf("%w: assessment cycle request completion conflict", shared.ErrConflict)
+		}
+		return nil
+	})
+}
+
+func (repository *AssessmentCycleRequestRepository) AbortAssessmentCycleRequest(ctx context.Context, scope ports.AssessmentCycleRequestScope, requestHash string) error {
+	tenantID := shared.TenantOrDefault(scope.TenantID)
+	if tenantID.IsZero() || strings.TrimSpace(scope.Actor) == "" || strings.TrimSpace(scope.Route) == "" || strings.TrimSpace(scope.IdempotencyKey) == "" || len(requestHash) != 64 {
+		return fmt.Errorf("%w: assessment cycle request abort is invalid", shared.ErrValidation)
+	}
+	return WithTenant(ctx, repository.pool, tenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `DELETE FROM assessment_cycle_api_requests
+			WHERE tenant_id=$1 AND actor=$2 AND route=$3 AND idempotency_key=$4
+			  AND request_hash=$5 AND completed_at IS NULL`, tenantID.String(), scope.Actor, scope.Route, scope.IdempotencyKey, requestHash)
+		return err
+	})
+}
+
+func scanAssessmentCycleRequest(row rowScanner) (ports.AssessmentCycleRequest, error) {
+	var (
+		request     ports.AssessmentCycleRequest
+		statusCode  pgtype.Int4
+		completedAt pgtype.Timestamptz
+	)
+	if err := row.Scan(&request.Scope.TenantID, &request.Scope.Actor, &request.Scope.Route, &request.Scope.IdempotencyKey,
+		&request.RequestHash, &statusCode, &request.ResponseBody, &request.CreatedAt, &request.ExpiresAt, &completedAt); err != nil {
+		return ports.AssessmentCycleRequest{}, fmt.Errorf("scan assessment cycle request: %w", err)
+	}
+	if statusCode.Valid {
+		request.StatusCode = int(statusCode.Int32)
+	}
+	if completedAt.Valid {
+		value := completedAt.Time.UTC()
+		request.CompletedAt = &value
+	}
+	return request, nil
+}
+
+func validatePostgresAssessmentCycleRequest(request ports.AssessmentCycleRequest) error {
+	if shared.TenantOrDefault(request.Scope.TenantID).IsZero() || strings.TrimSpace(request.Scope.Actor) == "" || len(request.Scope.Actor) > 256 || strings.TrimSpace(request.Scope.Route) == "" || len(request.Scope.Route) > 256 || strings.TrimSpace(request.Scope.IdempotencyKey) == "" || len(request.Scope.IdempotencyKey) > 128 || len(request.RequestHash) != 64 || request.CreatedAt.IsZero() || !request.ExpiresAt.After(request.CreatedAt) {
+		return fmt.Errorf("%w: assessment cycle idempotency request is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func clonePostgresAssessmentCycleRequest(request ports.AssessmentCycleRequest) ports.AssessmentCycleRequest {
+	request.ResponseBody = append([]byte(nil), request.ResponseBody...)
+	return request
+}

--- a/internal/usecase/assessmentcomparison/api.go
+++ b/internal/usecase/assessmentcomparison/api.go
@@ -1,0 +1,596 @@
+package assessmentcomparison
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	lineagedom "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	JobKind                        = "assessment_comparison_generate"
+	CodeIdempotencyKeyRequired     = "idempotency_key_required"
+	CodeIdempotencyBodyMismatch    = "idempotency_body_mismatch"
+	CodeIdempotencyRequestPending  = "idempotency_request_in_progress"
+	CodeComparisonVersionConflict  = "comparison_version_conflict"
+	CodeReviewCandidateMismatch    = "review_candidate_mismatch"
+	CodeReviewSourceMissing        = "review_source_observation_missing"
+	CodeReviewReasonRejected       = "review_reason_rejected"
+	DefaultAssessmentItemPageLimit = 100
+	MaxAssessmentItemPageLimit     = 200
+)
+
+type APIError struct {
+	Code  string
+	Cause error
+}
+
+func (err *APIError) Error() string { return err.Code }
+func (err *APIError) Unwrap() error { return err.Cause }
+
+func ErrorCode(err error) string {
+	var coded *APIError
+	if errors.As(err, &coded) {
+		return coded.Code
+	}
+	return ""
+}
+
+type RetainedRequest struct {
+	TenantID       shared.ID
+	Actor          string
+	Route          string
+	IdempotencyKey string
+}
+
+type RetainedResponse struct {
+	StatusCode int
+	Body       []byte
+	Replayed   bool
+}
+
+type Job struct {
+	ComparisonID shared.ID `json:"comparison_id"`
+}
+
+type ComparisonView struct {
+	ID                    shared.ID      `json:"id"`
+	CycleID               shared.ID      `json:"cycle_id"`
+	BaselineSnapshotID    shared.ID      `json:"baseline_snapshot_id"`
+	CurrentSnapshotID     shared.ID      `json:"current_snapshot_id"`
+	Mode                  domain.Mode    `json:"mode"`
+	InputHash             string         `json:"input_hash"`
+	AlgorithmVersion      int            `json:"algorithm_version"`
+	FingerprintVersion    int            `json:"fingerprint_version"`
+	RiskModelVersion      int            `json:"risk_model_version"`
+	CoveragePolicyVersion int            `json:"coverage_policy_version"`
+	Status                domain.Status  `json:"status"`
+	Version               int64          `json:"version"`
+	Attempts              int            `json:"attempts"`
+	FailureCode           string         `json:"failure_code,omitempty"`
+	ContentHash           string         `json:"content_hash,omitempty"`
+	Summary               domain.Summary `json:"summary"`
+	CreatedAt             time.Time      `json:"created_at"`
+	UpdatedAt             time.Time      `json:"updated_at"`
+	CompletedAt           *time.Time     `json:"completed_at,omitempty"`
+	SupersededAt          *time.Time     `json:"superseded_at,omitempty"`
+	SupersededBy          shared.ID      `json:"superseded_by,omitempty"`
+}
+
+type QueueResult struct {
+	Comparison ComparisonView `json:"comparison"`
+	Created    bool           `json:"created"`
+}
+
+type ItemPage struct {
+	Items      []domain.Item `json:"items"`
+	NextCursor string        `json:"next_cursor,omitempty"`
+}
+
+type ListItemsInput struct {
+	TenantID     shared.ID
+	ComparisonID shared.ID
+	Cursor       string
+	Limit        int
+	Scope        domain.Scope
+	Presence     string
+	ChangeFlag   domain.ChangeFlag
+	Severity     shared.Severity
+	ProducerKind string
+	FindingKind  string
+	Disposition  string
+	ReviewState  string
+}
+
+type ReviewAction string
+
+const (
+	ReviewConfirm ReviewAction = "confirm"
+	ReviewUnlink  ReviewAction = "unlink"
+)
+
+type ReviewInput struct {
+	Request             RetainedRequest
+	ComparisonID        shared.ID
+	ItemID              shared.ID
+	CandidateID         shared.ID
+	SourceObservationID shared.ID
+	TargetObservationID shared.ID
+	ExpectedVersion     int64
+	Action              ReviewAction
+	Reason              string
+}
+
+type ReviewResult struct {
+	OverrideEventID         shared.ID     `json:"override_event_id"`
+	SupersededComparisonID  shared.ID     `json:"superseded_comparison_id"`
+	ReplacementComparisonID shared.ID     `json:"replacement_comparison_id"`
+	ReplacementStatus       domain.Status `json:"replacement_status"`
+}
+
+func (service *Service) QueueRetained(ctx context.Context, request RetainedRequest, input QueueInput) (RetainedResponse, error) {
+	input.TenantID, input.Actor = request.TenantID, request.Actor
+	canonical := struct {
+		BaselineSnapshotID shared.ID   `json:"baseline_snapshot_id"`
+		CurrentSnapshotID  shared.ID   `json:"current_snapshot_id"`
+		Mode               domain.Mode `json:"mode"`
+		FingerprintVersion int         `json:"fingerprint_version"`
+		RiskModelVersion   int         `json:"risk_model_version"`
+	}{input.BaselineSnapshotID, input.CurrentSnapshotID, input.Mode, input.FingerprintVersion, input.RiskModelVersion}
+	return service.executeRetained(ctx, request, canonical, func(txCtx context.Context) (int, any, error) {
+		comparison, created, decision, err := service.Queue(txCtx, input)
+		if err != nil {
+			return 0, nil, err
+		}
+		if !decision.Allowed {
+			return 0, nil, &APIError{Code: decision.ReasonCode, Cause: shared.ErrValidation}
+		}
+		status := 200
+		if created && !isTerminal(comparison.Status) {
+			status = 202
+		}
+		return status, QueueResult{Comparison: projectComparison(comparison), Created: created}, nil
+	})
+}
+
+func (service *Service) Get(ctx context.Context, tenantID, comparisonID shared.ID) (ComparisonView, error) {
+	comparison, err := service.comparisons.GetMetadata(ctx, shared.TenantOrDefault(tenantID), comparisonID)
+	if err != nil {
+		return ComparisonView{}, err
+	}
+	return projectComparison(comparison), nil
+}
+
+func (service *Service) GetSummary(ctx context.Context, tenantID, comparisonID shared.ID, scope domain.Scope) (domain.Summary, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	if comparisonID.IsZero() {
+		return domain.Summary{}, fmt.Errorf("%w: comparison id is required", shared.ErrValidation)
+	}
+	if scope == "" {
+		scope = domain.ScopeAll
+	}
+	if !scope.Valid() {
+		return domain.Summary{}, fmt.Errorf("%w: comparison summary scope is invalid", shared.ErrValidation)
+	}
+	comparison, err := service.comparisons.GetMetadata(ctx, tenantID, comparisonID)
+	if err != nil {
+		return domain.Summary{}, err
+	}
+	if !isTerminal(comparison.Status) {
+		return domain.Summary{}, fmt.Errorf("%w: comparison summary is not ready", shared.ErrConflict)
+	}
+	if scope == domain.ScopeAll {
+		return comparison.Summary, nil
+	}
+	summary, err := service.comparisons.SummarizeItems(ctx, tenantID, comparisonID, scope)
+	if err != nil {
+		return domain.Summary{}, err
+	}
+	summary.ComparisonID = comparison.ID
+	summary.BaselineSnapshotID = comparison.BaselineSnapshotID
+	summary.CurrentSnapshotID = comparison.CurrentSnapshotID
+	summary.RiskModelVersion = comparison.RiskModelVersion
+	return summary, nil
+}
+
+func (service *Service) ListItems(ctx context.Context, input ListItemsInput) (ItemPage, error) {
+	input.TenantID = shared.TenantOrDefault(input.TenantID)
+	if input.ComparisonID.IsZero() {
+		return ItemPage{}, fmt.Errorf("%w: comparison id is required", shared.ErrValidation)
+	}
+	if input.Limit == 0 {
+		input.Limit = DefaultAssessmentItemPageLimit
+	}
+	if input.Scope == "" {
+		input.Scope = domain.ScopeAll
+	}
+	input.ProducerKind, input.FindingKind = strings.TrimSpace(input.ProducerKind), strings.TrimSpace(input.FindingKind)
+	if input.Limit < 1 || input.Limit > MaxAssessmentItemPageLimit || !input.Scope.Valid() || input.ChangeFlag != "" && !input.ChangeFlag.Valid() || !validPresenceFilter(input.Presence) ||
+		input.Severity != "" && !input.Severity.Valid() || !validItemTokenFilter(input.ProducerKind) || !validItemTokenFilter(input.FindingKind) ||
+		input.Disposition != "" && input.Disposition != "current_actionable" && input.Disposition != "baseline_only" && input.Disposition != "non_actionable" ||
+		input.ReviewState != "" && input.ReviewState != "needs_review" && input.ReviewState != "verified" && input.ReviewState != "clear" {
+		return ItemPage{}, fmt.Errorf("%w: comparison item filter is invalid", shared.ErrValidation)
+	}
+	after, err := decodeItemCursor(input.Cursor)
+	if err != nil {
+		return ItemPage{}, &APIError{Code: "invalid_cursor", Cause: shared.ErrValidation}
+	}
+	page, err := service.comparisons.ListItems(ctx, input.TenantID, input.ComparisonID, ports.AssessmentComparisonItemFilter{
+		AfterPosition: after, Limit: input.Limit, Scope: input.Scope, Presence: input.Presence, ChangeFlag: input.ChangeFlag, Severity: input.Severity,
+		ProducerKind: input.ProducerKind, FindingKind: input.FindingKind, Disposition: input.Disposition, ReviewState: input.ReviewState,
+	})
+	if err != nil {
+		return ItemPage{}, err
+	}
+	result := ItemPage{Items: page.Items}
+	if page.HasMore {
+		result.NextCursor = encodeItemCursor(page.NextPosition)
+	}
+	return result, nil
+}
+
+func (service *Service) Review(ctx context.Context, input ReviewInput) (RetainedResponse, error) {
+	if service.reviewer == nil {
+		return RetainedResponse{}, fmt.Errorf("%w: comparison review workflow is unavailable", shared.ErrValidation)
+	}
+	input.Reason = strings.TrimSpace(input.Reason)
+	if input.ComparisonID.IsZero() || input.ItemID.IsZero() || input.CandidateID.IsZero() || input.SourceObservationID.IsZero() || input.ExpectedVersion <= 0 || input.Action != ReviewConfirm && input.Action != ReviewUnlink {
+		return RetainedResponse{}, fmt.Errorf("%w: comparison review input is invalid", shared.ErrValidation)
+	}
+	if !safeReviewReason(input.Reason) {
+		return RetainedResponse{}, &APIError{Code: CodeReviewReasonRejected, Cause: shared.ErrValidation}
+	}
+	canonical := struct {
+		ComparisonID        shared.ID    `json:"comparison_id"`
+		ItemID              shared.ID    `json:"item_id"`
+		CandidateID         shared.ID    `json:"candidate_id"`
+		SourceObservationID shared.ID    `json:"source_observation_id"`
+		TargetObservationID shared.ID    `json:"target_observation_id,omitempty"`
+		ExpectedVersion     int64        `json:"expected_version"`
+		Action              ReviewAction `json:"action"`
+		Reason              string       `json:"reason"`
+	}{input.ComparisonID, input.ItemID, input.CandidateID, input.SourceObservationID, input.TargetObservationID, input.ExpectedVersion, input.Action, input.Reason}
+	return service.executeRetained(ctx, input.Request, canonical, func(txCtx context.Context) (int, any, error) {
+		comparison, err := service.comparisons.Get(txCtx, input.Request.TenantID, input.ComparisonID)
+		if err != nil {
+			return 0, nil, err
+		}
+		if comparison.Version != input.ExpectedVersion {
+			return 0, nil, &APIError{Code: CodeComparisonVersionConflict, Cause: shared.ErrConflict}
+		}
+		item, err := service.comparisons.GetItem(txCtx, input.Request.TenantID, input.ComparisonID, input.ItemID)
+		if err != nil {
+			return 0, nil, err
+		}
+		if item.Presence != domain.PresenceNeedsReview && item.NeutralPresence != domain.NeutralNeedsReview || !containsID(item.ReviewCandidateIDs, input.CandidateID) {
+			return 0, nil, &APIError{Code: CodeReviewCandidateMismatch, Cause: shared.ErrConflict}
+		}
+		candidate, err := service.lineage.GetCandidate(txCtx, input.Request.TenantID, comparison.CycleID, input.CandidateID)
+		if err != nil {
+			return 0, nil, err
+		}
+		source, err := service.lineage.GetObservation(txCtx, input.Request.TenantID, comparison.CycleID, input.SourceObservationID)
+		if err != nil || !candidateContainsObservation(candidate, input.SourceObservationID) {
+			return 0, nil, &APIError{Code: CodeReviewSourceMissing, Cause: shared.ErrValidation}
+		}
+		if !candidateContainsIdentity(candidate, item.IdentityID) {
+			return 0, nil, &APIError{Code: CodeReviewCandidateMismatch, Cause: shared.ErrConflict}
+		}
+		var targetObservationID shared.ID
+		if !input.TargetObservationID.IsZero() {
+			target, targetErr := service.lineage.GetObservation(txCtx, input.Request.TenantID, comparison.CycleID, input.TargetObservationID)
+			if targetErr != nil || target.IdentityID != item.IdentityID || !candidateContainsObservation(candidate, input.TargetObservationID) {
+				return 0, nil, &APIError{Code: CodeReviewCandidateMismatch, Cause: shared.ErrValidation}
+			}
+			targetObservationID = target.ID
+		}
+		action, overrideAction := lineagedom.ResolutionConfirmExisting, lineagedom.OverrideConfirm
+		if input.Action == ReviewUnlink {
+			action, overrideAction = lineagedom.ResolutionUnlink, lineagedom.OverrideUnlink
+		}
+		afterRefs := reviewedRefs(candidate.Refs, item.IdentityID, input.Action)
+		_, _, _, err = service.reviewer.ResolveCandidate(txCtx, lineageuc.ResolveInput{
+			TenantID: input.Request.TenantID, CycleID: comparison.CycleID, CandidateID: candidate.ID, EventID: service.ids.NewID(),
+			Action: action, Actor: input.Request.Actor, Reason: input.Reason, AfterRefs: afterRefs, ExpectedVersion: candidate.Version,
+		})
+		if err != nil {
+			return 0, nil, err
+		}
+		expectedOverrideVersion, priorOverrideID := int64(0), shared.ID("")
+		active, activeErr := service.lineage.GetActiveOverride(txCtx, input.Request.TenantID, comparison.CycleID, source.ID)
+		if activeErr == nil {
+			expectedOverrideVersion, priorOverrideID = active.Version, active.ID
+		} else if !errors.Is(activeErr, shared.ErrNotFound) {
+			return 0, nil, activeErr
+		}
+		override, _, err := service.reviewer.AppendOverride(txCtx, lineageuc.OverrideInput{
+			TenantID: input.Request.TenantID, CycleID: comparison.CycleID, EventID: service.ids.NewID(), Action: overrideAction,
+			SourceObservationID: source.ID, SourceIdentityID: source.IdentityID, TargetObservationID: targetObservationID, TargetIdentityID: item.IdentityID,
+			Actor: input.Request.Actor, Reason: input.Reason, ExpectedVersion: expectedOverrideVersion, PriorEventID: priorOverrideID,
+		})
+		if err != nil {
+			return 0, nil, err
+		}
+		replacement, _, err := service.Replace(txCtx, ReplaceInput{TenantID: input.Request.TenantID, ComparisonID: comparison.ID, Actor: input.Request.Actor})
+		if err != nil {
+			return 0, nil, err
+		}
+		status := 202
+		if isTerminal(replacement.Status) {
+			status = 200
+		}
+		return status, ReviewResult{OverrideEventID: override.ID, SupersededComparisonID: comparison.ID, ReplacementComparisonID: replacement.ID, ReplacementStatus: replacement.Status}, nil
+	})
+}
+
+func (service *Service) HandleJob(ctx context.Context, payload []byte) error {
+	job, err := decodeComparisonJob(payload)
+	if err != nil {
+		return err
+	}
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("%w: tenant context is required", shared.ErrValidation)
+	}
+	_, err = service.Generate(ctx, WorkInput{TenantID: tenantID, ComparisonID: job.ComparisonID, Actor: "system:assessment-comparison-worker"})
+	return err
+}
+
+func (service *Service) OnDeadLetter(ctx context.Context, payload []byte) error {
+	job, err := decodeComparisonJob(payload)
+	if err != nil {
+		return err
+	}
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok {
+		return fmt.Errorf("%w: tenant context is required", shared.ErrValidation)
+	}
+	defer service.observeBacklog(context.WithoutCancel(ctx), tenantID)
+	return service.transactions.Run(ctx, tenantID, func(txCtx context.Context) error {
+		comparison, err := service.comparisons.Get(txCtx, tenantID, job.ComparisonID)
+		if err != nil || isTerminal(comparison.Status) || comparison.Status == domain.StatusFailed {
+			return err
+		}
+		if comparison.Status == domain.StatusQueued {
+			expected := comparison.Version
+			if err := comparison.Start(expected, service.clock.Now().UTC()); err != nil {
+				return err
+			}
+			if err := service.comparisons.UpdateCAS(txCtx, comparison, expected); err != nil {
+				return err
+			}
+		}
+		expected := comparison.Version
+		if err := comparison.Fail("dead_lettered", false, DefaultMaxAttempts, expected, service.clock.Now().UTC()); err != nil {
+			return err
+		}
+		if err := service.comparisons.UpdateCAS(txCtx, comparison, expected); err != nil {
+			return err
+		}
+		return service.recordAudit(txCtx, "system:assessment-comparison-worker", "assessment_comparison.dead_lettered", comparison, nil)
+	})
+}
+
+func (service *Service) executeRetained(ctx context.Context, request RetainedRequest, canonical any, operation func(context.Context) (int, any, error)) (RetainedResponse, error) {
+	if service.requests == nil {
+		return RetainedResponse{}, fmt.Errorf("%w: assessment comparison request store is unavailable", shared.ErrValidation)
+	}
+	scope := ports.AssessmentCycleRequestScope{TenantID: shared.TenantOrDefault(request.TenantID), Actor: strings.TrimSpace(request.Actor), Route: strings.TrimSpace(request.Route), IdempotencyKey: strings.TrimSpace(request.IdempotencyKey)}
+	if scope.Actor == "" || scope.Route == "" {
+		return RetainedResponse{}, fmt.Errorf("%w: actor and route are required", shared.ErrValidation)
+	}
+	if scope.IdempotencyKey == "" || len(scope.IdempotencyKey) > 128 {
+		return RetainedResponse{}, &APIError{Code: CodeIdempotencyKeyRequired, Cause: shared.ErrValidation}
+	}
+	requestHash, err := comparisonCanonicalHash(canonical)
+	if err != nil {
+		return RetainedResponse{}, err
+	}
+	var response RetainedResponse
+	createdReservation := false
+	err = service.transactions.Run(ctx, scope.TenantID, func(txCtx context.Context) error {
+		stored, created, err := service.requests.BeginAssessmentCycleRequest(txCtx, ports.AssessmentCycleRequest{Scope: scope, RequestHash: requestHash, CreatedAt: service.clock.Now().UTC()})
+		if err != nil {
+			return err
+		}
+		createdReservation = created
+		if !created {
+			if stored.RequestHash != requestHash {
+				return &APIError{Code: CodeIdempotencyBodyMismatch, Cause: shared.ErrConflict}
+			}
+			if stored.CompletedAt == nil || stored.StatusCode == 0 || len(stored.ResponseBody) == 0 {
+				return &APIError{Code: CodeIdempotencyRequestPending, Cause: shared.ErrConflict}
+			}
+			response = RetainedResponse{StatusCode: stored.StatusCode, Body: append([]byte(nil), stored.ResponseBody...), Replayed: true}
+			return nil
+		}
+		statusCode, value, err := operation(txCtx)
+		if err != nil {
+			return err
+		}
+		body, err := json.Marshal(value)
+		if err != nil {
+			return err
+		}
+		if err := service.requests.CompleteAssessmentCycleRequest(txCtx, scope, requestHash, statusCode, body, service.clock.Now().UTC()); err != nil {
+			return err
+		}
+		response = RetainedResponse{StatusCode: statusCode, Body: body}
+		return nil
+	})
+	if err != nil && createdReservation {
+		_ = service.requests.AbortAssessmentCycleRequest(context.WithoutCancel(ctx), scope, requestHash)
+	}
+	return response, err
+}
+
+func projectComparison(comparison domain.Comparison) ComparisonView {
+	return ComparisonView{
+		ID: comparison.ID, CycleID: comparison.CycleID, BaselineSnapshotID: comparison.BaselineSnapshotID, CurrentSnapshotID: comparison.CurrentSnapshotID,
+		Mode: comparison.Mode, InputHash: comparison.InputHash, AlgorithmVersion: comparison.AlgorithmVersion, FingerprintVersion: comparison.FingerprintVersion,
+		RiskModelVersion: comparison.RiskModelVersion, CoveragePolicyVersion: comparison.CoveragePolicyVersion, Status: comparison.Status, Version: comparison.Version,
+		Attempts: comparison.Attempts, FailureCode: comparison.FailureCode, ContentHash: comparison.ContentHash, Summary: comparison.Summary,
+		CreatedAt: comparison.CreatedAt, UpdatedAt: comparison.UpdatedAt, CompletedAt: comparison.CompletedAt, SupersededAt: comparison.SupersededAt, SupersededBy: comparison.SupersededBy,
+	}
+}
+
+func reviewedRefs(refs []lineagedom.CandidateRef, targetIdentityID shared.ID, action ReviewAction) []lineagedom.CandidateRef {
+	result := append([]lineagedom.CandidateRef(nil), refs...)
+	for index := range result {
+		result[index].ReasonPayload = cloneReasonPayload(result[index].ReasonPayload)
+		if !result[index].IdentityID.IsZero() {
+			result[index].Role = lineagedom.RoleExcluded
+			if action == ReviewConfirm && result[index].IdentityID == targetIdentityID {
+				result[index].Role = lineagedom.RoleSelected
+			}
+		}
+	}
+	return result
+}
+
+func cloneReasonPayload(input map[string]string) map[string]string {
+	if input == nil {
+		return map[string]string{}
+	}
+	result := make(map[string]string, len(input))
+	for key, value := range input {
+		result[key] = value
+	}
+	return result
+}
+
+func candidateContainsIdentity(candidate lineagedom.MatchCandidate, identityID shared.ID) bool {
+	for _, reference := range candidate.Refs {
+		if reference.IdentityID == identityID {
+			return true
+		}
+	}
+	return false
+}
+
+func candidateContainsObservation(candidate lineagedom.MatchCandidate, observationID shared.ID) bool {
+	for _, reference := range candidate.Refs {
+		if reference.ObservationID == observationID {
+			return true
+		}
+	}
+	return false
+}
+
+func containsID(values []shared.ID, target shared.ID) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func safeReviewReason(reason string) bool {
+	if reason == "" || len(reason) > 512 {
+		return false
+	}
+	lower := strings.ToLower(reason)
+	for _, marker := range []string{"password=", "passwd=", "api_key", "apikey", "access_token", "authorization:", "bearer ", "private_key", "client_secret"} {
+		if strings.Contains(lower, marker) {
+			return false
+		}
+	}
+	return true
+}
+
+func validPresenceFilter(value string) bool {
+	if value == "" {
+		return true
+	}
+	return domain.Presence(value).Valid() || domain.NeutralPresence(value).Valid()
+}
+
+func validItemTokenFilter(value string) bool {
+	if value == "" {
+		return true
+	}
+	if len(value) > 256 || strings.TrimSpace(value) != value || !utf8.ValidString(value) {
+		return false
+	}
+	for _, char := range value {
+		if char < 32 || char == 127 {
+			return false
+		}
+	}
+	return true
+}
+
+func comparisonCanonicalHash(value any) (string, error) {
+	// ponytail: request schemas contain no maps or floats; use RFC 8785 if either is introduced.
+	var buffer bytes.Buffer
+	encoder := json.NewEncoder(&buffer)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(value); err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(bytes.TrimSuffix(buffer.Bytes(), []byte("\n")))
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func encodeItemCursor(position int) string {
+	payload, _ := json.Marshal(struct {
+		Position int `json:"position"`
+	}{position})
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+func decodeItemCursor(cursor string) (int, error) {
+	if strings.TrimSpace(cursor) == "" {
+		return -1, nil
+	}
+	if len(cursor) > 128 {
+		return 0, fmt.Errorf("invalid cursor")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil || len(raw) > 64 {
+		return 0, fmt.Errorf("invalid cursor")
+	}
+	var value struct {
+		Position int `json:"position"`
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&value); err != nil || value.Position < 0 {
+		return 0, fmt.Errorf("invalid cursor")
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return 0, fmt.Errorf("invalid cursor")
+	}
+	return value.Position, nil
+}
+
+func decodeComparisonJob(payload []byte) (Job, error) {
+	if len(payload) == 0 || len(payload) > 4096 {
+		return Job{}, fmt.Errorf("%w: comparison job payload is invalid", shared.ErrValidation)
+	}
+	var job Job
+	decoder := json.NewDecoder(bytes.NewReader(payload))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&job); err != nil || job.ComparisonID.IsZero() {
+		return Job{}, fmt.Errorf("%w: comparison job payload is invalid", shared.ErrValidation)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return Job{}, fmt.Errorf("%w: comparison job payload is invalid", shared.ErrValidation)
+	}
+	return job, nil
+}

--- a/internal/usecase/assessmentcomparison/api_test.go
+++ b/internal/usecase/assessmentcomparison/api_test.go
@@ -1,0 +1,141 @@
+package assessmentcomparison
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
+)
+
+func TestComparisonAPIIdempotencyPaginationAndReviewReplacement(t *testing.T) {
+	harness := newComparisonHarness(t)
+	ctx := context.Background()
+	targetIdentity, targetObservation := comparisonLineagePair(t, harness, "review-target", harness.snapshotsByNumber[3].ID, "review-target-observation", shared.SeverityMedium, 2100, harness.clock.Now())
+	createIdentity(t, harness.lineage, targetIdentity, targetObservation)
+	sourceIdentity, sourceObservation := comparisonLineagePair(t, harness, "review-source", harness.snapshotsByNumber[3].ID, "review-source-observation", shared.SeverityMedium, 2200, harness.clock.Now())
+	createIdentity(t, harness.lineage, sourceIdentity, sourceObservation)
+	candidate, err := findinglineage.NewMatchCandidate(findinglineage.MatchCandidate{
+		TenantID: harness.tenantID, CycleID: harness.cycleID, SnapshotID: harness.snapshotsByNumber[3].ID, ID: "review-candidate",
+		ProducerKind: "sca", FindingKind: "vulnerability", Reason: findinglineage.ReasonMerge, FingerprintSchemaVersion: 1,
+		Fingerprint: strings.Repeat("d", 64), SourceReferenceHash: strings.Repeat("c", 64), CreatedAt: harness.clock.Now(),
+		Refs: []findinglineage.CandidateRef{
+			{Position: 0, Role: findinglineage.RoleSource, ObservationID: sourceObservation.ID, Method: findinglineage.MethodMatcher, ScoreMilli: 1000, Confidence: findinglineage.ConfidenceHigh},
+			{Position: 1, Role: findinglineage.RoleCandidate, IdentityID: targetIdentity.ID, Method: findinglineage.MethodFingerprint, ScoreMilli: 900, Confidence: findinglineage.ConfidenceHigh},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, created, err := harness.lineage.CreateCandidate(ctx, candidate, ""); err != nil || !created {
+		t.Fatalf("candidate created=%v err=%v", created, err)
+	}
+	lineageService, err := lineageuc.NewService(harness.lineage, harness.service.transactions, harness.audit, harness.clock, &comparisonIDs{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requests := memory.NewAssessmentCycleRequestRepository()
+	queue := memory.NewJobQueue(&comparisonIDs{}, harness.clock.Now)
+	harness.service.SetAPIStores(requests, queue, lineageService)
+
+	request := RetainedRequest{TenantID: harness.tenantID, Actor: "operator", Route: "POST /api/v1/assessment-comparisons", IdempotencyKey: "comparison-create"}
+	queuedResponse, err := harness.service.QueueRetained(ctx, request, QueueInput{
+		BaselineSnapshotID: harness.snapshotsByNumber[2].ID, CurrentSnapshotID: harness.snapshotsByNumber[3].ID,
+		Mode: domain.ModeLifecycle, FingerprintVersion: 1, RiskModelVersion: 1,
+	})
+	if err != nil || queuedResponse.StatusCode != 202 {
+		t.Fatalf("queue status=%d err=%v body=%s", queuedResponse.StatusCode, err, queuedResponse.Body)
+	}
+	var queued QueueResult
+	if err := json.Unmarshal(queuedResponse.Body, &queued); err != nil || queued.Comparison.ID.IsZero() || !queued.Created {
+		t.Fatalf("queued=%+v err=%v", queued, err)
+	}
+	replay, err := harness.service.QueueRetained(ctx, request, QueueInput{
+		BaselineSnapshotID: harness.snapshotsByNumber[2].ID, CurrentSnapshotID: harness.snapshotsByNumber[3].ID,
+		Mode: domain.ModeLifecycle, FingerprintVersion: 1, RiskModelVersion: 1,
+	})
+	if err != nil || !replay.Replayed || string(replay.Body) != string(queuedResponse.Body) {
+		t.Fatalf("replay=%+v err=%v", replay, err)
+	}
+	_, err = harness.service.QueueRetained(ctx, request, QueueInput{
+		BaselineSnapshotID: harness.snapshotsByNumber[1].ID, CurrentSnapshotID: harness.snapshotsByNumber[3].ID,
+		Mode: domain.ModeLifecycle, FingerprintVersion: 1, RiskModelVersion: 1,
+	})
+	if !errors.Is(err, shared.ErrConflict) || ErrorCode(err) != CodeIdempotencyBodyMismatch {
+		t.Fatalf("body mismatch error=%v code=%s", err, ErrorCode(err))
+	}
+
+	completed, err := harness.service.Generate(ctx, WorkInput{TenantID: harness.tenantID, ComparisonID: queued.Comparison.ID, Actor: "worker"})
+	if err != nil || completed.Status != domain.StatusNeedsReview {
+		t.Fatalf("completed=%+v err=%v", completed, err)
+	}
+	vulnerabilitySummary, err := harness.service.GetSummary(ctx, harness.tenantID, completed.ID, domain.ScopeVulnerability)
+	if err != nil || vulnerabilitySummary.ComparisonID != completed.ID || vulnerabilitySummary.BaselineSnapshotID != completed.BaselineSnapshotID || vulnerabilitySummary.CurrentSnapshotID != completed.CurrentSnapshotID {
+		t.Fatalf("vulnerability summary=%+v err=%v", vulnerabilitySummary, err)
+	}
+	if _, err := harness.service.GetSummary(ctx, harness.tenantID, completed.ID, domain.Scope("quality")); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("invalid scope error=%v", err)
+	}
+	firstPage, err := harness.service.ListItems(ctx, ListItemsInput{TenantID: harness.tenantID, ComparisonID: completed.ID, Limit: 2})
+	if err != nil || len(firstPage.Items) != 2 || firstPage.NextCursor == "" {
+		t.Fatalf("first page=%+v err=%v", firstPage, err)
+	}
+	secondPage, err := harness.service.ListItems(ctx, ListItemsInput{TenantID: harness.tenantID, ComparisonID: completed.ID, Limit: 2, Cursor: firstPage.NextCursor})
+	if err != nil || len(secondPage.Items) == 0 || firstPage.Items[1].ID == secondPage.Items[0].ID {
+		t.Fatalf("second page=%+v err=%v", secondPage, err)
+	}
+
+	targetItem := comparisonItem(t, completed, targetIdentity.ID)
+	if !containsID(targetItem.ReviewCandidateIDs, candidate.ID) {
+		t.Fatalf("target review candidates=%v", targetItem.ReviewCandidateIDs)
+	}
+	if len(targetItem.ReviewCandidates) != 1 || targetItem.ReviewCandidates[0].ID != candidate.ID || !containsID(targetItem.ReviewCandidates[0].SourceObservationIDs, sourceObservation.ID) {
+		t.Fatalf("target review candidate metadata=%+v", targetItem.ReviewCandidates)
+	}
+	reviewRequest := RetainedRequest{TenantID: harness.tenantID, Actor: "reviewer", Route: "POST /api/v1/assessment-comparisons/{comparisonId}/items/{itemId}/confirm", IdempotencyKey: "review-confirm"}
+	reviewResponse, err := harness.service.Review(ctx, ReviewInput{
+		Request: reviewRequest, ComparisonID: completed.ID, ItemID: targetItem.ID, CandidateID: candidate.ID,
+		SourceObservationID: sourceObservation.ID, ExpectedVersion: completed.Version, Action: ReviewConfirm, Reason: "confirmed deterministic lineage",
+	})
+	if err != nil || reviewResponse.StatusCode != 202 {
+		t.Fatalf("review status=%d err=%v body=%s", reviewResponse.StatusCode, err, reviewResponse.Body)
+	}
+	var review ReviewResult
+	if err := json.Unmarshal(reviewResponse.Body, &review); err != nil || review.OverrideEventID.IsZero() || review.SupersededComparisonID != completed.ID || review.ReplacementComparisonID.IsZero() || review.ReplacementComparisonID == completed.ID {
+		t.Fatalf("review=%+v err=%v", review, err)
+	}
+	reviewReplay, err := harness.service.Review(ctx, ReviewInput{
+		Request: reviewRequest, ComparisonID: completed.ID, ItemID: targetItem.ID, CandidateID: candidate.ID,
+		SourceObservationID: sourceObservation.ID, ExpectedVersion: completed.Version, Action: ReviewConfirm, Reason: "confirmed deterministic lineage",
+	})
+	if err != nil || !reviewReplay.Replayed || string(reviewReplay.Body) != string(reviewResponse.Body) {
+		t.Fatalf("review replay=%+v err=%v", reviewReplay, err)
+	}
+	old, err := harness.comparisons.Get(ctx, harness.tenantID, completed.ID)
+	if err != nil || old.Status != domain.StatusSuperseded || old.SupersededBy != review.ReplacementComparisonID {
+		t.Fatalf("old comparison=%+v err=%v", old, err)
+	}
+	active, err := harness.lineage.GetActiveOverride(ctx, harness.tenantID, harness.cycleID, sourceObservation.ID)
+	if err != nil || active.Action != findinglineage.OverrideConfirm || active.TargetIdentityID != targetIdentity.ID {
+		t.Fatalf("active override=%+v err=%v", active, err)
+	}
+}
+
+func TestComparisonItemTokenFilterAcceptsCanonicalProducerNames(t *testing.T) {
+	for _, value := range []string{"", "semgrep.sast", "vendor-scanner_v2"} {
+		if !validItemTokenFilter(value) {
+			t.Fatalf("expected valid item token filter %q", value)
+		}
+	}
+	for _, value := range []string{" leading", "line\nbreak", strings.Repeat("x", 257)} {
+		if validItemTokenFilter(value) {
+			t.Fatalf("expected invalid item token filter %q", value)
+		}
+	}
+}

--- a/internal/usecase/assessmentcomparison/backfill.go
+++ b/internal/usecase/assessmentcomparison/backfill.go
@@ -1,0 +1,235 @@
+package assessmentcomparison
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	DefaultComparisonBackfillBatch     = 500
+	MaxComparisonBackfillBatch         = 2000
+	DefaultComparisonBacklogWarning    = 500
+	DefaultComparisonBacklogHardLimit  = 1000
+	DefaultComparisonOldestActiveLimit = 15 * time.Minute
+	DefaultComparisonRepairMaxAttempts = DefaultMaxAttempts
+)
+
+var (
+	ErrComparisonBacklogHardLimit = errors.New("assessment comparison backlog hard limit reached")
+	ErrComparisonOldestActive     = errors.New("assessment comparison oldest active job limit exceeded")
+)
+
+type comparisonBackfillService interface {
+	Queue(context.Context, QueueInput) (domain.Comparison, bool, domain.PairDecision, error)
+	Repair(context.Context, WorkInput) (domain.Comparison, error)
+}
+
+type BackfillRunner struct {
+	service     comparisonBackfillService
+	cycles      ports.AssessmentCycleListRepository
+	comparisons ports.AssessmentComparisonRepairRepository
+	clock       ports.Clock
+	audit       ports.AuditLogger
+}
+
+type BackfillRequest struct {
+	TenantID          shared.ID
+	Actor             string
+	DryRun            bool
+	RepairFailed      bool
+	BatchSize         int
+	BacklogWarning    int
+	BacklogHardLimit  int
+	OldestActiveLimit time.Duration
+	AfterUpdatedAt    time.Time
+	AfterCycleID      shared.ID
+}
+
+type BackfillResult struct {
+	Processed           int
+	Queued              int
+	Existing            int
+	WouldQueue          int
+	Skipped             int
+	RepairAttempted     int
+	Repaired            int
+	WouldRepair         int
+	BacklogWarning      bool
+	CheckpointUpdatedAt time.Time
+	CheckpointCycleID   shared.ID
+	Backlog             ports.AssessmentComparisonBacklog
+}
+
+func NewBackfillRunner(service comparisonBackfillService, cycles ports.AssessmentCycleListRepository, comparisons ports.AssessmentComparisonRepairRepository, clock ports.Clock, audit ports.AuditLogger) (*BackfillRunner, error) {
+	if service == nil || cycles == nil || comparisons == nil || clock == nil || audit == nil {
+		return nil, fmt.Errorf("%w: assessment comparison backfill dependencies are required", shared.ErrValidation)
+	}
+	return &BackfillRunner{service: service, cycles: cycles, comparisons: comparisons, clock: clock, audit: audit}, nil
+}
+
+func (runner *BackfillRunner) Run(ctx context.Context, request BackfillRequest) (BackfillResult, error) {
+	if err := normalizeBackfillRequest(&request); err != nil {
+		return BackfillResult{}, err
+	}
+	result := BackfillResult{CheckpointUpdatedAt: request.AfterUpdatedAt, CheckpointCycleID: request.AfterCycleID}
+	backlog, err := runner.comparisons.GetAssessmentComparisonBacklog(ctx, request.TenantID)
+	if err != nil {
+		return result, err
+	}
+	if err := enforceComparisonBacklog(backlog, request, runner.clock.Now().UTC()); err != nil {
+		return result, err
+	}
+
+	if request.RepairFailed {
+		failed, err := runner.comparisons.ListFailedAssessmentComparisons(ctx, request.TenantID, request.BatchSize)
+		if err != nil {
+			return result, err
+		}
+		for _, candidate := range failed {
+			result.RepairAttempted++
+			if request.DryRun {
+				result.WouldRepair++
+				continue
+			}
+			repaired, err := runner.service.Repair(ctx, WorkInput{
+				TenantID: request.TenantID, ComparisonID: candidate.ID, Actor: request.Actor, MaxAttempts: DefaultComparisonRepairMaxAttempts,
+			})
+			if err != nil {
+				return result, fmt.Errorf("repair assessment comparison %s: %w", candidate.ID, err)
+			}
+			readback, err := runner.comparisons.GetMetadata(ctx, request.TenantID, candidate.ID)
+			if err != nil {
+				return result, fmt.Errorf("read back repaired assessment comparison %s: %w", candidate.ID, err)
+			}
+			if repaired.ID != candidate.ID || readback.ID != candidate.ID || readback.InputHash != candidate.InputHash || readback.BaselineSnapshotID != candidate.BaselineSnapshotID || readback.CurrentSnapshotID != candidate.CurrentSnapshotID {
+				return result, fmt.Errorf("%w: repaired assessment comparison %s changed immutable projection identity", shared.ErrConflict, candidate.ID)
+			}
+			result.Repaired++
+		}
+	}
+
+	for {
+		backlog, err = runner.comparisons.GetAssessmentComparisonBacklog(ctx, request.TenantID)
+		if err != nil {
+			return result, err
+		}
+		if err := enforceComparisonBacklog(backlog, request, runner.clock.Now().UTC()); err != nil {
+			return result, err
+		}
+		records, err := runner.cycles.ListCycles(ctx, ports.AssessmentCycleListQuery{
+			TenantID: request.TenantID, Limit: request.BatchSize, MemberLimit: 1,
+			AfterUpdatedAt: result.CheckpointUpdatedAt, AfterCycleID: result.CheckpointCycleID,
+		})
+		if err != nil {
+			return result, err
+		}
+		if len(records) == 0 {
+			break
+		}
+		active := backlog.Active()
+		for _, record := range records {
+			result.Processed++
+			if record.RootSnapshotID.IsZero() || record.CurrentSnapshotID.IsZero() || record.RootSnapshotID == record.CurrentSnapshotID {
+				result.Skipped++
+				continue
+			}
+			if request.DryRun {
+				result.WouldQueue++
+				continue
+			}
+			if active >= request.BacklogHardLimit {
+				return result, fmt.Errorf("%w: tenant %s has %d queued or generating comparisons", ErrComparisonBacklogHardLimit, request.TenantID, active)
+			}
+			comparison, created, decision, err := runner.service.Queue(ctx, QueueInput{
+				TenantID: request.TenantID, BaselineSnapshotID: record.RootSnapshotID, CurrentSnapshotID: record.CurrentSnapshotID,
+				Mode: domain.ModeLifecycle, FingerprintVersion: 1, RiskModelVersion: RiskModelVersionV1, Actor: request.Actor,
+			})
+			if err != nil {
+				return result, fmt.Errorf("queue lifecycle comparison for cycle %s: %w", record.Cycle.ID, err)
+			}
+			if !decision.Allowed {
+				result.Skipped++
+				continue
+			}
+			if comparison.ID.IsZero() {
+				return result, fmt.Errorf("%w: queued lifecycle comparison for cycle %s has no id", shared.ErrConflict, record.Cycle.ID)
+			}
+			if created {
+				result.Queued++
+				active++
+			} else {
+				result.Existing++
+			}
+		}
+		last := records[len(records)-1].Cycle
+		result.CheckpointUpdatedAt, result.CheckpointCycleID = last.UpdatedAt.UTC(), last.ID
+		if err := runner.recordBatch(ctx, request, result); err != nil {
+			return result, err
+		}
+		if len(records) < request.BatchSize {
+			break
+		}
+	}
+
+	result.Backlog, err = runner.comparisons.GetAssessmentComparisonBacklog(ctx, request.TenantID)
+	if err != nil {
+		return result, err
+	}
+	result.BacklogWarning = result.Backlog.Active() >= request.BacklogWarning
+	return result, nil
+}
+
+func normalizeBackfillRequest(request *BackfillRequest) error {
+	request.TenantID = shared.TenantOrDefault(request.TenantID)
+	request.Actor = strings.TrimSpace(request.Actor)
+	if request.BatchSize == 0 {
+		request.BatchSize = DefaultComparisonBackfillBatch
+	}
+	if request.BacklogWarning == 0 {
+		request.BacklogWarning = DefaultComparisonBacklogWarning
+	}
+	if request.BacklogHardLimit == 0 {
+		request.BacklogHardLimit = DefaultComparisonBacklogHardLimit
+	}
+	if request.OldestActiveLimit == 0 {
+		request.OldestActiveLimit = DefaultComparisonOldestActiveLimit
+	}
+	if request.TenantID.IsZero() || request.Actor == "" || len(request.Actor) > 256 || request.BatchSize < 1 || request.BatchSize > MaxComparisonBackfillBatch || request.BacklogWarning < 1 || request.BacklogHardLimit < request.BacklogWarning || request.BacklogHardLimit > DefaultComparisonBacklogHardLimit || request.OldestActiveLimit <= 0 {
+		return fmt.Errorf("%w: assessment comparison backfill request is invalid", shared.ErrValidation)
+	}
+	if request.AfterUpdatedAt.IsZero() != request.AfterCycleID.IsZero() {
+		return fmt.Errorf("%w: assessment comparison backfill cursor requires updated time and cycle id", shared.ErrValidation)
+	}
+	request.AfterUpdatedAt = request.AfterUpdatedAt.UTC()
+	return nil
+}
+
+func enforceComparisonBacklog(backlog ports.AssessmentComparisonBacklog, request BackfillRequest, now time.Time) error {
+	if backlog.Active() >= request.BacklogHardLimit {
+		return fmt.Errorf("%w: tenant %s has %d queued or generating comparisons", ErrComparisonBacklogHardLimit, request.TenantID, backlog.Active())
+	}
+	if backlog.OldestActiveAt != nil && now.Sub(backlog.OldestActiveAt.UTC()) > request.OldestActiveLimit {
+		return fmt.Errorf("%w: tenant %s oldest active comparison is %s", ErrComparisonOldestActive, request.TenantID, now.Sub(backlog.OldestActiveAt.UTC()).Round(time.Second))
+	}
+	return nil
+}
+
+func (runner *BackfillRunner) recordBatch(ctx context.Context, request BackfillRequest, result BackfillResult) error {
+	return runner.audit.Record(ctx, ports.AuditEntry{
+		Actor: request.Actor, Action: "assessment_comparison.backfill_batch", Target: request.TenantID.String(), At: runner.clock.Now().UTC(),
+		Metadata: map[string]string{
+			"tenant_id": request.TenantID.String(), "dry_run": strconv.FormatBool(request.DryRun),
+			"processed": strconv.Itoa(result.Processed), "queued": strconv.Itoa(result.Queued), "existing": strconv.Itoa(result.Existing),
+			"would_queue": strconv.Itoa(result.WouldQueue), "skipped": strconv.Itoa(result.Skipped), "repaired": strconv.Itoa(result.Repaired), "would_repair": strconv.Itoa(result.WouldRepair),
+			"checkpoint_updated_at": result.CheckpointUpdatedAt.Format(time.RFC3339Nano), "checkpoint_cycle_id": result.CheckpointCycleID.String(),
+		},
+	})
+}

--- a/internal/usecase/assessmentcomparison/backfill_test.go
+++ b/internal/usecase/assessmentcomparison/backfill_test.go
@@ -1,0 +1,180 @@
+package assessmentcomparison
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestBackfillRunnerQueuesPagesAndHonorsBacklogWarning(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	repository := &backfillRepository{backlog: ports.AssessmentComparisonBacklog{Queued: 499}, metadata: map[shared.ID]domain.Comparison{}}
+	service := &backfillService{repository: repository, existingCurrent: "current-1"}
+	cycles := &backfillCycleLister{records: []ports.AssessmentCycleListRecord{
+		backfillCycle("cycle-3", "root-3", "current-3", now.Add(3*time.Minute)),
+		backfillCycle("cycle-2", "same-2", "same-2", now.Add(2*time.Minute)),
+		backfillCycle("cycle-1", "root-1", "current-1", now.Add(time.Minute)),
+	}}
+	runner, err := NewBackfillRunner(service, cycles, repository, fixedComparisonClock{now: now}, &backfillAudit{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := runner.Run(context.Background(), BackfillRequest{TenantID: "tenant-a", Actor: "operator", BatchSize: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Processed != 3 || result.Queued != 1 || result.Existing != 1 || result.Skipped != 1 || !result.BacklogWarning || result.Backlog.Active() != 500 || result.CheckpointCycleID != "cycle-1" {
+		t.Fatalf("unexpected backfill result: %+v", result)
+	}
+	if cycles.calls != 2 {
+		t.Fatalf("expected two cycle pages, got %d", cycles.calls)
+	}
+}
+
+func TestBackfillRunnerRepairsWithImmutableReadback(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	failed := domain.Comparison{TenantID: "tenant-a", ID: "comparison-1", BaselineSnapshotID: "root-1", CurrentSnapshotID: "current-1", InputHash: "input-hash", Status: domain.StatusFailed, UpdatedAt: now}
+	repository := &backfillRepository{failed: []domain.Comparison{failed}, metadata: map[shared.ID]domain.Comparison{failed.ID: failed}}
+	service := &backfillService{repository: repository}
+	runner, err := NewBackfillRunner(service, &backfillCycleLister{}, repository, fixedComparisonClock{now: now}, &backfillAudit{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := runner.Run(context.Background(), BackfillRequest{TenantID: "tenant-a", Actor: "operator", RepairFailed: true, BatchSize: 500})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.RepairAttempted != 1 || result.Repaired != 1 || service.repairs != 1 {
+		t.Fatalf("unexpected repair result: %+v repairs=%d", result, service.repairs)
+	}
+}
+
+func TestBackfillRunnerStopsAtHardAndAgeGates(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	for name, testCase := range map[string]struct {
+		backlog ports.AssessmentComparisonBacklog
+		want    error
+	}{
+		"hard": {backlog: ports.AssessmentComparisonBacklog{Queued: 1000}, want: ErrComparisonBacklogHardLimit},
+		"age":  {backlog: ports.AssessmentComparisonBacklog{Queued: 1, OldestActiveAt: timePointer(now.Add(-16 * time.Minute))}, want: ErrComparisonOldestActive},
+	} {
+		t.Run(name, func(t *testing.T) {
+			repository := &backfillRepository{backlog: testCase.backlog, metadata: map[shared.ID]domain.Comparison{}}
+			runner, err := NewBackfillRunner(&backfillService{repository: repository}, &backfillCycleLister{}, repository, fixedComparisonClock{now: now}, &backfillAudit{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = runner.Run(context.Background(), BackfillRequest{TenantID: "tenant-a", Actor: "operator"})
+			if !errors.Is(err, testCase.want) {
+				t.Fatalf("error=%v want=%v", err, testCase.want)
+			}
+		})
+	}
+}
+
+type backfillService struct {
+	repository      *backfillRepository
+	existingCurrent shared.ID
+	repairs         int
+	nextID          int
+}
+
+func (service *backfillService) Queue(_ context.Context, input QueueInput) (domain.Comparison, bool, domain.PairDecision, error) {
+	service.nextID++
+	comparison := domain.Comparison{ID: shared.ID(fmt.Sprintf("comparison-%d", service.nextID)), BaselineSnapshotID: input.BaselineSnapshotID, CurrentSnapshotID: input.CurrentSnapshotID}
+	if input.CurrentSnapshotID == service.existingCurrent {
+		return comparison, false, domain.PairDecision{Allowed: true}, nil
+	}
+	service.repository.backlog.Queued++
+	return comparison, true, domain.PairDecision{Allowed: true}, nil
+}
+
+func (service *backfillService) Repair(_ context.Context, input WorkInput) (domain.Comparison, error) {
+	service.repairs++
+	comparison := service.repository.metadata[input.ComparisonID]
+	comparison.Status = domain.StatusComplete
+	service.repository.metadata[input.ComparisonID] = comparison
+	return comparison, nil
+}
+
+type backfillRepository struct {
+	backlog  ports.AssessmentComparisonBacklog
+	failed   []domain.Comparison
+	metadata map[shared.ID]domain.Comparison
+}
+
+func (repository *backfillRepository) GetAssessmentComparisonBacklog(context.Context, shared.ID) (ports.AssessmentComparisonBacklog, error) {
+	return repository.backlog, nil
+}
+
+func (repository *backfillRepository) ListFailedAssessmentComparisons(_ context.Context, _ shared.ID, limit int) ([]domain.Comparison, error) {
+	failed := append([]domain.Comparison(nil), repository.failed...)
+	if len(failed) > limit {
+		failed = failed[:limit]
+	}
+	return failed, nil
+}
+
+func (repository *backfillRepository) GetMetadata(_ context.Context, _ shared.ID, comparisonID shared.ID) (domain.Comparison, error) {
+	comparison, ok := repository.metadata[comparisonID]
+	if !ok {
+		return domain.Comparison{}, shared.ErrNotFound
+	}
+	return comparison, nil
+}
+
+type backfillCycleLister struct {
+	records []ports.AssessmentCycleListRecord
+	calls   int
+}
+
+func (lister *backfillCycleLister) ListCycles(_ context.Context, query ports.AssessmentCycleListQuery) ([]ports.AssessmentCycleListRecord, error) {
+	lister.calls++
+	records := append([]ports.AssessmentCycleListRecord(nil), lister.records...)
+	sort.Slice(records, func(left, right int) bool {
+		if records[left].Cycle.UpdatedAt.Equal(records[right].Cycle.UpdatedAt) {
+			return records[left].Cycle.ID > records[right].Cycle.ID
+		}
+		return records[left].Cycle.UpdatedAt.After(records[right].Cycle.UpdatedAt)
+	})
+	result := make([]ports.AssessmentCycleListRecord, 0, query.Limit)
+	for _, record := range records {
+		if !query.AfterUpdatedAt.IsZero() && (record.Cycle.UpdatedAt.After(query.AfterUpdatedAt) || record.Cycle.UpdatedAt.Equal(query.AfterUpdatedAt) && record.Cycle.ID >= query.AfterCycleID) {
+			continue
+		}
+		result = append(result, record)
+		if len(result) == query.Limit {
+			break
+		}
+	}
+	return result, nil
+}
+
+func (*backfillCycleLister) ListMigrationPendingAssessments(context.Context, ports.AssessmentCycleListQuery) ([]ports.AssessmentCycleMigrationPendingRecord, int, error) {
+	return nil, 0, nil
+}
+
+type fixedComparisonClock struct{ now time.Time }
+
+func (clock fixedComparisonClock) Now() time.Time { return clock.now }
+
+type backfillAudit struct{}
+
+func (*backfillAudit) Record(context.Context, ports.AuditEntry) error { return nil }
+
+func backfillCycle(cycleID, rootSnapshotID, currentSnapshotID shared.ID, updatedAt time.Time) ports.AssessmentCycleListRecord {
+	return ports.AssessmentCycleListRecord{
+		Cycle:          assessmentcycle.AssessmentCycle{ID: cycleID, UpdatedAt: updatedAt},
+		RootSnapshotID: rootSnapshotID, CurrentSnapshotID: currentSnapshotID,
+	}
+}
+
+func timePointer(value time.Time) *time.Time { return &value }

--- a/internal/usecase/assessmentcomparison/retest_verification.go
+++ b/internal/usecase/assessmentcomparison/retest_verification.go
@@ -1,0 +1,149 @@
+package assessmentcomparison
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// RetestVerificationReader projects append-only Finding retest decisions onto
+// immutable lineage identities. The newest decision along the supplied Snapshot
+// order is the single effective decision for an identity.
+type RetestVerificationReader struct {
+	lineage   ports.FindingLineageRepository
+	snapshots ports.AssessmentSnapshotRepository
+	retests   ports.RetestRepository
+}
+
+func NewRetestVerificationReader(lineage ports.FindingLineageRepository, snapshots ports.AssessmentSnapshotRepository, retests ports.RetestRepository) (*RetestVerificationReader, error) {
+	if lineage == nil || snapshots == nil || retests == nil {
+		return nil, fmt.Errorf("%w: comparison verification dependencies are required", shared.ErrValidation)
+	}
+	return &RetestVerificationReader{lineage: lineage, snapshots: snapshots, retests: retests}, nil
+}
+
+func (reader *RetestVerificationReader) ListEffectiveComparisonVerifications(ctx context.Context, tenantID, cycleID shared.ID, snapshotIDs []shared.ID) ([]ports.AssessmentComparisonVerification, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	if tenantID.IsZero() || cycleID.IsZero() {
+		return nil, fmt.Errorf("%w: comparison verification ownership is required", shared.ErrValidation)
+	}
+	if contextTenant, ok := shared.TenantFrom(ctx); ok && contextTenant != tenantID {
+		return nil, fmt.Errorf("%w: comparison verification tenant mismatch", shared.ErrValidation)
+	}
+	ctx = shared.WithTenant(ctx, tenantID)
+	type effectiveDecision struct {
+		verification ports.AssessmentComparisonVerification
+		order        int
+		atUnixNano   int64
+	}
+	effective := make(map[shared.ID]effectiveDecision)
+	for order, snapshotID := range snapshotIDs {
+		if snapshotID.IsZero() {
+			return nil, fmt.Errorf("%w: comparison verification Snapshot is required", shared.ErrValidation)
+		}
+		snapshot, err := reader.snapshots.Get(ctx, tenantID, snapshotID)
+		if err != nil {
+			return nil, err
+		}
+		if snapshot.CycleID != cycleID {
+			return nil, fmt.Errorf("%w: comparison verification Snapshot belongs to another Cycle", shared.ErrValidation)
+		}
+		observations, err := reader.lineage.ListObservationsBySnapshot(ctx, tenantID, cycleID, snapshotID)
+		if err != nil {
+			return nil, err
+		}
+		latest, err := reader.latestDecisions(ctx, snapshot.AssessmentID, observations)
+		if err != nil {
+			return nil, err
+		}
+		for _, observation := range observations {
+			if observation.SourceFindingID == "" {
+				continue
+			}
+			decision, found := latest[shared.ID(observation.SourceFindingID)]
+			if !found {
+				continue
+			}
+			{
+				// A prior verification cannot attest evidence captured later. Keep
+				// it at the last eligible Snapshot so later detection can reopen it.
+				asOf := snapshot.CreatedAt
+				if snapshot.FinalizedAt != nil {
+					asOf = *snapshot.FinalizedAt
+				}
+				if decision.At.Before(asOf) {
+					continue
+				}
+				if !decision.Outcome.Valid() || decision.ID.IsZero() {
+					return nil, fmt.Errorf("%w: persisted Finding retest decision is invalid", shared.ErrValidation)
+				}
+				candidate := effectiveDecision{
+					verification: ports.AssessmentComparisonVerification{
+						ID: decision.ID, IdentityID: observation.IdentityID, EffectiveSnapshotID: snapshotID,
+						State: string(decision.Outcome), Remediated: decision.Outcome == finding.RetestRemediated,
+					},
+					order: order, atUnixNano: decision.At.UTC().UnixNano(),
+				}
+				current, exists := effective[observation.IdentityID]
+				if !exists || candidate.order > current.order || (candidate.order == current.order && (candidate.atUnixNano > current.atUnixNano || (candidate.atUnixNano == current.atUnixNano && candidate.verification.ID > current.verification.ID))) {
+					effective[observation.IdentityID] = candidate
+				}
+			}
+		}
+	}
+	out := make([]ports.AssessmentComparisonVerification, 0, len(effective))
+	for _, decision := range effective {
+		out = append(out, decision.verification)
+	}
+	sort.Slice(out, func(left, right int) bool { return out[left].IdentityID < out[right].IdentityID })
+	return out, nil
+}
+
+var _ ports.AssessmentComparisonVerificationReader = (*RetestVerificationReader)(nil)
+
+func (reader *RetestVerificationReader) latestDecisions(ctx context.Context, assessmentID shared.ID, observations []findinglineage.Observation) (map[shared.ID]finding.Retest, error) {
+	ids := make([]shared.ID, 0, len(observations))
+	seen := make(map[shared.ID]bool, len(observations))
+	for _, observation := range observations {
+		id := shared.ID(observation.SourceFindingID)
+		if !id.IsZero() && !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
+		}
+	}
+	out := make(map[shared.ID]finding.Retest)
+	if bulk, ok := reader.retests.(ports.RetestLatestReader); ok {
+		for offset := 0; offset < len(ids); offset += 1000 {
+			values, err := bulk.LatestByEngagementFindings(ctx, assessmentID, ids[offset:min(offset+1000, len(ids))])
+			if err != nil {
+				return nil, err
+			}
+			for id, value := range values {
+				if !seen[id] || value.FindingID != id || value.EngagementID != assessmentID {
+					return nil, shared.ErrValidation
+				}
+				out[id] = value
+			}
+		}
+		return out, nil
+	}
+	// Compatibility for alternative adapters. Production memory/PostgreSQL use batches.
+	for _, id := range ids {
+		values, err := reader.retests.ListByEngagementFinding(ctx, assessmentID, id)
+		if err != nil {
+			return nil, err
+		}
+		for _, value := range values {
+			previous, exists := out[id]
+			if !exists || value.At.After(previous.At) || value.At.Equal(previous.At) && value.ID > previous.ID {
+				out[id] = value
+			}
+		}
+	}
+	return out, nil
+}

--- a/internal/usecase/assessmentcomparison/retest_verification_test.go
+++ b/internal/usecase/assessmentcomparison/retest_verification_test.go
@@ -1,0 +1,139 @@
+package assessmentcomparison_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	lineagedom "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	uc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcomparison"
+)
+
+func TestRetestVerificationReaderChoosesNewestDecisionAtLatestSnapshot(t *testing.T) {
+	ctx := shared.WithTenant(context.Background(), "tenant")
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	first := verificationSnapshot(t, "snapshot-1", "request-1", "run-1", "assessment", now)
+	first, _, err := snapshots.CreateFinalizedCAS(ctx, first, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second := verificationSnapshot(t, "snapshot-2", "request-2", "run-2", "assessment", now.Add(time.Minute))
+	second, _, err = snapshots.CreateFinalizedCAS(ctx, second, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lineage := memory.NewFindingLineageRepository()
+	fingerprint, err := lineagedom.CanonicalizeFingerprintV1(lineagedom.FingerprintCanonicalInputV1{
+		CanonicalizationVersion: lineagedom.CanonicalizationVersionV1, ProducerKind: "sca", TargetIdentitySchemaVersion: 1,
+		TargetIdentityCanonical: "repo:example", IdentityFields: map[string]lineagedom.CanonicalValue{"rule_id": lineagedom.Text("CVE-1")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := lineagedom.Identity{
+		TenantID: "tenant", CycleID: "cycle", ID: "identity", ProducerKind: "sca", FindingKind: "vulnerability",
+		CanonicalizationVersion: 1, FingerprintSchemaVersion: 1, LineageFingerprint: fingerprint.Fingerprint,
+		TargetIdentitySchemaVersion: 1, TargetIdentityCanonical: "repo:example", CanonicalIdentityFields: fingerprint.IdentityFields,
+		FirstSeenSnapshotID: first.ID, CreatedAt: now,
+	}
+	observation := func(id shared.ID, snapshotID shared.ID, observedAt time.Time) lineagedom.Observation {
+		return lineagedom.Observation{
+			TenantID: "tenant", CycleID: "cycle", ID: id, SnapshotID: snapshotID, IdentityID: identity.ID,
+			ProducerKind: "sca", FindingKind: "vulnerability", TargetCanonical: "repo:example", SourceFindingID: "finding",
+			Severity: shared.SeverityHigh, ScannerProvenance: lineagedom.ScannerProvenance{ToolName: "scanner"}, ObservedAt: observedAt,
+		}
+	}
+	if err := lineage.CreateIdentityWithObservation(ctx, identity, observation("observation-1", first.ID, now)); err != nil {
+		t.Fatal(err)
+	}
+	if err := lineage.AppendObservation(ctx, observation("observation-2", second.ID, now.Add(time.Minute))); err != nil {
+		t.Fatal(err)
+	}
+
+	retests := memory.NewRetestRepository()
+	older, err := finding.NewRetest("retest-1", "assessment", "finding", finding.RetestStillVulnerable, "", "tester", now.Add(2*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	newer, err := finding.NewRetest("retest-2", "assessment", "finding", finding.RetestRemediated, "", "tester", now.Add(3*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := retests.Add(ctx, older); err != nil {
+		t.Fatal(err)
+	}
+	if err := retests.Add(ctx, newer); err != nil {
+		t.Fatal(err)
+	}
+
+	reader, err := uc.NewRetestVerificationReader(lineage, snapshots, retests)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A verification predating the next capture belongs to the older Snapshot.
+	older.At, newer.At = now.Add(15*time.Second), now.Add(30*time.Second)
+	earlier := memory.NewRetestRepository()
+	if err := earlier.Add(ctx, older); err != nil {
+		t.Fatal(err)
+	}
+	if err := earlier.Add(ctx, newer); err != nil {
+		t.Fatal(err)
+	}
+	historyReader, err := uc.NewRetestVerificationReader(lineage, snapshots, earlier)
+	if err != nil {
+		t.Fatal(err)
+	}
+	history, err := historyReader.ListEffectiveComparisonVerifications(ctx, "tenant", "cycle", []shared.ID{first.ID, second.ID})
+	if err != nil || len(history) != 1 || history[0].EffectiveSnapshotID != first.ID {
+		t.Fatalf("old verification moved to new evidence: %+v err=%v", history, err)
+	}
+	decisions, err := reader.ListEffectiveComparisonVerifications(ctx, "tenant", "cycle", []shared.ID{first.ID, second.ID})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(decisions) != 1 || decisions[0].ID != newer.ID || decisions[0].IdentityID != identity.ID || decisions[0].EffectiveSnapshotID != second.ID || !decisions[0].Remediated {
+		t.Fatalf("unexpected effective verification: %+v", decisions)
+	}
+}
+
+func verificationSnapshot(t *testing.T, id, requestKey, runID string, assessmentID shared.ID, now time.Time) *assessmentsnapshot.Snapshot {
+	t.Helper()
+	finished := now.Add(time.Second)
+	target, err := scanrun.CanonicalizeRepositoryTarget("https://example.com/repo.git", "0123456789abcdef0123456789abcdef01234567")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lane := scanrun.Lane{
+		TenantID: "tenant", EngagementID: assessmentID, ScanRunID: runID, LaneKey: "sca", Producer: "sca", TerminalStatus: scanrun.StatusSucceeded, Target: target,
+		AuthoritativeFindingKinds: []string{"vulnerability"}, IncludedScope: []string{"src/**"}, ExcludedScope: []string{"vendor/**"}, StartedAt: now, FinishedAt: &finished,
+		ResultRef: "result:" + runID, EvidenceRef: "evidence:" + runID,
+		ResultSHA256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion, SealedAt: &finished,
+		Versions: []scanrun.LaneVersion{{VersionKind: scanrun.VersionScanner, Name: "sca", Version: "1"}, {VersionKind: scanrun.VersionRulePack, Name: "rules", Version: "1"}},
+		Stages:   []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSucceeded, StartedAt: now, FinishedAt: &finished}},
+	}
+	lane.ManifestHash, err = scanrun.ComputeManifestHash(lane)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lanes := []scanrun.Lane{lane}
+	manifestHash, err := scanrun.ComputeRunManifestHash(lanes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := assessmentsnapshot.NewFinalized("tenant", shared.ID(id), "cycle", assessmentID, assessmentsnapshot.Boundary{Kind: assessmentcycle.BoundaryStandalone}, requestKey, "operator", now, []assessmentsnapshot.SelectedRun{{
+		ID: runID, ManifestHash: manifestHash, Provenance: scanrun.ProvenanceNative,
+		TerminalStatus: scanrun.StatusSucceeded, Trusted: true, Lanes: lanes,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snapshot
+}

--- a/internal/usecase/assessmentcomparison/service.go
+++ b/internal/usecase/assessmentcomparison/service.go
@@ -1,0 +1,1002 @@
+package assessmentcomparison
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+const (
+	DefaultMaxAttempts = 3
+	MaxAttempts        = 10
+	RiskModelVersionV1 = 1
+)
+
+var errGenerationInputChanged = errors.New("comparison generation input changed")
+
+type Service struct {
+	comparisons  ports.AssessmentComparisonRepository
+	snapshots    ports.AssessmentSnapshotRepository
+	cycles       ports.AssessmentCycleRepository
+	lineage      ports.FindingLineageRepository
+	transactions ports.TenantTransactionRunner
+	audit        ports.AuditLogger
+	clock        ports.Clock
+	ids          ports.IDGenerator
+	verification ports.AssessmentComparisonVerificationReader
+	observer     ports.AssessmentComparisonObserver
+	requests     ports.AssessmentCycleRequestStore
+	jobs         ports.JobQueue
+	reviewer     *lineageuc.Service
+}
+
+func NewService(
+	comparisons ports.AssessmentComparisonRepository,
+	snapshots ports.AssessmentSnapshotRepository,
+	cycles ports.AssessmentCycleRepository,
+	lineage ports.FindingLineageRepository,
+	transactions ports.TenantTransactionRunner,
+	audit ports.AuditLogger,
+	clock ports.Clock,
+	ids ports.IDGenerator,
+	verification ports.AssessmentComparisonVerificationReader,
+	observer ports.AssessmentComparisonObserver,
+) (*Service, error) {
+	if comparisons == nil || snapshots == nil || cycles == nil || lineage == nil || transactions == nil || audit == nil || clock == nil || ids == nil || verification == nil {
+		return nil, fmt.Errorf("%w: assessment comparison dependencies are required", shared.ErrValidation)
+	}
+	if observer == nil {
+		observer = noopObserver{}
+	}
+	return &Service{
+		comparisons: comparisons, snapshots: snapshots, cycles: cycles, lineage: lineage,
+		transactions: transactions, audit: audit, clock: clock, ids: ids,
+		verification: verification, observer: observer,
+	}, nil
+}
+
+func (service *Service) SetAPIStores(requests ports.AssessmentCycleRequestStore, jobs ports.JobQueue, reviewer *lineageuc.Service) {
+	service.requests, service.jobs, service.reviewer = requests, jobs, reviewer
+}
+
+func (service *Service) SetObserver(observer ports.AssessmentComparisonObserver) {
+	if observer == nil {
+		observer = noopObserver{}
+	}
+	service.observer = observer
+}
+
+type QueueInput struct {
+	TenantID           shared.ID
+	BaselineSnapshotID shared.ID
+	CurrentSnapshotID  shared.ID
+	Mode               assessmentcomparison.Mode
+	FingerprintVersion int
+	RiskModelVersion   int
+	Actor              string
+}
+
+func (service *Service) Queue(ctx context.Context, input QueueInput) (assessmentcomparison.Comparison, bool, assessmentcomparison.PairDecision, error) {
+	if err := validateQueueInput(&input); err != nil {
+		return assessmentcomparison.Comparison{}, false, assessmentcomparison.PairDecision{}, err
+	}
+	defer service.observeBacklog(context.WithoutCancel(ctx), input.TenantID)
+	var stored assessmentcomparison.Comparison
+	var created bool
+	var decision assessmentcomparison.PairDecision
+	err := service.transactions.Run(ctx, input.TenantID, func(txCtx context.Context) error {
+		prepared, err := service.prepare(txCtx, input.TenantID, input.BaselineSnapshotID, input.CurrentSnapshotID, input.Mode, input.FingerprintVersion, input.RiskModelVersion)
+		if err != nil {
+			return err
+		}
+		decision = prepared.decision
+		if !decision.Allowed {
+			return nil
+		}
+		payload, inputHash, err := assessmentcomparison.HashGenerationInput(prepared.input)
+		if err != nil {
+			return err
+		}
+		candidate, err := assessmentcomparison.NewQueued(input.TenantID, prepared.baseline.CycleID, service.ids.NewID(), prepared.input, payload, inputHash, service.clock.Now().UTC())
+		if err != nil {
+			return err
+		}
+		stored, created, err = service.comparisons.CreateQueued(txCtx, candidate)
+		if err != nil || !created {
+			return err
+		}
+		if err := service.enqueueGeneration(txCtx, stored.ID); err != nil {
+			return err
+		}
+		return service.recordAudit(txCtx, input.Actor, "assessment_comparison.queued", stored, map[string]string{"created": "true"})
+	})
+	if err != nil {
+		return assessmentcomparison.Comparison{}, false, decision, err
+	}
+	if !decision.Allowed {
+		if err := service.audit.Record(shared.WithTenant(ctx, input.TenantID), ports.AuditEntry{
+			Actor: input.Actor, Action: "assessment_comparison.rejected", Target: input.CurrentSnapshotID.String(), At: service.clock.Now().UTC(),
+			Metadata: map[string]string{"tenant_id": input.TenantID.String(), "mode": string(input.Mode), "reason": decision.ReasonCode},
+		}); err != nil {
+			return assessmentcomparison.Comparison{}, false, decision, err
+		}
+		service.observer.ObserveAssessmentComparison("rejected", string(input.Mode), decision.ReasonCode)
+		return assessmentcomparison.Comparison{}, false, decision, nil
+	}
+	if created {
+		service.observer.ObserveAssessmentComparison("queued", string(input.Mode), "created")
+	} else {
+		service.observer.ObserveAssessmentComparison("queued", string(input.Mode), "replayed")
+	}
+	return stored, created, decision, nil
+}
+
+type WorkInput struct {
+	TenantID     shared.ID
+	ComparisonID shared.ID
+	Actor        string
+	MaxAttempts  int
+}
+
+func (service *Service) Generate(ctx context.Context, input WorkInput) (assessmentcomparison.Comparison, error) {
+	return service.generate(ctx, input, false)
+}
+
+func (service *Service) Repair(ctx context.Context, input WorkInput) (assessmentcomparison.Comparison, error) {
+	return service.generate(ctx, input, true)
+}
+
+func (service *Service) generate(ctx context.Context, input WorkInput, repair bool) (assessmentcomparison.Comparison, error) {
+	if err := validateWorkInput(&input); err != nil {
+		return assessmentcomparison.Comparison{}, err
+	}
+	defer service.observeBacklog(context.WithoutCancel(ctx), input.TenantID)
+	startedAt := time.Now()
+	generatedItems := 0
+	generationStatus := "failed"
+	generationMode := ""
+	fingerprintVersion := 0
+	riskModelVersion := 0
+	measureGeneration := false
+	defer func() {
+		observer, ok := service.observer.(ports.AssessmentComparisonGenerationObserver)
+		if measureGeneration && ok {
+			observer.ObserveAssessmentComparisonGeneration(input.TenantID.String(), generationMode, generationStatus, fingerprintVersion, riskModelVersion, generatedItems, time.Since(startedAt))
+		}
+	}()
+	comparison, terminal, err := service.start(ctx, input, repair)
+	if err != nil || terminal {
+		return comparison, err
+	}
+	measureGeneration = true
+	generationMode, fingerprintVersion, riskModelVersion = string(comparison.Mode), comparison.FingerprintVersion, comparison.RiskModelVersion
+	prepared, err := service.prepare(ctx, input.TenantID, comparison.BaselineSnapshotID, comparison.CurrentSnapshotID, comparison.Mode, comparison.FingerprintVersion, comparison.RiskModelVersion)
+	if err != nil {
+		return assessmentcomparison.Comparison{}, service.failGeneration(ctx, input, comparison, err)
+	}
+	if !prepared.decision.Allowed {
+		return assessmentcomparison.Comparison{}, service.failGeneration(ctx, input, comparison, errGenerationInputChanged)
+	}
+	_, inputHash, err := assessmentcomparison.HashGenerationInput(prepared.input)
+	if err != nil || inputHash != comparison.InputHash {
+		if err == nil {
+			err = errGenerationInputChanged
+		}
+		return assessmentcomparison.Comparison{}, service.failGeneration(ctx, input, comparison, err)
+	}
+	items, err := service.buildItems(ctx, prepared)
+	if err != nil {
+		return assessmentcomparison.Comparison{}, service.failGeneration(ctx, input, comparison, err)
+	}
+	generatedItems = len(items)
+
+	var completed assessmentcomparison.Comparison
+	err = service.transactions.Run(ctx, input.TenantID, func(txCtx context.Context) error {
+		current, err := service.comparisons.Get(txCtx, input.TenantID, input.ComparisonID)
+		if err != nil {
+			return err
+		}
+		if isTerminal(current.Status) {
+			completed = current
+			return nil
+		}
+		if current.Status != assessmentcomparison.StatusGenerating {
+			return fmt.Errorf("%w: comparison is no longer generating", shared.ErrConflict)
+		}
+		latest, err := service.prepare(txCtx, input.TenantID, current.BaselineSnapshotID, current.CurrentSnapshotID, current.Mode, current.FingerprintVersion, current.RiskModelVersion)
+		if err != nil {
+			return err
+		}
+		if !latest.decision.Allowed {
+			return errGenerationInputChanged
+		}
+		_, latestHash, err := assessmentcomparison.HashGenerationInput(latest.input)
+		if err != nil {
+			return err
+		}
+		if latestHash != current.InputHash {
+			return errGenerationInputChanged
+		}
+		if err := current.Complete(items, current.Version, service.clock.Now().UTC()); err != nil {
+			return err
+		}
+		if err := service.comparisons.UpdateCAS(txCtx, current, current.Version-1); err != nil {
+			return err
+		}
+		if err := service.recordAudit(txCtx, input.Actor, "assessment_comparison.completed", current, map[string]string{"status": string(current.Status), "items": fmt.Sprintf("%d", len(current.Items))}); err != nil {
+			return err
+		}
+		completed = current
+		return nil
+	})
+	if errors.Is(err, errGenerationInputChanged) {
+		return assessmentcomparison.Comparison{}, service.failGeneration(ctx, input, comparison, err)
+	}
+	if err != nil {
+		if errors.Is(err, shared.ErrConflict) {
+			retained, getErr := service.comparisons.Get(context.WithoutCancel(ctx), input.TenantID, input.ComparisonID)
+			if getErr == nil && isTerminal(retained.Status) {
+				return retained, nil
+			}
+		}
+		return assessmentcomparison.Comparison{}, err
+	}
+	service.observer.ObserveAssessmentComparison(string(completed.Status), string(completed.Mode), "generated")
+	generationStatus = string(completed.Status)
+	return completed, nil
+}
+
+func (service *Service) start(ctx context.Context, input WorkInput, repair bool) (assessmentcomparison.Comparison, bool, error) {
+	var comparison assessmentcomparison.Comparison
+	err := service.transactions.Run(ctx, input.TenantID, func(txCtx context.Context) error {
+		loaded, err := service.comparisons.Get(txCtx, input.TenantID, input.ComparisonID)
+		if err != nil {
+			return err
+		}
+		comparison = loaded
+		if isTerminal(loaded.Status) {
+			return nil
+		}
+		if repair && loaded.Status != assessmentcomparison.StatusFailed {
+			return fmt.Errorf("%w: only a failed comparison can be repaired", shared.ErrValidation)
+		}
+		if loaded.Status == assessmentcomparison.StatusGenerating {
+			return nil
+		}
+		if loaded.Status == assessmentcomparison.StatusFailed && loaded.Attempts >= input.MaxAttempts && !repair {
+			return fmt.Errorf("%w: comparison is in dead letter after %d attempts", shared.ErrConflict, loaded.Attempts)
+		}
+		if err := loaded.Start(loaded.Version, service.clock.Now().UTC()); err != nil {
+			return err
+		}
+		if err := service.comparisons.UpdateCAS(txCtx, loaded, loaded.Version-1); err != nil {
+			return err
+		}
+		action := "assessment_comparison.started"
+		if repair {
+			action = "assessment_comparison.repaired"
+		}
+		if err := service.recordAudit(txCtx, input.Actor, action, loaded, map[string]string{"attempt": fmt.Sprintf("%d", loaded.Attempts)}); err != nil {
+			return err
+		}
+		comparison = loaded
+		return nil
+	})
+	return comparison, isTerminal(comparison.Status), err
+}
+
+func (service *Service) Recover(ctx context.Context, input WorkInput) (assessmentcomparison.Comparison, error) {
+	if err := validateWorkInput(&input); err != nil {
+		return assessmentcomparison.Comparison{}, err
+	}
+	var recovered assessmentcomparison.Comparison
+	err := service.transactions.Run(ctx, input.TenantID, func(txCtx context.Context) error {
+		current, err := service.comparisons.Get(txCtx, input.TenantID, input.ComparisonID)
+		if err != nil {
+			return err
+		}
+		if current.Status != assessmentcomparison.StatusGenerating {
+			return fmt.Errorf("%w: only a generating comparison can be recovered", shared.ErrValidation)
+		}
+		if err := current.Fail("worker_recovered", true, input.MaxAttempts, current.Version, service.clock.Now().UTC()); err != nil {
+			return err
+		}
+		if err := service.comparisons.UpdateCAS(txCtx, current, current.Version-1); err != nil {
+			return err
+		}
+		if err := service.recordAudit(txCtx, input.Actor, "assessment_comparison.recovered", current, map[string]string{"status": string(current.Status)}); err != nil {
+			return err
+		}
+		recovered = current
+		return nil
+	})
+	if err == nil {
+		service.observer.ObserveAssessmentComparison(string(recovered.Status), string(recovered.Mode), "worker_recovered")
+	}
+	return recovered, err
+}
+
+type ReplaceInput struct {
+	TenantID     shared.ID
+	ComparisonID shared.ID
+	Actor        string
+}
+
+func (service *Service) Replace(ctx context.Context, input ReplaceInput) (assessmentcomparison.Comparison, bool, error) {
+	input.Actor = strings.TrimSpace(input.Actor)
+	input.TenantID = shared.TenantOrDefault(input.TenantID)
+	if input.ComparisonID.IsZero() || !validActor(input.Actor) {
+		return assessmentcomparison.Comparison{}, false, fmt.Errorf("%w: comparison replacement identity and actor are required", shared.ErrValidation)
+	}
+	var replacement assessmentcomparison.Comparison
+	var replaced bool
+	err := service.transactions.Run(ctx, input.TenantID, func(txCtx context.Context) error {
+		current, err := service.comparisons.Get(txCtx, input.TenantID, input.ComparisonID)
+		if err != nil {
+			return err
+		}
+		if current.Status == assessmentcomparison.StatusSuperseded {
+			replacement, err = service.comparisons.Get(txCtx, input.TenantID, current.SupersededBy)
+			return err
+		}
+		if current.Status != assessmentcomparison.StatusComplete && current.Status != assessmentcomparison.StatusNeedsReview {
+			return fmt.Errorf("%w: only a completed comparison can be replaced", shared.ErrValidation)
+		}
+		prepared, err := service.prepare(txCtx, input.TenantID, current.BaselineSnapshotID, current.CurrentSnapshotID, current.Mode, current.FingerprintVersion, current.RiskModelVersion)
+		if err != nil {
+			return err
+		}
+		if !prepared.decision.Allowed {
+			return fmt.Errorf("%w: replacement pair is invalid: %s", shared.ErrConflict, prepared.decision.ReasonCode)
+		}
+		payload, inputHash, err := assessmentcomparison.HashGenerationInput(prepared.input)
+		if err != nil {
+			return err
+		}
+		if inputHash == current.InputHash {
+			replacement = current
+			return nil
+		}
+		candidate, err := assessmentcomparison.NewQueued(input.TenantID, current.CycleID, service.ids.NewID(), prepared.input, payload, inputHash, service.clock.Now().UTC())
+		if err != nil {
+			return err
+		}
+		var created bool
+		replacement, created, err = service.comparisons.CreateQueued(txCtx, candidate)
+		if err != nil {
+			return err
+		}
+		if created {
+			if err := service.enqueueGeneration(txCtx, replacement.ID); err != nil {
+				return err
+			}
+		}
+		if err := current.Supersede(replacement.ID, current.Version, service.clock.Now().UTC()); err != nil {
+			return err
+		}
+		if err := service.comparisons.UpdateCAS(txCtx, current, current.Version-1); err != nil {
+			return err
+		}
+		if err := service.recordAudit(txCtx, input.Actor, "assessment_comparison.superseded", current, map[string]string{"successor_id": replacement.ID.String()}); err != nil {
+			return err
+		}
+		replaced = true
+		return nil
+	})
+	if err == nil && replaced {
+		service.observer.ObserveAssessmentComparison("superseded", string(replacement.Mode), "input_changed")
+	}
+	return replacement, replaced, err
+}
+
+type preparedProjection struct {
+	decision      assessmentcomparison.PairDecision
+	baseline      *assessmentsnapshot.Snapshot
+	current       *assessmentsnapshot.Snapshot
+	members       []assessmentcycle.Member
+	snapshots     []*assessmentsnapshot.Snapshot
+	overrides     map[shared.ID][]findinglineage.OverrideEvent
+	candidates    map[shared.ID][]findinglineage.MatchCandidate
+	verifications []ports.AssessmentComparisonVerification
+	input         assessmentcomparison.GenerationInput
+}
+
+func (service *Service) prepare(ctx context.Context, tenantID, baselineID, currentID shared.ID, mode assessmentcomparison.Mode, fingerprintVersion, riskModelVersion int) (preparedProjection, error) {
+	if riskModelVersion != RiskModelVersionV1 || fingerprintVersion <= 0 {
+		return preparedProjection{}, fmt.Errorf("%w: unsupported comparison fingerprint or risk model version", shared.ErrValidation)
+	}
+	baseline, err := service.snapshots.Get(ctx, tenantID, baselineID)
+	if err != nil {
+		return preparedProjection{}, err
+	}
+	current, err := service.snapshots.Get(ctx, tenantID, currentID)
+	if err != nil {
+		return preparedProjection{}, err
+	}
+	members, err := service.cycles.ListMembers(ctx, tenantID, baseline.CycleID)
+	if err != nil {
+		return preparedProjection{}, err
+	}
+	decision, err := assessmentcomparison.DecidePair(mode, baseline, current, members)
+	if err != nil || !decision.Allowed {
+		return preparedProjection{decision: decision, baseline: baseline, current: current, members: members}, err
+	}
+	relevantMembers, err := relevantMembers(members, baseline.AssessmentID, current.AssessmentID)
+	if err != nil {
+		return preparedProjection{}, err
+	}
+	relevantSnapshots, err := service.relevantSnapshots(ctx, tenantID, mode, baseline, current, relevantMembers)
+	if err != nil {
+		return preparedProjection{}, err
+	}
+	prepared := preparedProjection{
+		decision: decision, baseline: baseline, current: current, members: relevantMembers, snapshots: relevantSnapshots,
+		overrides: map[shared.ID][]findinglineage.OverrideEvent{}, candidates: map[shared.ID][]findinglineage.MatchCandidate{},
+	}
+	var overrideIDs, candidateIDs []shared.ID
+	snapshotIDs := make([]shared.ID, 0, len(relevantSnapshots))
+	for _, snapshot := range relevantSnapshots {
+		snapshotIDs = append(snapshotIDs, snapshot.ID)
+		overrides, err := service.lineage.ListActiveOverridesBySnapshot(ctx, tenantID, baseline.CycleID, snapshot.ID)
+		if err != nil {
+			return preparedProjection{}, err
+		}
+		candidates, err := service.lineage.ListOpenCandidatesBySnapshot(ctx, tenantID, baseline.CycleID, snapshot.ID)
+		if err != nil {
+			return preparedProjection{}, err
+		}
+		prepared.overrides[snapshot.ID], prepared.candidates[snapshot.ID] = overrides, candidates
+		for _, override := range overrides {
+			overrideIDs = append(overrideIDs, override.ID)
+		}
+		for _, candidate := range candidates {
+			candidateIDs = append(candidateIDs, candidate.ID)
+		}
+	}
+	prepared.verifications, err = service.verification.ListEffectiveComparisonVerifications(ctx, tenantID, baseline.CycleID, snapshotIDs)
+	if err != nil {
+		return preparedProjection{}, err
+	}
+	if err := validateVerifications(prepared.verifications, snapshotIDs); err != nil {
+		return preparedProjection{}, err
+	}
+	history := make([]assessmentcomparison.SnapshotHashRef, 0, len(relevantSnapshots))
+	if mode == assessmentcomparison.ModeLifecycle {
+		for _, snapshot := range relevantSnapshots {
+			if snapshot.ID != baseline.ID && snapshot.ID != current.ID {
+				history = append(history, assessmentcomparison.SnapshotHashRef{ID: snapshot.ID, ContentHash: snapshot.ContentHash})
+			}
+		}
+	}
+	relationships := make([]assessmentcomparison.RelationshipRef, len(relevantMembers))
+	for index, member := range relevantMembers {
+		relationships[index] = assessmentcomparison.RelationshipRef{
+			AssessmentID: member.AssessmentID, PredecessorID: member.PredecessorAssessmentID, RelationshipVersion: member.RelationshipVersion,
+		}
+	}
+	verificationIDs := make([]shared.ID, len(prepared.verifications))
+	for index, verification := range prepared.verifications {
+		verificationIDs[index] = verification.ID
+	}
+	prepared.input = assessmentcomparison.GenerationInput{
+		Mode:             mode,
+		Baseline:         assessmentcomparison.SnapshotHashRef{ID: baseline.ID, ContentHash: baseline.ContentHash},
+		Current:          assessmentcomparison.SnapshotHashRef{ID: current.ID, ContentHash: current.ContentHash},
+		HistorySnapshots: history, Relationships: relationships,
+		AlgorithmVersion: assessmentcomparison.AlgorithmVersionV1, FingerprintVersion: fingerprintVersion,
+		RiskModelVersion: riskModelVersion, CoveragePolicyVersion: assessmentcomparison.CoveragePolicyVersionV1,
+		ActiveOverrideIDs: overrideIDs, MatchCandidateIDs: candidateIDs, VerificationDecisionIDs: verificationIDs,
+	}
+	return prepared, nil
+}
+
+func (service *Service) relevantSnapshots(ctx context.Context, tenantID shared.ID, mode assessmentcomparison.Mode, baseline, current *assessmentsnapshot.Snapshot, members []assessmentcycle.Member) ([]*assessmentsnapshot.Snapshot, error) {
+	if mode == assessmentcomparison.ModeNeutral {
+		return []*assessmentsnapshot.Snapshot{baseline, current}, nil
+	}
+	path, err := pathToAssessment(members, current.AssessmentID)
+	if err != nil {
+		return nil, err
+	}
+	var snapshots []*assessmentsnapshot.Snapshot
+	for _, member := range path {
+		listed, err := snapshotuc.ReadComparisonHistory(ctx, service.snapshots, tenantID, member.AssessmentID)
+		if err != nil {
+			return nil, err
+		}
+		sort.Slice(listed, func(left, right int) bool {
+			if listed[left].SnapshotNumber == listed[right].SnapshotNumber {
+				return listed[left].ID < listed[right].ID
+			}
+			return listed[left].SnapshotNumber < listed[right].SnapshotNumber
+		})
+		for index := range listed {
+			if member.AssessmentID == current.AssessmentID && listed[index].SnapshotNumber > current.SnapshotNumber {
+				continue
+			}
+			copySnapshot := listed[index]
+			snapshots = append(snapshots, &copySnapshot)
+		}
+	}
+	baselinePosition, currentPosition := -1, -1
+	for index, snapshot := range snapshots {
+		if snapshot.ID == baseline.ID {
+			baselinePosition = index
+		}
+		if snapshot.ID == current.ID {
+			currentPosition = index
+		}
+	}
+	if baselinePosition < 0 || currentPosition < 0 || baselinePosition >= currentPosition {
+		return nil, fmt.Errorf("%w: lifecycle snapshots are absent from effective ancestry order", shared.ErrValidation)
+	}
+	return snapshots[:currentPosition+1], nil
+}
+
+type projectedSnapshot struct {
+	snapshot     *assessmentsnapshot.Snapshot
+	observations map[shared.ID][]findinglineage.Observation
+	ambiguous    map[shared.ID]bool
+	candidates   map[shared.ID][]shared.ID
+	reviews      map[shared.ID][]assessmentcomparison.ReviewCandidateView
+	methods      map[shared.ID][]findinglineage.MatchMethod
+}
+
+func (service *Service) buildItems(ctx context.Context, prepared preparedProjection) ([]assessmentcomparison.Item, error) {
+	states := make(map[shared.ID]*projectedSnapshot, len(prepared.snapshots))
+	observationIdentity := map[shared.ID]shared.ID{}
+	for _, snapshot := range prepared.snapshots {
+		observations, err := service.lineage.ListObservationsBySnapshot(ctx, prepared.baseline.TenantID, prepared.baseline.CycleID, snapshot.ID)
+		if err != nil {
+			return nil, err
+		}
+		overrides := map[shared.ID]findinglineage.OverrideEvent{}
+		for _, event := range prepared.overrides[snapshot.ID] {
+			overrides[event.SourceObservationID] = event
+		}
+		state := &projectedSnapshot{snapshot: snapshot, observations: map[shared.ID][]findinglineage.Observation{}, ambiguous: map[shared.ID]bool{}, candidates: map[shared.ID][]shared.ID{}, reviews: map[shared.ID][]assessmentcomparison.ReviewCandidateView{}, methods: map[shared.ID][]findinglineage.MatchMethod{}}
+		for _, observation := range observations {
+			identityID := observation.IdentityID
+			if event, ok := overrides[observation.ID]; ok {
+				identityID = event.TargetIdentityID
+				delete(overrides, observation.ID)
+			}
+			state.observations[identityID] = append(state.observations[identityID], observation)
+			observationIdentity[observation.ID] = identityID
+		}
+		if len(overrides) != 0 {
+			return nil, fmt.Errorf("%w: active override source observation is absent from snapshot", shared.ErrValidation)
+		}
+		for identityID, observations := range state.observations {
+			sort.Slice(observations, func(left, right int) bool { return observations[left].ID < observations[right].ID })
+			state.observations[identityID] = observations
+			if len(observations) > 1 {
+				state.ambiguous[identityID] = true
+			}
+		}
+		states[snapshot.ID] = state
+	}
+	for snapshotID, candidates := range prepared.candidates {
+		state := states[snapshotID]
+		for _, candidate := range candidates {
+			sourceObservationIDs := make([]shared.ID, 0, len(candidate.Refs))
+			for _, reference := range candidate.Refs {
+				if reference.Role == findinglineage.RoleSource && !reference.ObservationID.IsZero() {
+					sourceObservationIDs = append(sourceObservationIDs, reference.ObservationID)
+				}
+			}
+			review := assessmentcomparison.ReviewCandidateView{ID: candidate.ID, SourceObservationIDs: sourceObservationIDs}
+			for _, reference := range candidate.Refs {
+				if !reference.IdentityID.IsZero() {
+					state.ambiguous[reference.IdentityID] = true
+					state.candidates[reference.IdentityID] = append(state.candidates[reference.IdentityID], candidate.ID)
+					state.reviews[reference.IdentityID] = append(state.reviews[reference.IdentityID], review)
+					state.methods[reference.IdentityID] = append(state.methods[reference.IdentityID], reference.Method)
+				}
+				if !reference.ObservationID.IsZero() {
+					if identityID := observationIdentity[reference.ObservationID]; !identityID.IsZero() {
+						state.ambiguous[identityID] = true
+						state.candidates[identityID] = append(state.candidates[identityID], candidate.ID)
+						state.reviews[identityID] = append(state.reviews[identityID], review)
+						state.methods[identityID] = append(state.methods[identityID], reference.Method)
+					}
+				}
+			}
+		}
+	}
+	baselineState, currentState := states[prepared.baseline.ID], states[prepared.current.ID]
+	identities := map[shared.ID]struct{}{}
+	for identityID := range baselineState.observations {
+		identities[identityID] = struct{}{}
+	}
+	for identityID := range currentState.observations {
+		identities[identityID] = struct{}{}
+	}
+	orderedIDs := make([]shared.ID, 0, len(identities))
+	for identityID := range identities {
+		orderedIDs = append(orderedIDs, identityID)
+	}
+	sort.Slice(orderedIDs, func(left, right int) bool { return orderedIDs[left] < orderedIDs[right] })
+	verificationByIdentity := make(map[shared.ID]ports.AssessmentComparisonVerification, len(prepared.verifications))
+	verificationBySnapshot := make(map[shared.ID]map[shared.ID]ports.AssessmentComparisonVerification)
+	for _, verification := range prepared.verifications {
+		verificationByIdentity[verification.IdentityID] = verification
+		if verificationBySnapshot[verification.EffectiveSnapshotID] == nil {
+			verificationBySnapshot[verification.EffectiveSnapshotID] = map[shared.ID]ports.AssessmentComparisonVerification{}
+		}
+		verificationBySnapshot[verification.EffectiveSnapshotID][verification.IdentityID] = verification
+	}
+	coverage := newCoverageCache()
+	items := make([]assessmentcomparison.Item, 0, len(orderedIDs))
+	for _, identityID := range orderedIDs {
+		baselineObservation := firstObservation(baselineState.observations[identityID])
+		currentObservation := firstObservation(currentState.observations[identityID])
+		verification := verificationByIdentity[identityID]
+		classification := assessmentcomparison.ClassifyInput{
+			IdentityID: identityID, Baseline: baselineObservation, Current: currentObservation,
+			Ambiguous:      baselineState.ambiguous[identityID] || currentState.ambiguous[identityID],
+			VerificationID: verification.ID, VerificationState: verification.State, VerificationRemediated: verification.Remediated,
+			BaselineActionable: baselineObservation != nil, CurrentActionable: currentObservation != nil,
+			BaselineRiskMilli: observationRisk(baselineObservation), CurrentRiskMilli: observationRisk(currentObservation),
+		}
+		if baselineObservation != nil && currentObservation == nil {
+			classification.CurrentCoverage = coverage.compare(prepared.baseline, prepared.current, baselineObservation)
+		}
+		if baselineObservation == nil && currentObservation != nil && prepared.input.Mode == assessmentcomparison.ModeLifecycle {
+			classification.History = buildHistory(identityID, prepared.current.ID, prepared.snapshots, states, verificationBySnapshot, coverage)
+		}
+		var item assessmentcomparison.Item
+		var err error
+		if prepared.input.Mode == assessmentcomparison.ModeLifecycle {
+			item, err = assessmentcomparison.ClassifyLifecycle(classification)
+		} else {
+			item, err = assessmentcomparison.ClassifyNeutral(classification)
+		}
+		if err != nil {
+			return nil, err
+		}
+		if baselineObservation != nil {
+			item.CoverageDecision = coverage.compare(prepared.baseline, prepared.current, baselineObservation)
+		}
+		item.ReviewCandidateIDs = append(item.ReviewCandidateIDs, baselineState.candidates[identityID]...)
+		item.ReviewCandidateIDs = append(item.ReviewCandidateIDs, currentState.candidates[identityID]...)
+		item.ReviewCandidates = append(item.ReviewCandidates, baselineState.reviews[identityID]...)
+		item.ReviewCandidates = append(item.ReviewCandidates, currentState.reviews[identityID]...)
+		item.MatchMethods = canonicalMatchMethods(append(append([]findinglineage.MatchMethod(nil), baselineState.methods[identityID]...), currentState.methods[identityID]...))
+		items = append(items, item)
+	}
+	return items, nil
+}
+
+func canonicalMatchMethods(methods []findinglineage.MatchMethod) []findinglineage.MatchMethod {
+	seen := map[findinglineage.MatchMethod]struct{}{}
+	result := make([]findinglineage.MatchMethod, 0, len(methods))
+	for _, method := range methods {
+		if !method.Valid() {
+			continue
+		}
+		if _, duplicate := seen[method]; duplicate {
+			continue
+		}
+		seen[method] = struct{}{}
+		result = append(result, method)
+	}
+	sort.Slice(result, func(left, right int) bool { return result[left] < result[right] })
+	return result
+}
+
+func buildHistory(identityID, currentSnapshotID shared.ID, snapshots []*assessmentsnapshot.Snapshot, states map[shared.ID]*projectedSnapshot, verifications map[shared.ID]map[shared.ID]ports.AssessmentComparisonVerification, coverage *coverageCache) []assessmentcomparison.HistoryState {
+	history := make([]assessmentcomparison.HistoryState, 0, len(snapshots))
+	var lastObserved *findinglineage.Observation
+	var lastObservedSnapshot *assessmentsnapshot.Snapshot
+	for index, snapshot := range snapshots {
+		if snapshot.ID == currentSnapshotID {
+			break
+		}
+		state := states[snapshot.ID]
+		observation := firstObservation(state.observations[identityID])
+		historyState := assessmentcomparison.HistoryState{Order: int64(index + 1), Ambiguous: state.ambiguous[identityID]}
+		if verification, ok := verifications[snapshot.ID][identityID]; ok {
+			historyState.VerifiedRemediation = verification.Remediated
+			historyState.VerificationDecision = verification.ID
+		}
+		if observation != nil {
+			historyState.Observed = true
+			lastObserved, lastObservedSnapshot = observation, snapshot
+		} else if lastObserved != nil {
+			historyState.ComparableAbsence = coverage.compare(lastObservedSnapshot, snapshot, lastObserved) == assessmentsnapshot.Comparable
+		}
+		history = append(history, historyState)
+	}
+	return history
+}
+
+type coverageCache struct {
+	pairs map[string]map[string]assessmentsnapshot.Comparability
+}
+
+func newCoverageCache() *coverageCache {
+	return &coverageCache{pairs: map[string]map[string]assessmentsnapshot.Comparability{}}
+}
+
+func (cache *coverageCache) compare(baseline, current *assessmentsnapshot.Snapshot, observation *findinglineage.Observation) assessmentsnapshot.Comparability {
+	if baseline == nil || current == nil || observation == nil {
+		return assessmentsnapshot.NotComparable
+	}
+	pairKey := baseline.ID.String() + "\x00" + current.ID.String()
+	index, ok := cache.pairs[pairKey]
+	if !ok {
+		index = map[string]assessmentsnapshot.Comparability{}
+		comparisons, err := assessmentsnapshot.Compare(baseline, current)
+		if err != nil {
+			return assessmentsnapshot.NotComparable
+		}
+		for _, comparison := range comparisons {
+			key := comparisonDimensionKey(comparison.Baseline.Producer, comparison.Baseline.FindingKind, comparison.Baseline.Target.Canonical)
+			if existing, exists := index[key]; !exists || comparabilityRank(comparison.Comparability) < comparabilityRank(existing) {
+				index[key] = comparison.Comparability
+			}
+		}
+		cache.pairs[pairKey] = index
+	}
+	comparability, exists := index[comparisonDimensionKey(observation.ProducerKind, observation.FindingKind, observation.TargetCanonical)]
+	if !exists {
+		return assessmentsnapshot.NotComparable
+	}
+	return comparability
+}
+
+func comparabilityRank(value assessmentsnapshot.Comparability) int {
+	switch value {
+	case assessmentsnapshot.Comparable:
+		return 2
+	case assessmentsnapshot.PartiallyComparable:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func comparisonDimensionKey(producer, findingKind, target string) string {
+	return strings.Join([]string{producer, findingKind, target}, "\x00")
+}
+
+func observationRisk(observation *findinglineage.Observation) int64 {
+	if observation == nil {
+		return 0
+	}
+	if observation.RiskScoreMilli != nil {
+		return int64(*observation.RiskScoreMilli)
+	}
+	// ponytail: v1 treats every immutable observation as actionable and derives missing risk from severity;
+	// add a versioned immutable actionability projection reader when workflow-policy IDs become part of #698 inputs.
+	return int64(shared.SeverityRank(observation.Severity) * 2000)
+}
+
+func firstObservation(observations []findinglineage.Observation) *findinglineage.Observation {
+	if len(observations) == 0 {
+		return nil
+	}
+	return &observations[0]
+}
+
+func relevantMembers(members []assessmentcycle.Member, baselineAssessmentID, currentAssessmentID shared.ID) ([]assessmentcycle.Member, error) {
+	baselinePath, err := pathToAssessment(members, baselineAssessmentID)
+	if err != nil {
+		return nil, err
+	}
+	currentPath, err := pathToAssessment(members, currentAssessmentID)
+	if err != nil {
+		return nil, err
+	}
+	byID := map[shared.ID]assessmentcycle.Member{}
+	depth := map[shared.ID]int{}
+	for _, path := range [][]assessmentcycle.Member{baselinePath, currentPath} {
+		for index, member := range path {
+			byID[member.AssessmentID] = member
+			if current, exists := depth[member.AssessmentID]; !exists || index < current {
+				depth[member.AssessmentID] = index
+			}
+		}
+	}
+	result := make([]assessmentcycle.Member, 0, len(byID))
+	for _, member := range byID {
+		result = append(result, member)
+	}
+	sort.Slice(result, func(left, right int) bool {
+		leftDepth, rightDepth := depth[result[left].AssessmentID], depth[result[right].AssessmentID]
+		if leftDepth == rightDepth {
+			return result[left].AssessmentID < result[right].AssessmentID
+		}
+		return leftDepth < rightDepth
+	})
+	return result, nil
+}
+
+func pathToAssessment(members []assessmentcycle.Member, assessmentID shared.ID) ([]assessmentcycle.Member, error) {
+	byID := make(map[shared.ID]assessmentcycle.Member, len(members))
+	for _, member := range members {
+		byID[member.AssessmentID] = member
+	}
+	current, exists := byID[assessmentID]
+	if !exists {
+		return nil, fmt.Errorf("%w: assessment %q is absent from cycle relationships", shared.ErrNotFound, assessmentID)
+	}
+	path := []assessmentcycle.Member{current}
+	seen := map[shared.ID]struct{}{current.AssessmentID: {}}
+	for !current.PredecessorAssessmentID.IsZero() {
+		predecessor, exists := byID[current.PredecessorAssessmentID]
+		if !exists {
+			return nil, fmt.Errorf("%w: predecessor %q is absent from cycle relationships", shared.ErrNotFound, current.PredecessorAssessmentID)
+		}
+		if _, duplicate := seen[predecessor.AssessmentID]; duplicate {
+			return nil, fmt.Errorf("%w: cycle relationship loop at %q", shared.ErrValidation, predecessor.AssessmentID)
+		}
+		seen[predecessor.AssessmentID] = struct{}{}
+		path = append(path, predecessor)
+		current = predecessor
+	}
+	for left, right := 0, len(path)-1; left < right; left, right = left+1, right-1 {
+		path[left], path[right] = path[right], path[left]
+	}
+	return path, nil
+}
+
+func validateQueueInput(input *QueueInput) error {
+	input.TenantID = shared.TenantOrDefault(input.TenantID)
+	input.Actor = strings.TrimSpace(input.Actor)
+	if input.BaselineSnapshotID.IsZero() || input.CurrentSnapshotID.IsZero() || !input.Mode.Valid() || input.FingerprintVersion <= 0 || input.RiskModelVersion != RiskModelVersionV1 || !validActor(input.Actor) {
+		return fmt.Errorf("%w: comparison queue input is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validateWorkInput(input *WorkInput) error {
+	input.TenantID = shared.TenantOrDefault(input.TenantID)
+	input.Actor = strings.TrimSpace(input.Actor)
+	if input.MaxAttempts == 0 {
+		input.MaxAttempts = DefaultMaxAttempts
+	}
+	if input.ComparisonID.IsZero() || !validActor(input.Actor) || input.MaxAttempts < 1 || input.MaxAttempts > MaxAttempts {
+		return fmt.Errorf("%w: comparison work input is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func validateVerifications(verifications []ports.AssessmentComparisonVerification, snapshotIDs []shared.ID) error {
+	allowedSnapshots := make(map[shared.ID]struct{}, len(snapshotIDs))
+	for _, snapshotID := range snapshotIDs {
+		allowedSnapshots[snapshotID] = struct{}{}
+	}
+	seenIDs := map[shared.ID]struct{}{}
+	seenIdentities := map[shared.ID]struct{}{}
+	for _, verification := range verifications {
+		_, allowed := allowedSnapshots[verification.EffectiveSnapshotID]
+		if verification.ID.IsZero() || verification.IdentityID.IsZero() || !allowed || !validToken(verification.State) {
+			return fmt.Errorf("%w: effective comparison verification is invalid", shared.ErrValidation)
+		}
+		if _, duplicate := seenIDs[verification.ID]; duplicate {
+			return fmt.Errorf("%w: effective comparison verification id is duplicated", shared.ErrValidation)
+		}
+		if _, duplicate := seenIdentities[verification.IdentityID]; duplicate {
+			return fmt.Errorf("%w: multiple effective comparison verifications exist for one identity", shared.ErrConflict)
+		}
+		seenIDs[verification.ID], seenIdentities[verification.IdentityID] = struct{}{}, struct{}{}
+	}
+	return nil
+}
+
+func validActor(actor string) bool {
+	return actor != "" && len(actor) <= 256
+}
+
+func validToken(value string) bool {
+	if value == "" || len(value) > 64 || strings.TrimSpace(value) != value {
+		return false
+	}
+	for _, char := range value {
+		if char != '_' && (char < 'a' || char > 'z') && (char < '0' || char > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func (service *Service) failGeneration(ctx context.Context, input WorkInput, comparison assessmentcomparison.Comparison, cause error) error {
+	code, retryable := generationFailure(cause)
+	failCtx := context.WithoutCancel(ctx)
+	err := service.transactions.Run(failCtx, input.TenantID, func(txCtx context.Context) error {
+		current, err := service.comparisons.Get(txCtx, input.TenantID, input.ComparisonID)
+		if err != nil {
+			return err
+		}
+		if current.Status != assessmentcomparison.StatusGenerating {
+			return nil
+		}
+		if err := current.Fail(code, retryable, input.MaxAttempts, current.Version, service.clock.Now().UTC()); err != nil {
+			return err
+		}
+		if err := service.comparisons.UpdateCAS(txCtx, current, current.Version-1); err != nil {
+			return err
+		}
+		return service.recordAudit(txCtx, input.Actor, "assessment_comparison.failed", current, map[string]string{"reason": code, "retryable": fmt.Sprintf("%t", retryable), "status": string(current.Status)})
+	})
+	service.observer.ObserveAssessmentComparison("failed", string(comparison.Mode), code)
+	if err != nil {
+		return errors.Join(cause, err)
+	}
+	return cause
+}
+
+func generationFailure(err error) (string, bool) {
+	switch {
+	case errors.Is(err, errGenerationInputChanged), errors.Is(err, shared.ErrConflict):
+		return "input_changed", false
+	case errors.Is(err, shared.ErrNotFound):
+		return "input_missing", false
+	case errors.Is(err, shared.ErrValidation):
+		return "invalid_input", false
+	case errors.Is(err, context.Canceled), errors.Is(err, context.DeadlineExceeded):
+		return "worker_cancelled", true
+	default:
+		return "generation_failed", true
+	}
+}
+
+func (service *Service) recordAudit(ctx context.Context, actor, action string, comparison assessmentcomparison.Comparison, metadata map[string]string) error {
+	if metadata == nil {
+		metadata = map[string]string{}
+	}
+	metadata["tenant_id"] = comparison.TenantID.String()
+	metadata["cycle_id"] = comparison.CycleID.String()
+	metadata["mode"] = string(comparison.Mode)
+	metadata["input_hash"] = comparison.InputHash
+	return service.audit.Record(ctx, ports.AuditEntry{Actor: actor, Action: action, Target: comparison.ID.String(), Metadata: metadata, At: service.clock.Now().UTC()})
+}
+
+func (service *Service) enqueueGeneration(ctx context.Context, comparisonID shared.ID) error {
+	if service.jobs == nil {
+		return nil
+	}
+	payload, err := json.Marshal(Job{ComparisonID: comparisonID})
+	if err != nil {
+		return err
+	}
+	_, err = service.jobs.Enqueue(ctx, JobKind, payload)
+	return err
+}
+
+func (service *Service) observeBacklog(ctx context.Context, tenantID shared.ID) {
+	reader, readable := service.comparisons.(ports.AssessmentComparisonBacklogReader)
+	observer, observable := service.observer.(ports.AssessmentComparisonBacklogObserver)
+	if !readable || !observable {
+		return
+	}
+	metricCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	backlog, err := reader.GetAssessmentComparisonBacklog(metricCtx, tenantID)
+	if err == nil {
+		observer.ObserveAssessmentComparisonBacklog(tenantID.String(), backlog, service.clock.Now().UTC())
+	}
+}
+
+func isTerminal(status assessmentcomparison.Status) bool {
+	return status == assessmentcomparison.StatusComplete || status == assessmentcomparison.StatusNeedsReview || status == assessmentcomparison.StatusSuperseded
+}
+
+type noopObserver struct{}
+
+func (noopObserver) ObserveAssessmentComparison(string, string, string) {}

--- a/internal/usecase/assessmentcomparison/service_test.go
+++ b/internal/usecase/assessmentcomparison/service_test.go
@@ -1,0 +1,451 @@
+package assessmentcomparison
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestServiceGeneratesReplaysAndSupersedesComparison(t *testing.T) {
+	harness := newComparisonHarness(t)
+	ctx := context.Background()
+	queued, created, decision, err := harness.service.Queue(ctx, QueueInput{
+		TenantID: harness.tenantID, BaselineSnapshotID: harness.snapshotsByNumber[2].ID, CurrentSnapshotID: harness.snapshotsByNumber[3].ID,
+		Mode: assessmentcomparison.ModeLifecycle, FingerprintVersion: 1, RiskModelVersion: 1, Actor: "operator",
+	})
+	if err != nil || !created || !decision.Allowed {
+		t.Fatalf("queue=%+v created=%v decision=%+v err=%v", queued, created, decision, err)
+	}
+	completed, err := harness.service.Generate(ctx, WorkInput{TenantID: harness.tenantID, ComparisonID: queued.ID, Actor: "worker", MaxAttempts: 3})
+	if err != nil || completed.Status != assessmentcomparison.StatusNeedsReview {
+		t.Fatalf("completed=%+v err=%v", completed, err)
+	}
+	if completed.Summary.FixedRate != (assessmentcomparison.Ratio{Numerator: 1, Denominator: 3}) || completed.Summary.ComparisonID != completed.ID || completed.Summary.RiskModelVersion != 1 {
+		t.Fatalf("summary=%+v", completed.Summary)
+	}
+	assertPresence(t, completed, "fixed", assessmentcomparison.PresenceNotDetected)
+	assertPresence(t, completed, "reopened", assessmentcomparison.PresenceReopened)
+	assertPresence(t, completed, "still", assessmentcomparison.PresenceDetected)
+	assertPresence(t, completed, "new", assessmentcomparison.PresenceNew)
+	assertPresence(t, completed, "ambiguous", assessmentcomparison.PresenceNeedsReview)
+	reopened := comparisonItem(t, completed, "reopened")
+	if reopened.VerificationID != "verification-reopened" || reopened.VerificationState != "remediated" {
+		t.Fatalf("reopened verification=%+v", reopened)
+	}
+	overridden := comparisonItem(t, completed, "override-target")
+	if overridden.Presence != assessmentcomparison.PresenceDetected || overridden.CurrentObservationID != "observation-override-source-current" {
+		t.Fatalf("overridden item=%+v", overridden)
+	}
+	for _, item := range completed.Items {
+		if item.IdentityID == "override-source" {
+			t.Fatalf("source identity leaked despite active override: %+v", item)
+		}
+	}
+
+	replayed, err := harness.service.Generate(ctx, WorkInput{TenantID: harness.tenantID, ComparisonID: queued.ID, Actor: "worker", MaxAttempts: 3})
+	if err != nil || replayed.ContentHash != completed.ContentHash || replayed.Version != completed.Version {
+		t.Fatalf("generation replay=%+v err=%v", replayed, err)
+	}
+	requeued, created, _, err := harness.service.Queue(ctx, QueueInput{
+		TenantID: harness.tenantID, BaselineSnapshotID: harness.snapshotsByNumber[2].ID, CurrentSnapshotID: harness.snapshotsByNumber[3].ID,
+		Mode: assessmentcomparison.ModeLifecycle, FingerprintVersion: 1, RiskModelVersion: 1, Actor: "operator",
+	})
+	if err != nil || created || requeued.ID != completed.ID || requeued.ContentHash != completed.ContentHash {
+		t.Fatalf("queue replay=%+v created=%v err=%v", requeued, created, err)
+	}
+
+	updatedCandidate, event, err := findinglineage.ResolveCandidate(harness.candidate, "candidate-resolution", findinglineage.ResolutionDismiss,
+		"reviewer", "resolved ambiguity", nil, "", harness.candidate.Version, "", harness.clock.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, applied, err := harness.lineage.ResolveCandidateCAS(ctx, updatedCandidate, event); err != nil || !applied {
+		t.Fatalf("resolve candidate applied=%v err=%v", applied, err)
+	}
+	replacement, replaced, err := harness.service.Replace(ctx, ReplaceInput{TenantID: harness.tenantID, ComparisonID: completed.ID, Actor: "operator"})
+	if err != nil || !replaced || replacement.ID == completed.ID || replacement.Status != assessmentcomparison.StatusQueued {
+		t.Fatalf("replacement=%+v replaced=%v err=%v", replacement, replaced, err)
+	}
+	old, err := harness.comparisons.Get(ctx, harness.tenantID, completed.ID)
+	if err != nil || old.Status != assessmentcomparison.StatusSuperseded || old.ContentHash != completed.ContentHash || len(old.Items) != len(completed.Items) {
+		t.Fatalf("superseded old=%+v err=%v", old, err)
+	}
+	regenerated, err := harness.service.Generate(ctx, WorkInput{TenantID: harness.tenantID, ComparisonID: replacement.ID, Actor: "worker", MaxAttempts: 3})
+	if err != nil || regenerated.Status != assessmentcomparison.StatusComplete {
+		t.Fatalf("regenerated=%+v err=%v", regenerated, err)
+	}
+	assertPresence(t, regenerated, "ambiguous", assessmentcomparison.PresenceNew)
+	replayedReplacement, replaced, err := harness.service.Replace(ctx, ReplaceInput{TenantID: harness.tenantID, ComparisonID: completed.ID, Actor: "operator"})
+	if err != nil || replaced || replayedReplacement.ID != replacement.ID {
+		t.Fatalf("replacement replay=%+v replaced=%v err=%v", replayedReplacement, replaced, err)
+	}
+	if len(harness.audit.entries) == 0 || len(harness.observer.entries) == 0 {
+		t.Fatalf("missing audit or observer records: audit=%d observer=%d", len(harness.audit.entries), len(harness.observer.entries))
+	}
+}
+
+func TestServiceRetriesDeadLettersAndRepairs(t *testing.T) {
+	harness := newComparisonHarness(t)
+	ctx := context.Background()
+	queued, created, _, err := harness.service.Queue(ctx, QueueInput{
+		TenantID: harness.tenantID, BaselineSnapshotID: harness.snapshotsByNumber[2].ID, CurrentSnapshotID: harness.snapshotsByNumber[3].ID,
+		Mode: assessmentcomparison.ModeLifecycle, FingerprintVersion: 2, RiskModelVersion: 1, Actor: "operator",
+	})
+	if err != nil || !created {
+		t.Fatalf("queue created=%v err=%v", created, err)
+	}
+	harness.verification.err = errors.New("verification backend unavailable")
+	for attempt := 1; attempt <= 2; attempt++ {
+		if _, err := harness.service.Generate(ctx, WorkInput{TenantID: harness.tenantID, ComparisonID: queued.ID, Actor: "worker", MaxAttempts: 2}); err == nil {
+			t.Fatalf("attempt %d unexpectedly succeeded", attempt)
+		}
+		stored, getErr := harness.comparisons.Get(ctx, harness.tenantID, queued.ID)
+		if getErr != nil {
+			t.Fatal(getErr)
+		}
+		want := assessmentcomparison.StatusQueued
+		if attempt == 2 {
+			want = assessmentcomparison.StatusFailed
+		}
+		if stored.Status != want || stored.Attempts != attempt {
+			t.Fatalf("attempt=%d stored=%+v", attempt, stored)
+		}
+	}
+	if _, err := harness.service.Generate(ctx, WorkInput{TenantID: harness.tenantID, ComparisonID: queued.ID, Actor: "worker", MaxAttempts: 2}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("dead-letter generate error=%v", err)
+	}
+	harness.verification.err = nil
+	repaired, err := harness.service.Repair(ctx, WorkInput{TenantID: harness.tenantID, ComparisonID: queued.ID, Actor: "operator", MaxAttempts: 2})
+	if err != nil || repaired.Status != assessmentcomparison.StatusNeedsReview || repaired.Attempts != 3 {
+		t.Fatalf("repaired=%+v err=%v", repaired, err)
+	}
+}
+
+func TestServiceRecoversGeneratingComparison(t *testing.T) {
+	harness := newComparisonHarness(t)
+	ctx := context.Background()
+	queued, created, _, err := harness.service.Queue(ctx, QueueInput{
+		TenantID: harness.tenantID, BaselineSnapshotID: harness.snapshotsByNumber[2].ID, CurrentSnapshotID: harness.snapshotsByNumber[3].ID,
+		Mode: assessmentcomparison.ModeLifecycle, FingerprintVersion: 3, RiskModelVersion: 1, Actor: "operator",
+	})
+	if err != nil || !created {
+		t.Fatalf("queue created=%v err=%v", created, err)
+	}
+	if err := queued.Start(queued.Version, harness.clock.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := harness.comparisons.UpdateCAS(ctx, queued, queued.Version-1); err != nil {
+		t.Fatal(err)
+	}
+	recovered, err := harness.service.Recover(ctx, WorkInput{TenantID: harness.tenantID, ComparisonID: queued.ID, Actor: "repair-worker", MaxAttempts: 2})
+	if err != nil || recovered.Status != assessmentcomparison.StatusQueued || recovered.Attempts != 1 {
+		t.Fatalf("recovered=%+v err=%v", recovered, err)
+	}
+	completed, err := harness.service.Generate(ctx, WorkInput{TenantID: harness.tenantID, ComparisonID: queued.ID, Actor: "worker", MaxAttempts: 2})
+	if err != nil || completed.Status != assessmentcomparison.StatusNeedsReview || completed.Attempts != 2 {
+		t.Fatalf("completed after recovery=%+v err=%v", completed, err)
+	}
+}
+
+func TestServiceRejectsNeutralWhenLifecycleDirectionExists(t *testing.T) {
+	harness := newComparisonHarness(t)
+	comparison, created, decision, err := harness.service.Queue(context.Background(), QueueInput{
+		TenantID: harness.tenantID, BaselineSnapshotID: harness.snapshotsByNumber[2].ID, CurrentSnapshotID: harness.snapshotsByNumber[3].ID,
+		Mode: assessmentcomparison.ModeNeutral, FingerprintVersion: 1, RiskModelVersion: 1, Actor: "operator",
+	})
+	if err != nil || created || comparison.ID != "" || decision.Allowed || decision.ReasonCode != assessmentcomparison.ReasonLifecycleDirectionAvailable {
+		t.Fatalf("comparison=%+v created=%v decision=%+v err=%v", comparison, created, decision, err)
+	}
+}
+
+type comparisonHarness struct {
+	tenantID          shared.ID
+	cycleID           shared.ID
+	assessmentID      shared.ID
+	targetCanonical   string
+	snapshotsByNumber map[int]*assessmentsnapshot.Snapshot
+	comparisons       *memory.AssessmentComparisonRepository
+	snapshots         *memory.AssessmentSnapshotRepository
+	cycles            *memory.AssessmentCycleRepository
+	lineage           *memory.FindingLineageRepository
+	verification      *comparisonVerificationReader
+	clock             *comparisonClock
+	audit             *comparisonAudit
+	observer          *comparisonObserver
+	service           *Service
+	candidate         findinglineage.MatchCandidate
+}
+
+func newComparisonHarness(t *testing.T) *comparisonHarness {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	harness := &comparisonHarness{
+		tenantID: "tenant", cycleID: "cycle", assessmentID: "assessment",
+		snapshotsByNumber: map[int]*assessmentsnapshot.Snapshot{}, comparisons: memory.NewAssessmentComparisonRepository(),
+		snapshots: memory.NewAssessmentSnapshotRepository(), cycles: memory.NewAssessmentCycleRepository(), lineage: memory.NewFindingLineageRepository(),
+		clock: &comparisonClock{now: now}, audit: &comparisonAudit{}, observer: &comparisonObserver{},
+	}
+	cycle, err := assessmentcycle.NewAssessmentCycle(harness.cycleID, harness.tenantID, "Cycle", assessmentcycle.BoundaryStandalone, "", "", harness.assessmentID, "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember(harness.tenantID, harness.cycleID, harness.assessmentID, "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := harness.cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := harness.cycles.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+	for number, marker := range []string{"a", "b", "c"} {
+		snapshot := createComparisonSnapshot(t, harness, number+1, marker, int64(number))
+		harness.snapshotsByNumber[number+1] = snapshot
+	}
+
+	reopenedIdentity, reopenedFirst := comparisonLineagePair(t, harness, "reopened", harness.snapshotsByNumber[1].ID, "observation-reopened-first", shared.SeverityHigh, 8000, now)
+	createIdentity(t, harness.lineage, reopenedIdentity, reopenedFirst)
+	reopenedCurrent := comparisonObservation(harness, reopenedIdentity.ID, harness.snapshotsByNumber[3].ID, "observation-reopened-current", "source-reopened-current", shared.SeverityMedium, 5000, now.Add(3*time.Minute))
+	appendObservation(t, harness.lineage, reopenedCurrent)
+
+	fixedIdentity, fixedBaseline := comparisonLineagePair(t, harness, "fixed", harness.snapshotsByNumber[2].ID, "observation-fixed-baseline", shared.SeverityHigh, 7000, now.Add(time.Minute))
+	createIdentity(t, harness.lineage, fixedIdentity, fixedBaseline)
+
+	stillIdentity, stillBaseline := comparisonLineagePair(t, harness, "still", harness.snapshotsByNumber[2].ID, "observation-still-baseline", shared.SeverityHigh, 6000, now.Add(time.Minute))
+	createIdentity(t, harness.lineage, stillIdentity, stillBaseline)
+	stillCurrent := comparisonObservation(harness, stillIdentity.ID, harness.snapshotsByNumber[3].ID, "observation-still-current", "source-still-current", shared.SeverityMedium, 4000, now.Add(3*time.Minute))
+	appendObservation(t, harness.lineage, stillCurrent)
+
+	newIdentity, newCurrent := comparisonLineagePair(t, harness, "new", harness.snapshotsByNumber[3].ID, "observation-new-current", shared.SeverityMedium, 3000, now.Add(3*time.Minute))
+	createIdentity(t, harness.lineage, newIdentity, newCurrent)
+
+	ambiguousIdentity, ambiguousCurrent := comparisonLineagePair(t, harness, "ambiguous", harness.snapshotsByNumber[3].ID, "observation-ambiguous-current", shared.SeverityMedium, 2000, now.Add(3*time.Minute))
+	createIdentity(t, harness.lineage, ambiguousIdentity, ambiguousCurrent)
+	harness.candidate = comparisonCandidate(t, harness, ambiguousIdentity.ID, harness.snapshotsByNumber[3].ID, now.Add(4*time.Minute))
+	if _, created, err := harness.lineage.CreateCandidate(ctx, harness.candidate, ""); err != nil || !created {
+		t.Fatalf("candidate created=%v err=%v", created, err)
+	}
+
+	overrideTargetIdentity, overrideBaseline := comparisonLineagePair(t, harness, "override-target", harness.snapshotsByNumber[2].ID, "observation-override-target-baseline", shared.SeverityHigh, 5000, now.Add(time.Minute))
+	createIdentity(t, harness.lineage, overrideTargetIdentity, overrideBaseline)
+	overrideSourceIdentity, overrideCurrent := comparisonLineagePair(t, harness, "override-source", harness.snapshotsByNumber[3].ID, "observation-override-source-current", shared.SeverityMedium, 4000, now.Add(3*time.Minute))
+	createIdentity(t, harness.lineage, overrideSourceIdentity, overrideCurrent)
+	override, err := findinglineage.NewOverrideEvent(findinglineage.OverrideEvent{
+		TenantID: harness.tenantID, CycleID: harness.cycleID, ID: "override-current-source", Action: findinglineage.OverrideConfirm,
+		SourceObservationID: overrideCurrent.ID, SourceIdentityID: overrideSourceIdentity.ID, TargetIdentityID: overrideTargetIdentity.ID,
+		Actor: "reviewer", Reason: "confirmed lineage", ExpectedVersion: 0, Version: 1, CreatedAt: now.Add(5 * time.Minute),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, applied, err := harness.lineage.AppendOverrideCAS(ctx, override); err != nil || !applied {
+		t.Fatalf("override applied=%v err=%v", applied, err)
+	}
+
+	harness.verification = &comparisonVerificationReader{decisions: []ports.AssessmentComparisonVerification{{
+		ID: "verification-reopened", IdentityID: reopenedIdentity.ID, EffectiveSnapshotID: harness.snapshotsByNumber[2].ID, State: "remediated", Remediated: true,
+	}}}
+	harness.service, err = NewService(harness.comparisons, harness.snapshots, harness.cycles, harness.lineage, memory.NewTenantTransactionRunner(), harness.audit, harness.clock, &comparisonIDs{}, harness.verification, harness.observer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return harness
+}
+
+func createComparisonSnapshot(t *testing.T, harness *comparisonHarness, number int, marker string, expectedVersion int64) *assessmentsnapshot.Snapshot {
+	t.Helper()
+	started := harness.clock.Now()
+	finished := started.Add(time.Minute)
+	target, err := scanrun.CanonicalizeRepositoryTarget("https://example.com/repo.git", strings.Repeat(marker, 40))
+	if err != nil {
+		t.Fatal(err)
+	}
+	harness.targetCanonical = target.TargetIdentityCanonical
+	run := scanrun.ScanRun{
+		TenantID: harness.tenantID, ID: fmt.Sprintf("run-%d", number), EngagementID: harness.assessmentID, CreatedAt: started, UpdatedAt: started,
+		Provenance: scanrun.ProvenanceNative, TerminalStatus: scanrun.StatusBuilding,
+		ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion,
+		Lanes: []scanrun.Lane{{
+			TenantID: harness.tenantID, EngagementID: harness.assessmentID, ScanRunID: fmt.Sprintf("run-%d", number), LaneKey: "sca", Producer: "sca", TerminalStatus: scanrun.StatusSucceeded, Target: target,
+			AuthoritativeFindingKinds: []string{"vulnerability"}, IncludedScope: []string{"src/**"}, ExcludedScope: []string{"vendor/**"},
+			StartedAt: started, FinishedAt: &finished, ResultRef: fmt.Sprintf("result-%d", number), EvidenceRef: fmt.Sprintf("evidence-%d", number),
+			ResultSHA256: strings.Repeat(marker, 64), ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion,
+			Versions: []scanrun.LaneVersion{{VersionKind: scanrun.VersionScanner, Name: "sca", Version: "1"}, {VersionKind: scanrun.VersionRulePack, Name: "rules", Version: "1"}},
+			Stages:   []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSucceeded, StartedAt: started, FinishedAt: &finished}},
+		}},
+	}
+	run.Lanes[0].SealedAt = &finished
+	run.Lanes[0].ManifestHash, err = scanrun.ComputeManifestHash(run.Lanes[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.ManifestHash, err = scanrun.ComputeRunManifestHash(run.Lanes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.TerminalStatus, run.SealedAt, run.UpdatedAt = scanrun.StatusSucceeded, &finished, finished
+	snapshot, err := assessmentsnapshot.NewFinalized(harness.tenantID, shared.ID(fmt.Sprintf("snapshot-%d", number)), harness.cycleID, harness.assessmentID,
+		assessmentsnapshot.Boundary{Kind: assessmentcycle.BoundaryStandalone}, fmt.Sprintf("request-%d", number), "operator", finished,
+		[]assessmentsnapshot.SelectedRun{{ID: run.ID, ManifestHash: run.ManifestHash, Provenance: run.Provenance, TerminalStatus: run.TerminalStatus, Trusted: true, Lanes: run.Lanes}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stored, created, err := harness.snapshots.CreateFinalizedCAS(context.Background(), snapshot, expectedVersion)
+	if err != nil || !created {
+		t.Fatalf("snapshot %d created=%v err=%v", number, created, err)
+	}
+	return stored
+}
+
+func comparisonLineagePair(t *testing.T, harness *comparisonHarness, identityID string, snapshotID shared.ID, observationID string, severity shared.Severity, risk int, now time.Time) (findinglineage.Identity, findinglineage.Observation) {
+	t.Helper()
+	canonical, err := findinglineage.CanonicalizeFingerprintV1(findinglineage.FingerprintCanonicalInputV1{
+		CanonicalizationVersion: 1, ProducerKind: "sca", TargetIdentitySchemaVersion: 1, TargetIdentityCanonical: harness.targetCanonical,
+		IdentityFields: map[string]findinglineage.CanonicalValue{"rule_id": findinglineage.Text("rule-" + identityID)},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity := findinglineage.Identity{
+		TenantID: harness.tenantID, CycleID: harness.cycleID, ID: shared.ID(identityID), ProducerKind: "sca", FindingKind: "vulnerability",
+		CanonicalizationVersion: 1, FingerprintSchemaVersion: 1, LineageFingerprint: canonical.Fingerprint,
+		TargetIdentitySchemaVersion: 1, TargetIdentityCanonical: harness.targetCanonical, CanonicalIdentityFields: canonical.IdentityFields,
+		FirstSeenSnapshotID: snapshotID, CreatedAt: now,
+	}
+	return identity, comparisonObservation(harness, identity.ID, snapshotID, observationID, "source-"+observationID, severity, risk, now)
+}
+
+func comparisonObservation(harness *comparisonHarness, identityID, snapshotID shared.ID, observationID, sourceID string, severity shared.Severity, risk int, now time.Time) findinglineage.Observation {
+	return findinglineage.Observation{
+		TenantID: harness.tenantID, CycleID: harness.cycleID, ID: shared.ID(observationID), SnapshotID: snapshotID, IdentityID: identityID,
+		ProducerKind: "sca", FindingKind: "vulnerability", TargetCanonical: harness.targetCanonical, SourceFindingID: sourceID,
+		Severity: severity, RiskScoreMilli: &risk, ComponentVersion: "1.0.0", Location: "go.mod", Reachability: "reachable",
+		EvidenceDigest: strings.Repeat("a", 64), ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "sca", ToolVersion: "1", LaneKey: "sca", RuleID: "rule-" + identityID.String()},
+		ObservedAt: now,
+	}
+}
+
+func createIdentity(t *testing.T, repository *memory.FindingLineageRepository, identity findinglineage.Identity, observation findinglineage.Observation) {
+	t.Helper()
+	if err := repository.CreateIdentityWithObservation(context.Background(), identity, observation); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func appendObservation(t *testing.T, repository *memory.FindingLineageRepository, observation findinglineage.Observation) {
+	t.Helper()
+	if err := repository.AppendObservation(context.Background(), observation); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func comparisonCandidate(t *testing.T, harness *comparisonHarness, identityID, snapshotID shared.ID, now time.Time) findinglineage.MatchCandidate {
+	t.Helper()
+	sourceHash := strings.Repeat("f", 64)
+	candidate, err := findinglineage.NewMatchCandidate(findinglineage.MatchCandidate{
+		TenantID: harness.tenantID, CycleID: harness.cycleID, SnapshotID: snapshotID, ID: "candidate-ambiguous",
+		ProducerKind: "sca", FindingKind: "vulnerability", Reason: findinglineage.ReasonFingerprintCollision,
+		FingerprintSchemaVersion: 1, Fingerprint: strings.Repeat("e", 64), SourceReferenceHash: sourceHash,
+		Refs: []findinglineage.CandidateRef{
+			{Position: 0, Role: findinglineage.RoleSource, ExternalReferenceHash: sourceHash, Method: findinglineage.MethodMatcher, ScoreMilli: 1000, Confidence: findinglineage.ConfidenceHigh},
+			{Position: 1, Role: findinglineage.RoleCandidate, IdentityID: identityID, Method: findinglineage.MethodFingerprint, ScoreMilli: 900, Confidence: findinglineage.ConfidenceHigh},
+		},
+		CreatedAt: now,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return candidate
+}
+
+func comparisonItem(t *testing.T, comparison assessmentcomparison.Comparison, identityID shared.ID) assessmentcomparison.Item {
+	t.Helper()
+	for _, item := range comparison.Items {
+		if item.IdentityID == identityID {
+			return item
+		}
+	}
+	t.Fatalf("comparison item %s not found", identityID)
+	return assessmentcomparison.Item{}
+}
+
+func assertPresence(t *testing.T, comparison assessmentcomparison.Comparison, identityID shared.ID, want assessmentcomparison.Presence) {
+	t.Helper()
+	if item := comparisonItem(t, comparison, identityID); item.Presence != want {
+		t.Fatalf("identity=%s presence=%s want=%s item=%+v", identityID, item.Presence, want, item)
+	}
+}
+
+type comparisonClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (clock *comparisonClock) Now() time.Time {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	clock.now = clock.now.Add(time.Second)
+	return clock.now
+}
+
+type comparisonIDs struct {
+	mu   sync.Mutex
+	next int
+}
+
+func (ids *comparisonIDs) NewID() shared.ID {
+	ids.mu.Lock()
+	defer ids.mu.Unlock()
+	ids.next++
+	return shared.ID(fmt.Sprintf("comparison-%d", ids.next))
+}
+
+type comparisonVerificationReader struct {
+	decisions []ports.AssessmentComparisonVerification
+	err       error
+}
+
+func (reader *comparisonVerificationReader) ListEffectiveComparisonVerifications(context.Context, shared.ID, shared.ID, []shared.ID) ([]ports.AssessmentComparisonVerification, error) {
+	if reader.err != nil {
+		return nil, reader.err
+	}
+	return append([]ports.AssessmentComparisonVerification(nil), reader.decisions...), nil
+}
+
+type comparisonAudit struct {
+	mu      sync.Mutex
+	entries []ports.AuditEntry
+}
+
+func (audit *comparisonAudit) Record(_ context.Context, entry ports.AuditEntry) error {
+	audit.mu.Lock()
+	defer audit.mu.Unlock()
+	audit.entries = append(audit.entries, entry)
+	return nil
+}
+
+type comparisonObserver struct {
+	mu      sync.Mutex
+	entries [][3]string
+}
+
+func (observer *comparisonObserver) ObserveAssessmentComparison(status, mode, reason string) {
+	observer.mu.Lock()
+	defer observer.mu.Unlock()
+	observer.entries = append(observer.entries, [3]string{status, mode, reason})
+}


### PR DESCRIPTION
Compare immutable snapshots through retained finding lineage and record governed comparison review state. Add idempotent request persistence and comparison backfill service; the rollout-dependent operator CLI is delivered in phase 10.

Phase 5/10. Base: `codex/868-phase-05-finding-lineage`. Keep #868 as tracking/reference only; do not merge it.

## Review follow-up: migration 0145 collision

Addressed the new review on #884 and the dependent holds on #885–#893. Main `9a7bae2d` includes #921's `0145_advisory_alias_index.sql`; the entire unmerged assessment block moves from 0145–0159 to **0146–0160**. #884 adds only 0146; #885 adds 0147–0160. All 15 assessment SQL bodies and their relative order are preserved. Existing main migrations (including 0145), core ScanRun and governed response/correlation code remain unchanged.

Updated migration test filenames and embedded-file references, Goose UpTo/DownTo targets, upgrade fixtures from main version 0145, diagnostics, and operational documentation. The complete payload is preserved through an explicit old/new filename map; runtime assessment code is unchanged by renumbering. Each PR still contains one capability commit against its immediate predecessor.

## Validation

Local validation after this update: all 10 phases passed scoped tests and repository-wide Go builds; the final stack passed repository-wide Go tests and vet. Isolated PostgreSQL 17 tests passed for duplicate migration inventory, authoritative main migrations, assessment upgrade/rollback paths, tenant isolation, immutable evidence and source bindings. Frontend typecheck, 116 test files / 694 tests, production build and lint passed (0 errors, 10 existing warnings); Helm lint/render assertions passed. CI is disabled, so these are explicitly local results. Final GitHub heads, bases and incremental file diffs are checked against the tested commits.

## Stack merge order

#884 → #885 → #886 → #887 → #888 → #889 → #890 → #891 → #892 → #893

Merge #884 first, then proceed in order. Prefer merge commits to retain ancestry; after each predecessor merges, retarget the next PR to `main` and inspect its remaining diff. Branch names remain stable. See the [preservation and migration audit](https://github.com/KKloudTarus/synapse-ce/blob/codex/868-phase-11-operations-docs/docs/architecture/assessment-stack-868-audit.md).
