### PR TITLE
feat(assessment): [6/10] preserve immutable sources across retests

### DIFF
--- a/internal/infrastructure/blob/filesystem.go
+++ b/internal/infrastructure/blob/filesystem.go
@@ -1,0 +1,155 @@
+package blob
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// Filesystem retains immutable uploaded objects on a volume shared by API and
+// workers. Root-relative operations confine every object path, including symlinks.
+type Filesystem struct{ root *os.Root }
+
+var _ ports.ObjectStore = (*Filesystem)(nil)
+
+func NewFilesystem(directory string) (*Filesystem, error) {
+	if !filepath.IsAbs(directory) || filepath.Clean(directory) == string(filepath.Separator) {
+		return nil, fmt.Errorf("object directory must be an absolute, non-root path")
+	}
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return nil, fmt.Errorf("create object directory: %w", err)
+	}
+	info, err := os.Lstat(directory)
+	if err != nil || !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("object directory must be a real directory")
+	}
+	root, err := os.OpenRoot(directory)
+	if err != nil {
+		return nil, fmt.Errorf("open object directory: %w", err)
+	}
+	return &Filesystem{root: root}, nil
+}
+
+func (s *Filesystem) Close() error { return s.root.Close() }
+
+func validateObjectKey(key string) error {
+	if key == "" || len(key) > 1024 || path.IsAbs(key) || path.Clean(key) != key || key == "." || key == ".." || strings.HasPrefix(key, "../") || strings.ContainsAny(key, "\\\x00\r\n") {
+		return fmt.Errorf("%w: invalid object key", shared.ErrValidation)
+	}
+	for _, part := range strings.Split(key, "/") {
+		if strings.HasPrefix(part, ".") {
+			return fmt.Errorf("%w: hidden object paths are reserved", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+type contextReader struct {
+	ctx context.Context
+	src io.Reader
+}
+
+func (r contextReader) Read(p []byte) (int, error) {
+	if err := r.ctx.Err(); err != nil {
+		return 0, err
+	}
+	return r.src.Read(p)
+}
+
+func (s *Filesystem) PutObject(ctx context.Context, key string, src io.Reader, size int64) error {
+	if err := validateObjectKey(key); err != nil {
+		return err
+	}
+	if src == nil || size < 0 || size == math.MaxInt64 {
+		return fmt.Errorf("%w: invalid object stream size", shared.ErrValidation)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	dir := path.Dir(key)
+	if err := s.root.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("create object path: %w", err)
+	}
+	staging := path.Join(dir, ".upload-"+idgen.RandomID{}.NewID().String())
+	file, err := s.root.OpenFile(staging, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return fmt.Errorf("stage object: %w", err)
+	}
+	defer func() { _ = s.root.Remove(staging) }()
+	written, copyErr := io.Copy(file, io.LimitReader(contextReader{ctx: ctx, src: src}, size+1))
+	if copyErr == nil && written != size {
+		copyErr = fmt.Errorf("%w: object size mismatch", shared.ErrValidation)
+	}
+	if copyErr == nil {
+		copyErr = ctx.Err()
+	}
+	if copyErr == nil {
+		copyErr = file.Sync()
+	}
+	if err := errors.Join(copyErr, file.Close()); err != nil {
+		return err
+	}
+	// Link is atomic and create-only: concurrent uploads never replace the
+	// published bytes, and no reader can observe a partial staging file.
+	if err := s.root.Link(staging, key); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return shared.ErrConflict
+		}
+		return fmt.Errorf("publish object: %w", err)
+	}
+	directory, err := s.root.Open(dir)
+	if err != nil {
+		return err
+	}
+	return errors.Join(directory.Sync(), directory.Close())
+}
+
+func (s *Filesystem) OpenObject(ctx context.Context, key string) (io.ReadCloser, error) {
+	if err := validateObjectKey(key); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	info, err := s.root.Lstat(key)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, shared.ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%w: object is not a regular file", shared.ErrValidation)
+	}
+	return s.root.Open(key)
+}
+
+func (s *Filesystem) DeleteObject(ctx context.Context, key string) error {
+	if err := validateObjectKey(key); err != nil {
+		return err
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	info, err := s.root.Lstat(key)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("%w: object is not a regular file", shared.ErrValidation)
+	}
+	return s.root.Remove(key)
+}

--- a/internal/infrastructure/blob/filesystem_test.go
+++ b/internal/infrastructure/blob/filesystem_test.go
@@ -1,0 +1,105 @@
+package blob
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestFilesystemDurableImmutableObjects(t *testing.T) {
+	directory := t.TempDir()
+	store, err := NewFilesystem(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	key := "tenant/version/archive.zip"
+	data := []byte("uploaded bytes")
+	if err := store.PutObject(ctx, key, bytes.NewReader(data), int64(len(data))); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutObject(ctx, key, bytes.NewReader([]byte("changed")), 7); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("immutable overwrite = %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := NewFilesystem(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	reader, err := reopened.OpenObject(ctx, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(reader)
+	_ = reader.Close()
+	if err != nil || !bytes.Equal(got, data) {
+		t.Fatalf("reopened bytes = %q, %v", got, err)
+	}
+	info, err := os.Stat(filepath.Join(directory, key))
+	if err != nil || info.Mode().Perm() != 0o600 {
+		t.Fatalf("object permission = %v, %v", info, err)
+	}
+	if err := reopened.DeleteObject(ctx, key); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reopened.OpenObject(ctx, key); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("deleted object = %v", err)
+	}
+}
+
+func TestFilesystemRejectsUnsafePathsAndPartialWrites(t *testing.T) {
+	directory := t.TempDir()
+	store, err := NewFilesystem(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	ctx := context.Background()
+	for _, key := range []string{"", "/outside", "../outside", "a/../../outside", "a\\outside", "a/./b", ".upload-secret", "a\nline"} {
+		if err := store.PutObject(ctx, key, bytes.NewReader([]byte("x")), 1); err == nil {
+			t.Errorf("accepted key %q", key)
+		}
+	}
+	for _, size := range []int64{1, 3} {
+		if err := store.PutObject(ctx, "partial", bytes.NewReader([]byte("xx")), size); err == nil {
+			t.Fatalf("accepted invalid size %d", size)
+		}
+		if _, err := store.OpenObject(ctx, "partial"); !errors.Is(err, shared.ErrNotFound) {
+			t.Fatalf("partial object was published: %v", err)
+		}
+	}
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	if err := store.PutObject(canceled, "canceled", bytes.NewReader([]byte("x")), 1); !errors.Is(err, context.Canceled) {
+		t.Fatalf("canceled upload = %v", err)
+	}
+	outside := t.TempDir()
+	if err := os.Symlink(outside, filepath.Join(directory, "escape")); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.PutObject(ctx, "escape/object", bytes.NewReader([]byte("x")), 1); err == nil {
+		t.Fatal("accepted symlink escape")
+	}
+	entries, err := os.ReadDir(outside)
+	if err != nil || len(entries) != 0 {
+		t.Fatalf("outside directory changed: %v %v", entries, err)
+	}
+	entries, err = os.ReadDir(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range entries {
+		if entry.Name() != "escape" {
+			t.Errorf("failed write left %q", entry.Name())
+		}
+	}
+}

--- a/internal/infrastructure/persistence/memory/engagement_source_repo.go
+++ b/internal/infrastructure/persistence/memory/engagement_source_repo.go
@@ -1,0 +1,124 @@
+package memory
+
+import (
+	"context"
+	"sync"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type EngagementSourceRepository struct {
+	mu    sync.Mutex
+	items map[sourcePackageKey]sourcepackage.Package
+}
+
+type sourcePackageKey struct{ tenantID, versionID shared.ID }
+
+func NewEngagementSourceRepository() *EngagementSourceRepository {
+	return &EngagementSourceRepository{items: map[sourcePackageKey]sourcepackage.Package{}}
+}
+
+var _ ports.EngagementSourceRepository = (*EngagementSourceRepository)(nil)
+
+func (r *EngagementSourceRepository) checkpoint(ctx context.Context) {
+	registerTenantCheckpoint(ctx, r, func(tenantID shared.ID) func() {
+		restore := captureTenantEntries(r.items, func(_ sourcePackageKey, p sourcepackage.Package) bool { return p.TenantID == tenantID })
+		return func() { r.mu.Lock(); defer r.mu.Unlock(); restore() }
+	})
+}
+func (r *EngagementSourceRepository) Create(ctx context.Context, item sourcepackage.Package) (sourcepackage.Package, bool, error) {
+	if err := item.ValidateVersion(); err != nil {
+		return sourcepackage.Package{}, false, err
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, old := range r.items {
+		if old.TenantID == item.TenantID && (old.EngagementID == item.EngagementID || old.VersionID == item.VersionID || old.Locator == item.Locator) {
+			if old == item {
+				return old, false, nil
+			}
+			return old, false, shared.ErrConflict
+		}
+	}
+	if !item.ReusedFromVersionID.IsZero() {
+		parent, ok := r.items[sourcePackageKey{item.TenantID, item.ReusedFromVersionID}]
+		if !ok || parent.TenantID != item.TenantID || parent.EngagementID == item.EngagementID || parent.ObjectKey != item.ObjectKey || parent.SHA256 != item.SHA256 || parent.Size != item.Size || parent.Filename != item.Filename || parent.CreatedBy != item.CreatedBy || !parent.CreatedAt.Equal(item.CreatedAt) {
+			return sourcepackage.Package{}, false, shared.ErrValidation
+		}
+	}
+	r.checkpoint(ctx)
+	r.items[sourcePackageKey{item.TenantID, item.VersionID}] = item
+	return item, true, nil
+}
+func (r *EngagementSourceRepository) Get(_ context.Context, tenantID, engID shared.ID) (sourcepackage.Package, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, item := range r.items {
+		if item.TenantID == tenantID && item.EngagementID == engID {
+			return item, nil
+		}
+	}
+	return sourcepackage.Package{}, shared.ErrNotFound
+}
+func (r *EngagementSourceRepository) GetByVersion(ctx context.Context, tenantID, engID, versionID shared.ID) (sourcepackage.Package, error) {
+	item, err := r.Get(ctx, tenantID, engID)
+	if err == nil && item.VersionID != versionID {
+		return sourcepackage.Package{}, shared.ErrNotFound
+	}
+	return item, err
+}
+func (r *EngagementSourceRepository) GetByLocator(_ context.Context, tenantID shared.ID, locator string) (sourcepackage.Package, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, item := range r.items {
+		if item.TenantID == tenantID && item.Locator == locator {
+			return item, nil
+		}
+	}
+	return sourcepackage.Package{}, shared.ErrNotFound
+}
+func (r *EngagementSourceRepository) Delete(ctx context.Context, tenantID, engID shared.ID) (sourcepackage.Package, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var item sourcepackage.Package
+	for _, candidate := range r.items {
+		if candidate.TenantID == tenantID && candidate.EngagementID == engID {
+			item = candidate
+			break
+		}
+	}
+	if item.VersionID.IsZero() {
+		return item, false, shared.ErrNotFound
+	}
+	for _, candidate := range r.items {
+		if candidate.TenantID == tenantID && candidate.ReusedFromVersionID == item.VersionID {
+			return item, false, shared.ErrConflict
+		}
+	}
+	r.checkpoint(ctx)
+	delete(r.items, sourcePackageKey{item.TenantID, item.VersionID})
+	unreferenced := true
+	for _, candidate := range r.items {
+		if candidate.TenantID == tenantID && candidate.ObjectKey == item.ObjectKey {
+			unreferenced = false
+		}
+	}
+	_, inTransaction := ctx.Value(tenantTransactionKey{}).(*tenantTransaction)
+	return item, unreferenced && !inTransaction, nil
+}
+
+func (r *EngagementSourceRepository) ObjectUnreferenced(ctx context.Context, tenantID shared.ID, objectKey string) (bool, error) {
+	if _, inTransaction := ctx.Value(tenantTransactionKey{}).(*tenantTransaction); inTransaction {
+		return false, nil // Defer cleanup until the enclosing transaction finishes.
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, item := range r.items {
+		if item.TenantID == tenantID && item.ObjectKey == objectKey {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/internal/infrastructure/persistence/memory/engagement_source_repo_test.go
+++ b/internal/infrastructure/persistence/memory/engagement_source_repo_test.go
@@ -1,0 +1,44 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+)
+
+func TestEngagementSourceRepositoryTenantScopedVersionsAndReplay(t *testing.T) {
+	ctx := context.Background()
+	repo := NewEngagementSourceRepository()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	item := sourcepackage.Package{TenantID: "tenant-a", EngagementID: "eng-a", VersionID: shared.ID(strings.Repeat("a", 32)), Filename: "source.zip", Size: 10, SHA256: strings.Repeat("b", 64), CreatedBy: "alice", CreatedAt: now, AssociatedBy: "alice", AssociatedAt: now, Locator: "tenant-a/eng-a/version", ObjectKey: "tenant-a/eng-a/version/archive.zip"}
+	if _, created, err := repo.Create(ctx, item); err != nil || !created {
+		t.Fatalf("initial create = %v %v", created, err)
+	}
+	if _, created, err := repo.Create(ctx, item); err != nil || created {
+		t.Fatalf("idempotent create = %v %v", created, err)
+	}
+	other := item
+	other.TenantID, other.EngagementID = "tenant-b", "eng-b"
+	other.Locator, other.ObjectKey = "tenant-b/eng-b/version", "tenant-b/eng-b/version/archive.zip"
+	if _, created, err := repo.Create(ctx, other); err != nil || !created {
+		t.Fatalf("same opaque version in another tenant = %v %v", created, err)
+	}
+	for _, expected := range []sourcepackage.Package{item, other} {
+		if got, err := repo.GetByVersion(ctx, expected.TenantID, expected.EngagementID, expected.VersionID); err != nil || got != expected {
+			t.Fatalf("tenant version overwritten: %+v %v", got, err)
+		}
+	}
+	changed := item
+	changed.CreatedBy = "forged"
+	if _, _, err := repo.Create(ctx, changed); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("immutable replay mutation = %v", err)
+	}
+	if _, err := repo.GetByLocator(ctx, "tenant-b", item.Locator); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant locator = %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/memory/scan_job_repo.go
+++ b/internal/infrastructure/persistence/memory/scan_job_repo.go
@@ -33,7 +33,7 @@ func (s *ScanJobStore) CreateRunning(_ context.Context, j ports.ScanJob) error {
 			return shared.ErrConflict
 		}
 	}
-	s.byID[j.ID] = j
+	s.byID[j.ID] = cloneScanJobSource(j)
 	s.latest[shared.ID(j.EngagementID)] = j.ID
 	return nil
 }
@@ -42,10 +42,16 @@ func (s *ScanJobStore) CreateRunning(_ context.Context, j ports.ScanJob) error {
 func (s *ScanJobStore) Save(_ context.Context, j ports.ScanJob) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if _, existed := s.byID[j.ID]; !existed {
+	if stored, existed := s.byID[j.ID]; !existed {
 		s.latest[shared.ID(j.EngagementID)] = j.ID
+	} else {
+		// Match the PostgreSQL status-only upsert: admission identity and source
+		// cannot be rewritten by a later progress/status update.
+		j.EngagementID, j.Target, j.Kind = stored.EngagementID, stored.Target, stored.Kind
+		j.StartedAt = stored.StartedAt
+		j.SourcePackage = stored.SourcePackage
 	}
-	s.byID[j.ID] = j
+	s.byID[j.ID] = cloneScanJobSource(j)
 	return nil
 }
 
@@ -57,7 +63,7 @@ func (s *ScanJobStore) ListStaleRunning(_ context.Context, olderThan time.Time, 
 	out := []ports.ScanJob{}
 	for _, j := range s.byID {
 		if j.Status == ports.ScanRunning && j.StartedAt.Before(olderThan) {
-			out = append(out, j)
+			out = append(out, cloneScanJobSource(j))
 		}
 	}
 	sort.Slice(out, func(i, k int) bool { return out[i].StartedAt.Before(out[k].StartedAt) })
@@ -75,7 +81,7 @@ func (s *ScanJobStore) GetJob(_ context.Context, id string) (ports.ScanJob, erro
 	if !ok {
 		return ports.ScanJob{}, fmt.Errorf("scan job %s: %w", id, shared.ErrNotFound)
 	}
-	return j, nil
+	return cloneScanJobSource(j), nil
 }
 
 // LatestForEngagement returns the engagement's most recent job, or ErrNotFound.
@@ -86,7 +92,7 @@ func (s *ScanJobStore) LatestForEngagement(_ context.Context, engagementID share
 	if !ok {
 		return ports.ScanJob{}, fmt.Errorf("scan job for %s: %w", engagementID, shared.ErrNotFound)
 	}
-	return s.byID[id], nil
+	return cloneScanJobSource(s.byID[id]), nil
 }
 
 func (s *ScanJobStore) LatestForEngagements(_ context.Context, engagementIDs []shared.ID) (map[shared.ID]ports.ScanJob, error) {
@@ -95,8 +101,17 @@ func (s *ScanJobStore) LatestForEngagements(_ context.Context, engagementIDs []s
 	out := map[shared.ID]ports.ScanJob{}
 	for _, engagementID := range engagementIDs {
 		if id, ok := s.latest[engagementID]; ok {
-			out[engagementID] = s.byID[id]
+			out[engagementID] = cloneScanJobSource(s.byID[id])
 		}
 	}
 	return out, nil
+}
+
+func cloneScanJobSource(job ports.ScanJob) ports.ScanJob {
+	if job.SourcePackage != nil {
+		item := *job.SourcePackage
+		item.Locator, item.ObjectKey = "", ""
+		job.SourcePackage = &item
+	}
+	return job
 }

--- a/internal/infrastructure/persistence/memory/scan_job_repo_test.go
+++ b/internal/infrastructure/persistence/memory/scan_job_repo_test.go
@@ -1,0 +1,43 @@
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestScanJobStatusUpdatesPreserveAdmissionBinding(t *testing.T) {
+	ctx := context.Background()
+	store := NewScanJobStore()
+	packageAtAdmission := sourcepackage.Package{VersionID: "owned-version", TenantID: "tenant", EngagementID: "assessment", SHA256: "original"}
+	job := ports.ScanJob{ID: "job", EngagementID: "assessment", Kind: ports.TargetUpload, Target: packageAtAdmission.Target(),
+		Status: ports.ScanRunning, StartedAt: time.Now().UTC(), SourcePackage: &packageAtAdmission}
+	if err := store.CreateRunning(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	packageAtAdmission.SHA256 = "mutated-by-caller"
+	changed := job
+	changed.EngagementID, changed.Kind, changed.Target = "other-assessment", ports.TargetGit, "other-target"
+	changed.Status, changed.SourcePackage = ports.ScanFailed, nil
+	if err := store.Save(ctx, changed); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.LatestForEngagement(ctx, "assessment")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.EngagementID != job.EngagementID || got.Kind != job.Kind || got.Target != job.Target || !got.StartedAt.Equal(job.StartedAt) {
+		t.Fatalf("status update changed admitted identity: %+v", got)
+	}
+	if got.Status != ports.ScanFailed || got.SourcePackage == nil || got.SourcePackage.SHA256 != "original" {
+		t.Fatalf("status/source not retained: %+v", got)
+	}
+	got.SourcePackage.SHA256 = "mutated-by-reader"
+	again, err := store.GetJob(ctx, job.ID)
+	if err != nil || again.SourcePackage.SHA256 != "original" {
+		t.Fatalf("reader mutated stored source: %+v %v", again, err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/engagement_source_repo.go
+++ b/internal/infrastructure/persistence/postgres/engagement_source_repo.go
@@ -1,0 +1,129 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type EngagementSourceRepository struct{ pool *pgxpool.Pool }
+
+func NewEngagementSourceRepository(pool *pgxpool.Pool) *EngagementSourceRepository {
+	return &EngagementSourceRepository{pool: pool}
+}
+
+var _ ports.EngagementSourceRepository = (*EngagementSourceRepository)(nil)
+
+const sourcePackageColumns = `tenant_id,engagement_id,version_id,filename,size_bytes,sha256,locator,object_key,created_by,created_at,associated_by,associated_at,COALESCE(reused_from_version_id,'')`
+
+func scanSourcePackage(row pgx.Row) (sourcepackage.Package, error) {
+	var item sourcepackage.Package
+	err := row.Scan(&item.TenantID, &item.EngagementID, &item.VersionID, &item.Filename, &item.Size, &item.SHA256, &item.Locator, &item.ObjectKey, &item.CreatedBy, &item.CreatedAt, &item.AssociatedBy, &item.AssociatedAt, &item.ReusedFromVersionID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return item, shared.ErrNotFound
+	}
+	item.CreatedAt = item.CreatedAt.UTC()
+	item.AssociatedAt = item.AssociatedAt.UTC()
+	return item, err
+}
+
+func sourcePackageError(err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		switch pgErr.Code {
+		case "23503", "23505":
+			return fmt.Errorf("%w: uploaded source package is already bound or referenced", shared.ErrConflict)
+		case "23514":
+			return fmt.Errorf("%w: uploaded source package metadata is invalid or immutable", shared.ErrValidation)
+		}
+	}
+	return err
+}
+
+func (r *EngagementSourceRepository) Create(ctx context.Context, item sourcepackage.Package) (sourcepackage.Package, bool, error) {
+	if err := item.ValidateVersion(); err != nil {
+		return sourcepackage.Package{}, false, err
+	}
+	var stored sourcepackage.Package
+	created := false
+	err := WithTenant(ctx, r.pool, item.TenantID.String(), func(tx pgx.Tx) error {
+		result, err := tx.Exec(ctx, `INSERT INTO engagement_source_packages
+ (tenant_id,engagement_id,version_id,filename,size_bytes,sha256,locator,object_key,created_by,created_at,associated_by,associated_at,reused_from_version_id)
+ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,NULLIF($13,'')) ON CONFLICT DO NOTHING`, item.TenantID, item.EngagementID, item.VersionID, item.Filename, item.Size, item.SHA256, item.Locator, item.ObjectKey, item.CreatedBy, item.CreatedAt, item.AssociatedBy, item.AssociatedAt, item.ReusedFromVersionID)
+		if err != nil {
+			return err
+		}
+		created = result.RowsAffected() == 1
+		stored, err = scanSourcePackage(tx.QueryRow(ctx, `SELECT `+sourcePackageColumns+` FROM engagement_source_packages WHERE tenant_id=$1 AND engagement_id=$2`, item.TenantID, item.EngagementID))
+		if err != nil {
+			return err
+		}
+		if stored.VersionID != item.VersionID || stored.Filename != item.Filename || stored.SHA256 != item.SHA256 || stored.Size != item.Size || stored.Locator != item.Locator || stored.ObjectKey != item.ObjectKey || stored.ReusedFromVersionID != item.ReusedFromVersionID || stored.CreatedBy != item.CreatedBy || !stored.CreatedAt.Equal(item.CreatedAt) || stored.AssociatedBy != item.AssociatedBy || !stored.AssociatedAt.Equal(item.AssociatedAt) {
+			return shared.ErrConflict
+		}
+		return nil
+	})
+	return stored, created, sourcePackageError(err)
+}
+
+func (r *EngagementSourceRepository) Get(ctx context.Context, tenantID, engagementID shared.ID) (sourcepackage.Package, error) {
+	return r.read(ctx, tenantID, `engagement_id=$2`, engagementID.String())
+}
+func (r *EngagementSourceRepository) GetByVersion(ctx context.Context, tenantID, engagementID, versionID shared.ID) (sourcepackage.Package, error) {
+	item, err := r.Get(ctx, tenantID, engagementID)
+	if err == nil && item.VersionID != versionID {
+		return sourcepackage.Package{}, shared.ErrNotFound
+	}
+	return item, err
+}
+func (r *EngagementSourceRepository) GetByLocator(ctx context.Context, tenantID shared.ID, locator string) (sourcepackage.Package, error) {
+	return r.read(ctx, tenantID, `locator=$2`, locator)
+}
+func (r *EngagementSourceRepository) read(ctx context.Context, tenantID shared.ID, predicate, value string) (sourcepackage.Package, error) {
+	var item sourcepackage.Package
+	if tenantID.IsZero() {
+		return item, shared.ErrValidation
+	}
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var err error
+		item, err = scanSourcePackage(tx.QueryRow(ctx, `SELECT `+sourcePackageColumns+` FROM engagement_source_packages WHERE tenant_id=$1 AND `+predicate, tenantID, value))
+		return err
+	})
+	return item, sourcePackageError(err)
+}
+
+func (r *EngagementSourceRepository) Delete(ctx context.Context, tenantID, engagementID shared.ID) (sourcepackage.Package, bool, error) {
+	var item sourcepackage.Package
+	unreferenced := false
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var err error
+		item, err = scanSourcePackage(tx.QueryRow(ctx, `DELETE FROM engagement_source_packages WHERE tenant_id=$1 AND engagement_id=$2 RETURNING `+sourcePackageColumns, tenantID, engagementID))
+		if err != nil {
+			return err
+		}
+		return tx.QueryRow(ctx, `SELECT NOT EXISTS(SELECT 1 FROM engagement_source_packages WHERE tenant_id=$1 AND object_key=$2)`, tenantID, item.ObjectKey).Scan(&unreferenced)
+	})
+	_, inTransaction, _ := contextTenantTx(ctx, tenantID)
+	return item, unreferenced && !inTransaction, sourcePackageError(err)
+}
+
+func (r *EngagementSourceRepository) ObjectUnreferenced(ctx context.Context, tenantID shared.ID, objectKey string) (bool, error) {
+	if _, inTransaction, err := contextTenantTx(ctx, tenantID); err != nil || inTransaction {
+		return false, err // A matching uncommitted transaction defers cleanup.
+	}
+	if tenantID.IsZero() || objectKey == "" {
+		return false, shared.ErrValidation
+	}
+	var unreferenced bool
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT NOT EXISTS(SELECT 1 FROM engagement_source_packages WHERE tenant_id=$1 AND object_key=$2)`, tenantID, objectKey).Scan(&unreferenced)
+	})
+	return unreferenced, err
+}

--- a/internal/infrastructure/persistence/postgres/engagement_source_repo_test.go
+++ b/internal/infrastructure/persistence/postgres/engagement_source_repo_test.go
@@ -1,0 +1,239 @@
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/blob"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sourceupload"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func sourceDigest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func TestPostgresEngagementSourceLifecycleDurabilityAndRetention(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	tenant := shared.ID("source-lifecycle-tenant")
+	ctx = shared.WithTenant(ctx, tenant)
+	for _, eng := range []shared.ID{"source-initial", "source-retest", "source-retest-2", "source-new-upload"} {
+		ensureTestTenantAndEngagement(t, ctx, pool, tenant, eng, "", "")
+	}
+	directory := t.TempDir()
+	objects, err := blob.NewFilesystem(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := sourceupload.NewStoreWithRepository(objects, NewEngagementSourceRepository(pool), 0)
+	now := time.Date(2026, 9, 8, 10, 0, 0, 123456789, time.UTC)
+	data := []byte("durable uploaded archive")
+	initial, err := store.Save(ctx, tenant, "source-initial", "source.zip", "alice", now, int64(len(data)), sourceDigest(data), bytes.NewReader(data))
+	if err != nil || initial.VersionID.IsZero() || initial.CreatedAt.Nanosecond() != 123456000 {
+		t.Fatalf("initial source: %+v %v", initial, err)
+	}
+	if err := objects.Close(); err != nil {
+		t.Fatal(err)
+	}
+	objects, err = blob.NewFilesystem(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = objects.Close() })
+	repo := NewEngagementSourceRepository(pool)
+	store = sourceupload.NewStoreWithRepository(objects, repo, 0)
+	got, err := store.GetByVersion(ctx, tenant, "source-initial", initial.VersionID)
+	if err != nil || got != initial {
+		t.Fatalf("fresh adapter roundtrip = %+v %v", got, err)
+	}
+	if replay, err := store.Save(ctx, tenant, "source-initial", "source.zip", "alice", now, int64(len(data)), sourceDigest(data), bytes.NewReader(data)); err != nil || replay.VersionID != initial.VersionID {
+		t.Fatalf("upload replay = %+v %v", replay, err)
+	}
+	child, err := store.Reuse(ctx, tenant, "source-initial", "source-retest", initial.VersionID, "bob", now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	grandchild, err := store.Reuse(ctx, tenant, "source-retest", "source-retest-2", child.VersionID, "carol", now.Add(2*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range []sourcepackage.Package{initial, child, grandchild} {
+		if item.ObjectKey != initial.ObjectKey || item.SHA256 != initial.SHA256 || item.CreatedBy != initial.CreatedBy || !item.CreatedAt.Equal(initial.CreatedAt) {
+			t.Fatalf("reuse changed original source: %+v", item)
+		}
+		path, materialized, cleanup, err := store.Materialize(ctx, item.Locator)
+		if err != nil {
+			t.Fatal(err)
+		}
+		read, err := os.ReadFile(path)
+		_ = cleanup()
+		if err != nil || !bytes.Equal(read, data) || materialized.VersionID != item.VersionID {
+			t.Fatalf("source materialization = %q %+v %v", read, materialized, err)
+		}
+	}
+	if grandchild.ReusedFromVersionID != child.VersionID || child.ReusedFromVersionID != initial.VersionID || child.AssociatedBy != "bob" {
+		t.Fatal("reuse chain or association attribution changed")
+	}
+	if err := store.Delete(ctx, tenant, "source-initial"); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("parent deletion with child references = %v", err)
+	}
+	if err := store.Delete(ctx, tenant, "source-retest-2"); err != nil {
+		t.Fatal(err)
+	}
+	reader, err := objects.OpenObject(ctx, initial.ObjectKey)
+	if err != nil {
+		t.Fatal("deleting child removed shared archive", err)
+	}
+	_ = reader.Close()
+	changed := []byte("new uploaded version")
+	newUpload, err := store.Save(ctx, tenant, "source-new-upload", "source.zip", "dave", now.Add(3*time.Hour), int64(len(changed)), sourceDigest(changed), bytes.NewReader(changed))
+	if err != nil || newUpload.ObjectKey == initial.ObjectKey || !newUpload.ReusedFromVersionID.IsZero() || newUpload.CreatedBy != "dave" {
+		t.Fatalf("new upload = %+v %v", newUpload, err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE engagement_source_packages SET created_by='forged' WHERE tenant_id=$1 AND engagement_id=$2`, tenant, "source-new-upload"); !isSourcePGCode(err, "23514") {
+		t.Fatalf("metadata mutation = %v", err)
+	}
+	public := newUpload
+	public.ObjectKey, public.Locator = "", ""
+	job := ports.ScanJob{ID: "source-bound-job", EngagementID: newUpload.EngagementID.String(), Target: newUpload.Target(), Kind: "upload", SourcePackage: &public, Status: ports.ScanRunning, StartedAt: now}
+	if err := NewScanJobStore(pool).CreateRunning(ctx, job); err != nil {
+		t.Fatal("source-bound job", err)
+	}
+	run := ports.ScanRun{ID: "source-bound-run", EngagementID: newUpload.EngagementID.String(), CreatedAt: now, Manifest: ports.ScanManifest{SourcePackage: &public}}
+	if err := NewScanRunStore(pool).Save(ctx, run); err != nil {
+		t.Fatal("source-bound run", err)
+	}
+	if err := store.Delete(ctx, tenant, newUpload.EngagementID); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("historical package deletion = %v", err)
+	}
+	if err := store.DiscardUnpublished(ctx, newUpload); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE scan_jobs SET source_package=NULL WHERE id=$1`, job.ID); !isSourcePGCode(err, "23514") {
+		t.Fatalf("job binding mutation = %v", err)
+	}
+	gotRun, err := NewScanRunStore(pool).Get(ctx, run.ID)
+	if err != nil || gotRun.Manifest.SourcePackage == nil || *gotRun.Manifest.SourcePackage != public {
+		t.Fatalf("frozen run metadata = %+v %v", gotRun.Manifest.SourcePackage, err)
+	}
+}
+
+func isSourcePGCode(err error, code string) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == code
+}
+
+func TestPostgresEngagementSourceTenantIsolationAndAtomicCompensation(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	tenant := shared.ID("source-owner")
+	foreign := shared.ID("source-foreign")
+	for _, eng := range []shared.ID{"source-parent", "source-rollback", "source-delete-rollback"} {
+		ensureTestTenantAndEngagement(t, ctx, pool, tenant, eng, "", "")
+	}
+	ensureTestTenantAndEngagement(t, ctx, pool, foreign, "source-foreign-eng", "", "")
+	ctx = shared.WithTenant(ctx, tenant)
+	objects := blob.NewMemory()
+	repo := NewEngagementSourceRepository(pool)
+	store := sourceupload.NewStoreWithRepository(objects, repo, 0)
+	data := []byte("archive")
+	initial, err := store.Save(ctx, tenant, "source-parent", "source.zip", "alice", time.Now(), int64(len(data)), sourceDigest(data), bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.GetByVersion(ctx, foreign, "source-parent", initial.VersionID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant version = %v", err)
+	}
+	forged := initial
+	forged.TenantID, forged.EngagementID = foreign, "source-foreign-eng"
+	forged.ReusedFromVersionID, forged.VersionID = initial.VersionID, shared.ID("11111111111111111111111111111111")
+	if _, _, err := repo.Create(ctx, forged); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("cross-tenant reuse = %v", err)
+	}
+	role := pgx.Identifier{fmt.Sprintf("source_rls_%d", time.Now().UnixNano())}.Sanitize()
+	if _, err := pool.Exec(ctx, `CREATE ROLE `+role+` NOLOGIN NOSUPERUSER NOBYPASSRLS`); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DROP OWNED BY `+role)
+		_, _ = pool.Exec(ctx, `DROP ROLE `+role)
+	})
+	if _, err := pool.Exec(ctx, `GRANT USAGE ON SCHEMA public TO `+role); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `GRANT SELECT ON engagement_source_packages TO `+role); err != nil {
+		t.Fatal(err)
+	}
+	err = WithTenant(ctx, pool, foreign.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `SET LOCAL ROLE `+role); err != nil {
+			return err
+		}
+		var count int
+		if err := tx.QueryRow(ctx, `SELECT count(*) FROM engagement_source_packages`).Scan(&count); err != nil {
+			return err
+		}
+		if count != 0 {
+			return fmt.Errorf("RLS leaked %d packages", count)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var unpublished sourcepackage.Package
+	failure := errors.New("completion audit failed")
+	err = NewTenantTransactionRunner(pool).Run(ctx, tenant, func(txCtx context.Context) error {
+		var err error
+		unpublished, err = store.Save(txCtx, tenant, "source-rollback", "source.zip", "alice", time.Now(), int64(len(data)), sourceDigest(data), bytes.NewReader(data))
+		if err != nil {
+			return err
+		}
+		if err := store.DiscardUnpublished(txCtx, unpublished); err != nil {
+			t.Fatalf("uncommitted discard = %v", err)
+		}
+		return failure
+	})
+	if !errors.Is(err, failure) {
+		t.Fatal(err)
+	}
+	if err := store.DiscardUnpublished(ctx, unpublished); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := objects.OpenObject(ctx, unpublished.ObjectKey); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("unpublished rollback object retained: %v", err)
+	}
+	err = NewTenantTransactionRunner(pool).Run(ctx, tenant, func(txCtx context.Context) error {
+		if err := store.Delete(txCtx, tenant, initial.EngagementID); err != nil {
+			return err
+		}
+		return failure
+	})
+	if !errors.Is(err, failure) {
+		t.Fatal(err)
+	}
+	if err := store.DiscardUnpublished(ctx, initial); err != nil {
+		t.Fatal(err)
+	}
+	reader, err := objects.OpenObject(ctx, initial.ObjectKey)
+	if err != nil {
+		t.Fatalf("rolled-back deletion lost original bytes: %v", err)
+	}
+	read, err := io.ReadAll(reader)
+	_ = reader.Close()
+	if err != nil || !bytes.Equal(read, data) {
+		t.Fatalf("retained original bytes = %q %v", read, err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/scan_job_repo.go
+++ b/internal/infrastructure/persistence/postgres/scan_job_repo.go
@@ -24,13 +24,17 @@ func NewScanJobStore(pool *pgxpool.Pool) *ScanJobStore { return &ScanJobStore{po
 var _ ports.ScanJobStore = (*ScanJobStore)(nil)
 
 func (r *ScanJobStore) CreateRunning(ctx context.Context, j ports.ScanJob) error {
+	sourcePackage, err := encodeScanJobSource(j)
+	if err != nil {
+		return err
+	}
 	debugEvents, err := json.Marshal(j.DebugEvents)
 	if err != nil {
 		return fmt.Errorf("marshal scan job debug events: %w", err)
 	}
-	_, err = r.pool.Exec(ctx, `INSERT INTO scan_jobs (id, engagement_id, target, kind, status, stage, progress, error, started_at, finished_at, debug_events)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
-		j.ID, j.EngagementID, j.Target, j.Kind, string(j.Status), j.Stage, j.Progress, j.Error, j.StartedAt, j.FinishedAt, debugEvents)
+	_, err = r.execSourceJob(ctx, j, `INSERT INTO scan_jobs (id, engagement_id, target, kind, status, stage, progress, error, started_at, finished_at, debug_events, source_package)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+		j.ID, j.EngagementID, j.Target, j.Kind, string(j.Status), j.Stage, j.Progress, j.Error, j.StartedAt, j.FinishedAt, debugEvents, sourcePackage)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
@@ -43,17 +47,21 @@ func (r *ScanJobStore) CreateRunning(ctx context.Context, j ports.ScanJob) error
 
 // Save upserts a scan job (used on create and on every stage/status update).
 func (r *ScanJobStore) Save(ctx context.Context, j ports.ScanJob) error {
+	sourcePackage, err := encodeScanJobSource(j)
+	if err != nil {
+		return err
+	}
 	debugEvents, err := json.Marshal(j.DebugEvents)
 	if err != nil {
 		return fmt.Errorf("marshal scan job debug events: %w", err)
 	}
-	_, err = r.pool.Exec(ctx,
-		`INSERT INTO scan_jobs (id, engagement_id, target, kind, status, stage, progress, error, started_at, finished_at, debug_events)
-		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
+	_, err = r.execSourceJob(ctx, j,
+		`INSERT INTO scan_jobs (id, engagement_id, target, kind, status, stage, progress, error, started_at, finished_at, debug_events, source_package)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
 		 ON CONFLICT (id) DO UPDATE SET status=EXCLUDED.status, stage=EXCLUDED.stage,
 		     progress=EXCLUDED.progress, error=EXCLUDED.error, finished_at=EXCLUDED.finished_at,
 		     debug_events=EXCLUDED.debug_events`,
-		j.ID, j.EngagementID, j.Target, j.Kind, string(j.Status), j.Stage, j.Progress, j.Error, j.StartedAt, j.FinishedAt, debugEvents)
+		j.ID, j.EngagementID, j.Target, j.Kind, string(j.Status), j.Stage, j.Progress, j.Error, j.StartedAt, j.FinishedAt, debugEvents, sourcePackage)
 	if err != nil {
 		return fmt.Errorf("save scan job: %w", err)
 	}
@@ -67,7 +75,7 @@ func (r *ScanJobStore) ListStaleRunning(ctx context.Context, olderThan time.Time
 		limit = 100
 	}
 	rows, err := r.pool.Query(ctx,
-		`SELECT id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at, debug_events
+		`SELECT id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at, debug_events, source_package
 		 FROM scan_jobs WHERE status='running' AND started_at < $1 ORDER BY started_at LIMIT $2`,
 		olderThan, limit)
 	if err != nil {
@@ -81,13 +89,16 @@ func (r *ScanJobStore) ListStaleRunning(ctx context.Context, olderThan time.Time
 			status   string
 			finished *time.Time
 		)
-		var debugEvents []byte
-		if err := rows.Scan(&j.ID, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &debugEvents); err != nil {
+		var debugEvents, sourcePackage []byte
+		if err := rows.Scan(&j.ID, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &debugEvents, &sourcePackage); err != nil {
 			return nil, fmt.Errorf("scan scan job: %w", err)
 		}
 		j.Status = ports.ScanStatus(status)
 		j.FinishedAt = finished
 		if err := decodeScanDebugEvents(debugEvents, &j); err != nil {
+			return nil, err
+		}
+		if err := decodeScanJobSource(sourcePackage, &j); err != nil {
 			return nil, err
 		}
 		out = append(out, j)
@@ -98,15 +109,16 @@ func (r *ScanJobStore) ListStaleRunning(ctx context.Context, olderThan time.Time
 // GetJob returns a scan job by its own id, or ErrNotFound.
 func (r *ScanJobStore) GetJob(ctx context.Context, id string) (ports.ScanJob, error) {
 	var (
-		j           ports.ScanJob
-		status      string
-		finished    *time.Time
-		debugEvents []byte
+		j             ports.ScanJob
+		status        string
+		finished      *time.Time
+		debugEvents   []byte
+		sourcePackage []byte
 	)
 	err := r.pool.QueryRow(ctx,
-		`SELECT id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at, debug_events
+		`SELECT id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at, debug_events, source_package
 		 FROM scan_jobs WHERE id=$1`, id).
-		Scan(&j.ID, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &debugEvents)
+		Scan(&j.ID, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &debugEvents, &sourcePackage)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return ports.ScanJob{}, fmt.Errorf("scan job %s: %w", id, shared.ErrNotFound)
 	}
@@ -116,6 +128,9 @@ func (r *ScanJobStore) GetJob(ctx context.Context, id string) (ports.ScanJob, er
 	j.Status = ports.ScanStatus(status)
 	j.FinishedAt = finished
 	if err := decodeScanDebugEvents(debugEvents, &j); err != nil {
+		return ports.ScanJob{}, err
+	}
+	if err := decodeScanJobSource(sourcePackage, &j); err != nil {
 		return ports.ScanJob{}, err
 	}
 	return j, nil
@@ -132,10 +147,10 @@ func (r *ScanJobStore) LatestForEngagements(ctx context.Context, engagementIDs [
 	}
 	// A LATERAL top-1 per engagement walks idx_scan_jobs_engagement once per id; DISTINCT ON over every
 	// job of every engagement sorted the whole set (an on-disk merge at tens of thousands of jobs).
-	rows, err := r.pool.Query(ctx, `SELECT j.id, j.engagement_id, j.target, j.kind, j.status, j.stage, j.progress, COALESCE(j.error,''), j.started_at, j.finished_at
+	rows, err := r.pool.Query(ctx, `SELECT j.id, j.engagement_id, j.target, j.kind, j.status, j.stage, j.progress, COALESCE(j.error,''), j.started_at, j.finished_at, j.source_package
 		FROM unnest($1::text[]) AS e(engagement_id)
 		JOIN LATERAL (
-			SELECT id, engagement_id, target, kind, status, stage, progress, error, started_at, finished_at
+			SELECT id, engagement_id, target, kind, status, stage, progress, error, started_at, finished_at, source_package
 			FROM scan_jobs WHERE engagement_id = e.engagement_id
 			ORDER BY started_at DESC, id DESC LIMIT 1
 		) j ON true`, ids)
@@ -148,10 +163,14 @@ func (r *ScanJobStore) LatestForEngagements(ctx context.Context, engagementIDs [
 		var j ports.ScanJob
 		var status string
 		var finished *time.Time
-		if err := rows.Scan(&j.ID, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished); err != nil {
+		var sourcePackage []byte
+		if err := rows.Scan(&j.ID, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &sourcePackage); err != nil {
 			return nil, fmt.Errorf("scan latest scan job: %w", err)
 		}
 		j.Status, j.FinishedAt, j.DebugEvents = ports.ScanStatus(status), finished, []ports.ScanDebugEvent{}
+		if err := decodeScanJobSource(sourcePackage, &j); err != nil {
+			return nil, err
+		}
 		out[shared.ID(j.EngagementID)] = j
 	}
 	return out, rows.Err()
@@ -159,15 +178,16 @@ func (r *ScanJobStore) LatestForEngagements(ctx context.Context, engagementIDs [
 
 func (r *ScanJobStore) LatestForEngagement(ctx context.Context, engagementID shared.ID) (ports.ScanJob, error) {
 	var (
-		j           ports.ScanJob
-		status      string
-		finished    *time.Time
-		debugEvents []byte
+		j             ports.ScanJob
+		status        string
+		finished      *time.Time
+		debugEvents   []byte
+		sourcePackage []byte
 	)
 	err := r.pool.QueryRow(ctx,
-		`SELECT id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at, debug_events
+		`SELECT id, engagement_id, target, kind, status, stage, progress, COALESCE(error,''), started_at, finished_at, debug_events, source_package
 		 FROM scan_jobs WHERE engagement_id=$1 ORDER BY started_at DESC LIMIT 1`, engagementID.String()).
-		Scan(&j.ID, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &debugEvents)
+		Scan(&j.ID, &j.EngagementID, &j.Target, &j.Kind, &status, &j.Stage, &j.Progress, &j.Error, &j.StartedAt, &finished, &debugEvents, &sourcePackage)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return ports.ScanJob{}, fmt.Errorf("scan job for %s: %w", engagementID, shared.ErrNotFound)
 	}
@@ -179,7 +199,51 @@ func (r *ScanJobStore) LatestForEngagement(ctx context.Context, engagementID sha
 	if err := decodeScanDebugEvents(debugEvents, &j); err != nil {
 		return ports.ScanJob{}, err
 	}
+	if err := decodeScanJobSource(sourcePackage, &j); err != nil {
+		return ports.ScanJob{}, err
+	}
 	return j, nil
+}
+
+func encodeScanJobSource(job ports.ScanJob) ([]byte, error) {
+	if job.SourcePackage == nil {
+		return nil, nil
+	}
+	if err := job.SourcePackage.Validate(); err != nil {
+		return nil, err
+	}
+	if job.Kind != ports.TargetUpload || job.SourcePackage.EngagementID.String() != job.EngagementID || job.SourcePackage.Target() != job.Target {
+		return nil, fmt.Errorf("%w: scan source binding does not match the job", shared.ErrValidation)
+	}
+	return json.Marshal(job.SourcePackage)
+}
+
+func decodeScanJobSource(data []byte, job *ports.ScanJob) error {
+	if len(data) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(data, &job.SourcePackage); err != nil {
+		return fmt.Errorf("decode scan source metadata: %w", err)
+	}
+	_, err := encodeScanJobSource(*job)
+	return err
+}
+
+func (r *ScanJobStore) execSourceJob(ctx context.Context, job ports.ScanJob, query string, args ...any) (pgconn.CommandTag, error) {
+	if job.SourcePackage == nil {
+		return r.pool.Exec(ctx, query, args...)
+	}
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok || tenantID != job.SourcePackage.TenantID {
+		return pgconn.CommandTag{}, fmt.Errorf("%w: scan source tenant context does not match", shared.ErrValidation)
+	}
+	var result pgconn.CommandTag
+	err := WithTenant(ctx, r.pool, tenantID.String(), func(tx pgx.Tx) error {
+		var err error
+		result, err = tx.Exec(ctx, query, args...)
+		return err
+	})
+	return result, err
 }
 
 func decodeScanDebugEvents(data []byte, j *ports.ScanJob) error {

--- a/internal/infrastructure/persistence/postgres/scan_source_binding_test.go
+++ b/internal/infrastructure/persistence/postgres/scan_source_binding_test.go
@@ -1,0 +1,419 @@
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/blob"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sourceupload"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func scanSourceFixture(t *testing.T, ctx context.Context, pool *pgxpool.Pool, tenantID, engagementID shared.ID) (*sourceupload.Store, sourcepackage.Package) {
+	t.Helper()
+	ensureTestTenantAndEngagement(t, ctx, pool, tenantID, engagementID, "", "")
+	sources := sourceupload.NewStoreWithRepository(blob.NewMemory(), NewEngagementSourceRepository(pool), sourcepackage.MaxArchiveBytes)
+	content := []byte("immutable archive fixture")
+	digest := sha256.Sum256(content)
+	item, err := sources.Save(ctx, tenantID, engagementID, "application.zip", "original-uploader", time.Now().UTC().Truncate(time.Microsecond), int64(len(content)), hex.EncodeToString(digest[:]), bytes.NewReader(content))
+	if err != nil {
+		t.Fatalf("save owned source fixture: %v", err)
+	}
+	return sources, item
+}
+
+func scanSourceJob(item sourcepackage.Package, id string) ports.ScanJob {
+	return ports.ScanJob{ID: id, EngagementID: item.EngagementID.String(), Target: item.Target(), Kind: ports.TargetUpload,
+		Status: ports.ScanRunning, Stage: "queued", StartedAt: time.Now().UTC().Add(-time.Hour).Truncate(time.Microsecond), SourcePackage: &item}
+}
+
+func assertFrozenScanSource(t *testing.T, got *sourcepackage.Package, want sourcepackage.Package) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("frozen source package is missing")
+	}
+	// Storage locators and object keys must never enter either persisted JSON
+	// manifest or job status. The remaining metadata is the exact queued version.
+	want.Locator, want.ObjectKey = "", ""
+	if !reflect.DeepEqual(*got, want) {
+		t.Fatalf("frozen source package changed: got %+v, want %+v", *got, want)
+	}
+}
+
+func TestPostgresScanSourceJobRoundTripAndStatusUpdates(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	sources, item := scanSourceFixture(t, ctx, pool, "source-tenant", "source-assessment")
+	ctx = shared.WithTenant(ctx, item.TenantID)
+	store := NewScanJobStore(pool)
+	job := scanSourceJob(item, "source-job")
+	if err := store.CreateRunning(ctx, job); err != nil {
+		t.Fatalf("create source-bound job: %v", err)
+	}
+
+	for name, read := range map[string]func() (ports.ScanJob, error){
+		"get":    func() (ports.ScanJob, error) { return store.GetJob(ctx, job.ID) },
+		"latest": func() (ports.ScanJob, error) { return store.LatestForEngagement(ctx, item.EngagementID) },
+		"latest batch": func() (ports.ScanJob, error) {
+			jobs, err := store.LatestForEngagements(ctx, []shared.ID{item.EngagementID})
+			return jobs[item.EngagementID], err
+		},
+		"stale running": func() (ports.ScanJob, error) {
+			jobs, err := store.ListStaleRunning(ctx, time.Now().UTC(), 10)
+			if err != nil {
+				return ports.ScanJob{}, err
+			}
+			if len(jobs) != 1 {
+				t.Fatalf("stale running count = %d, want 1", len(jobs))
+			}
+			return jobs[0], nil
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, err := read()
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertFrozenScanSource(t, got.SourcePackage, item)
+		})
+	}
+
+	// Status-only workers from older versions may omit source metadata. They
+	// must retain the admitted source, including after a failed scan.
+	finished := time.Now().UTC().Truncate(time.Microsecond)
+	job.Status, job.Stage, job.Error, job.FinishedAt = ports.ScanFailed, "failed", "scanner unavailable", &finished
+	job.SourcePackage = nil
+	if err := store.Save(ctx, job); err != nil {
+		t.Fatalf("save failed status without rewriting source: %v", err)
+	}
+	got, err := store.GetJob(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != ports.ScanFailed || got.Error != "scanner unavailable" {
+		t.Fatalf("failed status lost: %+v", got)
+	}
+	assertFrozenScanSource(t, got.SourcePackage, item)
+	if err := sources.Delete(ctx, item.TenantID, item.EngagementID); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("failed job did not retain its source: %v", err)
+	}
+
+	// Even a valid package owned by another assessment cannot rewrite an
+	// existing job through the status upsert path.
+	_, other := scanSourceFixture(t, ctx, pool, item.TenantID, "other-assessment")
+	changed := scanSourceJob(other, job.ID)
+	changed.Status = ports.ScanFailed
+	if err := store.Save(ctx, changed); err != nil {
+		t.Fatalf("status-only upsert with another source: %v", err)
+	}
+	got, err = store.GetJob(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.EngagementID != item.EngagementID.String() || got.Target != item.Target() {
+		t.Fatalf("status upsert changed source owner/target: %+v", got)
+	}
+	assertFrozenScanSource(t, got.SourcePackage, item)
+
+	for name, tenantCtx := range map[string]context.Context{
+		"missing tenant": context.Background(),
+		"wrong tenant":   shared.WithTenant(context.Background(), "foreign-tenant"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := store.CreateRunning(tenantCtx, scanSourceJob(item, "forbidden-"+name)); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("source job tenant context not enforced: %v", err)
+			}
+		})
+	}
+}
+
+func TestPostgresScanSourceDatabaseRejectsForgedBindings(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	_, item := scanSourceFixture(t, ctx, pool, "source-tenant", "source-assessment")
+	_, other := scanSourceFixture(t, ctx, pool, item.TenantID, "other-assessment")
+	_, foreign := scanSourceFixture(t, ctx, pool, "foreign-tenant", "foreign-assessment")
+	store := NewScanJobStore(pool)
+	job := scanSourceJob(item, "source-job")
+	if err := store.CreateRunning(shared.WithTenant(ctx, item.TenantID), job); err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(item)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(encoded), item.Locator) || strings.Contains(string(encoded), item.ObjectKey) {
+		t.Fatalf("source JSON exposed an object-store locator: %s", encoded)
+	}
+	var metadata map[string]any
+	if err := json.Unmarshal(encoded, &metadata); err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name, key string
+		value     any
+	}{
+		{"filename", "filename", "substituted.zip"},
+		{"size", "size", item.Size + 1},
+		{"digest", "sha256", strings.Repeat("a", 64)},
+		{"uploader", "created_by", "forged-actor"},
+		{"upload time", "created_at", item.CreatedAt.Add(time.Hour)},
+		{"associator", "associated_by", "forged-actor"},
+		{"association time", "associated_at", item.AssociatedAt.Add(time.Hour)},
+		{"unknown version", "version_id", strings.Repeat("e", 32)},
+		{"other assessment version", "version_id", other.VersionID},
+		{"foreign tenant version", "version_id", foreign.VersionID},
+		{"foreign tenant", "tenant_id", foreign.TenantID},
+		{"other owner", "engagement_id", other.EngagementID},
+		{"invented reuse", "reused_from_version_id", other.VersionID},
+		{"private locator", "locator", "private-object-key"},
+		{"missing version", "version_id", nil},
+		{"malformed size", "size", "not-a-number"},
+		{"malformed timestamp", "created_at", "not-a-timestamp"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			changed := make(map[string]any, len(metadata))
+			for key, value := range metadata {
+				changed[key] = value
+			}
+			changed[test.key] = test.value
+			forged, err := json.Marshal(changed)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = pool.Exec(ctx, `INSERT INTO scan_jobs (id,engagement_id,target,kind,status,started_at,source_package)
+				VALUES ($1,$2,$3,'upload','running',$4,$5)`, "forged-"+test.name, item.EngagementID, item.Target(), job.StartedAt, forged)
+			if err == nil {
+				t.Fatalf("database accepted forged source %s", test.name)
+			}
+		})
+	}
+	for _, statement := range []string{
+		`UPDATE scan_jobs SET source_package=NULL WHERE id=$1`,
+		`UPDATE scan_jobs SET source_package=jsonb_set(source_package,'{filename}','"changed.zip"') WHERE id=$1`,
+		`UPDATE scan_jobs SET engagement_id='other-assessment' WHERE id=$1`,
+		`UPDATE scan_jobs SET target='different-target' WHERE id=$1`,
+		`UPDATE scan_jobs SET kind='git' WHERE id=$1`,
+	} {
+		if _, err := pool.Exec(ctx, statement, job.ID); err == nil {
+			t.Fatalf("database allowed source-bound job mutation: %s", statement)
+		}
+	}
+	for _, values := range []struct{ kind, target string }{
+		{ports.TargetGit, item.Target()},
+		{string(ports.TargetUpload), "wrong-target"},
+	} {
+		if _, err := pool.Exec(ctx, `INSERT INTO scan_jobs (id,engagement_id,target,kind,status,started_at,source_package)
+			VALUES ($1,$2,$3,$4,'running',$5,$6)`, "wrong-target-"+values.kind, item.EngagementID, values.target, values.kind, job.StartedAt, encoded); err == nil {
+			t.Fatalf("database accepted source kind/target mismatch: %+v", values)
+		}
+	}
+	got, err := store.GetJob(ctx, job.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertFrozenScanSource(t, got.SourcePackage, item)
+}
+
+func TestPostgresScanSourceRunManifestFrozenForNativeAndLegacy(t *testing.T) {
+	for _, native := range []bool{false, true} {
+		name := "legacy"
+		if native {
+			name = "native"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx, pool := setupTestDB(t)
+			sources, item := scanSourceFixture(t, ctx, pool, "source-tenant", "source-assessment")
+			ctx = shared.WithTenant(ctx, item.TenantID)
+			store := NewScanRunStore(pool)
+			run := ports.ScanRun{ID: "source-run", EngagementID: item.EngagementID.String(), CreatedAt: time.Now().UTC().Truncate(time.Microsecond), Manifest: ports.ScanManifest{SourcePackage: &item}}
+			manifest, err := json.Marshal(run.Manifest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if native {
+				err = store.SaveScanRun(ctx, scanrun.ScanRun{TenantID: item.TenantID, EngagementID: item.EngagementID, ID: run.ID,
+					Provenance: scanrun.ProvenanceNative, TerminalStatus: scanrun.StatusBuilding, ManifestSchemaVersion: 1,
+					CreatedAt: run.CreatedAt, UpdatedAt: run.CreatedAt, LegacyManifest: manifest})
+			} else {
+				err = store.Save(ctx, run)
+			}
+			if err != nil {
+				t.Fatalf("create %s run: %v", name, err)
+			}
+			if native {
+				if _, err := pool.Exec(ctx, `UPDATE scan_runs SET manifest=manifest-'source_package' WHERE id=$1`, run.ID); err == nil {
+					t.Fatal("unsealed native run lost its admitted source")
+				}
+				finished := run.CreatedAt.Add(time.Minute)
+				lane := scanrun.Lane{TenantID: item.TenantID, EngagementID: item.EngagementID, ScanRunID: run.ID,
+					LaneKey: "sca", Producer: "synapse-sca", TerminalStatus: scanrun.StatusFailed,
+					Target:    scanrun.TargetIdentity{TargetKind: scanrun.TargetRepository, TargetIdentitySchemaVersion: 1, TargetIdentityCanonical: item.Target(), EvaluatedRevision: item.SHA256},
+					StartedAt: run.CreatedAt, FinishedAt: &finished, ManifestSchemaVersion: 1}
+				lane.ManifestHash, err = scanrun.ComputeManifestHash(lane)
+				if err != nil {
+					t.Fatal(err)
+				}
+				runHash, err := scanrun.ComputeRunManifestHash([]scanrun.Lane{lane})
+				if err != nil {
+					t.Fatal(err)
+				}
+				if err := store.SealScanRun(ctx, ports.SealScanRunCommand{TenantID: item.TenantID, RunID: run.ID, TerminalStatus: scanrun.StatusFailed,
+					Lanes: []scanrun.Lane{lane}, ManifestSchemaVersion: 1, ManifestHash: runHash, SealedAt: finished}); err != nil {
+					t.Fatalf("seal failed native run with frozen source: %v", err)
+				}
+			}
+			got, err := store.Get(ctx, run.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertFrozenScanSource(t, got.Manifest.SourcePackage, item)
+			runs, err := store.List(ctx, item.EngagementID)
+			if err != nil || len(runs) != 1 {
+				t.Fatalf("list source-bound runs: %v %+v", err, runs)
+			}
+			assertFrozenScanSource(t, runs[0].Manifest.SourcePackage, item)
+			aggregate, err := store.GetScanRun(ctx, item.TenantID, run.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if native && (!aggregate.IsSealed() || aggregate.TerminalStatus != scanrun.StatusFailed) {
+				t.Fatalf("native source binding prevented terminal sealing: %+v", aggregate)
+			}
+			var roundTrip ports.ScanManifest
+			if err := json.Unmarshal(aggregate.LegacyManifest, &roundTrip); err != nil {
+				t.Fatal(err)
+			}
+			assertFrozenScanSource(t, roundTrip.SourcePackage, item)
+			aggregates, err := store.ListScanRuns(ctx, item.TenantID, item.EngagementID)
+			if err != nil || len(aggregates) != 1 {
+				t.Fatalf("list aggregate source-bound runs: %v %+v", err, aggregates)
+			}
+			if err := json.Unmarshal(aggregates[0].LegacyManifest, &roundTrip); err != nil {
+				t.Fatal(err)
+			}
+			assertFrozenScanSource(t, roundTrip.SourcePackage, item)
+			if _, err := store.Get(shared.WithTenant(ctx, "foreign-tenant"), run.ID); !errors.Is(err, shared.ErrNotFound) {
+				t.Fatalf("foreign tenant read source-bound run: %v", err)
+			}
+			for _, statement := range []string{
+				`UPDATE scan_runs SET manifest=manifest-'source_package' WHERE id=$1`,
+				`UPDATE scan_runs SET manifest=jsonb_set(manifest,'{source_package,filename}','"changed.zip"') WHERE id=$1`,
+				`UPDATE scan_runs SET engagement_id='other-assessment' WHERE id=$1`,
+				`UPDATE scan_runs SET tenant_id='foreign-tenant' WHERE id=$1`,
+			} {
+				if _, err := pool.Exec(ctx, statement, run.ID); err == nil {
+					t.Fatalf("database allowed source-bound run mutation: %s", statement)
+				}
+			}
+			if err := sources.Delete(ctx, item.TenantID, item.EngagementID); !errors.Is(err, shared.ErrConflict) {
+				t.Fatalf("%s run did not retain its source: %v", name, err)
+			}
+			if _, err := sources.Get(ctx, item.TenantID, item.EngagementID); err != nil {
+				t.Fatalf("source missing after refused deletion: %v", err)
+			}
+
+			forged := run
+			forged.ID = "forged-run"
+			changed := item
+			changed.VersionID = shared.ID(strings.Repeat("d", 32))
+			forged.Manifest.SourcePackage = &changed
+			if err := store.Save(ctx, forged); err == nil {
+				t.Fatal("run accepted nonexistent source version")
+			}
+			if err := store.Save(shared.WithTenant(ctx, "foreign-tenant"), run); err == nil {
+				t.Fatal("run accepted source owned by another tenant")
+			}
+		})
+	}
+}
+
+func TestPostgresScanSourceDoesNotReconstructUnboundHistory(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	_, item := scanSourceFixture(t, ctx, pool, "source-tenant", "source-assessment")
+	ctx = shared.WithTenant(ctx, item.TenantID)
+	jobs := NewScanJobStore(pool)
+	for _, kind := range []string{ports.TargetGit, ports.TargetLocal, ports.TargetImage, ports.TargetArchive, ports.TargetUpload} {
+		t.Run(kind, func(t *testing.T) {
+			job := scanSourceJob(item, "unbound-"+kind)
+			job.Kind, job.SourcePackage = kind, nil
+			if err := jobs.CreateRunning(ctx, job); err != nil {
+				t.Fatalf("existing target kind no longer admitted: %v", err)
+			}
+			job.Status = ports.ScanFailed
+			if err := jobs.Save(ctx, job); err != nil {
+				t.Fatalf("unbound status transition failed: %v", err)
+			}
+			got, err := jobs.GetJob(ctx, job.ID)
+			if err != nil || got.SourcePackage != nil {
+				t.Fatalf("unbound history acquired current source metadata: %+v %v", got.SourcePackage, err)
+			}
+		})
+	}
+	runs := NewScanRunStore(pool)
+	run := ports.ScanRun{ID: "unbound-run", EngagementID: item.EngagementID.String(), CreatedAt: time.Now().UTC()}
+	if err := runs.Save(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	got, err := runs.Get(ctx, run.ID)
+	if err != nil || got.Manifest.SourcePackage != nil {
+		t.Fatalf("legacy run acquired current source metadata: %+v %v", got.Manifest.SourcePackage, err)
+	}
+	encoded, err := json.Marshal(item)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE scan_jobs SET source_package=$1 WHERE id='unbound-upload'`, encoded); err == nil {
+		t.Fatal("database allowed retroactive source reconstruction on an old job")
+	}
+	if _, err := pool.Exec(ctx, `UPDATE scan_runs SET manifest=jsonb_set(manifest,'{source_package}',$1::jsonb) WHERE id=$2`, encoded, run.ID); err == nil {
+		t.Fatal("database allowed retroactive source reconstruction on an old run")
+	}
+}
+
+func TestPostgresScanSourceMigrationRollbackGuard(t *testing.T) {
+	ctx, pool := setupTestDB(t)
+	db, err := goose.OpenDBWithDriver("pgx", pool.Config().ConnString())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	// Empty metadata can safely migrate in both directions.
+	if err := goose.DownTo(db, ".", 159); err != nil {
+		t.Fatalf("empty source binding rollback: %v", err)
+	}
+	if err := goose.UpTo(db, ".", 160); err != nil {
+		t.Fatal(err)
+	}
+	_, item := scanSourceFixture(t, ctx, pool, "source-tenant", "source-assessment")
+	ctx = shared.WithTenant(ctx, item.TenantID)
+	job := scanSourceJob(item, "source-job")
+	if err := NewScanJobStore(pool).CreateRunning(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	if err := goose.DownTo(db, ".", 159); err == nil || !strings.Contains(err.Error(), "cannot roll back source bindings") {
+		t.Fatalf("rollback discarded queued source binding: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `DELETE FROM scan_jobs WHERE id=$1`, job.ID); err != nil {
+		t.Fatal(err)
+	}
+	run := ports.ScanRun{ID: "source-run", EngagementID: item.EngagementID.String(), CreatedAt: time.Now().UTC(), Manifest: ports.ScanManifest{SourcePackage: &item}}
+	if err := NewScanRunStore(pool).Save(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	if err := goose.DownTo(db, ".", 159); err == nil || !strings.Contains(err.Error(), "cannot roll back source bindings") {
+		t.Fatalf("rollback discarded historical run source: %v", err)
+	}
+}

--- a/internal/infrastructure/sourceupload/acquirer.go
+++ b/internal/infrastructure/sourceupload/acquirer.go
@@ -35,6 +35,14 @@ func (a *Acquirer) Acquire(ctx context.Context, request ports.AcquireRequest) (*
 		_ = cleanupSource()
 		return nil, fmt.Errorf("%w: uploaded source identity does not match stored content", shared.ErrValidation)
 	}
+	if tenantID, ok := shared.TenantFrom(ctx); ok && tenantID != item.TenantID {
+		_ = cleanupSource()
+		return nil, fmt.Errorf("%w: uploaded source belongs to a different tenant", shared.ErrNotFound)
+	}
+	if pinned := request.SourcePackage; pinned != nil && (pinned.VersionID != item.VersionID || pinned.TenantID != item.TenantID || pinned.EngagementID != item.EngagementID || pinned.SHA256 != item.SHA256 || pinned.Size != item.Size) {
+		_ = cleanupSource()
+		return nil, fmt.Errorf("%w: uploaded source does not match the admitted package version", shared.ErrConflict)
+	}
 	workspace, err := a.next.Acquire(ctx, ports.AcquireRequest{Kind: ports.TargetArchive, Value: path})
 	if err != nil {
 		_ = cleanupSource()

--- a/internal/infrastructure/sourceupload/sourceupload_test.go
+++ b/internal/infrastructure/sourceupload/sourceupload_test.go
@@ -23,7 +23,8 @@ func digest(data []byte) string {
 func TestStoreSaveGetMaterializeAndVerify(t *testing.T) {
 	ctx := context.Background()
 	objects := blob.NewMemory()
-	store := NewStore(objects, 0)
+	// Keep legacy manifest compatibility covered independently of v2 metadata.
+	store := NewStoreWithRepository(objects, nil, 0)
 	data := []byte("source archive bytes")
 	item, err := store.Save(ctx, "tenant-a", "eng-a", "../source.tar.gz", "alice", time.Date(2026, 8, 28, 0, 0, 0, 0, time.UTC), int64(len(data)), digest(data), bytes.NewReader(data))
 	if err != nil {
@@ -35,6 +36,9 @@ func TestStoreSaveGetMaterializeAndVerify(t *testing.T) {
 	got, err := store.Get(ctx, "tenant-a", "eng-a")
 	if err != nil || got.SHA256 != item.SHA256 {
 		t.Fatalf("Get: item=%+v err=%v", got, err)
+	}
+	if _, _, _, err := store.Materialize(shared.WithTenant(ctx, "tenant-b"), item.Locator); err == nil {
+		t.Fatal("legacy Materialize accepted a foreign tenant context")
 	}
 	path, materialized, cleanup, err := store.Materialize(ctx, item.Locator)
 	if err != nil {
@@ -139,7 +143,7 @@ func (a *captureAcquirer) Acquire(_ context.Context, request ports.AcquireReques
 }
 
 func TestAcquirerMaterializesAndCleansUploadedSource(t *testing.T) {
-	ctx := context.Background()
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
 	store := NewStore(blob.NewMemory(), 0)
 	data := []byte("archive")
 	item, err := store.Save(ctx, "tenant-a", "eng-a", "source.zip", "alice", time.Date(2026, 8, 28, 0, 0, 0, 0, time.UTC), int64(len(data)), digest(data), bytes.NewReader(data))

--- a/internal/infrastructure/sourceupload/store.go
+++ b/internal/infrastructure/sourceupload/store.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -24,8 +25,9 @@ const metadataLimit = int64(64 << 10)
 var locatorPattern = regexp.MustCompile(`^engagement-sources/v1/[0-9a-f]{64}/[0-9a-f]{64}$`)
 
 type Store struct {
-	objects  ports.ObjectStore
-	maxBytes int64
+	objects    ports.ObjectStore
+	repository ports.EngagementSourceRepository
+	maxBytes   int64
 }
 
 type manifest struct {
@@ -37,12 +39,25 @@ func NewStore(objects ports.ObjectStore, maxBytes int64) *Store {
 	if maxBytes <= 0 || maxBytes > sourcepackage.MaxArchiveBytes {
 		maxBytes = sourcepackage.MaxArchiveBytes
 	}
-	return &Store{objects: objects, maxBytes: maxBytes}
+	return &Store{objects: objects, repository: memory.NewEngagementSourceRepository(), maxBytes: maxBytes}
+}
+
+func NewStoreWithRepository(objects ports.ObjectStore, repository ports.EngagementSourceRepository, maxBytes int64) *Store {
+	store := NewStore(objects, maxBytes)
+	store.repository = repository
+	return store
 }
 
 var _ ports.EngagementSourceStore = (*Store)(nil)
 
 func (s *Store) Save(ctx context.Context, tenantID, engagementID shared.ID, filename, actor string, createdAt time.Time, size int64, sha256hex string, src io.Reader) (sourcepackage.Package, error) {
+	if s != nil && s.repository != nil {
+		return s.saveVersioned(ctx, tenantID, engagementID, filename, actor, createdAt, size, sha256hex, src)
+	}
+	return s.saveLegacy(ctx, tenantID, engagementID, filename, actor, createdAt, size, sha256hex, src)
+}
+
+func (s *Store) saveLegacy(ctx context.Context, tenantID, engagementID shared.ID, filename, actor string, createdAt time.Time, size int64, sha256hex string, src io.Reader) (sourcepackage.Package, error) {
 	if s == nil || s.objects == nil {
 		return sourcepackage.Package{}, fmt.Errorf("%w: engagement source uploads are not configured", shared.ErrValidation)
 	}
@@ -96,6 +111,9 @@ func (s *Store) Get(ctx context.Context, tenantID, engagementID shared.ID) (sour
 	if tenantID.IsZero() || engagementID.IsZero() {
 		return sourcepackage.Package{}, fmt.Errorf("%w: source package tenant and engagement are required", shared.ErrValidation)
 	}
+	if s.repository != nil {
+		return s.getVersioned(ctx, tenantID, engagementID)
+	}
 	item, err := s.getByLocator(ctx, locatorFor(tenantID, engagementID))
 	if err != nil {
 		return sourcepackage.Package{}, err
@@ -107,6 +125,19 @@ func (s *Store) Get(ctx context.Context, tenantID, engagementID shared.ID) (sour
 }
 
 func (s *Store) Delete(ctx context.Context, tenantID, engagementID shared.ID) error {
+	if s.repository != nil {
+		item, unreferenced, err := s.repository.Delete(ctx, tenantID, engagementID)
+		if errors.Is(err, shared.ErrNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if unreferenced {
+			return s.objects.DeleteObject(ctx, item.ObjectKey)
+		}
+		return nil
+	}
 	locator := locatorFor(tenantID, engagementID)
 	stored, err := s.readManifest(ctx, locator)
 	if err != nil && !errors.Is(err, shared.ErrNotFound) {
@@ -124,6 +155,9 @@ func (s *Store) Materialize(ctx context.Context, locator string) (string, source
 	stored, err := s.readManifest(ctx, locator)
 	if err != nil {
 		return "", sourcepackage.Package{}, nil, err
+	}
+	if tenantID, ok := shared.TenantFrom(ctx); ok && tenantID != stored.Package.TenantID {
+		return "", sourcepackage.Package{}, nil, shared.ErrNotFound
 	}
 	if stored.Package.Size > s.maxBytes {
 		return "", sourcepackage.Package{}, nil, fmt.Errorf("%w: uploaded source exceeds %d bytes", shared.ErrValidation, s.maxBytes)
@@ -165,6 +199,20 @@ func (s *Store) getByLocator(ctx context.Context, locator string) (sourcepackage
 }
 
 func (s *Store) readManifest(ctx context.Context, locator string) (manifest, error) {
+	if s != nil && s.repository != nil && versionLocatorPattern.MatchString(locator) {
+		tenantID, ok := shared.TenantFrom(ctx)
+		if !ok || tenantID.IsZero() {
+			return manifest{}, fmt.Errorf("%w: source materialization requires tenant context", shared.ErrValidation)
+		}
+		item, err := s.repository.GetByLocator(ctx, tenantID, locator)
+		if err != nil {
+			return manifest{}, err
+		}
+		if err := validateStoredVersion(item); err != nil {
+			return manifest{}, err
+		}
+		return manifest{Package: item, ObjectKey: item.ObjectKey}, nil
+	}
 	if s == nil || s.objects == nil || !locatorPattern.MatchString(locator) {
 		return manifest{}, fmt.Errorf("%w: uploaded source locator is invalid", shared.ErrValidation)
 	}

--- a/internal/infrastructure/sourceupload/versioned.go
+++ b/internal/infrastructure/sourceupload/versioned.go
@@ -1,0 +1,213 @@
+package sourceupload
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+var versionLocatorPattern = regexp.MustCompile(`^engagement-sources/v2/[0-9a-f]{64}/[0-9a-f]{64}/[0-9a-f]{32}$`)
+var versionObjectPattern = regexp.MustCompile(`^engagement-sources/(v1/[0-9a-f]{64}/[0-9a-f]{64}|v2/[0-9a-f]{64}/[0-9a-f]{64}/[0-9a-f]{32})/archive\.(zip|tar|tar\.gz|tgz)$`)
+
+var _ ports.EngagementSourceReuser = (*Store)(nil)
+var _ ports.EngagementSourceVersionReader = (*Store)(nil)
+var _ ports.EngagementSourceCompensator = (*Store)(nil)
+
+func versionLocator(tenantID, engID, versionID shared.ID) string {
+	return strings.Replace(locatorFor(tenantID, engID), "/v1/", "/v2/", 1) + "/" + versionID.String()
+}
+
+func validateStoredVersion(item sourcepackage.Package) error {
+	if err := item.ValidateVersion(); err != nil {
+		return err
+	}
+	if item.Locator != versionLocator(item.TenantID, item.EngagementID, item.VersionID) || !versionObjectPattern.MatchString(item.ObjectKey) {
+		return fmt.Errorf("%w: source package storage identity is invalid", shared.ErrValidation)
+	}
+	tenantHash := sha256.Sum256([]byte(item.TenantID.String()))
+	tenantPrefix := hex.EncodeToString(tenantHash[:]) + "/"
+	if !strings.HasPrefix(item.ObjectKey, "engagement-sources/v1/"+tenantPrefix) && !strings.HasPrefix(item.ObjectKey, "engagement-sources/v2/"+tenantPrefix) {
+		return fmt.Errorf("%w: source package object tenant is invalid", shared.ErrValidation)
+	}
+	archiveSuffix := "/archive" + sourcepackage.ArchiveExtension(item.Filename)
+	if !strings.HasSuffix(item.ObjectKey, archiveSuffix) || item.ReusedFromVersionID.IsZero() && item.ObjectKey != item.Locator+archiveSuffix && item.ObjectKey != locatorFor(item.TenantID, item.EngagementID)+archiveSuffix {
+		return fmt.Errorf("%w: source package object ownership is invalid", shared.ErrValidation)
+	}
+	return nil
+}
+
+func (s *Store) saveVersioned(ctx context.Context, tenantID, engID shared.ID, filename, actor string, at time.Time, size int64, digest string, src io.Reader) (sourcepackage.Package, error) {
+	if s.objects == nil || src == nil {
+		return sourcepackage.Package{}, fmt.Errorf("%w: source upload storage is unavailable", shared.ErrValidation)
+	}
+	item := sourcepackage.Package{TenantID: tenantID, EngagementID: engID, VersionID: idgen.RandomID{}.NewID(), Filename: sourcepackage.BaseFilename(filename), Size: size, SHA256: strings.ToLower(strings.TrimSpace(digest)), CreatedBy: strings.TrimSpace(actor), CreatedAt: at.UTC().Truncate(time.Microsecond), AssociatedBy: strings.TrimSpace(actor), AssociatedAt: at.UTC().Truncate(time.Microsecond)}
+	item.Locator = versionLocator(tenantID, engID, item.VersionID)
+	item.ObjectKey = item.Locator + "/archive" + sourcepackage.ArchiveExtension(item.Filename)
+	if err := validateStoredVersion(item); err != nil {
+		return sourcepackage.Package{}, err
+	}
+	if size > s.maxBytes {
+		return sourcepackage.Package{}, fmt.Errorf("%w: uploaded source exceeds configured limit", shared.ErrValidation)
+	}
+	if old, err := s.Get(ctx, tenantID, engID); err == nil {
+		if samePackageContent(old, item) {
+			return old, nil
+		}
+		return sourcepackage.Package{}, shared.ErrConflict
+	} else if !errors.Is(err, shared.ErrNotFound) {
+		return sourcepackage.Package{}, err
+	}
+	hash := sha256.New()
+	counter := &countingReader{reader: io.TeeReader(src, hash)}
+	if err := s.objects.PutObject(ctx, item.ObjectKey, counter, size); err != nil {
+		return item, fmt.Errorf("store uploaded source: %w", err)
+	}
+	var trailing [1]byte
+	n, err := counter.Read(trailing[:])
+	if counter.bytes != size || n != 0 || (err != nil && !errors.Is(err, io.EOF)) || hex.EncodeToString(hash.Sum(nil)) != item.SHA256 {
+		_ = s.objects.DeleteObject(context.WithoutCancel(ctx), item.ObjectKey)
+		return sourcepackage.Package{}, fmt.Errorf("%w: uploaded source content does not match size or SHA-256", shared.ErrValidation)
+	}
+	stored, _, err := s.repository.Create(ctx, item)
+	if err != nil {
+		// A failed COMMIT can still be durable. Only discard this unique staging
+		// object when a different immutable binding demonstrably won the race.
+		if errors.Is(err, shared.ErrConflict) && !stored.VersionID.IsZero() && stored.VersionID != item.VersionID {
+			_ = s.objects.DeleteObject(context.WithoutCancel(ctx), item.ObjectKey)
+			if samePackageContent(stored, item) {
+				return stored, nil
+			}
+		}
+		return item, fmt.Errorf("persist uploaded source metadata: %w", err)
+	}
+	return stored, nil
+}
+
+// DiscardUnpublished is only for compensation after the enclosing transaction.
+// A version owns one unguessable object key; reuse cannot create a new reference
+// once its original binding is absent. Unknown transaction outcomes retain bytes.
+func (s *Store) DiscardUnpublished(ctx context.Context, item sourcepackage.Package) error {
+	if s == nil || s.repository == nil || s.objects == nil {
+		return shared.ErrValidation
+	}
+	if item.VersionID.IsZero() || !item.ReusedFromVersionID.IsZero() {
+		return nil
+	}
+	if err := validateStoredVersion(item); err != nil {
+		return err
+	}
+	if item.ObjectKey != item.Locator+"/archive"+sourcepackage.ArchiveExtension(item.Filename) {
+		return nil // Verified legacy promotion does not own the original v1 object.
+	}
+	unreferenced, err := s.repository.ObjectUnreferenced(ctx, item.TenantID, item.ObjectKey)
+	if err != nil || !unreferenced {
+		return err
+	}
+	return s.objects.DeleteObject(ctx, item.ObjectKey)
+}
+
+func samePackageContent(left, right sourcepackage.Package) bool {
+	return left.TenantID == right.TenantID && left.EngagementID == right.EngagementID && left.Filename == right.Filename && left.Size == right.Size && left.SHA256 == right.SHA256
+}
+
+func (s *Store) getVersioned(ctx context.Context, tenantID, engID shared.ID) (sourcepackage.Package, error) {
+	item, err := s.repository.Get(ctx, tenantID, engID)
+	if err == nil {
+		return item, validateStoredVersion(item)
+	}
+	if !errors.Is(err, shared.ErrNotFound) {
+		return sourcepackage.Package{}, err
+	}
+	// Upgrade only a verifiable v1 archive. A digest in engagement scope alone
+	// cannot restore missing in-memory bytes or prove legacy upload attribution.
+	legacy, err := s.readManifest(ctx, locatorFor(tenantID, engID))
+	if err != nil {
+		return sourcepackage.Package{}, err
+	}
+	if err := s.verifyObject(ctx, legacy.Package, legacy.ObjectKey); err != nil {
+		return sourcepackage.Package{}, err
+	}
+	item = legacy.Package
+	item.VersionID = idgen.RandomID{}.NewID()
+	item.CreatedAt = item.CreatedAt.UTC().Truncate(time.Microsecond)
+	item.AssociatedBy, item.AssociatedAt = item.CreatedBy, item.CreatedAt
+	item.Locator = versionLocator(tenantID, engID, item.VersionID)
+	item.ObjectKey = legacy.ObjectKey
+	stored, _, err := s.repository.Create(ctx, item)
+	if errors.Is(err, shared.ErrConflict) {
+		if winner, getErr := s.repository.Get(ctx, tenantID, engID); getErr == nil && samePackageContent(winner, item) {
+			return winner, nil
+		}
+	}
+	return stored, err
+}
+
+func (s *Store) GetByVersion(ctx context.Context, tenantID, engID, versionID shared.ID) (sourcepackage.Package, error) {
+	item, err := s.Get(ctx, tenantID, engID)
+	if err == nil && (versionID.IsZero() || item.VersionID != versionID) {
+		return sourcepackage.Package{}, shared.ErrNotFound
+	}
+	return item, err
+}
+
+func (s *Store) Reuse(ctx context.Context, tenantID, parentEngID, childEngID, expectedVersionID shared.ID, actor string, at time.Time) (sourcepackage.Package, error) {
+	if s == nil || s.repository == nil || tenantID.IsZero() || parentEngID.IsZero() || childEngID.IsZero() || parentEngID == childEngID || expectedVersionID.IsZero() {
+		return sourcepackage.Package{}, fmt.Errorf("%w: source reuse ownership and expected version are required", shared.ErrValidation)
+	}
+	parent, err := s.GetByVersion(ctx, tenantID, parentEngID, expectedVersionID)
+	if err != nil {
+		return sourcepackage.Package{}, err
+	}
+	if err := s.verifyObject(ctx, parent, parent.ObjectKey); err != nil {
+		return sourcepackage.Package{}, err
+	}
+	if existing, err := s.repository.Get(ctx, tenantID, childEngID); err == nil {
+		if existing.ReusedFromVersionID == parent.VersionID {
+			return existing, nil
+		}
+		return sourcepackage.Package{}, shared.ErrConflict
+	} else if !errors.Is(err, shared.ErrNotFound) {
+		return sourcepackage.Package{}, err
+	}
+	child := parent
+	child.EngagementID, child.VersionID = childEngID, idgen.RandomID{}.NewID()
+	child.ReusedFromVersionID = parent.VersionID
+	child.AssociatedBy, child.AssociatedAt = strings.TrimSpace(actor), at.UTC().Truncate(time.Microsecond)
+	child.Locator = versionLocator(tenantID, childEngID, child.VersionID)
+	if err := validateStoredVersion(child); err != nil {
+		return sourcepackage.Package{}, err
+	}
+	stored, _, err := s.repository.Create(ctx, child)
+	if errors.Is(err, shared.ErrConflict) && stored.ReusedFromVersionID == parent.VersionID {
+		return stored, nil
+	}
+	return stored, err
+}
+
+func (s *Store) verifyObject(ctx context.Context, item sourcepackage.Package, key string) error {
+	reader, err := s.objects.OpenObject(ctx, key)
+	if err != nil {
+		return fmt.Errorf("uploaded source archive is unavailable: %w", err)
+	}
+	defer func() { _ = reader.Close() }()
+	hash := sha256.New()
+	n, err := io.Copy(hash, io.LimitReader(reader, item.Size+1))
+	if err != nil {
+		return fmt.Errorf("verify source archive: %w", err)
+	}
+	if n != item.Size || hex.EncodeToString(hash.Sum(nil)) != item.SHA256 {
+		return fmt.Errorf("%w: uploaded source failed integrity verification", shared.ErrValidation)
+	}
+	return nil
+}

--- a/internal/infrastructure/sourceupload/versioned_test.go
+++ b/internal/infrastructure/sourceupload/versioned_test.go
@@ -1,0 +1,292 @@
+package sourceupload
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/blob"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+)
+
+func TestVersionedSourceDurableReuseAndImmutableBindings(t *testing.T) {
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
+	directory := t.TempDir()
+	objects, err := blob.NewFilesystem(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := memory.NewEngagementSourceRepository()
+	store := NewStoreWithRepository(objects, repo, 0)
+	data := []byte("source archive bytes")
+	now := time.Date(2026, 9, 8, 10, 0, 0, 123456789, time.UTC)
+	initial, err := store.Save(ctx, "tenant-a", "initial", "source.zip", "alice", now, int64(len(data)), digest(data), bytes.NewReader(data))
+	if err != nil || initial.VersionID.IsZero() || initial.CreatedAt.Nanosecond() != 123456000 {
+		t.Fatalf("save immutable package: %+v %v", initial, err)
+	}
+	if err := objects.Close(); err != nil {
+		t.Fatal(err)
+	}
+	objects, err = blob.NewFilesystem(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = objects.Close() })
+	// A fresh API/worker adapter can recover metadata and bytes independently.
+	store = NewStoreWithRepository(objects, repo, 0)
+	got, err := store.GetByVersion(ctx, "tenant-a", "initial", initial.VersionID)
+	if err != nil || got != initial {
+		t.Fatalf("reopened metadata: %+v %v", got, err)
+	}
+	child, err := store.Reuse(ctx, "tenant-a", "initial", "retest-1", initial.VersionID, "bob", now.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	grandchild, err := store.Reuse(ctx, "tenant-a", "retest-1", "retest-2", child.VersionID, "carol", now.Add(2*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range []sourcepackage.Package{child, grandchild} {
+		if item.VersionID == initial.VersionID || item.ObjectKey != initial.ObjectKey || item.SHA256 != initial.SHA256 || item.CreatedBy != "alice" || !item.CreatedAt.Equal(initial.CreatedAt) || item.AssociatedBy == "alice" {
+			t.Fatalf("reuse did not retain original attribution and immutable bytes: %+v", item)
+		}
+		path, materialized, cleanup, err := store.Materialize(ctx, item.Locator)
+		if err != nil {
+			t.Fatal(err)
+		}
+		read, err := os.ReadFile(path)
+		_ = cleanup()
+		if err != nil || !bytes.Equal(read, data) || materialized.VersionID != item.VersionID {
+			t.Fatalf("child materialized wrong source: %q %+v %v", read, materialized, err)
+		}
+	}
+	if grandchild.ReusedFromVersionID != child.VersionID || child.ReusedFromVersionID != initial.VersionID {
+		t.Fatal("reuse chain lost immediate predecessor")
+	}
+	if _, err := store.Reuse(ctx, "tenant-a", "initial", "stale", child.VersionID, "bob", now); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("stale version = %v", err)
+	}
+	if _, _, _, err := store.Materialize(shared.WithTenant(ctx, "tenant-b"), child.Locator); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant materialization = %v", err)
+	}
+	if _, _, _, err := store.Materialize(context.Background(), child.Locator); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("unscoped materialization = %v", err)
+	}
+	changed := []byte("new bytes")
+	if _, err := store.Save(ctx, "tenant-a", "initial", "source.zip", "bob", now, int64(len(changed)), digest(changed), bytes.NewReader(changed)); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("existing assessment source overwrite = %v", err)
+	}
+	if err := store.Delete(ctx, "tenant-a", "initial"); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("referenced parent deletion = %v", err)
+	}
+	if err := store.DiscardUnpublished(ctx, child); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Delete(ctx, "tenant-a", "retest-2"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Delete(ctx, "tenant-a", "retest-1"); err != nil {
+		t.Fatal(err)
+	}
+	reader, err := objects.OpenObject(ctx, initial.ObjectKey)
+	if err != nil {
+		t.Fatalf("child cleanup deleted parent archive: %v", err)
+	}
+	_ = reader.Close()
+}
+
+func TestVersionedSourceLegacyPromotionRequiresVerifiedBytes(t *testing.T) {
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
+	objects := blob.NewMemory()
+	legacy := NewStoreWithRepository(objects, nil, 0)
+	data := []byte("legacy archive")
+	old, err := legacy.Save(ctx, "tenant-a", "legacy", "source.tar", "original", time.Now(), int64(len(data)), digest(data), bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := NewStoreWithRepository(objects, memory.NewEngagementSourceRepository(), 0)
+	promoted, err := store.Get(ctx, "tenant-a", "legacy")
+	if err != nil || promoted.VersionID.IsZero() || promoted.CreatedBy != "original" || promoted.ObjectKey != old.Locator+"/archive.tar" {
+		t.Fatalf("verified promotion: %+v %v", promoted, err)
+	}
+	if err := store.DiscardUnpublished(ctx, promoted); err != nil {
+		t.Fatal(err)
+	}
+	if err := objects.DeleteObject(ctx, promoted.ObjectKey); err != nil {
+		t.Fatal(err)
+	}
+	// A legacy manifest/digest alone must never be presented as reusable bytes.
+	unrestored := NewStoreWithRepository(objects, memory.NewEngagementSourceRepository(), 0)
+	if _, err := unrestored.Get(ctx, "tenant-a", "legacy"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("promoted missing bytes = %v", err)
+	}
+	if _, err := store.Reuse(ctx, "tenant-a", "legacy", "child", promoted.VersionID, "bob", time.Now()); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("reused unavailable bytes = %v", err)
+	}
+	if err := objects.Put(ctx, promoted.ObjectKey, []byte("tampered bytes")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := unrestored.Get(ctx, "tenant-a", "legacy"); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("promoted corrupt bytes = %v", err)
+	}
+}
+
+func TestVersionedSourceRollbackCompensationRetainsPublishedAndSharedBytes(t *testing.T) {
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
+	objects := blob.NewMemory()
+	repo := memory.NewEngagementSourceRepository()
+	store := NewStoreWithRepository(objects, repo, 0)
+	data := []byte("archive")
+	var unpublished sourcepackage.Package
+	failure := errors.New("audit completion failed")
+	err := memory.NewTenantTransactionRunner().Run(ctx, "tenant-a", func(txCtx context.Context) error {
+		var err error
+		unpublished, err = store.Save(txCtx, "tenant-a", "child", "source.zip", "alice", time.Now(), int64(len(data)), digest(data), bytes.NewReader(data))
+		if err != nil {
+			return err
+		}
+		if err := store.DiscardUnpublished(txCtx, unpublished); err != nil {
+			t.Fatalf("discard inside uncommitted transaction = %v", err)
+		}
+		return failure
+	})
+	if !errors.Is(err, failure) {
+		t.Fatal(err)
+	}
+	if _, err := store.Get(ctx, "tenant-a", "child"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("rolled back source metadata = %v", err)
+	}
+	if err := store.DiscardUnpublished(ctx, unpublished); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := objects.OpenObject(ctx, unpublished.ObjectKey); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("rollback orphan remained: %v", err)
+	}
+	published, err := store.Save(ctx, "tenant-a", "published", "source.zip", "alice", time.Now(), int64(len(data)), digest(data), bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = memory.NewTenantTransactionRunner().Run(ctx, "tenant-a", func(txCtx context.Context) error {
+		if err := store.Delete(txCtx, "tenant-a", "published"); err != nil {
+			return err
+		}
+		return failure
+	})
+	if !errors.Is(err, failure) {
+		t.Fatal(err)
+	}
+	if err := store.DiscardUnpublished(ctx, published); err != nil {
+		t.Fatal(err)
+	}
+	reader, err := objects.OpenObject(ctx, published.ObjectKey)
+	if err != nil {
+		t.Fatal("rollback or compensation deleted published bytes", err)
+	}
+	_ = reader.Close()
+}
+
+type unavailableSourceRepository struct {
+	*memory.EngagementSourceRepository
+}
+
+func (r unavailableSourceRepository) ObjectUnreferenced(context.Context, shared.ID, string) (bool, error) {
+	return false, io.ErrUnexpectedEOF
+}
+
+func TestVersionedSourceAmbiguousCleanupRetainsBytes(t *testing.T) {
+	ctx := context.Background()
+	objects := blob.NewMemory()
+	repo := unavailableSourceRepository{memory.NewEngagementSourceRepository()}
+	store := NewStoreWithRepository(objects, repo, 0)
+	data := []byte("archive")
+	item, err := store.Save(ctx, "tenant-a", "eng-a", "source.zip", "alice", time.Now(), int64(len(data)), digest(data), bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.DiscardUnpublished(ctx, item); !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("uncertain query = %v", err)
+	}
+	reader, err := objects.OpenObject(ctx, item.ObjectKey)
+	if err != nil {
+		t.Fatal("ambiguous query removed bytes", err)
+	}
+	_ = reader.Close()
+}
+
+func TestVersionedSourceConcurrentUploadPublishesOneImmutableObject(t *testing.T) {
+	ctx := shared.WithTenant(context.Background(), "tenant-a")
+	directory := t.TempDir()
+	objects, err := blob.NewFilesystem(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = objects.Close() })
+	store := NewStoreWithRepository(objects, memory.NewEngagementSourceRepository(), 0)
+	data := []byte("same archive uploaded concurrently")
+	now := time.Now()
+	const count = 16
+	results := make([]sourcepackage.Package, count)
+	errorsByIndex := make([]error, count)
+	var workers sync.WaitGroup
+	start := make(chan struct{})
+	for index := range count {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			results[index], errorsByIndex[index] = store.Save(ctx, "tenant-a", "eng-a", "source.zip", "alice", now, int64(len(data)), digest(data), bytes.NewReader(data))
+		}()
+	}
+	close(start)
+	workers.Wait()
+	for index, item := range results {
+		if errorsByIndex[index] != nil || item.VersionID != results[0].VersionID || item.VersionID.IsZero() {
+			t.Fatalf("concurrent upload %d = %+v %v", index, item, errorsByIndex[index])
+		}
+	}
+	files := 0
+	if err := filepath.WalkDir(directory, func(_ string, entry os.DirEntry, err error) error {
+		if err == nil && !entry.IsDir() {
+			files++
+		}
+		return err
+	}); err != nil || files != 1 {
+		t.Fatalf("concurrent uploads left %d files, %v", files, err)
+	}
+}
+
+func TestVersionedSourceRejectsForgedObjectOwnership(t *testing.T) {
+	ctx := context.Background()
+	store := NewStore(blob.NewMemory(), 0)
+	data := []byte("archive")
+	item, err := store.Save(ctx, "tenant-a", "eng-a", "source.zip", "alice", time.Now(), int64(len(data)), digest(data), bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreignTenant := sha256.Sum256([]byte("tenant-b"))
+	ownerHash := sha256.Sum256([]byte(item.TenantID.String()))
+	for _, key := range []string{
+		// The real owner's hash in the engagement position must not satisfy tenancy.
+		"engagement-sources/v2/" + hex.EncodeToString(foreignTenant[:]) + "/" + hex.EncodeToString(ownerHash[:]) + "/" + item.VersionID.String() + "/archive.zip",
+		strings.Replace(item.ObjectKey, "/v2/", "/v1/", 1),
+		strings.TrimSuffix(item.ObjectKey, ".zip") + ".tar",
+		versionLocator(item.TenantID, "another-engagement", item.VersionID) + "/archive.zip",
+	} {
+		forged := item
+		forged.ObjectKey = key
+		if err := validateStoredVersion(forged); !errors.Is(err, shared.ErrValidation) {
+			t.Errorf("forged object key accepted: %q %v", key, err)
+		}
+	}
+}

--- a/internal/usecase/engagement/service.go
+++ b/internal/usecase/engagement/service.go
@@ -3,12 +3,14 @@ package engagement
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
 	domain "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
@@ -17,11 +19,13 @@ import (
 
 // Service implements engagement use cases.
 type Service struct {
-	repo    ports.EngagementRepository
-	clock   ports.Clock
-	ids     ports.IDGenerator
-	audit   ports.AuditLogger
-	sources ports.EngagementSourceStore
+	repo                      ports.EngagementRepository
+	clock                     ports.Clock
+	ids                       ports.IDGenerator
+	audit                     ports.AuditLogger
+	sources                   ports.EngagementSourceStore
+	snapshots                 ports.AssessmentSnapshotDefaultReader
+	requireCompletionSnapshot func(string) bool
 }
 
 // NewService wires the engagement use case with its driven ports.
@@ -31,18 +35,34 @@ func NewService(repo ports.EngagementRepository, clock ports.Clock, ids ports.ID
 
 func (s *Service) SetSourceStore(store ports.EngagementSourceStore) { s.sources = store }
 
+func (s *Service) SetCompletionSnapshotReader(reader ports.AssessmentSnapshotDefaultReader) {
+	s.snapshots = reader
+	s.requireCompletionSnapshot = func(string) bool { return true }
+}
+
+// SetCompletionSnapshotPolicy enables the finalized-Snapshot completion guard
+// only for tenants that have passed the lifecycle rollout. A disabled policy
+// preserves legacy completion behavior.
+func (s *Service) SetCompletionSnapshotPolicy(reader ports.AssessmentSnapshotDefaultReader, required func(string) bool) {
+	s.snapshots = reader
+	s.requireCompletionSnapshot = required
+}
+
 // CreateInput is the input for creating an engagement.
 type CreateInput struct {
-	TenantID        shared.ID
-	BusinessAssetID shared.ID
-	CreatedBy       string // the authenticated actor that owns the engagement (ownership)
-	Name            string
-	Client          string
-	InScope         []domain.Target
-	OutOfScope      []domain.Target
-	AuthorizedFrom  *time.Time
-	AuthorizedTo    *time.Time
-	Timezone        string
+	AssessmentProjectID                    shared.ID
+	TenantID                               shared.ID
+	BusinessAssetID                        shared.ID
+	CreatedBy                              string // the authenticated actor that owns the engagement (ownership)
+	Name                                   string
+	Client                                 string
+	InScope                                []domain.Target
+	OutOfScope                             []domain.Target
+	AuthorizedFrom                         *time.Time
+	AuthorizedTo                           *time.Time
+	Timezone                               string
+	RoE                                    *domain.RoE
+	RequiresExplicitExecutionAuthorization bool
 }
 
 // Create validates and persists a new engagement with its scope.
@@ -55,27 +75,130 @@ func (s *Service) CreateFromSourcePackage(ctx context.Context, in CreateInput, f
 		return nil, sourcepackage.Package{}, fmt.Errorf("%w: engagement source uploads are not configured", shared.ErrValidation)
 	}
 	id := s.ids.NewID()
-	item, err := s.sources.Save(ctx, shared.TenantOrDefault(in.TenantID), id, filename, in.CreatedBy, s.clock.Now(), size, sha256hex, src)
+	metadata := sourcepackage.Package{
+		TenantID: shared.TenantOrDefault(in.TenantID), EngagementID: id, Filename: sourcepackage.BaseFilename(filename),
+		Size: size, SHA256: strings.ToLower(strings.TrimSpace(sha256hex)), CreatedBy: in.CreatedBy, CreatedAt: s.clock.Now(),
+	}
+	if err := metadata.Validate(); err != nil || src == nil {
+		if err != nil {
+			return nil, sourcepackage.Package{}, err
+		}
+		return nil, sourcepackage.Package{}, fmt.Errorf("%w: source upload is required", shared.ErrValidation)
+	}
+	// Persist the draft owner before its source association so metadata stores
+	// can enforce the engagement foreign key. No scan can execute this draft.
+	in.InScope = append([]domain.Target{{Kind: domain.TargetRepo, Value: metadata.Target()}}, in.InScope...)
+	engagement, err := s.create(ctx, in, id)
 	if err != nil {
 		return nil, sourcepackage.Package{}, err
 	}
-	in.InScope = append([]domain.Target{{Kind: domain.TargetRepo, Value: item.Target()}}, in.InScope...)
-	engagement, err := s.create(ctx, in, id)
+	item, err := s.sources.Save(ctx, metadata.TenantID, id, metadata.Filename, in.CreatedBy, metadata.CreatedAt, size, metadata.SHA256, src)
 	if err != nil {
-		// Compensating delete: the engagement didn't persist, so the stored source would be orphaned.
-		_ = s.sources.Delete(context.WithoutCancel(ctx), item.TenantID, id)
-		return nil, sourcepackage.Package{}, err
+		return nil, item, errors.Join(err, s.CompensateCreate(context.WithoutCancel(ctx), metadata.TenantID, id, item))
 	}
 	// Chain-of-custody: record the ingest of untrusted source bytes in the append-only, hash-chained
 	// audit log (who uploaded which archive to which engagement), not only in the manifest metadata.
 	if err := s.auditChange(ctx, in.CreatedBy, "engagement.source_uploaded", id, map[string]string{
-		"filename": item.Filename,
-		"sha256":   item.SHA256,
-		"size":     strconv.FormatInt(item.Size, 10),
+		"filename":          item.Filename,
+		"sha256":            item.SHA256,
+		"size":              strconv.FormatInt(item.Size, 10),
+		"source_version_id": item.VersionID.String(),
 	}, s.clock.Now()); err != nil {
-		return nil, sourcepackage.Package{}, err
+		// Reject an unaudited upload and remove both the newly created engagement
+		// and external source bytes, including when the request was cancelled.
+		return nil, item, errors.Join(err, s.CompensateCreate(context.WithoutCancel(ctx), item.TenantID, id, item))
 	}
 	return engagement, item, nil
+}
+
+// SourcePackage resolves metadata only through the tenant-scoped engagement.
+// Storage locators remain internal; callers use the immutable version identity.
+func (s *Service) SourcePackage(ctx context.Context, tenantID, engagementID shared.ID) (sourcepackage.Package, error) {
+	tenantID = shared.TenantOrDefault(tenantID)
+	if _, err := s.Get(ctx, tenantID, engagementID); err != nil {
+		return sourcepackage.Package{}, err
+	}
+	if s.sources == nil {
+		return sourcepackage.Package{}, shared.ErrNotFound
+	}
+	return s.sources.Get(ctx, tenantID, engagementID)
+}
+
+// CreateFromReusedSource creates a child-owned immutable association to the
+// selected predecessor archive. Reuse never changes the predecessor package or
+// inherits its execution authorization, and original upload attribution is kept.
+func (s *Service) CreateFromReusedSource(ctx context.Context, in CreateInput, predecessorID, expectedVersionID shared.ID) (*domain.Engagement, sourcepackage.Package, error) {
+	reuser, ok := s.sources.(ports.EngagementSourceReuser)
+	if !ok {
+		return nil, sourcepackage.Package{}, fmt.Errorf("%w: source reuse is not configured", shared.ErrValidation)
+	}
+	parent, err := s.SourcePackage(ctx, in.TenantID, predecessorID)
+	if err != nil {
+		return nil, sourcepackage.Package{}, err
+	}
+	if !expectedVersionID.IsZero() && parent.VersionID != expectedVersionID {
+		return nil, sourcepackage.Package{}, fmt.Errorf("%w: selected source version no longer matches the predecessor", shared.ErrConflict)
+	}
+	id := s.ids.NewID()
+	in.InScope = append([]domain.Target{{Kind: domain.TargetRepo, Value: parent.Target()}}, in.InScope...)
+	assessment, err := s.create(ctx, in, id)
+	if err != nil {
+		return nil, sourcepackage.Package{}, err
+	}
+	item, err := reuser.Reuse(ctx, shared.TenantOrDefault(in.TenantID), predecessorID, id, parent.VersionID, in.CreatedBy, s.clock.Now())
+	if err != nil {
+		return nil, item, errors.Join(err, s.CompensateCreate(context.WithoutCancel(ctx), parent.TenantID, id, item))
+	}
+	if err := s.auditChange(ctx, in.CreatedBy, "engagement.source_reused", id, map[string]string{
+		"source_version_id": item.VersionID.String(), "sha256": item.SHA256,
+		"source_assessment_id": predecessorID.String(), "reused_from_version_id": parent.VersionID.String(),
+	}, s.clock.Now()); err != nil {
+		return nil, item, errors.Join(err, s.CompensateCreate(context.WithoutCancel(ctx), item.TenantID, id, item))
+	}
+	return assessment, item, nil
+}
+
+func (s *Service) CompensateCreate(ctx context.Context, tenantID, engagementID shared.ID, createdSources ...sourcepackage.Package) error {
+	for _, item := range createdSources {
+		if !item.VersionID.IsZero() && (item.TenantID != shared.TenantOrDefault(tenantID) || item.EngagementID != engagementID) {
+			return fmt.Errorf("%w: source cleanup ownership mismatch", shared.ErrValidation)
+		}
+	}
+	var cleanupErr error
+	if s.sources != nil {
+		cleanupErr = s.sources.Delete(context.WithoutCancel(ctx), shared.TenantOrDefault(tenantID), engagementID)
+	}
+	deleteErr := s.repo.Delete(ctx, engagementID)
+	if cleanupErr != nil || deleteErr != nil {
+		return errors.Join(cleanupErr, deleteErr)
+	}
+	if compensator, ok := s.sources.(ports.EngagementSourceCompensator); ok {
+		for _, item := range createdSources {
+			if item.VersionID.IsZero() {
+				continue
+			}
+			// A retained-command transaction may already have rolled back its
+			// metadata. The captured package identifies only this child's bytes.
+			if err := compensator.DiscardUnpublished(ctx, item); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// DiscardUnpublishedSource releases only the private object captured by a failed
+// create command, after its enclosing transaction has rolled back. It never
+// removes engagement or source metadata; the store verifies that no durable
+// reference remains and retains bytes if that outcome cannot be established.
+func (s *Service) DiscardUnpublishedSource(ctx context.Context, item sourcepackage.Package) error {
+	if item.VersionID.IsZero() {
+		return nil
+	}
+	if compensator, ok := s.sources.(ports.EngagementSourceCompensator); ok {
+		return compensator.DiscardUnpublished(ctx, item)
+	}
+	return nil
 }
 
 func (s *Service) create(ctx context.Context, in CreateInput, id shared.ID) (*domain.Engagement, error) {
@@ -85,11 +208,18 @@ func (s *Service) create(ctx context.Context, in CreateInput, id shared.ID) (*do
 		return nil, err
 	}
 	e.BusinessAssetID = in.BusinessAssetID
+	e.AssessmentProjectID = in.AssessmentProjectID
+	e.RequiresExplicitExecutionAuthorization = in.RequiresExplicitExecutionAuthorization
 	if err := e.SetScope(in.InScope, in.OutOfScope, now); err != nil {
 		return nil, err
 	}
 	if err := e.SetAuthorizationWindow(in.AuthorizedFrom, in.AuthorizedTo, in.Timezone, now); err != nil {
 		return nil, err
+	}
+	if in.RoE != nil {
+		if err := e.SetRoE(*in.RoE, now); err != nil {
+			return nil, err
+		}
 	}
 	// Ownership: the creating actor owns the engagement; updated_by starts equal.
 	e.Audit.CreatedBy = in.CreatedBy
@@ -177,6 +307,25 @@ func (s *Service) Transition(ctx context.Context, actor string, tenantID, id sha
 	if err != nil {
 		return nil, err
 	}
+	if to == domain.StatusCompleted && e.Status != domain.StatusCompleted {
+		required := s.requireCompletionSnapshot != nil && s.requireCompletionSnapshot(shared.TenantOrDefault(tenantID).String())
+		if required {
+			if s.snapshots == nil {
+				return nil, fmt.Errorf("%w: assessment snapshot completion guard is not configured", shared.ErrValidation)
+			}
+			snapshot, _, err := s.snapshots.GetDefault(ctx, shared.TenantOrDefault(tenantID), id)
+			if err != nil {
+				if errors.Is(err, shared.ErrNotFound) {
+					return nil, fmt.Errorf("%w: engagement requires a default finalized assessment snapshot before completion", shared.ErrValidation)
+				}
+				return nil, fmt.Errorf("load default assessment snapshot: %w", err)
+			}
+			if snapshot.Lifecycle != assessmentsnapshot.LifecycleFinalized {
+				return nil, fmt.Errorf("%w: engagement default assessment snapshot is not finalized", shared.ErrValidation)
+			}
+		}
+	}
+
 	now := s.clock.Now()
 	cp := *e
 	if err := cp.Transition(to, now); err != nil {

--- a/internal/usecase/engagement/service_test.go
+++ b/internal/usecase/engagement/service_test.go
@@ -3,14 +3,20 @@ package engagement
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
 	domain "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/blob"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sourceupload"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/execution"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
@@ -87,6 +93,12 @@ type fixedIDs struct{}
 
 func (fixedIDs) NewID() shared.ID { return shared.ID("eng-1") }
 
+type finalizedSnapshotReader struct{}
+
+func (finalizedSnapshotReader) GetDefault(context.Context, shared.ID, shared.ID) (*assessmentsnapshot.Snapshot, ports.AssessmentSnapshotDefault, error) {
+	return &assessmentsnapshot.Snapshot{Lifecycle: assessmentsnapshot.LifecycleFinalized}, ports.AssessmentSnapshotDefault{}, nil
+}
+
 type capAudit struct{ entries []ports.AuditEntry }
 
 func (a *capAudit) Record(_ context.Context, e ports.AuditEntry) error {
@@ -106,6 +118,71 @@ type sourceStoreFake struct {
 	item    sourcepackage.Package
 	saved   []byte
 	deleted bool
+}
+
+type failedUploadAudit struct{ err error }
+
+type failedSourcePublishStore struct {
+	sourceStoreFake
+	discarded []sourcepackage.Package
+}
+
+func (s *failedSourcePublishStore) Save(ctx context.Context, tenantID, engagementID shared.ID, filename, actor string, at time.Time, size int64, digest string, src io.Reader) (sourcepackage.Package, error) {
+	item, err := s.sourceStoreFake.Save(ctx, tenantID, engagementID, filename, actor, at, size, digest, src)
+	if err != nil {
+		return item, err
+	}
+	item.VersionID, item.AssociatedBy, item.AssociatedAt = "private-version", actor, at
+	return item, errors.New("source metadata publication failed")
+}
+
+func (s *failedSourcePublishStore) DiscardUnpublished(_ context.Context, item sourcepackage.Package) error {
+	s.discarded = append(s.discarded, item)
+	return nil
+}
+
+func (a failedUploadAudit) Record(context.Context, ports.AuditEntry) error { return a.err }
+
+func TestSourceUploadAuditFailureCompensatesEngagementAndArchive(t *testing.T) {
+	ctx := context.Background()
+	repo, sources := newMemRepo(), &sourceStoreFake{}
+	auditErr := errors.New("audit unavailable")
+	svc := NewService(repo, fixedClock{time.Now()}, fixedIDs{}, failedUploadAudit{auditErr})
+	svc.SetSourceStore(sources)
+	_, _, err := svc.CreateFromSourcePackage(ctx, CreateInput{
+		TenantID: "tenant-a", Name: "Unaudited upload", CreatedBy: "alice",
+	}, "source.zip", 7, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", bytes.NewBufferString("archive"))
+	if !errors.Is(err, auditErr) {
+		t.Fatalf("expected original audit failure, got %v", err)
+	}
+	if !sources.deleted || len(repo.data) != 0 {
+		t.Fatalf("unaudited upload left durable state: deleted=%v engagements=%d", sources.deleted, len(repo.data))
+	}
+}
+
+func TestSourcePublicationFailureRetainsOwnedCleanupToken(t *testing.T) {
+	sources := &failedSourcePublishStore{}
+	repo := newMemRepo()
+	svc := NewService(repo, fixedClock{time.Now()}, fixedIDs{}, &capAudit{})
+	svc.SetSourceStore(sources)
+	_, item, err := svc.CreateFromSourcePackage(context.Background(), CreateInput{TenantID: "tenant-a", Name: "Upload", CreatedBy: "actor"}, "source.zip", 7, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", strings.NewReader("archive"))
+	if err == nil || item.VersionID != "private-version" || !sources.deleted || len(repo.data) != 0 || len(sources.discarded) != 1 || sources.discarded[0].VersionID != item.VersionID {
+		t.Fatalf("metadata failure lost cleanup token or draft owner: item=%+v discarded=%+v deleted=%v engagements=%d err=%v", item, sources.discarded, sources.deleted, len(repo.data), err)
+	}
+}
+
+func TestSourceCompensationRejectsForeignCleanupTokenBeforeMutation(t *testing.T) {
+	sources, repo := &failedSourcePublishStore{}, newMemRepo()
+	svc := NewService(repo, fixedClock{time.Now()}, fixedIDs{}, &capAudit{})
+	svc.SetSourceStore(sources)
+	child, err := svc.Create(context.Background(), CreateInput{TenantID: "tenant-a", Name: "Child", CreatedBy: "actor"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = svc.CompensateCreate(context.Background(), "tenant-a", child.ID, sourcepackage.Package{VersionID: "parent-version", TenantID: "tenant-a", EngagementID: "parent"})
+	if !errors.Is(err, shared.ErrValidation) || sources.deleted || len(sources.discarded) != 0 || len(repo.data) != 1 {
+		t.Fatalf("foreign cleanup token mutated state: deleted=%v discarded=%d engagements=%d err=%v", sources.deleted, len(sources.discarded), len(repo.data), err)
+	}
 }
 
 func (s *sourceStoreFake) Save(_ context.Context, tenantID, engagementID shared.ID, filename, actor string, createdAt time.Time, size int64, sha256hex string, src io.Reader) (sourcepackage.Package, error) {
@@ -199,8 +276,99 @@ func TestCreateFromSourcePackageAddsImmutableScopeAndCleansFailure(t *testing.T)
 	}, "source.zip", int64(len(data)), "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", bytes.NewReader(data)); err == nil {
 		t.Fatal("CreateFromSourcePackage succeeded when engagement persistence failed")
 	}
-	if !failingSources.deleted {
-		t.Fatal("uploaded source was not cleaned up after engagement persistence failed")
+	if len(failingSources.saved) != 0 || failingSources.deleted {
+		t.Fatal("source storage was mutated even though its owning engagement could not be created")
+	}
+}
+
+func TestCreateFromReusedSourceOwnsChildAndPreservesUploadAttribution(t *testing.T) {
+	for _, auditFails := range []bool{false, true} {
+		t.Run(map[bool]string{false: "success", true: "audit rollback"}[auditFails], func(t *testing.T) {
+			ctx := context.Background()
+			now := time.Date(2026, 9, 9, 0, 0, 0, 0, time.UTC)
+			repo := newMemRepo()
+			parent, err := domain.New("parent", "tenant-a", "Original", "", now)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := repo.Create(ctx, parent); err != nil {
+				t.Fatal(err)
+			}
+			sources := sourceupload.NewStore(blob.NewMemory(), 0)
+			payload := []byte("immutable archive fixture")
+			digest := sha256.Sum256(payload)
+			original, err := sources.Save(ctx, "tenant-a", parent.ID, "original.zip", "original-uploader", now, int64(len(payload)), hex.EncodeToString(digest[:]), bytes.NewReader(payload))
+			if err != nil {
+				t.Fatal(err)
+			}
+			audit := &capAudit{}
+			var auditLog ports.AuditLogger = audit
+			if auditFails {
+				auditLog = failedUploadAudit{errors.New("audit unavailable")}
+			}
+			svc := NewService(repo, fixedClock{now.Add(time.Hour)}, fixedIDs{}, auditLog)
+			svc.SetSourceStore(sources)
+			input := CreateInput{TenantID: "tenant-a", Name: "Re-test", CreatedBy: "retest-creator", RequiresExplicitExecutionAuthorization: true}
+			child, reused, err := svc.CreateFromReusedSource(ctx, input, parent.ID, original.VersionID)
+			if auditFails {
+				if err == nil {
+					t.Fatal("unaudited source reuse succeeded")
+				}
+				if _, err := repo.GetByID(ctx, "eng-1"); !errors.Is(err, shared.ErrNotFound) {
+					t.Fatalf("child survived rollback: %v", err)
+				}
+				if _, err := sources.Get(ctx, "tenant-a", "eng-1"); !errors.Is(err, shared.ErrNotFound) {
+					t.Fatalf("child source survived rollback: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if reused.EngagementID != child.ID || reused.VersionID.IsZero() || reused.VersionID == original.VersionID || reused.ReusedFromVersionID != original.VersionID || reused.SHA256 != original.SHA256 || reused.CreatedBy != original.CreatedBy || !reused.CreatedAt.Equal(original.CreatedAt) || reused.AssociatedBy != input.CreatedBy || !reused.AssociatedAt.Equal(now.Add(time.Hour)) {
+					t.Fatalf("reuse lost ownership or attribution: original=%+v reused=%+v", original, reused)
+				}
+				if len(child.Scope.InScope) != 1 || child.Scope.InScope[0].Value != original.Target() || child.AllowsExecution() || !child.RequiresExplicitExecutionAuthorization || !audit.has("engagement.source_reused") {
+					t.Fatalf("reuse lost scope/audit or inherited execution authorization: %+v", child)
+				}
+			}
+			retained, err := sources.Get(ctx, "tenant-a", parent.ID)
+			if err != nil || retained.VersionID != original.VersionID || retained.SHA256 != original.SHA256 {
+				t.Fatalf("reuse changed predecessor: %+v err=%v", retained, err)
+			}
+		})
+	}
+}
+
+func TestCreateFromReusedSourceRejectsForeignPredecessorAndStaleVersion(t *testing.T) {
+	ctx := context.Background()
+	now := time.Date(2026, 9, 9, 0, 0, 0, 0, time.UTC)
+	repo := newMemRepo()
+	parent, err := domain.New("parent", "tenant-a", "Original", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Create(ctx, parent); err != nil {
+		t.Fatal(err)
+	}
+	sources := sourceupload.NewStore(blob.NewMemory(), 0)
+	digest := sha256.Sum256([]byte("archive"))
+	if _, err := sources.Save(ctx, "tenant-a", parent.ID, "original.zip", "uploader", now, 7, hex.EncodeToString(digest[:]), bytes.NewBufferString("archive")); err != nil {
+		t.Fatal(err)
+	}
+	svc := NewService(repo, fixedClock{now}, fixedIDs{}, &capAudit{})
+	svc.SetSourceStore(sources)
+	for _, test := range []struct {
+		tenant, version shared.ID
+		want            error
+	}{
+		{"other-tenant", "", shared.ErrNotFound}, {"tenant-a", "stale-version", shared.ErrConflict},
+	} {
+		if _, _, err := svc.CreateFromReusedSource(ctx, CreateInput{TenantID: test.tenant, Name: "Denied", CreatedBy: "actor"}, parent.ID, test.version); !errors.Is(err, test.want) {
+			t.Fatalf("reuse error=%v want=%v", err, test.want)
+		}
+		if _, err := repo.GetByID(ctx, "eng-1"); !errors.Is(err, shared.ErrNotFound) {
+			t.Fatalf("invalid reuse created child: %v", err)
+		}
 	}
 }
 
@@ -269,6 +437,7 @@ func TestEngagementMutationsAndGatePickup(t *testing.T) {
 	}
 
 	// Lifecycle: draft -> active -> completed; completed blocks execution.
+	svc.SetCompletionSnapshotReader(finalizedSnapshotReader{})
 	if _, err := svc.Transition(ctx, "operator", "", id, domain.StatusActive); err != nil {
 		t.Fatalf("activate: %v", err)
 	}
@@ -288,6 +457,37 @@ func TestEngagementMutationsAndGatePickup(t *testing.T) {
 	}
 	if _, err := svc.UpdateScope(ctx, "  ", "", id, nil, nil); !errors.Is(err, shared.ErrValidation) {
 		t.Errorf("empty actor should be ErrValidation, got %v", err)
+	}
+}
+
+func TestCompletionRequiresDefaultFinalizedSnapshot(t *testing.T) {
+	repo := newMemRepo()
+	svc := NewService(repo, fixedClock{time.Now().UTC()}, fixedIDs{}, &capAudit{})
+	item, err := svc.Create(context.Background(), CreateInput{Name: "Assessment", CreatedBy: "operator"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Transition(context.Background(), "operator", "", item.ID, domain.StatusActive); err != nil {
+		t.Fatal(err)
+	}
+	svc.SetCompletionSnapshotPolicy(nil, func(string) bool { return true })
+	if _, err := svc.Transition(context.Background(), "operator", "", item.ID, domain.StatusCompleted); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("completion without default snapshot=%v", err)
+	}
+}
+
+func TestCompletionSnapshotPolicyDefaultsToLegacyCompatible(t *testing.T) {
+	repo := newMemRepo()
+	svc := NewService(repo, fixedClock{time.Now().UTC()}, fixedIDs{}, &capAudit{})
+	item, err := svc.Create(context.Background(), CreateInput{Name: "Legacy Assessment", CreatedBy: "operator"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Transition(context.Background(), "operator", "", item.ID, domain.StatusActive); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.Transition(context.Background(), "operator", "", item.ID, domain.StatusCompleted); err != nil {
+		t.Fatalf("default-off completion must preserve legacy behavior: %v", err)
 	}
 }
 


### PR DESCRIPTION
Allow a retest to reuse an exact predecessor source version or retain a new uploaded source without overwriting history. Persist tenant-owned source metadata, object attribution and immutable job/run bindings.

Phase 6/10. Base: `codex/868-phase-06-comparison`. Keep #868 as tracking/reference only; do not merge it.

## Review follow-up: migration 0145 collision

Addressed the new review on #884 and the dependent holds on #885–#893. Main `9a7bae2d` includes #921's `0145_advisory_alias_index.sql`; the entire unmerged assessment block moves from 0145–0159 to **0146–0160**. #884 adds only 0146; #885 adds 0147–0160. All 15 assessment SQL bodies and their relative order are preserved. Existing main migrations (including 0145), core ScanRun and governed response/correlation code remain unchanged.

Updated migration test filenames and embedded-file references, Goose UpTo/DownTo targets, upgrade fixtures from main version 0145, diagnostics, and operational documentation. The complete payload is preserved through an explicit old/new filename map; runtime assessment code is unchanged by renumbering. Each PR still contains one capability commit against its immediate predecessor.

## Validation

Local validation after this update: all 10 phases passed scoped tests and repository-wide Go builds; the final stack passed repository-wide Go tests and vet. Isolated PostgreSQL 17 tests passed for duplicate migration inventory, authoritative main migrations, assessment upgrade/rollback paths, tenant isolation, immutable evidence and source bindings. Frontend typecheck, 116 test files / 694 tests, production build and lint passed (0 errors, 10 existing warnings); Helm lint/render assertions passed. CI is disabled, so these are explicitly local results. Final GitHub heads, bases and incremental file diffs are checked against the tested commits.

## Stack merge order

#884 → #885 → #886 → #887 → #888 → #889 → #890 → #891 → #892 → #893

Merge #884 first, then proceed in order. Prefer merge commits to retain ancestry; after each predecessor merges, retarget the next PR to `main` and inspect its remaining diff. Branch names remain stable. See the [preservation and migration audit](https://github.com/KKloudTarus/synapse-ce/blob/codex/868-phase-11-operations-docs/docs/architecture/assessment-stack-868-audit.md).
