### PR TITLE
feat(assessment): [8/10] wire lifecycle APIs and scan workers

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -25,31 +25,38 @@ security:
 - bearerAuth: []
 
 tags:
-- name: users
-  description: Operator identities, roles, and API-key lifecycle
-- name: platform
-  description: Deployment-wide configuration a client needs before it renders navigation
-- name: health
-- name: aup
-- name: engagements
-- name: findings
-- name: sca
-- name: export
-- name: projects
-  description: Long-lived code-quality Projects and immutable analysis read models
-- name: rules
-  description: Built-in code-quality and security rule catalog
-- name: assets
-  description: Business-level Asset Management and security posture
-- name: dashboard
-  description: Tenant-scoped security operations summaries
-- name: vulnerability-intelligence
-  description: Tenant-scoped vulnerability feeds, exposure correlation, risk transitions, and durable operations
-- name: remediation-sla
-  description: Risk-based remediation deadlines, immutable assessments, policy versions, and human-owned lifecycle governance
-- name: fleet
-  description: Agent-plane fleet telemetry transport
-
+  - name: users
+    description: Operator identities, roles, and API-key lifecycle
+  - name: platform
+    description: Deployment-wide configuration a client needs before it renders navigation
+  - name: health
+  - name: aup
+  - name: engagements
+  - name: assessment-cycles
+    description: Tenant-scoped initial Assessment and Re-test lifecycle Cycles
+  - name: assessment-snapshots
+    description: Immutable coverage snapshots finalized from trusted Scan Runs
+  - name: assessment-relationships
+    description: Human-reviewed historical Assessment relationship candidates and blocked repair plans
+  - name: assessment-comparisons
+    description: Immutable ancestry-aware Snapshot comparisons and append-only match review
+  - name: findings
+  - name: sca
+  - name: export
+  - name: projects
+    description: Long-lived code-quality Projects and immutable analysis read models
+  - name: rules
+    description: Built-in code-quality and security rule catalog
+  - name: assets
+    description: Business-level Asset Management and security posture
+  - name: dashboard
+    description: Tenant-scoped security operations summaries
+  - name: vulnerability-intelligence
+    description: Tenant-scoped vulnerability feeds, exposure correlation, risk transitions, and durable operations
+  - name: remediation-sla
+    description: Risk-based remediation deadlines, immutable assessments, policy versions, and human-owned lifecycle governance
+  - name: fleet
+    description: Agent-plane fleet telemetry transport
 paths:
   /healthz:
     get:
@@ -156,7 +163,13 @@ paths:
         "403": {$ref: "#/components/responses/Forbidden"}
     post:
       tags: [engagements]
-      summary: Create an engagement
+      summary: Create an initial Assessment and Assessment Cycle
+      parameters:
+      - name: Idempotency-Key
+        in: header
+        required: false
+        description: Optional client key. When omitted, the server derives a stable key from the canonical create request for safe retries.
+        schema: {type: string, minLength: 1, maxLength: 128}
       requestBody:
         required: true
         content:
@@ -183,7 +196,7 @@ paths:
         "400": {$ref: "#/components/responses/BadRequest"}
         "401": {$ref: "#/components/responses/Unauthorized"}
         "403": {$ref: "#/components/responses/Forbidden"}
-        "409": {description: Engagement already has a different uploaded source package}
+        "409": {description: Idempotency body mismatch or source-package conflict}
         "413": {description: Uploaded source package exceeds 512 MiB}
 
   /api/v1/engagements/{id}:
@@ -3869,6 +3882,765 @@ paths:
         "403": {$ref: "#/components/responses/Forbidden"}
         "404": {$ref: "#/components/responses/NotFound"}
 
+  /api/v1/engagements/{assessmentId}/retests:
+    parameters:
+    - name: assessmentId
+      in: path
+      required: true
+      schema: {type: string}
+    post:
+      tags: [engagements, assessment-cycles]
+      operationId: createAssessmentRetest
+      summary: Create an Assessment Re-test with separate execution authorization
+      description: |
+        Requires a completed predecessor in an open Cycle. Omit execution authorization
+        to save a non-executable draft; planned_date never grants authorization.
+        For an uploaded-source predecessor, choose reuse_current to create a child-owned
+        association to its immutable archive, or upload_new with a new archive via multipart.
+        When source_strategy is omitted, a file selects upload_new; without a file, copied
+        uploaded-source scope selects reuse_current. Non-uploaded scopes are unchanged.
+        source_version_id, when provided, must match the selected predecessor's immutable
+        source version. Source selection cannot be combined with empty scope.
+        Idempotency binds the source strategy/version and uploaded filename, size, and SHA-256.
+      parameters:
+      - name: Idempotency-Key
+        in: header
+        required: true
+        schema: {type: string, minLength: 1, maxLength: 128}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: "#/components/schemas/CreateAssessmentRetestRequest"}
+          multipart/form-data:
+            schema:
+              type: object
+              required: [metadata, source]
+              properties:
+                metadata:
+                  type: string
+                  description: JSON-encoded CreateAssessmentRetestRequest; at most 1 MiB.
+                source:
+                  type: string
+                  format: binary
+                  description: Non-empty ZIP, TAR, TAR.GZ, or TGZ archive; at most 512 MiB.
+      responses:
+        "201":
+          description: Re-test created
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/CreateAssessmentRetestResponse"}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Idempotency mismatch, completed Cycle, or concurrent conflict}
+
+  /api/v1/engagements/{assessmentId}/lifecycle:
+    parameters:
+    - name: assessmentId
+      in: path
+      required: true
+      schema: {type: string}
+    get:
+      tags: [engagements, assessment-cycles]
+      operationId: getAssessmentLifecycle
+      summary: Get the Assessment lifecycle containing an Assessment
+      responses:
+        "200":
+          description: Assessment lifecycle
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/AssessmentLifecycle"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/engagements/{assessmentId}/snapshots/finalize:
+    parameters:
+    - name: assessmentId
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
+    post:
+      tags: [assessment-snapshots]
+      operationId: finalizeAssessmentSnapshot
+      summary: Finalize an immutable Assessment Snapshot
+      parameters:
+      - name: Idempotency-Key
+        in: header
+        required: true
+        schema: {type: string, minLength: 1, maxLength: 128}
+      - name: If-Match
+        in: header
+        required: true
+        description: Current default Snapshot version; use 0 when no default Snapshot exists.
+        schema: {type: string, pattern: '^(W/)?"?[0-9]+"?$'}
+        example: '"0"'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: "#/components/schemas/FinalizeAssessmentSnapshotRequest"}
+            example:
+              selected_runs:
+              - run_id: scan-run-01
+                lane_keys: [sca, sast]
+      responses:
+        "201":
+          description: Finalized Snapshot or retained idempotent response
+          headers:
+            ETag:
+              description: Default Snapshot version accepted by the next If-Match request.
+              schema: {type: string}
+            Idempotency-Replayed:
+              description: Present and true when the retained response was replayed.
+              schema: {type: string, enum: ['true']}
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/FinalizeAssessmentSnapshotResponse"}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Idempotency body mismatch, stale default version, or concurrent conflict}
+        "413": {description: Request body exceeds 64 KiB}
+        "428": {description: If-Match is required}
+
+  /api/v1/engagements/{assessmentId}/snapshots:
+    parameters:
+    - name: assessmentId
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
+    get:
+      tags: [assessment-snapshots]
+      operationId: listAssessmentSnapshots
+      summary: List immutable Snapshots for one Assessment
+      parameters:
+      - {name: cursor, in: query, schema: {type: string, maxLength: 128}}
+      - {name: limit, in: query, schema: {type: integer, minimum: 1, maximum: 100, default: 50}}
+      responses:
+        "200":
+          description: Snapshot history and current default pointer
+          headers:
+            ETag:
+              description: Current default Snapshot version, or 0 when none exists.
+              schema: {type: string}
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/AssessmentSnapshotListResponse"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/assessment-snapshots/{snapshotId}:
+    parameters:
+    - name: snapshotId
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
+    get:
+      tags: [assessment-snapshots]
+      operationId: getAssessmentSnapshot
+      summary: Get one immutable tenant-scoped Assessment Snapshot
+      responses:
+        "200":
+          description: Immutable Assessment Snapshot
+          headers:
+            ETag:
+              description: SHA-256 content-hash entity tag.
+              schema: {type: string}
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/AssessmentSnapshot"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/assessment-cycles:
+    get:
+      tags: [assessment-cycles]
+      operationId: listAssessmentCycles
+      summary: List tenant-scoped Assessment Cycles
+      parameters:
+      - {name: status, in: query, schema: {type: string, enum: [open, completed, archived]}}
+      - {name: boundary_kind, in: query, schema: {type: string, enum: [standalone, asset, project, asset_project]}}
+      - {name: assessment_status, in: query, description: Selected-head Assessment status., schema: {type: string, enum: [draft, active, completed, archived]}}
+      - {name: selected_head_assessment_id, in: query, schema: {type: string, maxLength: 256}}
+      - {name: assessment_type, in: query, description: Require at least one member of this type., schema: {type: string, enum: [initial, retest]}}
+      - {name: producer, in: query, description: Require a matching item in the authoritative root-to-selected/final lifecycle Comparison., schema: {type: string, maxLength: 256}}
+      - {name: finding_kind, in: query, schema: {type: string, maxLength: 256}}
+      - {name: review_state, in: query, schema: {type: string, enum: [needs_review, verified, clear]}}
+      - {name: change_presence, in: query, schema: {type: string, enum: [new, reopened]}}
+      - {name: change_severity, in: query, schema: {type: string, enum: [critical, high]}}
+      - {name: scan_staleness, in: query, description: Fresh means a sealed native succeeded/partial selected-head scan within 24 hours., schema: {type: string, enum: [fresh, stale, missing]}}
+      - {name: q, in: query, description: Bounded literal search across Cycle name/ID, root ID, and selected-head ID., schema: {type: string, maxLength: 256}}
+      - {name: cursor, in: query, schema: {type: string, maxLength: 512}}
+      - {name: limit, in: query, schema: {type: integer, minimum: 1, maximum: 100, default: 50}}
+      responses:
+        "200":
+          description: Stable descending page ordered by updated_at and cycle_id
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/AssessmentCyclePage"}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+
+  /api/v1/assessment-cycles/{cycleId}:
+    parameters:
+    - name: cycleId
+      in: path
+      required: true
+      schema: {type: string}
+    get:
+      tags: [assessment-cycles]
+      operationId: getAssessmentCycle
+      summary: Get an Assessment Cycle and immutable member projection IDs
+      responses:
+        "200": {description: Assessment Cycle detail, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentCycleDetail"}}}}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/assessment-cycles/{cycleId}/members:
+    parameters:
+    - name: cycleId
+      in: path
+      required: true
+      schema: {type: string}
+    get:
+      tags: [assessment-cycles]
+      operationId: listAssessmentCycleMembers
+      summary: Continue the deterministic member page for one Assessment Cycle
+      parameters:
+      - {name: cursor, in: query, schema: {type: string, maxLength: 684}}
+      - {name: limit, in: query, schema: {type: integer, minimum: 1, maximum: 100, default: 25}}
+      responses:
+        "200": {description: Root-first member page, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentCycleMemberPage"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/assessment-cycles/{cycleId}/archive:
+    parameters:
+    - name: cycleId
+      in: path
+      required: true
+      schema: {type: string}
+    post:
+      tags: [assessment-cycles]
+      operationId: archiveAssessmentCycle
+      summary: Archive an Assessment Cycle with optimistic concurrency
+      parameters:
+      - name: Idempotency-Key
+        in: header
+        required: true
+        schema: {type: string, minLength: 1, maxLength: 128}
+      - name: If-Match
+        in: header
+        required: true
+        description: Current Cycle version, optionally quoted as an ETag.
+        schema: {type: string, pattern: '^(W/)?"?[1-9][0-9]*"?$'}
+      responses:
+        "200": {description: Archived Assessment Cycle, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentCycleDetail"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Idempotency body mismatch or Cycle version conflict}
+        "428": {description: If-Match is missing or invalid}
+
+  /api/v1/assessment-cycles/{cycleId}/reopen:
+    parameters:
+    - name: cycleId
+      in: path
+      required: true
+      schema: {type: string}
+    post:
+      tags: [assessment-cycles]
+      operationId: reopenAssessmentCycle
+      summary: Reopen a completed Assessment Cycle with an audited reason
+      parameters:
+      - name: Idempotency-Key
+        in: header
+        required: true
+        schema: {type: string, minLength: 1, maxLength: 128}
+      - name: If-Match
+        in: header
+        required: true
+        description: Current Cycle version, optionally quoted as an ETag.
+        schema: {type: string, pattern: '^(W/)?"?[1-9][0-9]*"?$'}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [reason]
+              properties:
+                reason: {type: string, minLength: 1, maxLength: 1024}
+      responses:
+        "200": {description: Reopened Assessment Cycle, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentCycleDetail"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Idempotency body mismatch or Cycle version conflict}
+        "428": {description: If-Match is missing or invalid}
+
+  /api/v1/assessment-comparisons:
+    post:
+      tags: [assessment-comparisons]
+      operationId: createAssessmentComparison
+      summary: Queue or replay an immutable Assessment Snapshot comparison
+      parameters:
+      - name: Idempotency-Key
+        in: header
+        required: true
+        schema: {type: string, minLength: 1, maxLength: 128}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: "#/components/schemas/CreateAssessmentComparisonRequest"}
+      responses:
+        "200": {description: Existing identical comparison, content: {application/json: {schema: {$ref: "#/components/schemas/CreateAssessmentComparisonResponse"}}}}
+        "202": {description: Comparison queued for durable generation, content: {application/json: {schema: {$ref: "#/components/schemas/CreateAssessmentComparisonResponse"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Idempotency body mismatch or concurrent request}
+        "413": {description: Request body exceeds 16 KiB}
+        "422": {description: Snapshot pair is invalid for the requested lifecycle or neutral mode}
+
+  /api/v1/assessment-comparisons/{comparisonId}:
+    parameters:
+    - {$ref: "#/components/parameters/AssessmentComparisonId"}
+    get:
+      tags: [assessment-comparisons]
+      operationId: getAssessmentComparison
+      summary: Get immutable comparison metadata and summary
+      responses:
+        "200":
+          description: Comparison metadata without loading item pages
+          headers:
+            ETag: {description: Comparison review projection version, schema: {type: string}}
+          content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentComparison"}}}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/assessment-comparisons/{comparisonId}/summary:
+    parameters:
+    - {$ref: "#/components/parameters/AssessmentComparisonId"}
+    get:
+      tags: [assessment-comparisons]
+      operationId: getAssessmentComparisonSummary
+      summary: Summarize an immutable comparison for a finding scope
+      parameters:
+      - name: scope
+        in: query
+        required: true
+        description: Scope used consistently by the summary and item explorer
+        schema: {type: string, enum: [vulnerability, security, all]}
+      responses:
+        "200": {description: Scope-specific before and after metrics, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentComparisonSummary"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Comparison is not complete enough to summarize}
+
+  /api/v1/assessment-comparisons/{comparisonId}/items:
+    parameters:
+    - {$ref: "#/components/parameters/AssessmentComparisonId"}
+    get:
+      tags: [assessment-comparisons]
+      operationId: listAssessmentComparisonItems
+      summary: Page immutable comparison items using a stable cursor
+      parameters:
+      - {name: cursor, in: query, schema: {type: string, maxLength: 128}}
+      - {name: limit, in: query, schema: {type: integer, minimum: 1, maximum: 200, default: 100}}
+      - {name: presence, in: query, schema: {type: string, enum: [new, still_detected, not_detected_under_comparable_coverage, not_evaluated, reopened, needs_review, only_in_a, both, only_in_b]}}
+      - {name: change_flag, in: query, schema: {$ref: "#/components/schemas/AssessmentComparisonChangeFlag"}}
+      - {name: severity, in: query, schema: {type: string, enum: [unknown, info, low, medium, high, critical]}}
+      - {name: producer, in: query, schema: {type: string, maxLength: 256}}
+      - {name: finding_kind, in: query, schema: {type: string, maxLength: 256}}
+      - {name: disposition, in: query, schema: {type: string, enum: [current_actionable, baseline_only, non_actionable]}}
+      - {name: review_state, in: query, schema: {type: string, enum: [needs_review, verified, clear]}}
+      - {name: scope, in: query, schema: {type: string, enum: [vulnerability, security, all], default: all}}
+      responses:
+        "200": {description: Stable item page, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentComparisonItemPage"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/assessment-comparisons/{comparisonId}/items/{itemId}/confirm:
+    parameters:
+    - {$ref: "#/components/parameters/AssessmentComparisonId"}
+    - {$ref: "#/components/parameters/AssessmentComparisonItemId"}
+    post:
+      tags: [assessment-comparisons]
+      operationId: confirmAssessmentComparisonItem
+      summary: Confirm a lineage match and queue a replacement comparison
+      parameters:
+      - {$ref: "#/components/parameters/AssessmentComparisonIfMatch"}
+      - {$ref: "#/components/parameters/IdempotencyKey"}
+      requestBody: {required: true, content: {application/json: {schema: {$ref: "#/components/schemas/ReviewAssessmentComparisonItemRequest"}}}}
+      responses:
+        "200": {description: Retained or already materialized replacement, content: {application/json: {schema: {$ref: "#/components/schemas/ReviewAssessmentComparisonItemResponse"}}}}
+        "202": {description: Replacement queued, content: {application/json: {schema: {$ref: "#/components/schemas/ReviewAssessmentComparisonItemResponse"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Stale review projection, candidate conflict, or idempotency mismatch}
+        "413": {description: Request body exceeds 16 KiB}
+        "428": {description: If-Match is required}
+
+  /api/v1/assessment-comparisons/{comparisonId}/items/{itemId}/unlink:
+    parameters:
+    - {$ref: "#/components/parameters/AssessmentComparisonId"}
+    - {$ref: "#/components/parameters/AssessmentComparisonItemId"}
+    post:
+      tags: [assessment-comparisons]
+      operationId: unlinkAssessmentComparisonItem
+      summary: Unlink a lineage match and queue a replacement comparison
+      parameters:
+      - {$ref: "#/components/parameters/AssessmentComparisonIfMatch"}
+      - {$ref: "#/components/parameters/IdempotencyKey"}
+      requestBody: {required: true, content: {application/json: {schema: {$ref: "#/components/schemas/ReviewAssessmentComparisonItemRequest"}}}}
+      responses:
+        "200": {description: Retained or already materialized replacement, content: {application/json: {schema: {$ref: "#/components/schemas/ReviewAssessmentComparisonItemResponse"}}}}
+        "202": {description: Replacement queued, content: {application/json: {schema: {$ref: "#/components/schemas/ReviewAssessmentComparisonItemResponse"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Stale review projection, candidate conflict, or idempotency mismatch}
+        "413": {description: Request body exceeds 16 KiB}
+        "428": {description: If-Match is required}
+
+  /api/v1/assessment-cycles/{cycleId}/relationship-previews:
+    parameters:
+    - name: cycleId
+      in: path
+      required: true
+      schema: {type: string}
+    post:
+      tags: [assessment-cycles]
+      operationId: previewAssessmentRelationshipChange
+      summary: Preview a supported same-Cycle relationship correction
+      requestBody: {required: true, content: {application/json: {schema: {$ref: "#/components/schemas/PreviewAssessmentRelationshipChangeRequest"}}}}
+      responses:
+        "200": {description: Server-authoritative impact and short-lived signed preview, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentRelationshipPreview"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/assessment-cycles/{cycleId}/relationship-commits:
+    parameters:
+    - name: cycleId
+      in: path
+      required: true
+      schema: {type: string}
+    post:
+      tags: [assessment-cycles]
+      operationId: commitAssessmentRelationshipChange
+      summary: Commit an unchanged signed relationship preview
+      parameters:
+      - {$ref: "#/components/parameters/IdempotencyKey"}
+      - name: If-Match
+        in: header
+        required: true
+        description: Cycle version bound into the preview token.
+        schema: {type: string, pattern: '^(W/)?"?[1-9][0-9]*"?$'}
+      requestBody: {required: true, content: {application/json: {schema: {$ref: "#/components/schemas/CommitAssessmentRelationshipChangeRequest"}}}}
+      responses:
+        "200": {description: Relationship committed and affected comparisons replaced, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentRelationshipCommitResponse"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Preview expired, stale, reused, locked, or idempotency body mismatch}
+        "428": {description: If-Match is missing or invalid}
+
+  /api/v1/assessment-cycles/{cycleId}/closure-previews:
+    parameters:
+    - {$ref: "#/components/parameters/AssessmentCycleId"}
+    post:
+      tags: [assessment-cycles]
+      operationId: previewAssessmentCycleClosure
+      summary: Evaluate the conservative closure policy and create a signed preview
+      description: The preview binds the actor, Cycle version, immutable Snapshot and Comparison references, policy result, exact override IDs, and expiry. A blocked preview is returned with no preview token.
+      requestBody: {required: true, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentClosurePreviewRequest"}}}}
+      responses:
+        "200": {description: Server-authoritative closure policy result, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentClosurePreview"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Cycle state cannot be previewed for closure}
+        "413": {description: Request body exceeds 1 MiB}
+
+  /api/v1/assessment-cycles/{cycleId}/closure-commits:
+    parameters:
+    - {$ref: "#/components/parameters/AssessmentCycleId"}
+    post:
+      tags: [assessment-cycles]
+      operationId: commitAssessmentCycleClosure
+      summary: Atomically close a Cycle from an unchanged signed preview
+      parameters:
+      - {$ref: "#/components/parameters/IdempotencyKey"}
+      - {$ref: "#/components/parameters/AssessmentCycleIfMatch"}
+      requestBody: {required: true, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentClosureCommitRequest"}}}}
+      responses:
+        "201": {description: Cycle closed, immutable manifest sealed, and deterministic report job enqueued, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentClosureCommitResponse"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Preview expired, stale, reused, blocked, Cycle version conflict, or idempotency body mismatch}
+        "413": {description: Request body exceeds 1 MiB}
+        "428": {description: If-Match is missing or invalid}
+
+  /api/v1/assessment-cycles/{cycleId}/reopen-previews:
+    parameters:
+    - {$ref: "#/components/parameters/AssessmentCycleId"}
+    post:
+      tags: [assessment-cycles]
+      operationId: previewAssessmentCycleReopen
+      summary: Preview reopening a completed Cycle without mutating its active manifest
+      requestBody: {required: true, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentReopenPreviewRequest"}}}}
+      responses:
+        "200": {description: Signed reopen preview and immutable-manifest impact, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentReopenPreview"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Cycle is not completed or its active manifest binding is stale}
+        "413": {description: Request body exceeds 1 MiB}
+
+  /api/v1/assessment-cycles/{cycleId}/reopen-commits:
+    parameters:
+    - {$ref: "#/components/parameters/AssessmentCycleId"}
+    post:
+      tags: [assessment-cycles]
+      operationId: commitAssessmentCycleReopen
+      summary: Atomically supersede the active manifest and reopen the Cycle
+      parameters:
+      - {$ref: "#/components/parameters/IdempotencyKey"}
+      - {$ref: "#/components/parameters/AssessmentCycleIfMatch"}
+      requestBody: {required: true, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentReopenCommitRequest"}}}}
+      responses:
+        "200": {description: Cycle reopened and prior manifest superseded immutably, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentReopenCommitResponse"}}}}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Preview expired, stale, reused, Cycle version conflict, or idempotency body mismatch}
+        "413": {description: Request body exceeds 1 MiB}
+        "428": {description: If-Match is missing or invalid}
+
+  /api/v1/assessment-cycles/{cycleId}/closure-manifests:
+    parameters:
+    - {$ref: "#/components/parameters/AssessmentCycleId"}
+    get:
+      tags: [assessment-cycles]
+      operationId: listAssessmentClosureManifests
+      summary: List immutable closure manifest history for one Cycle
+      responses:
+        "200": {description: Active and superseded manifests, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentClosureManifestList"}}}}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/assessment-cycles/{cycleId}/closure-manifests/{manifestId}:
+    parameters:
+    - {$ref: "#/components/parameters/AssessmentCycleId"}
+    - {$ref: "#/components/parameters/AssessmentClosureManifestId"}
+    get:
+      tags: [assessment-cycles]
+      operationId: getAssessmentClosureManifest
+      summary: Get one immutable closure manifest
+      responses:
+        "200": {description: Closure manifest, content: {application/json: {schema: {$ref: "#/components/schemas/AssessmentClosureManifest"}}}}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/assessment-cycles/{cycleId}/closure-manifests/{manifestId}/report:
+    parameters:
+    - {$ref: "#/components/parameters/AssessmentCycleId"}
+    - {$ref: "#/components/parameters/AssessmentClosureManifestId"}
+    get:
+      tags: [assessment-cycles]
+      operationId: downloadAssessmentClosureReport
+      summary: Download the deterministic immutable report for one closure manifest
+      description: The renderer reads only the manifest and its immutable Snapshot and Comparison references. Missing or tampered references fail closed.
+      parameters:
+      - name: If-None-Match
+        in: header
+        schema: {type: string, pattern: '^"sha256:[0-9a-f]{64}"$'}
+      responses:
+        "200":
+          description: Byte-stable JSON report for the manifest renderer contract version
+          headers:
+            ETag: {description: SHA-256 of the immutable report artifact, schema: {type: string}}
+            Content-Disposition: {description: Safe fixed attachment filename, schema: {type: string}}
+            Cache-Control: {description: Private immutable cache policy, schema: {type: string}}
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/AssessmentClosureReportDocument"}
+        "304": {description: Client already has the immutable artifact identified by ETag}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Referenced immutable artifact is missing or fails integrity validation}
+
+  /api/v1/assessment-relationship-candidates/generate:
+    post:
+      tags: [assessment-relationships]
+      operationId: generateAssessmentRelationshipCandidate
+      summary: Generate an immutable historical relationship candidate
+      description: Requires review permission. Exact frozen boundary alone is insufficient; the server also requires a hash-only imported reference, compatible trusted manifests, or strong deterministic Finding overlap.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: "#/components/schemas/GenerateAssessmentRelationshipCandidateRequest"}
+      responses:
+        "201":
+          description: Candidate artifact created
+          headers:
+            ETag: {description: Candidate review version, schema: {type: string}}
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/AssessmentRelationshipCandidate"}
+        "200":
+          description: Identical candidate artifact already exists
+          headers:
+            ETag: {description: Candidate review version, schema: {type: string}}
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/AssessmentRelationshipCandidate"}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Concurrent candidate conflict}
+        "413": {description: Request body exceeds 16 KiB}
+
+  /api/v1/assessment-relationship-candidates:
+    get:
+      tags: [assessment-relationships]
+      operationId: listAssessmentRelationshipCandidates
+      summary: List the tenant-scoped relationship review queue
+      parameters:
+      - name: status
+        in: query
+        schema: {type: string, enum: [all, open, confirmed, rejected, dismissed, expired], default: open}
+      - name: limit
+        in: query
+        schema: {type: integer, minimum: 1, maximum: 200, default: 50}
+      responses:
+        "200":
+          description: Relationship candidate review queue
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/AssessmentRelationshipCandidateList"}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+
+  /api/v1/assessment-relationship-candidates/{candidateId}:
+    parameters:
+    - name: candidateId
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
+    get:
+      tags: [assessment-relationships]
+      operationId: getAssessmentRelationshipCandidate
+      summary: Get one historical relationship candidate and its terminal decision
+      responses:
+        "200":
+          description: Relationship candidate
+          headers:
+            ETag: {description: Candidate review version, schema: {type: string}}
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/AssessmentRelationshipCandidate"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
+  /api/v1/assessment-relationship-candidates/{candidateId}/decisions:
+    parameters:
+    - name: candidateId
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
+    post:
+      tags: [assessment-relationships]
+      operationId: decideAssessmentRelationshipCandidate
+      summary: Confirm, reject, or dismiss a relationship candidate
+      description: Confirmation seals only a deterministic blocked repair plan. This endpoint never moves or merges Cycle members.
+      parameters:
+      - name: If-Match
+        in: header
+        required: true
+        schema: {type: string, pattern: '^(W/)?"?1"?$'}
+      - name: Idempotency-Key
+        in: header
+        required: true
+        schema: {type: string, minLength: 1, maxLength: 128}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: "#/components/schemas/AssessmentRelationshipDecisionRequest"}
+      responses:
+        "200":
+          description: Terminal decision recorded
+          headers:
+            ETag: {description: Terminal candidate review version, schema: {type: string}}
+            Idempotency-Replayed: {description: Present and true when the exact decision was replayed, schema: {type: string, enum: ['true']}}
+          content:
+            application/json:
+              schema: {$ref: "#/components/schemas/AssessmentRelationshipCandidate"}
+        "400": {$ref: "#/components/responses/BadRequest"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+        "409": {description: Candidate expired, already decided, stale version, or idempotency body mismatch}
+        "413": {description: Request body exceeds 16 KiB}
+        "428": {description: If-Match is required}
+  /api/v1/engagements/{id}/scan-runs:
+    parameters:
+    - $ref: "#/components/parameters/EngagementId"
+    get:
+      tags: [engagements, sca]
+      summary: List immutable scan history with the source version used by each run
+      responses:
+        "200":
+          description: Runs with native or legacy provenance; source metadata is omitted when historically unavailable.
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {$ref: "#/components/schemas/ScanRunHistory"}
+        "401": {$ref: "#/components/responses/Unauthorized"}
+        "403": {$ref: "#/components/responses/Forbidden"}
+        "404": {$ref: "#/components/responses/NotFound"}
+
 components:
   securitySchemes:
     bearerAuth:
@@ -4013,6 +4785,49 @@ components:
       schema: {type: string}
       description: Stable tie-breaker; must be supplied together with `before_time`
 
+    IdempotencyKey:
+      name: Idempotency-Key
+      in: header
+      required: true
+      schema: {type: string, minLength: 1, maxLength: 128}
+
+    AssessmentCycleId:
+      name: cycleId
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
+
+    AssessmentClosureManifestId:
+      name: manifestId
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
+
+    AssessmentCycleIfMatch:
+      name: If-Match
+      in: header
+      required: true
+      description: Current Cycle version bound into the signed preview token, optionally quoted as an ETag.
+      schema: {type: string, pattern: '^(W/)?"?[1-9][0-9]*"?$'}
+
+    AssessmentComparisonId:
+      name: comparisonId
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
+
+    AssessmentComparisonItemId:
+      name: itemId
+      in: path
+      required: true
+      schema: {type: string, minLength: 1}
+
+    AssessmentComparisonIfMatch:
+      name: If-Match
+      in: header
+      required: true
+      description: Current comparison review projection version, optionally quoted as an ETag.
+      schema: {type: string, pattern: '^(W/)?"?[1-9][0-9]*"?$'}
   responses:
     BadRequest:
       description: Invalid request
@@ -6578,11 +7393,19 @@ components:
         authorized_to: {type: string, format: date-time}
         timezone: {type: string, description: IANA timezone name}
         asset_id: {type: string}
+        assessment_project_id:
+          type: string
+          description: Optional visible Project association, distinct from a hidden analysis context. Requires Cycle dual-write and freezes the exact Asset/Project boundary.
 
     UploadedSourcePackage:
       type: object
+      description: Immutable source association. Reuse retains original upload attribution; each assessment gets its own version. Storage keys and archive bytes are never returned.
       required: [filename, size, sha256, target, uploaded_by, uploaded_at]
       properties:
+        version_id: {type: string, description: Immutable source association ID; absent only for legacy metadata.}
+        reused_from_version_id: {type: string}
+        associated_by: {type: string}
+        associated_at: {type: string, format: date-time}
         filename: {type: string}
         size: {type: integer, format: int64, minimum: 1, maximum: 536870912}
         sha256: {type: string, pattern: '^[0-9a-f]{64}$'}
@@ -6620,6 +7443,9 @@ components:
         project_id:
           type: string
           description: Present when the engagement is the analysis context of a code-quality Project.
+        assessment_project_id:
+          type: string
+          description: Optional visible Assessment Project association; inherited unchanged by Re-tests in its Cycle.
         business_asset_id:
           type: string
           description: Present when a primary business-level Asset is assigned.
@@ -6670,6 +7496,7 @@ components:
             emergency_contact: {type: string}
             risk_ceiling: {type: string, enum: ["", low, medium, high, prohibited]}
             exclusions_checked: {type: boolean}
+        requires_explicit_execution_authorization: {type: boolean}
         created_at: {type: string, format: date-time}
         updated_at: {type: string, format: date-time}
 
@@ -6916,6 +7743,7 @@ components:
       required: [engagement_id]
       properties:
         engagement_id: {type: string}
+        source_version_id: {type: string, description: Optional expected source version for kind upload. A mismatch returns409; other target kinds reject this field.}
         target: {type: string, description: Path or git URL; must be empty for kind upload and may be empty when an imported SBOM is active.}
         kind:
           type: string
@@ -6935,6 +7763,8 @@ components:
         engagement_id: {type: string}
         target: {type: string}
         kind: {type: string}
+        source_package:
+          $ref: "#/components/schemas/ScanSourceBinding"
         status:
           type: string
           enum: [running, succeeded, failed]
@@ -7769,3 +8599,957 @@ components:
         - included_domains
         - node
         - children
+    AssessmentCycleMember:
+      type: object
+      required: [assessment_id, assessment_type, retest_number, relationship_version, created_at, created_by]
+      properties:
+        assessment_id: {type: string}
+        assessment_status: {type: string, enum: [draft, active, completed, archived]}
+        planned_date: {type: string, format: date, description: 'Optional planning date; never grants execution authorization.'}
+        assessment_type: {type: string, enum: [initial, retest]}
+        predecessor_assessment_id: {type: string}
+        retest_number: {type: integer, minimum: 0}
+        relationship_version: {type: integer, format: int64, minimum: 1}
+        created_at: {type: string, format: date-time}
+        created_by: {type: string}
+        archived_at: {type: [string, "null"], format: date-time}
+
+    AssessmentCycle:
+      type: object
+      required: [id, name, boundary_kind, status, root_assessment_id, selected_head_assessment_id, next_retest_number, version, created_at, updated_at, created_by, updated_by]
+      properties:
+        id: {type: string}
+        name: {type: string}
+        boundary_kind: {type: string, enum: [standalone, asset, project, asset_project]}
+        business_asset_id: {type: string}
+        project_id: {type: string}
+        status: {type: string, enum: [open, completed, archived]}
+        root_assessment_id: {type: string}
+        selected_head_assessment_id: {type: string}
+        active_closure_manifest_id: {type: string}
+        active_closure_cycle_version: {type: integer, format: int64, minimum: 1}
+        next_retest_number: {type: integer, minimum: 1}
+        version: {type: integer, format: int64, minimum: 1}
+        created_at: {type: string, format: date-time}
+        updated_at: {type: string, format: date-time}
+        created_by: {type: string}
+        updated_by: {type: string}
+
+    AssessmentCycleDetail:
+      type: object
+      required: [cycle, members, branch_heads]
+      properties:
+        cycle: {$ref: "#/components/schemas/AssessmentCycle"}
+        members:
+          type: array
+          items: {$ref: "#/components/schemas/AssessmentCycleMember"}
+        branch_heads:
+          type: array
+          items: {$ref: "#/components/schemas/AssessmentCycleMember"}
+
+    AssessmentLifecycle:
+      allOf:
+      - $ref: "#/components/schemas/AssessmentCycleDetail"
+      - type: object
+        required: [assessment_id]
+        properties:
+          assessment_id: {type: string}
+
+    AssessmentCycleSummary:
+      allOf:
+      - $ref: "#/components/schemas/AssessmentCycle"
+      - type: object
+        required: [member_count, active_branch_count, latest_retest_number, members, scan_staleness]
+        properties:
+          member_count: {type: integer, minimum: 0}
+          active_branch_count: {type: integer, minimum: 0}
+          latest_assessment_id: {type: string}
+          latest_retest_number: {type: integer, minimum: 0}
+          members: {type: array, maxItems: 10, items: {$ref: "#/components/schemas/AssessmentCycleMember"}}
+          members_next_cursor: {type: string}
+          root_snapshot_id: {type: string}
+          current_snapshot_id: {type: string}
+          comparison_id: {type: string}
+          comparison_status: {type: string, enum: [complete, needs_review]}
+          comparison_summary: {$ref: "#/components/schemas/AssessmentComparisonSummary"}
+          active_closure_manifest_id: {type: string}
+          selected_head_last_scan_at: {type: string, format: date-time}
+          scan_staleness: {type: string, enum: [fresh, stale, missing]}
+
+    AssessmentCycleMemberPage:
+      type: object
+      required: [items]
+      properties:
+        items: {type: array, maxItems: 100, items: {$ref: "#/components/schemas/AssessmentCycleMember"}}
+        next_cursor: {type: string}
+
+    AssessmentCycleMigrationPending:
+      type: object
+      required: [assessment_id, name, status, boundary_kind, updated_at]
+      properties:
+        assessment_id: {type: string}
+        name: {type: string}
+        status: {type: string, enum: [draft, active, completed, archived]}
+        boundary_kind: {type: string, enum: [standalone, asset]}
+        business_asset_id: {type: string}
+        updated_at: {type: string, format: date-time}
+
+    AssessmentCyclePage:
+      type: object
+      required: [items, migration_pending, migration_pending_total]
+      properties:
+        items:
+          type: array
+          maxItems: 100
+          items: {$ref: "#/components/schemas/AssessmentCycleSummary"}
+        next_cursor: {type: string}
+        migration_pending:
+          type: array
+          maxItems: 100
+          items: {$ref: "#/components/schemas/AssessmentCycleMigrationPending"}
+        migration_pending_total: {type: integer, minimum: 0}
+
+    AssessmentClosureBlocker:
+      type: object
+      required: [id, code, message, overrideable, overridden]
+      properties:
+        id: {type: string}
+        code: {type: string}
+        message: {type: string}
+        overrideable: {type: boolean}
+        overridden: {type: boolean}
+
+    AssessmentClosureWarning:
+      type: object
+      required: [code, message]
+      properties:
+        code: {type: string}
+        message: {type: string}
+
+    AssessmentClosureCoverageDecision:
+      type: object
+      required: [snapshot_id, dimension_id, state, reason_code, waived]
+      properties:
+        snapshot_id: {type: string}
+        dimension_id: {type: string}
+        state: {type: string, enum: [complete, partial, unknown]}
+        reason_code: {type: string}
+        waived: {type: boolean}
+
+    AssessmentClosureCoverageDecisions:
+      type: object
+      required: [initial, final]
+      properties:
+        initial:
+          type: array
+          items: {$ref: "#/components/schemas/AssessmentClosureCoverageDecision"}
+        final:
+          type: array
+          items: {$ref: "#/components/schemas/AssessmentClosureCoverageDecision"}
+
+    AssessmentClosurePathMember:
+      type: object
+      required: [path_position, assessment_id, assessment_type, retest_number, relationship_version]
+      properties:
+        path_position: {type: integer, minimum: 0}
+        assessment_id: {type: string}
+        assessment_type: {type: string, enum: [initial, retest]}
+        retest_number: {type: integer, minimum: 0}
+        relationship_version: {type: integer, format: int64, minimum: 1}
+        snapshot_id: {type: string}
+
+    AssessmentClosureReference:
+      type: object
+      required: [kind, id, version]
+      properties:
+        kind: {type: string}
+        id: {type: string}
+        version: {type: integer, format: int64, minimum: 1}
+        content_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        expires_at: {type: string, format: date-time}
+        metadata: {}
+
+    AssessmentClosureBranchState:
+      type: object
+      required: [assessment_id, relationship_version, archived]
+      properties:
+        assessment_id: {type: string}
+        relationship_version: {type: integer, format: int64, minimum: 1}
+        archived: {type: boolean}
+
+    AssessmentClosureScopeProfileChange:
+      type: object
+      required: [assessment_id, kind, summary]
+      properties:
+        assessment_id: {type: string}
+        kind: {type: string, enum: [scope, profile]}
+        summary: {type: string}
+
+    AssessmentClosurePolicyResult:
+      type: object
+      required: [policy_version, blockers, warnings, coverage_decisions, commit_allowed]
+      properties:
+        policy_version: {type: string}
+        blockers: {type: array, items: {$ref: "#/components/schemas/AssessmentClosureBlocker"}}
+        warnings: {type: array, items: {$ref: "#/components/schemas/AssessmentClosureWarning"}}
+        coverage_decisions: {$ref: "#/components/schemas/AssessmentClosureCoverageDecisions"}
+        commit_allowed: {type: boolean}
+
+    AssessmentClosurePreviewRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        reason: {type: string, maxLength: 4096}
+        override_blocker_ids:
+          type: array
+          uniqueItems: true
+          items: {type: string}
+        override_reason: {type: string, maxLength: 4096}
+
+    AssessmentClosurePreview:
+      type: object
+      required: [cycle_id, cycle_version, manifest_version, final_assessment_id, path, non_final_branches, policy, references, scope_profile_changes, renderer_contract_version]
+      properties:
+        cycle_id: {type: string}
+        cycle_version: {type: integer, format: int64, minimum: 1}
+        manifest_version: {type: integer, format: int64, minimum: 1}
+        final_assessment_id: {type: string}
+        path: {type: array, minItems: 1, items: {$ref: "#/components/schemas/AssessmentClosurePathMember"}}
+        non_final_branches: {type: [array, "null"], items: {$ref: "#/components/schemas/AssessmentClosureBranchState"}}
+        initial_snapshot_id: {type: string}
+        final_snapshot_id: {type: string}
+        comparison_id: {type: string}
+        policy: {$ref: "#/components/schemas/AssessmentClosurePolicyResult"}
+        references: {type: [array, "null"], items: {$ref: "#/components/schemas/AssessmentClosureReference"}}
+        scope_profile_changes: {type: [array, "null"], items: {$ref: "#/components/schemas/AssessmentClosureScopeProfileChange"}}
+        renderer_contract_version: {type: string}
+        expires_at: {type: string, format: date-time}
+        preview_token: {type: string, maxLength: 16384}
+
+    AssessmentClosureCommitRequest:
+      type: object
+      additionalProperties: false
+      required: [preview_token, reason]
+      properties:
+        preview_token: {type: string, minLength: 1, maxLength: 16384}
+        reason: {type: string, minLength: 1, maxLength: 4096}
+        override_blocker_ids:
+          type: array
+          uniqueItems: true
+          items: {type: string}
+        override_reason: {type: string, maxLength: 4096}
+
+    AssessmentClosureManifest:
+      type: object
+      required: [id, cycle_id, manifest_version, lifecycle, cycle_version, root_assessment_id, final_assessment_id, initial_snapshot_id, final_snapshot_id, comparison_id, initial_snapshot_hash, final_snapshot_hash, comparison_hash, canonical_input_hash, content_hash, policy_version, algorithm_version, fingerprint_version, risk_version, renderer_contract_version, coverage_decisions, scope_profile_changes, override_blocker_ids, non_final_branches, path, references, reason, as_of_at, created_at, created_by]
+      properties:
+        id: {type: string}
+        cycle_id: {type: string}
+        manifest_version: {type: integer, format: int64, minimum: 1}
+        lifecycle: {type: string, enum: [building, active, superseded]}
+        cycle_version: {type: integer, format: int64, minimum: 1}
+        root_assessment_id: {type: string}
+        final_assessment_id: {type: string}
+        initial_snapshot_id: {type: string}
+        final_snapshot_id: {type: string}
+        comparison_id: {type: string}
+        initial_snapshot_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        final_snapshot_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        comparison_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        canonical_input_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        content_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        policy_version: {type: string}
+        algorithm_version: {type: string}
+        fingerprint_version: {type: string}
+        risk_version: {type: string}
+        renderer_contract_version: {type: string}
+        coverage_decisions: {$ref: "#/components/schemas/AssessmentClosureCoverageDecisions"}
+        scope_profile_changes: {type: [array, "null"], items: {$ref: "#/components/schemas/AssessmentClosureScopeProfileChange"}}
+        override_blocker_ids: {type: array, items: {type: string}}
+        non_final_branches: {type: [array, "null"], items: {$ref: "#/components/schemas/AssessmentClosureBranchState"}}
+        path: {type: array, minItems: 1, items: {$ref: "#/components/schemas/AssessmentClosurePathMember"}}
+        references: {type: [array, "null"], items: {$ref: "#/components/schemas/AssessmentClosureReference"}}
+        reason: {type: string, minLength: 1, maxLength: 4096}
+        override_reason: {type: string, maxLength: 4096}
+        as_of_at: {type: string, format: date-time}
+        created_at: {type: string, format: date-time}
+        created_by: {type: string}
+        sealed_at: {type: string, format: date-time}
+        sealed_by: {type: string}
+        superseded_at: {type: string, format: date-time}
+
+    AssessmentClosureManifestList:
+      type: object
+      required: [items]
+      properties:
+        items: {type: array, items: {$ref: "#/components/schemas/AssessmentClosureManifest"}}
+
+    AssessmentClosureCommitResponse:
+      type: object
+      required: [cycle, manifest, report_job_id]
+      properties:
+        cycle: {$ref: "#/components/schemas/AssessmentCycle"}
+        manifest: {$ref: "#/components/schemas/AssessmentClosureManifest"}
+        report_job_id: {type: string}
+
+    AssessmentReopenPreviewRequest:
+      type: object
+      additionalProperties: false
+
+    AssessmentReopenPreview:
+      type: object
+      required: [cycle_id, cycle_version, manifest, impact, expires_at, preview_token]
+      properties:
+        cycle_id: {type: string}
+        cycle_version: {type: integer, format: int64, minimum: 1}
+        manifest: {$ref: "#/components/schemas/AssessmentClosureManifest"}
+        impact: {type: string}
+        expires_at: {type: string, format: date-time}
+        preview_token: {type: string, minLength: 1, maxLength: 16384}
+
+    AssessmentReopenCommitRequest:
+      type: object
+      additionalProperties: false
+      required: [preview_token, reason]
+      properties:
+        preview_token: {type: string, minLength: 1, maxLength: 16384}
+        reason: {type: string, minLength: 1, maxLength: 4096}
+
+    AssessmentReopenCommitResponse:
+      type: object
+      required: [cycle, superseded_manifest]
+      properties:
+        cycle: {$ref: "#/components/schemas/AssessmentCycle"}
+        superseded_manifest: {$ref: "#/components/schemas/AssessmentClosureManifest"}
+
+    AssessmentClosureReportSnapshot:
+      type: object
+      required: [id, content_hash]
+      properties:
+        id: {type: string}
+        content_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+
+    AssessmentClosureReportComparison:
+      type: object
+      required: [id, content_hash, summary]
+      properties:
+        id: {type: string}
+        content_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        summary: {$ref: "#/components/schemas/AssessmentComparisonSummary"}
+
+    AssessmentClosureReportManifest:
+      type: object
+      required: [id, canonical_input_hash, content_hash, policy_version, algorithm_version, fingerprint_version, risk_version, renderer_contract_version, reason, as_of_at, created_at, created_by]
+      properties:
+        id: {type: string}
+        canonical_input_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        content_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        policy_version: {type: string}
+        algorithm_version: {type: string}
+        fingerprint_version: {type: string}
+        risk_version: {type: string}
+        renderer_contract_version: {type: string}
+        reason: {type: string}
+        override_reason: {type: string}
+        as_of_at: {type: string, format: date-time}
+        created_at: {type: string, format: date-time}
+        created_by: {type: string}
+
+    AssessmentClosureReportPayload:
+      type: object
+      required: [schema_version, renderer_contract_version, generated_at, cycle, path, initial_snapshot, final_snapshot, comparison, decision_references, coverage_decisions, scope_profile_changes, override_blocker_ids, non_final_branches, manifest]
+      properties:
+        schema_version: {type: integer, const: 1}
+        renderer_contract_version: {type: string}
+        generated_at: {type: string, format: date-time}
+        cycle:
+          type: object
+          required: [id, version, manifest_version, root_assessment_id, final_assessment_id]
+          properties:
+            id: {type: string}
+            version: {type: integer, format: int64, minimum: 1}
+            manifest_version: {type: integer, format: int64, minimum: 1}
+            root_assessment_id: {type: string}
+            final_assessment_id: {type: string}
+        path: {type: array, minItems: 1, items: {$ref: "#/components/schemas/AssessmentClosurePathMember"}}
+        initial_snapshot: {$ref: "#/components/schemas/AssessmentClosureReportSnapshot"}
+        final_snapshot: {$ref: "#/components/schemas/AssessmentClosureReportSnapshot"}
+        comparison: {$ref: "#/components/schemas/AssessmentClosureReportComparison"}
+        decision_references: {type: [array, "null"], items: {$ref: "#/components/schemas/AssessmentClosureReference"}}
+        coverage_decisions: {$ref: "#/components/schemas/AssessmentClosureCoverageDecisions"}
+        scope_profile_changes: {type: [array, "null"], items: {$ref: "#/components/schemas/AssessmentClosureScopeProfileChange"}}
+        override_blocker_ids: {type: array, items: {type: string}}
+        non_final_branches: {type: [array, "null"], items: {$ref: "#/components/schemas/AssessmentClosureBranchState"}}
+        manifest: {$ref: "#/components/schemas/AssessmentClosureReportManifest"}
+
+    AssessmentClosureReportDocument:
+      type: object
+      required: [report_hash, report]
+      properties:
+        report_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        report: {$ref: "#/components/schemas/AssessmentClosureReportPayload"}
+
+    PreviewAssessmentRelationshipChangeRequest:
+      type: object
+      additionalProperties: false
+      required: [command]
+      properties:
+        command: {type: string, enum: [reparent_within_cycle, select_head]}
+        assessment_id: {type: string}
+        new_predecessor_assessment_id: {type: string}
+        selected_head_assessment_id: {type: string}
+
+    CommitAssessmentRelationshipChangeRequest:
+      allOf:
+      - $ref: "#/components/schemas/PreviewAssessmentRelationshipChangeRequest"
+      - type: object
+        required: [preview_token, reason]
+        properties:
+          preview_token: {type: string, minLength: 1, maxLength: 65536}
+          reason: {type: string, maxLength: 512}
+
+    AssessmentRelationshipImpact:
+      type: object
+      required: [member_ids, snapshot_ids, identity_ids, comparison_ids, projection_ids]
+      properties:
+        member_ids: {type: array, uniqueItems: true, items: {type: string}}
+        snapshot_ids: {type: array, uniqueItems: true, items: {type: string}}
+        identity_ids: {type: array, uniqueItems: true, items: {type: string}}
+        comparison_ids: {type: array, uniqueItems: true, items: {type: string}}
+        projection_ids: {type: array, uniqueItems: true, items: {type: string}}
+
+    AssessmentRelationshipPreview:
+      type: object
+      required: [cycle_id, command, old_selected_head_assessment_id, new_selected_head_assessment_id, descendant_assessment_ids, impact, locks, reason_required, commit_allowed, cycle_version]
+      properties:
+        cycle_id: {type: string}
+        command: {type: string, enum: [reparent_within_cycle, select_head]}
+        assessment_id: {type: string}
+        old_predecessor_assessment_id: {type: string}
+        new_predecessor_assessment_id: {type: string}
+        old_selected_head_assessment_id: {type: string}
+        new_selected_head_assessment_id: {type: string}
+        descendant_assessment_ids: {type: array, uniqueItems: true, items: {type: string}}
+        impact: {$ref: "#/components/schemas/AssessmentRelationshipImpact"}
+        locks: {type: array, uniqueItems: true, items: {type: string}}
+        reason_required: {type: boolean}
+        commit_allowed: {type: boolean}
+        cycle_version: {type: integer, format: int64, minimum: 1}
+        expires_at: {type: string, format: date-time}
+        preview_token: {type: string}
+
+    AssessmentRelationshipCommitResponse:
+      type: object
+      required: [cycle, replaced_comparison_ids, replacement_comparison_ids]
+      properties:
+        cycle: {$ref: "#/components/schemas/AssessmentCycle"}
+        replaced_comparison_ids: {type: array, uniqueItems: true, items: {type: string}}
+        replacement_comparison_ids: {type: array, uniqueItems: true, items: {type: string}}
+
+    GenerateAssessmentRelationshipCandidateRequest:
+      type: object
+      additionalProperties: false
+      required: [predecessor_cycle_id, successor_cycle_id]
+      properties:
+        predecessor_cycle_id: {type: string, minLength: 1}
+        successor_cycle_id: {type: string, minLength: 1}
+        imported_reference_hash:
+          type: string
+          pattern: '^[0-9a-f]{64}$'
+          description: SHA-256 of explicit imported relationship metadata; raw metadata is never accepted.
+        expires_in_days: {type: integer, minimum: 1, maximum: 90, default: 30}
+
+    AssessmentRelationshipSignal:
+      type: object
+      additionalProperties: false
+      required: [kind, evidence_hash, schema_version]
+      properties:
+        kind:
+          type: string
+          enum: [exact_frozen_boundary, explicit_imported_reference, trusted_manifest_compatible, deterministic_finding_overlap]
+        evidence_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        match_count: {type: integer, minimum: 0}
+        score_milli: {type: integer, minimum: 0, maximum: 1000}
+        schema_version: {type: integer, enum: [1]}
+
+    AssessmentRelationshipDecisionRequest:
+      type: object
+      additionalProperties: false
+      required: [action, reason]
+      properties:
+        action: {type: string, enum: [confirm, reject, dismiss]}
+        reason: {type: string, minLength: 1, maxLength: 2000}
+
+    AssessmentRelationshipDecision:
+      type: object
+      required: [id, action, actor, reason, version, created_at]
+      properties:
+        id: {type: string}
+        action: {type: string, enum: [confirm, reject, dismiss]}
+        actor: {type: string}
+        reason: {type: string}
+        version: {type: integer, format: int64, enum: [2]}
+        created_at: {type: string, format: date-time}
+
+    AssessmentRelationshipRepairPlan:
+      type: object
+      required: [id, input_hash, plan_hash, body, created_by, created_at]
+      properties:
+        id: {type: string}
+        input_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        plan_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        body:
+          type: object
+          description: Deterministic command artifact with execution=blocked and a separate move/merge approval requirement.
+          additionalProperties: true
+        created_by: {type: string}
+        created_at: {type: string, format: date-time}
+
+    AssessmentRelationshipCandidate:
+      type: object
+      required: [id, predecessor_cycle_id, predecessor_assessment_id, predecessor_relationship_version, predecessor_snapshot_id, successor_cycle_id, successor_assessment_id, successor_relationship_version, successor_snapshot_id, boundary_key_hash, signals, input_hash, confidence, status, version, expires_at, created_by, created_at]
+      properties:
+        id: {type: string}
+        predecessor_cycle_id: {type: string}
+        predecessor_assessment_id: {type: string}
+        predecessor_relationship_version: {type: integer, format: int64, minimum: 1}
+        predecessor_snapshot_id: {type: string}
+        successor_cycle_id: {type: string}
+        successor_assessment_id: {type: string}
+        successor_relationship_version: {type: integer, format: int64, minimum: 1}
+        successor_snapshot_id: {type: string}
+        boundary_key_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        signals:
+          type: array
+          minItems: 2
+          maxItems: 4
+          items: {$ref: "#/components/schemas/AssessmentRelationshipSignal"}
+        input_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        confidence: {type: string, enum: [medium, high]}
+        status: {type: string, enum: [open, confirmed, rejected, dismissed, expired]}
+        version: {type: integer, format: int64, enum: [1, 2]}
+        expires_at: {type: string, format: date-time}
+        created_by: {type: string}
+        created_at: {type: string, format: date-time}
+        decision: {$ref: "#/components/schemas/AssessmentRelationshipDecision"}
+        repair_plan: {$ref: "#/components/schemas/AssessmentRelationshipRepairPlan"}
+
+    AssessmentRelationshipCandidateList:
+      type: object
+      required: [items]
+      properties:
+        items:
+          type: array
+          maxItems: 200
+          items: {$ref: "#/components/schemas/AssessmentRelationshipCandidate"}
+
+    CreateAssessmentComparisonRequest:
+      type: object
+      additionalProperties: false
+      required: [baseline_snapshot_id, current_snapshot_id, mode]
+      properties:
+        baseline_snapshot_id: {type: string, minLength: 1}
+        current_snapshot_id: {type: string, minLength: 1}
+        mode: {type: string, enum: [lifecycle, neutral_diff]}
+
+    AssessmentComparisonRatio:
+      type: object
+      required: [numerator, denominator]
+      properties:
+        numerator: {type: integer, format: int64}
+        denominator: {type: integer, format: int64}
+        na_reason: {type: string}
+
+    AssessmentComparisonSummary:
+      type: object
+      required: [comparison_id, baseline_snapshot_id, current_snapshot_id, risk_model_version, fixed_rate, count_reduction, risk_reduction, fixed_count, baseline_count, current_count, baseline_risk, current_risk, new_count, reopened_count, still_detected_count, not_evaluated_count, review_count, new_risk, reopened_risk, baseline_severity, current_severity]
+      properties:
+        comparison_id: {type: string}
+        baseline_snapshot_id: {type: string}
+        current_snapshot_id: {type: string}
+        risk_model_version: {type: integer, minimum: 1}
+        fixed_rate: {$ref: "#/components/schemas/AssessmentComparisonRatio"}
+        count_reduction: {$ref: "#/components/schemas/AssessmentComparisonRatio"}
+        risk_reduction: {$ref: "#/components/schemas/AssessmentComparisonRatio"}
+        fixed_count: {type: integer, format: int64, minimum: 0}
+        baseline_count: {type: integer, format: int64, minimum: 0}
+        current_count: {type: integer, format: int64, minimum: 0}
+        baseline_risk: {type: integer, format: int64, minimum: 0}
+        current_risk: {type: integer, format: int64, minimum: 0}
+        new_count: {type: integer, format: int64, minimum: 0}
+        reopened_count: {type: integer, format: int64, minimum: 0}
+        still_detected_count: {type: integer, format: int64, minimum: 0}
+        not_evaluated_count: {type: integer, format: int64, minimum: 0}
+        review_count: {type: integer, format: int64, minimum: 0}
+        new_risk: {type: integer, format: int64, minimum: 0}
+        reopened_risk: {type: integer, format: int64, minimum: 0}
+        baseline_severity: {$ref: "#/components/schemas/AssessmentComparisonSeverityCounts"}
+        current_severity: {$ref: "#/components/schemas/AssessmentComparisonSeverityCounts"}
+
+    AssessmentComparisonSeverityCounts:
+      type: object
+      required: [critical, high, medium, low, info, unknown]
+      properties:
+        critical: {type: integer, format: int64, minimum: 0}
+        high: {type: integer, format: int64, minimum: 0}
+        medium: {type: integer, format: int64, minimum: 0}
+        low: {type: integer, format: int64, minimum: 0}
+        info: {type: integer, format: int64, minimum: 0}
+        unknown: {type: integer, format: int64, minimum: 0}
+
+    AssessmentComparison:
+      type: object
+      required: [id, cycle_id, baseline_snapshot_id, current_snapshot_id, mode, input_hash, algorithm_version, fingerprint_version, risk_model_version, coverage_policy_version, status, version, attempts, summary, created_at, updated_at]
+      properties:
+        id: {type: string}
+        cycle_id: {type: string}
+        baseline_snapshot_id: {type: string}
+        current_snapshot_id: {type: string}
+        mode: {type: string, enum: [lifecycle, neutral_diff]}
+        input_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        algorithm_version: {type: integer, minimum: 1}
+        fingerprint_version: {type: integer, minimum: 1}
+        risk_model_version: {type: integer, minimum: 1}
+        coverage_policy_version: {type: integer, minimum: 1}
+        status: {type: string, enum: [queued, generating, complete, needs_review, failed, superseded]}
+        version: {type: integer, format: int64, minimum: 1}
+        attempts: {type: integer, minimum: 0}
+        failure_code: {type: string}
+        content_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        summary: {$ref: "#/components/schemas/AssessmentComparisonSummary"}
+        created_at: {type: string, format: date-time}
+        updated_at: {type: string, format: date-time}
+        completed_at: {type: string, format: date-time}
+        superseded_at: {type: string, format: date-time}
+        superseded_by: {type: string}
+
+    CreateAssessmentComparisonResponse:
+      type: object
+      required: [comparison, created]
+      properties:
+        comparison: {$ref: "#/components/schemas/AssessmentComparison"}
+        created: {type: boolean}
+
+    AssessmentComparisonChangeFlag:
+      type: string
+      enum: [severity_increased, severity_decreased, component_version_changed, location_changed, reachability_changed, evidence_changed, scanner_changed, rule_profile_changed, advisory_changed]
+
+    AssessmentComparisonItem:
+      type: object
+      required: [id, position, identity_id, producer_kind, finding_kind, target_canonical, change_flags, coverage_decision, baseline_actionable, current_actionable, comparable_baseline, baseline_risk_milli, current_risk_milli]
+      properties:
+        id: {type: string}
+        position: {type: integer, minimum: 0}
+        identity_id: {type: string}
+        producer_kind: {type: string}
+        finding_kind: {type: string}
+        target_canonical: {type: string}
+        baseline_observation_id: {type: string}
+        current_observation_id: {type: string}
+        baseline_observation: {$ref: "#/components/schemas/AssessmentComparisonObservation"}
+        current_observation: {$ref: "#/components/schemas/AssessmentComparisonObservation"}
+        presence: {type: string, enum: [new, still_detected, not_detected_under_comparable_coverage, not_evaluated, reopened, needs_review]}
+        neutral_presence: {type: string, enum: [only_in_a, both, only_in_b, needs_review]}
+        change_flags: {type: array, uniqueItems: true, items: {$ref: "#/components/schemas/AssessmentComparisonChangeFlag"}}
+        coverage_decision: {type: string, enum: [comparable, partially_comparable, not_comparable]}
+        match_methods: {type: array, uniqueItems: true, items: {type: string, enum: [override, producer_id, fingerprint, alias, matcher, manual, new_identity]}}
+        verification_id: {type: string}
+        verification_state: {type: string}
+        fixed_basis: {type: string, enum: [comparable_absence, explicit_verification]}
+        baseline_actionable: {type: boolean}
+        current_actionable: {type: boolean}
+        comparable_baseline: {type: boolean}
+        baseline_risk_milli: {type: integer, format: int64, minimum: 0}
+        current_risk_milli: {type: integer, format: int64, minimum: 0}
+        review_candidate_ids: {type: array, uniqueItems: true, items: {type: string}}
+        review_candidates: {type: array, uniqueItems: true, items: {$ref: "#/components/schemas/AssessmentComparisonReviewCandidate"}}
+
+    AssessmentComparisonReviewCandidate:
+      type: object
+      required: [id, source_observation_ids]
+      properties:
+        id: {type: string}
+        source_observation_ids: {type: array, uniqueItems: true, items: {type: string}}
+
+    AssessmentComparisonObservation:
+      type: object
+      properties:
+        severity: {type: string, enum: [unknown, info, low, medium, high, critical]}
+        component_version: {type: string}
+        location: {type: string}
+        reachability: {type: string}
+        evidence_digest: {type: string, pattern: '^[0-9a-f]{64}$'}
+        scanner:
+          type: object
+          properties:
+            scan_run_id: {type: string}
+            lane_key: {type: string}
+            tool_name: {type: string}
+            tool_version: {type: string}
+            rule_id: {type: string}
+        observed_at: {type: string, format: date-time}
+
+    AssessmentComparisonItemPage:
+      type: object
+      required: [items]
+      properties:
+        items: {type: array, items: {$ref: "#/components/schemas/AssessmentComparisonItem"}}
+        next_cursor: {type: string}
+
+    ReviewAssessmentComparisonItemRequest:
+      type: object
+      additionalProperties: false
+      required: [candidate_id, source_observation_id, reason]
+      properties:
+        candidate_id: {type: string, minLength: 1}
+        source_observation_id: {type: string, minLength: 1}
+        target_observation_id: {type: string, minLength: 1}
+        reason: {type: string, minLength: 1, maxLength: 512}
+
+    ReviewAssessmentComparisonItemResponse:
+      type: object
+      required: [override_event_id, superseded_comparison_id, replacement_comparison_id, replacement_status]
+      properties:
+        override_event_id: {type: string}
+        superseded_comparison_id: {type: string}
+        replacement_comparison_id: {type: string}
+        replacement_status: {type: string, enum: [queued, generating, complete, needs_review]}
+    CreateAssessmentRetestRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        name: {type: string}
+        predecessor_assessment_id: {type: string}
+        source_strategy:
+          type: string
+          enum: [reuse_current, upload_new]
+          description: Optional explicit archive choice. A file defaults to upload_new; copied uploaded-source scope without a file defaults to reuse_current.
+        source_version_id:
+          type: string
+          maxLength: 256
+          description: Optional expected immutable version of the selected predecessor source, not an arbitrary archive locator or another Assessment's version.
+        scope_strategy: {type: string, enum: [copy, empty], default: copy}
+        profile_strategy: {type: string, enum: [none], default: none}
+        planned_date: {type: string, description: 'Optional YYYY-MM-DD planning date or empty string; never grants execution authorization.'}
+        authorized_from: {type: string, format: date-time}
+        authorized_to: {type: string, format: date-time}
+        timezone: {type: string}
+        roe:
+          type: object
+          properties:
+            allowed_tool_classes:
+              type: array
+              items: {type: string}
+            blackouts:
+              type: array
+              items:
+                type: object
+                required: [from, to]
+                properties:
+                  from: {type: string, format: date-time}
+                  to: {type: string, format: date-time}
+
+    AssessmentInheritanceDiff:
+      type: object
+      required: [scope, authorization, roe, scanner_profile]
+      properties:
+        scope: {type: string, enum: [copy, empty]}
+        authorization: {type: string, enum: [explicit_only]}
+        roe: {type: string, enum: [explicit_only]}
+        scanner_profile: {type: string, enum: [none]}
+
+    CreateAssessmentRetestResponse:
+      type: object
+      required: [engagement, cycle, member, inheritance_diff, warnings]
+      properties:
+        engagement: {$ref: "#/components/schemas/Engagement"}
+        cycle: {$ref: "#/components/schemas/AssessmentCycle"}
+        member: {$ref: "#/components/schemas/AssessmentCycleMember"}
+        inheritance_diff: {$ref: "#/components/schemas/AssessmentInheritanceDiff"}
+        source_selection: {$ref: "#/components/schemas/AssessmentRetestSourceSelection"}
+        warnings:
+          type: array
+          items:
+            type: string
+            enum: [authorization_not_inherited, roe_not_inherited, scanner_profile_not_inherited]
+
+    AssessmentRetestSourceSelection:
+      type: object
+      required: [strategy, version_id, filename, size, sha256]
+      properties:
+        strategy: {type: string, enum: [reuse_current, upload_new]}
+        version_id: {type: string, description: Immutable child-owned source association version.}
+        filename: {type: string}
+        size: {type: integer, format: int64}
+        sha256: {type: string, pattern: '^[0-9a-f]{64}$'}
+        source_assessment_id: {type: string, description: Predecessor Assessment whose archive was reused.}
+        reused_from_version_id: {type: string, description: Exact predecessor source version reused by this child.}
+
+    FinalizeAssessmentSnapshotRun:
+      type: object
+      additionalProperties: false
+      required: [run_id]
+      properties:
+        run_id: {type: string, minLength: 1, maxLength: 256}
+        lane_keys:
+          type: array
+          maxItems: 100
+          uniqueItems: true
+          description: Omit to select every eligible lane in the run.
+          items: {type: string, minLength: 1, maxLength: 256}
+
+    FinalizeAssessmentSnapshotRequest:
+      type: object
+      additionalProperties: false
+      required: [selected_runs]
+      properties:
+        selected_runs:
+          type: array
+          minItems: 1
+          maxItems: 100
+          items: {$ref: "#/components/schemas/FinalizeAssessmentSnapshotRun"}
+
+    AssessmentSnapshotBoundary:
+      type: object
+      required: [boundary_kind]
+      properties:
+        boundary_kind: {type: string, enum: [standalone, asset, project, asset_project]}
+        business_asset_id: {type: string}
+        project_id: {type: string}
+
+    AssessmentSnapshotLaneReference:
+      type: object
+      required: [lane_key, manifest_hash]
+      properties:
+        lane_key: {type: string}
+        manifest_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+
+    AssessmentSnapshotRunReference:
+      type: object
+      required: [run_id, manifest_hash, lane_refs]
+      properties:
+        run_id: {type: string}
+        manifest_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        lane_refs:
+          type: array
+          items: {$ref: "#/components/schemas/AssessmentSnapshotLaneReference"}
+
+    AssessmentSnapshotTarget:
+      type: object
+      required: [kind, schema_version, canonical]
+      properties:
+        kind: {type: string, enum: [repository, oci, host, url, cloud_resource]}
+        schema_version: {type: integer, minimum: 1}
+        canonical: {type: string}
+        evaluated_revision: {type: string}
+
+    AssessmentSnapshotVersion:
+      type: object
+      required: [kind, name, version]
+      properties:
+        kind: {type: string, enum: [tool, scanner, profile, rule_pack, advisory_database, correlation, schema]}
+        name: {type: string}
+        version: {type: string}
+        digest: {type: string}
+
+    AssessmentSnapshotDimension:
+      type: object
+      required: [run_id, lane_key, lane_manifest_hash, producer, finding_kind, target, state, reason_code, included_scope, excluded_scope, versions]
+      properties:
+        run_id: {type: string}
+        lane_key: {type: string}
+        lane_manifest_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        producer: {type: string}
+        finding_kind: {type: string}
+        target: {$ref: "#/components/schemas/AssessmentSnapshotTarget"}
+        state: {type: string, enum: [complete, partial, unknown]}
+        reason_code:
+          type: string
+          enum: [trusted_terminal_lane, legacy_provenance, run_partial, run_failed, run_cancelled, lane_partial, lane_failed, lane_cancelled, stage_failed, stage_skipped]
+        included_scope: {type: array, items: {type: string}}
+        excluded_scope: {type: array, items: {type: string}}
+        versions:
+          type: array
+          items: {$ref: "#/components/schemas/AssessmentSnapshotVersion"}
+
+    AssessmentSnapshot:
+      type: object
+      required: [id, cycle_id, assessment_id, snapshot_number, lifecycle, provenance, boundary, run_references, dimensions, schema_version, content_hash, created_at, created_by, finalized_at, finalized_by]
+      properties:
+        id: {type: string}
+        cycle_id: {type: string}
+        assessment_id: {type: string}
+        snapshot_number: {type: integer, minimum: 1}
+        lifecycle: {type: string, enum: [finalized, superseded]}
+        provenance: {type: string, enum: [native, legacy]}
+        boundary: {$ref: "#/components/schemas/AssessmentSnapshotBoundary"}
+        run_references:
+          type: array
+          minItems: 1
+          items: {$ref: "#/components/schemas/AssessmentSnapshotRunReference"}
+        dimensions:
+          type: array
+          items: {$ref: "#/components/schemas/AssessmentSnapshotDimension"}
+        schema_version: {type: integer, const: 1}
+        content_hash: {type: string, pattern: '^[0-9a-f]{64}$'}
+        created_at: {type: string, format: date-time}
+        created_by: {type: string}
+        finalized_at: {type: string, format: date-time}
+        finalized_by: {type: string}
+        superseded_at: {type: string, format: date-time}
+        superseded_by: {type: string}
+
+    FinalizeAssessmentSnapshotResponse:
+      type: object
+      required: [snapshot, default_version]
+      properties:
+        snapshot: {$ref: "#/components/schemas/AssessmentSnapshot"}
+        default_version: {type: integer, minimum: 1}
+
+    AssessmentSnapshotListResponse:
+      type: object
+      required: [items, default_version]
+      properties:
+        items:
+          type: array
+          maxItems: 100
+          items: {$ref: "#/components/schemas/AssessmentSnapshot"}
+        next_cursor: {type: string}
+        default_snapshot_id: {type: string}
+        default_version: {type: integer, minimum: 0}
+
+    ScanSourceBinding:
+      type: object
+      description: Source metadata frozen at job admission and copied to the immutable run manifest, including failed jobs. Legacy runs are not backfilled from current source.
+      required: [tenant_id, engagement_id, filename, size, sha256, created_by, created_at]
+      properties:
+        tenant_id: {type: string}
+        engagement_id: {type: string}
+        version_id: {type: string}
+        reused_from_version_id: {type: string}
+        filename: {type: string}
+        size: {type: integer, format: int64}
+        sha256: {type: string, pattern: '^[0-9a-f]{64}$'}
+        created_by: {type: string, description: Original uploader, unchanged on reuse.}
+        created_at: {type: string, format: date-time}
+        associated_by: {type: string}
+        associated_at: {type: string, format: date-time}
+
+    ScanRunHistory:
+      type: object
+      description: A run's source_package comes only from its own immutable manifest, never from the engagement's current source.
+      properties:
+        id: {type: string}
+        engagement_id: {type: string}
+        created_at: {type: string, format: date-time}
+        provenance: {type: string, enum: [native, legacy]}
+        terminal_status: {type: string}
+        source_package: {$ref: "#/components/schemas/UploadedSourcePackage"}
+        target_kind: {type: string}
+        target: {type: string}
+        manifest: {type: object}
+        finding_keys: {type: array, items: {type: string}}
+        manifest_hash: {type: string}
+        sealed_at: {type: string, format: date-time}
+        lane_count: {type: integer}
+        complete_coverage: {type: boolean}

--- a/api/openapi_test.go
+++ b/api/openapi_test.go
@@ -307,3 +307,120 @@ func TestAttackPathOpenAPIContract(t *testing.T) {
 		}
 	}
 }
+
+func TestAssessmentCycleOpenAPIContract(t *testing.T) {
+	b, err := os.ReadFile("openapi.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	paths, _ := doc["paths"].(map[string]any)
+	for path, methods := range map[string]map[string]string{
+		"/api/v1/engagements/{assessmentId}/retests":   {"post": "createAssessmentRetest"},
+		"/api/v1/engagements/{assessmentId}/lifecycle": {"get": "getAssessmentLifecycle"},
+		"/api/v1/assessment-cycles":                    {"get": "listAssessmentCycles"},
+		"/api/v1/assessment-cycles/{cycleId}":          {"get": "getAssessmentCycle"},
+		"/api/v1/assessment-cycles/{cycleId}/members":  {"get": "listAssessmentCycleMembers"},
+		"/api/v1/assessment-cycles/{cycleId}/archive":  {"post": "archiveAssessmentCycle"},
+	} {
+		route, ok := paths[path].(map[string]any)
+		if !ok {
+			t.Errorf("assessment cycle path %s missing", path)
+			continue
+		}
+		for method, operationID := range methods {
+			operation, ok := route[method].(map[string]any)
+			if !ok || operation["operationId"] != operationID {
+				t.Errorf("%s %s operationId=%v, want %s", method, path, operation["operationId"], operationID)
+			}
+		}
+	}
+}
+
+func TestAssessmentSnapshotOpenAPIContract(t *testing.T) {
+	b, err := os.ReadFile("openapi.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	paths, _ := doc["paths"].(map[string]any)
+	for path, methods := range map[string]map[string]string{
+		"/api/v1/engagements/{assessmentId}/snapshots/finalize": {"post": "finalizeAssessmentSnapshot"},
+		"/api/v1/engagements/{assessmentId}/snapshots":          {"get": "listAssessmentSnapshots"},
+		"/api/v1/assessment-snapshots/{snapshotId}":             {"get": "getAssessmentSnapshot"},
+	} {
+		route, ok := paths[path].(map[string]any)
+		if !ok {
+			t.Errorf("assessment snapshot path %s missing", path)
+			continue
+		}
+		for method, operationID := range methods {
+			operation, ok := route[method].(map[string]any)
+			if !ok || operation["operationId"] != operationID {
+				t.Errorf("%s %s operationId=%v, want %s", method, path, operation["operationId"], operationID)
+			}
+		}
+	}
+
+	components, _ := doc["components"].(map[string]any)
+	schemas, _ := components["schemas"].(map[string]any)
+	snapshot, _ := schemas["AssessmentSnapshot"].(map[string]any)
+	snapshotProperties, _ := snapshot["properties"].(map[string]any)
+	for _, forbidden := range []string{"tenant_id", "request_key", "request_hash", "evidence", "credentials"} {
+		if _, ok := snapshotProperties[forbidden]; ok {
+			t.Errorf("AssessmentSnapshot response exposes forbidden property %q", forbidden)
+		}
+	}
+	request, _ := schemas["FinalizeAssessmentSnapshotRequest"].(map[string]any)
+	requestProperties, _ := request["properties"].(map[string]any)
+	if len(requestProperties) != 1 || requestProperties["selected_runs"] == nil {
+		t.Errorf("FinalizeAssessmentSnapshotRequest must contain only server-resolved run/lane selections: %v", requestProperties)
+	}
+}
+
+func TestAssessmentComparisonOpenAPIContract(t *testing.T) {
+	b, err := os.ReadFile("openapi.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(b, &doc); err != nil {
+		t.Fatal(err)
+	}
+	paths, _ := doc["paths"].(map[string]any)
+	for path, methods := range map[string]map[string]string{
+		"/api/v1/assessment-comparisons":                                       {"post": "createAssessmentComparison"},
+		"/api/v1/assessment-comparisons/{comparisonId}":                        {"get": "getAssessmentComparison"},
+		"/api/v1/assessment-comparisons/{comparisonId}/summary":                {"get": "getAssessmentComparisonSummary"},
+		"/api/v1/assessment-comparisons/{comparisonId}/items":                  {"get": "listAssessmentComparisonItems"},
+		"/api/v1/assessment-comparisons/{comparisonId}/items/{itemId}/confirm": {"post": "confirmAssessmentComparisonItem"},
+		"/api/v1/assessment-comparisons/{comparisonId}/items/{itemId}/unlink":  {"post": "unlinkAssessmentComparisonItem"},
+	} {
+		route, ok := paths[path].(map[string]any)
+		if !ok {
+			t.Errorf("assessment comparison path %s missing", path)
+			continue
+		}
+		for method, operationID := range methods {
+			operation, ok := route[method].(map[string]any)
+			if !ok || operation["operationId"] != operationID {
+				t.Errorf("%s %s operationId=%v, want %s", method, path, operation["operationId"], operationID)
+			}
+		}
+	}
+	components, _ := doc["components"].(map[string]any)
+	schemas, _ := components["schemas"].(map[string]any)
+	comparison, _ := schemas["AssessmentComparison"].(map[string]any)
+	properties, _ := comparison["properties"].(map[string]any)
+	for _, forbidden := range []string{"tenant_id", "input_payload", "credentials", "evidence"} {
+		if _, ok := properties[forbidden]; ok {
+			t.Errorf("AssessmentComparison response exposes forbidden property %q", forbidden)
+		}
+	}
+}

--- a/api/testdata/openapi-coverage-debt.txt
+++ b/api/testdata/openapi-coverage-debt.txt
@@ -50,7 +50,6 @@ GET /api/v1/engagements/{p}/risk-stories
 GET /api/v1/engagements/{p}/risk-stories/{p}
 GET /api/v1/engagements/{p}/sbom
 GET /api/v1/engagements/{p}/scan
-GET /api/v1/engagements/{p}/scan-runs
 GET /api/v1/engagements/{p}/scan-runs/compare
 GET /api/v1/engagements/{p}/scan-status
 GET /api/v1/engagements/{p}/threat-model

--- a/cmd/synapse-api/main.go
+++ b/cmd/synapse-api/main.go
@@ -11,6 +11,7 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"fmt"
 	"log/slog"
 	"net"
@@ -100,6 +101,11 @@ import (
 	alertinguc "github.com/KKloudTarus/synapse-ce/internal/usecase/alerting"
 	analysisuc "github.com/KKloudTarus/synapse-ce/internal/usecase/analysis"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/approval"
+	comparisonuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcomparison"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	lifecycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentlifecycle"
+	relationshipuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentrelationship"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
 	attackpathuc "github.com/KKloudTarus/synapse-ce/internal/usecase/attackpath"
 	audituc "github.com/KKloudTarus/synapse-ce/internal/usecase/audit"
@@ -124,6 +130,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/execution"
 	exploitationuc "github.com/KKloudTarus/synapse-ce/internal/usecase/exploitation"
 	exportuc "github.com/KKloudTarus/synapse-ce/internal/usecase/export"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
 	findingsuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findings"
 	baselineuc "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/baselineuc"
 	behaviorbaseline "github.com/KKloudTarus/synapse-ce/internal/usecase/fleet/behaviorbaseline"
@@ -300,6 +307,10 @@ func main() {
 		log.Error("network execution posture invalid", "err", err)
 		os.Exit(1)
 	}
+	if err := cfg.ValidateAssessmentLifecycleRollout(); err != nil {
+		log.Error("assessment lifecycle rollout invalid", "err", err)
+		os.Exit(1)
+	}
 	if err := cfg.ValidateResponseExecutionPosture(); err != nil {
 		log.Error("response execution posture invalid", "err", err)
 		os.Exit(1)
@@ -405,8 +416,10 @@ func main() {
 	var correlationStateStore ports.CorrelationStateStore // #594 C2 event-time watermark + assignments
 	var promotionStore ports.PendingPromotionAuditStore
 	var scanJobStore ports.ScanJobStore
+	var engagementSourceRepo ports.EngagementSourceRepository
 	var scanRunStore ports.ScanRunStore
 	var scanRunTransactions ports.TenantTransactionRunner
+	var assessmentSnapshotStore ports.AssessmentSnapshotRepository
 	var projectAnalysisStore ports.ProjectAnalysisStore
 	var qualityGateStore ports.QualityGateStore
 	var qualityProfileStore ports.QualityProfileStore
@@ -438,6 +451,20 @@ func main() {
 	var vulnerabilityTransactions ports.TenantTransactionRunner
 	var integrationStore ports.IntegrationStore
 	var integrationMatcher ports.IntegrationAnalysisMatcher
+	var assessmentCycleStore interface {
+		ports.AssessmentCycleRepository
+		ports.AssessmentCycleListRepository
+		ports.AssessmentClosureRepository
+		ports.AssessmentClosureReportStore
+	}
+	var assessmentCycleRequests ports.AssessmentCycleRequestStore
+	var assessmentCycleTransactions ports.TenantTransactionRunner
+	var assessmentComparisonStore ports.AssessmentComparisonRepository
+	var findingLineageStore ports.FindingLineageRepository
+	var assessmentRelationshipStore ports.AssessmentRelationshipRepository
+	var assessmentComparisonService *comparisonuc.Service
+	var assessmentClosureReportService *cycleuc.ClosureReportService
+	var closureDecisionReader ports.AssessmentClosureDecisionReader
 	var slaStore ports.SLAStore
 	var vulnerabilityWorker *worker.Worker
 	var reconRunLock ports.RunLocker              // recon run lease (Postgres only); row-lease, no pinned conn
@@ -566,7 +593,15 @@ func main() {
 			os.Exit(1)
 		}
 		scanJobStore = postgres.NewScanJobStore(pool)
+		engagementSourceRepo = postgres.NewEngagementSourceRepository(pool)
 		scanRunStore = postgres.NewScanRunStore(pool)
+		assessmentSnapshotStore = postgres.NewAssessmentSnapshotRepository(pool)
+		assessmentComparisonStore = postgres.NewAssessmentComparisonRepository(pool)
+		assessmentCycleStore = postgres.NewAssessmentCycleRepository(pool)
+		assessmentCycleRequests = postgres.NewAssessmentCycleRequestRepository(pool)
+		assessmentCycleTransactions = postgres.NewTenantTransactionRunner(pool)
+		findingLineageStore = postgres.NewFindingLineageRepository(pool)
+		assessmentRelationshipStore = postgres.NewAssessmentRelationshipRepository(pool)
 		projectAnalysisStore = postgres.NewProjectAnalysisStore(pool)
 		qualityGateStore = postgres.NewQualityGateStore(pool)
 		qualityProfileStore = postgres.NewQualityProfileStore(pool)
@@ -745,8 +780,19 @@ func main() {
 			os.Exit(1)
 		}
 		scanJobStore = memory.NewScanJobStore()
-		scanRunStore = memory.NewScanRunStore()
+		engagementSourceRepo = memory.NewEngagementSourceRepository()
+		memoryScanRuns := memory.NewScanRunStore()
+		scanRunStore = memoryScanRuns
 		scanRunTransactions = memory.NewTenantTransactionRunner()
+		assessmentSnapshotStore = memory.NewAssessmentSnapshotRepository()
+		assessmentComparisonStore = memory.NewAssessmentComparisonRepository()
+		assessmentCycleStore = memory.NewAssessmentCycleRepository(memory.AssessmentCycleReaders{
+			Engagements: repo, Snapshots: assessmentSnapshotStore, Comparisons: assessmentComparisonStore, Runs: memoryScanRuns,
+		})
+		assessmentCycleRequests = memory.NewAssessmentCycleRequestRepository()
+		assessmentCycleTransactions = memory.NewTenantTransactionRunner()
+		findingLineageStore = memory.NewFindingLineageRepository()
+		assessmentRelationshipStore = memory.NewAssessmentRelationshipRepository()
 		projectAnalysisStore = memory.NewProjectAnalysisStore()
 		qualityGateStore = memory.NewQualityGateStore()
 		qualityProfileStore = memory.NewQualityProfileStore()
@@ -795,9 +841,13 @@ func main() {
 		},
 		VulnDBSource: "osv.dev",
 	}
+	if cfg.Offline {
+		prov.VulnDBSource = "" // No live OSV query: do not invent a per-scan feed revision.
+	}
 
 	// Use cases.
 	engService := enguc.NewService(repo, clock, ids, auditLog)
+	engService.SetCompletionSnapshotPolicy(assessmentSnapshotStore, cfg.AssessmentSnapshotCompletionForTenant)
 	projectService := projectuc.NewService(projectRepo, repo, clock, ids, auditLog, !cfg.IsProduction())
 	integrationRegistry := integrationdom.NewRegistry()
 	if err := jenkinsintegration.Register(integrationRegistry); err != nil {
@@ -889,7 +939,20 @@ func main() {
 		objectStore = memoryStore
 		log.Info("blob store: in-memory (set SYNAPSE_BLOB_ENDPOINT for MinIO/S3)")
 	}
-	uploadedSources := sourceupload.NewStore(objectStore, 0)
+	// Raw source archives must survive an API restart and be readable by a
+	// separate worker. Evidence's development memory fallback is not suitable.
+	sourceObjects := objectStore
+	if cfg.BlobEndpoint == "" {
+		localSources, err := blob.NewFilesystem(cfg.EngagementSourceDir)
+		if err != nil {
+			log.Error("durable engagement source store init failed", "err", err)
+			os.Exit(1)
+		}
+		defer func() { _ = localSources.Close() }()
+		sourceObjects = localSources
+		log.Info("engagement source archives: durable filesystem")
+	}
+	uploadedSources := sourceupload.NewStoreWithRepository(sourceObjects, engagementSourceRepo, 0)
 	engService.SetSourceStore(uploadedSources)
 	// Evidence vault: the one tamper-evident chain + verify-on-read path per engagement.
 	evidenceService, err := evidenceuc.NewService(evidenceStore, blobStore, auditLog, clock, ids)
@@ -977,6 +1040,10 @@ func main() {
 	if !ok || scanRunTransactions == nil {
 		log.Error("scan-run provenance dependencies are not configured")
 		os.Exit(1)
+	}
+	if cfg.AssessmentSnapshotEnabled {
+		scaService.SetScanRunProvenance(provenanceStore, assessmentCycleTransactions)
+		scaService.SetAssessmentCycleMembership(assessmentCycleStore, assessmentSnapshotStore)
 	}
 	scanRunService, err := scanrunuc.NewService(provenanceStore, repo, scanRunTransactions, ids, clock, auditLog)
 	if err != nil {
@@ -1488,6 +1555,89 @@ func main() {
 		}
 	}
 	router.SetObservability(cfg.AccessLogEnabled, httpObserver)
+	router.SetAssessmentLifecycleRollout(cfg.AssessmentLifecycleReadForTenant, cfg.AssessmentLifecycleUIForTenant)
+	var snapshotService *snapshotuc.Service
+	if cfg.AssessmentSnapshotEnabled {
+		snapshotService, err = snapshotuc.NewService(assessmentSnapshotStore, assessmentCycleStore, repo, provenanceStore, assessmentCycleTransactions, ids, clock, auditLog)
+		if err != nil {
+			log.Error("assessment snapshot service init failed", "err", err)
+			os.Exit(1)
+		}
+		snapshotService.SetScanJobStore(scanJobStore)
+	}
+	if cfg.AssessmentShadowEnabled {
+		var lineageObserver ports.FindingLineageObserver
+		if metrics != nil {
+			lineageObserver = metrics
+		}
+		lineageService, lineageErr := lineageuc.NewService(findingLineageStore, assessmentCycleTransactions, auditLog, clock, ids, lineageObserver)
+		if lineageErr != nil {
+			log.Error("finding lineage service init failed", "err", lineageErr)
+			os.Exit(1)
+		}
+		shadowProjector, shadowErr := lineageuc.NewShadowProjector(lineageService, assessmentCycleStore, assessmentSnapshotStore, findingRepo, cfg.AssessmentShadowForTenant)
+		if shadowErr != nil {
+			log.Error("finding lineage shadow projector init failed", "err", shadowErr)
+			os.Exit(1)
+		}
+		if evidenceStore, ok := provenanceStore.(ports.ScanRunEvidenceStore); ok {
+			shadowProjector.SetNativeEvidence(evidenceStore, provenanceStore)
+		}
+		if err := findingsService.SetLifecycleShadow(assessmentCycleTransactions, shadowProjector, cfg.AssessmentShadowForTenant); err != nil {
+			log.Error("manual finding lineage shadow init failed", "err", err)
+			os.Exit(1)
+		}
+		if err := exploitationService.SetLifecycleShadow(assessmentCycleTransactions, shadowProjector, cfg.AssessmentShadowForTenant, repo); err != nil {
+			log.Error("offensive finding lineage shadow init failed", "err", err)
+			os.Exit(1)
+		}
+		snapshotService.SetFinalizationObserver(shadowProjector)
+		comparisonVerification, verificationErr := comparisonuc.NewRetestVerificationReader(findingLineageStore, assessmentSnapshotStore, retestRepo)
+		if verificationErr != nil {
+			log.Error("assessment comparison verification reader init failed", "err", verificationErr)
+			os.Exit(1)
+		}
+		assessmentComparisonService, err = comparisonuc.NewService(assessmentComparisonStore, assessmentSnapshotStore, assessmentCycleStore, findingLineageStore, assessmentCycleTransactions, auditLog, clock, ids, comparisonVerification, nil)
+		if err != nil {
+			log.Error("assessment comparison service init failed", "err", err)
+			os.Exit(1)
+		}
+		if metrics != nil {
+			assessmentComparisonService.SetObserver(metrics)
+		}
+		assessmentComparisonService.SetAPIStores(assessmentCycleRequests, vulnerabilityQueue, lineageService)
+		shadowSnapshotService, shadowErr := snapshotuc.NewService(assessmentSnapshotStore, assessmentCycleStore, repo, provenanceStore, assessmentCycleTransactions, ids, clock, auditLog)
+		if shadowErr != nil {
+			log.Error("assessment lifecycle shadow snapshot writer init failed", "err", shadowErr)
+			os.Exit(1)
+		}
+		shadowSnapshotService.SetFinalizationObserver(shadowProjector)
+		shadowCoordinator, shadowErr := lifecycleuc.NewShadowCoordinator(assessmentCycleStore, assessmentSnapshotStore, shadowSnapshotService, assessmentComparisonService, cfg.AssessmentShadowForTenant)
+		if shadowErr != nil {
+			log.Error("assessment lifecycle shadow coordinator init failed", "err", shadowErr)
+			os.Exit(1)
+		}
+		scaService.SetScanRunObserver(shadowCoordinator)
+		if cfg.AssessmentLifecycleReadEnabled {
+			router.SetAssessmentComparisons(assessmentComparisonService)
+		}
+		if cfg.AssessmentClosureEnabled {
+			closureDecisionReader, err = cycleuc.NewClosureDecisionReader(findingLineageStore, assessmentSnapshotStore, retestRepo, slaStore)
+			if err != nil {
+				log.Error("assessment closure decision reader init failed", "err", err)
+				os.Exit(1)
+			}
+			assessmentClosureReportService, err = cycleuc.NewClosureReportService(assessmentCycleStore, assessmentCycleStore, assessmentSnapshotStore, assessmentComparisonStore, closureDecisionReader, auditLog)
+			if err != nil {
+				log.Error("assessment closure report service init failed", "err", err)
+				os.Exit(1)
+			}
+			if metrics != nil {
+				assessmentClosureReportService.SetObserver(metrics)
+			}
+		}
+		log.Info("assessment lifecycle shadow writers configured", "tenant_count", len(cfg.AssessmentShadowTenants))
+	}
 	vulnerabilityRollout, err := vulnerabilityrollout.New(vulnerabilityrollout.Config{
 		ProviderSync: cfg.VulnerabilityProviderSyncEnabled, OccurrenceWrites: cfg.VulnerabilityOccurrenceWritesEnabled,
 		FindingProjection: cfg.VulnerabilityFindingProjectionEnabled, Actions: cfg.VulnerabilityActionsEnabled,
@@ -1632,11 +1782,18 @@ func main() {
 	router.SetVulnerabilityReadModel(vulnerabilityRead)
 	router.SetVulnerabilityActions(vulnerabilityActionService)
 	if cfg.DBDSN == "" {
-		vulnerabilityWorker = worker.New(vulnerabilityQueue, map[string]worker.Handler{
+		handlers := map[string]worker.Handler{
 			vulnerabilitymonitor.JobKind:   vulnerabilitySyncJobHandler{svc: vulnerabilityMonitor},
 			vulnerabilityreconcile.JobKind: vulnerabilityReconcileJobHandler{svc: vulnerabilityReconciliation},
 			integrationuc.JobKind:          integrationJobHandler{svc: integrationService},
-		}, worker.Config{Visibility: 2 * time.Minute, Poll: 100 * time.Millisecond, MaxAttempts: 3}, log)
+		}
+		if assessmentComparisonService != nil {
+			handlers[comparisonuc.JobKind] = assessmentComparisonJobHandler{svc: assessmentComparisonService}
+		}
+		if assessmentClosureReportService != nil {
+			handlers[cycleuc.AssessmentClosureReportJobKind] = assessmentClosureReportJobHandler{svc: assessmentClosureReportService}
+		}
+		vulnerabilityWorker = worker.New(vulnerabilityQueue, handlers, worker.Config{Visibility: 2 * time.Minute, Poll: 100 * time.Millisecond, MaxAttempts: 3}, log)
 	}
 	router.SetAITriageReviews(aiTriageReviewService)
 	projectService.SetScanner(scaService)
@@ -1682,7 +1839,67 @@ func main() {
 		log.Error("business asset service init failed", "err", err)
 		os.Exit(1)
 	}
+	businessAssetService.SetAssessmentCycleReader(assessmentCycleStore)
 	router.SetBusinessAssets(businessAssetService)
+	if cfg.AssessmentCycleAPIEnabled || cfg.AssessmentCycleDualWriteEnabled {
+		cycleService, cycleErr := cycleuc.NewService(assessmentCycleStore, repo, businessAssetStore, projectRepo, assessmentCycleTransactions, ids, clock, auditLog)
+		if cycleErr != nil {
+			log.Error("assessment cycle service init failed", "err", cycleErr)
+			os.Exit(1)
+		}
+		cycleAPI, cycleErr := cycleuc.NewAPIService(cycleService, assessmentCycleStore, assessmentCycleRequests, engService, assessmentCycleTransactions, clock, auditLog)
+		if cycleErr != nil {
+			log.Error("assessment cycle API init failed", "err", cycleErr)
+			os.Exit(1)
+		}
+		if assessmentComparisonService != nil {
+			relationshipTokenKey := make([]byte, 32)
+			if cfg.MeasureCursorSecret != "" {
+				digest := sha256.Sum256([]byte("synapse:assessment-relationship-preview:v1\x00" + cfg.MeasureCursorSecret))
+				relationshipTokenKey = digest[:]
+			} else if _, keyErr := rand.Read(relationshipTokenKey); keyErr != nil {
+				log.Error("assessment relationship preview key generation failed", "err", keyErr)
+				os.Exit(1)
+			}
+			if cycleErr := cycleAPI.SetRelationshipChangeDependencies(assessmentSnapshotStore, assessmentComparisonStore, findingLineageStore, scanJobStore, assessmentComparisonService, relationshipTokenKey); cycleErr != nil {
+				log.Error("assessment relationship change service init failed", "err", cycleErr)
+				os.Exit(1)
+			}
+		}
+		if cfg.AssessmentClosureEnabled {
+			closureTokenKey := make([]byte, 32)
+			if cfg.MeasureCursorSecret != "" {
+				digest := sha256.Sum256([]byte("synapse:assessment-closure-preview:v1\x00" + cfg.MeasureCursorSecret))
+				closureTokenKey = digest[:]
+			} else if _, keyErr := rand.Read(closureTokenKey); keyErr != nil {
+				log.Error("assessment closure preview key generation failed", "err", keyErr)
+				os.Exit(1)
+			}
+			if cycleErr := cycleAPI.SetClosureDependencies(assessmentCycleStore, assessmentSnapshotStore, assessmentComparisonStore, closureDecisionReader, vulnerabilityQueue, closureTokenKey); cycleErr != nil {
+				log.Error("assessment closure service init failed", "err", cycleErr)
+				os.Exit(1)
+			}
+			if metrics != nil {
+				cycleAPI.SetClosureReportObserver(metrics)
+			}
+		}
+		router.SetAssessmentCycles(cycleAPI, cfg.AssessmentCycleAPIEnabled, cfg.AssessmentCycleDualWriteForTenant)
+		log.Info("assessment cycle services configured", "api_enabled", cfg.AssessmentCycleAPIEnabled, "dual_write_enabled", cfg.AssessmentCycleDualWriteEnabled, "dual_write_tenant_count", len(cfg.AssessmentCycleDualWriteTenants))
+	}
+	if snapshotService != nil {
+		router.SetAssessmentSnapshots(snapshotService)
+		log.Info("assessment snapshot API configured")
+	}
+	var relationshipObserver ports.AssessmentRelationshipObserver
+	if metrics != nil {
+		relationshipObserver = metrics
+	}
+	assessmentRelationshipService, relationshipErr := relationshipuc.NewService(assessmentRelationshipStore, assessmentCycleStore, assessmentSnapshotStore, findingLineageStore, assessmentCycleTransactions, ids, clock, auditLog, relationshipObserver)
+	if relationshipErr != nil {
+		log.Error("assessment relationship review service init failed", "err", relationshipErr)
+		os.Exit(1)
+	}
+	router.SetAssessmentRelationships(assessmentRelationshipService)
 	router.SetExploitation(exploitationService) // evidence-gated finding verify endpoint
 	// Read-only code-quality dashboard. Server-side analysis is PURE-GO and memory-safe only (pattern
 	// rules + duplication + Go-parser inventory); tree-sitter complexity is intentionally NOT wired here
@@ -3042,6 +3259,21 @@ func (handler integrationJobHandler) OnDeadLetter(ctx context.Context, job ports
 	return handler.svc.OnDeadLetter(ctx, job.Payload)
 }
 
+type assessmentComparisonJobHandler struct{ svc *comparisonuc.Service }
+
+type assessmentClosureReportJobHandler struct{ svc *cycleuc.ClosureReportService }
+
+func (handler assessmentClosureReportJobHandler) Handle(ctx context.Context, job ports.QueuedJob) error {
+	return handler.svc.HandleJob(ctx, job)
+}
+
+func (handler assessmentComparisonJobHandler) Handle(ctx context.Context, job ports.QueuedJob) error {
+	return handler.svc.HandleJob(ctx, job.Payload)
+}
+
+func (handler assessmentComparisonJobHandler) OnDeadLetter(ctx context.Context, job ports.QueuedJob, _ error) error {
+	return handler.svc.OnDeadLetter(ctx, job.Payload)
+}
 func (h vulnerabilityReconcileJobHandler) Handle(ctx context.Context, job ports.QueuedJob) error {
 	_, err := h.svc.ExecuteJob(ctx, job.ID)
 	return err

--- a/cmd/synapse-worker/main.go
+++ b/cmd/synapse-worker/main.go
@@ -55,6 +55,10 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/agenttools"
 	analysisuc "github.com/KKloudTarus/synapse-ce/internal/usecase/analysis"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/approval"
+	comparisonuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcomparison"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	lifecycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentlifecycle"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/assetuc"
 	attackpathuc "github.com/KKloudTarus/synapse-ce/internal/usecase/attackpath"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/cspm"
@@ -66,6 +70,7 @@ import (
 	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/execution"
 	exploitationuc "github.com/KKloudTarus/synapse-ce/internal/usecase/exploitation"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
 	integrationuc "github.com/KKloudTarus/synapse-ce/internal/usecase/integrations"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/leaderuc"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/orchestrator"
@@ -115,6 +120,10 @@ func main() {
 	}
 	if err := cfg.ValidateNetworkExecutionPosture(config.ProcessRoleWorker); err != nil {
 		log.Error("network execution posture invalid", "err", err)
+		os.Exit(1)
+	}
+	if err := cfg.ValidateAssessmentLifecycleRollout(); err != nil {
+		log.Error("assessment lifecycle rollout invalid", "err", err)
 		os.Exit(1)
 	}
 
@@ -174,6 +183,48 @@ func main() {
 	evidenceStore := postgres.NewEvidenceStore(pool)
 	auditLog := postgres.NewAuditLog(pool)
 	queue := postgres.NewJobQueue(pool, ids)
+	assessmentCycleStore := postgres.NewAssessmentCycleRepository(pool)
+	assessmentSnapshotStore := postgres.NewAssessmentSnapshotRepository(pool)
+	assessmentComparisonStore := postgres.NewAssessmentComparisonRepository(pool)
+	assessmentLineageStore := postgres.NewFindingLineageRepository(pool)
+	assessmentTransactions := postgres.NewTenantTransactionRunner(pool)
+	comparisonVerification, err := comparisonuc.NewRetestVerificationReader(assessmentLineageStore, assessmentSnapshotStore, postgres.NewRetestRepository(pool))
+	if err != nil {
+		log.Error("assessment comparison verification reader init failed", "err", err)
+		os.Exit(1)
+	}
+	assessmentComparisonService, err := comparisonuc.NewService(
+		assessmentComparisonStore, assessmentSnapshotStore, assessmentCycleStore, assessmentLineageStore,
+		assessmentTransactions, auditLog, clock, ids, comparisonVerification, nil,
+	)
+	if err != nil {
+		log.Error("assessment comparison service init failed", "err", err)
+		os.Exit(1)
+	}
+	var lineageObserver ports.FindingLineageObserver
+	assessmentLineageService, err := lineageuc.NewService(assessmentLineageStore, assessmentTransactions, auditLog, clock, ids, lineageObserver)
+	if err != nil {
+		log.Error("assessment lineage service init failed", "err", err)
+		os.Exit(1)
+	}
+	assessmentComparisonService.SetAPIStores(nil, queue, assessmentLineageService)
+	closureDecisionReader, err := cycleuc.NewClosureDecisionReader(assessmentLineageStore, assessmentSnapshotStore, postgres.NewRetestRepository(pool), postgres.NewSLAStore(pool))
+	if err != nil {
+		log.Error("assessment closure decision reader init failed", "err", err)
+		os.Exit(1)
+	}
+	assessmentClosureReportService, err := cycleuc.NewClosureReportService(assessmentCycleStore, assessmentCycleStore, assessmentSnapshotStore, assessmentComparisonStore, closureDecisionReader, auditLog)
+	if err != nil {
+		log.Error("assessment closure report service init failed", "err", err)
+		os.Exit(1)
+	}
+	if cfg.WorkerProfile == config.WorkerProfileLifecycle {
+		runWorkerRuntime(ctx, cfg, queue, map[string]worker.Handler{
+			comparisonuc.JobKind:                   assessmentComparisonJobHandler{svc: assessmentComparisonService},
+			cycleuc.AssessmentClosureReportJobKind: assessmentClosureReportJobHandler{svc: assessmentClosureReportService},
+		}, nil, postgres.NewLeaderStore(pool), auditLog, clock, ids, 6*time.Minute, log)
+		return
+	}
 	vulnerabilitySources := postgres.NewVulnerabilitySourceStore(pool)
 	vulnerabilityRuns := postgres.NewSyncRunStore(pool, ids)
 	vulnerabilityMaterializer := postgres.NewAdvisoryMaterializer(pool)
@@ -254,7 +305,17 @@ func main() {
 		blobStore = memoryStore
 		objectStore = memoryStore
 	}
-	uploadedSources := sourceupload.NewStore(objectStore, 0)
+	sourceObjects := objectStore
+	if cfg.BlobEndpoint == "" {
+		localSources, err := blob.NewFilesystem(cfg.EngagementSourceDir)
+		if err != nil {
+			log.Error("durable engagement source store init failed", "err", err)
+			os.Exit(1)
+		}
+		defer func() { _ = localSources.Close() }()
+		sourceObjects = localSources
+	}
+	uploadedSources := sourceupload.NewStoreWithRepository(sourceObjects, postgres.NewEngagementSourceRepository(pool), 0)
 
 	guard, err := execution.NewGuard(repo, clock, auditLog)
 	if err != nil {
@@ -309,6 +370,9 @@ func main() {
 		},
 		VulnDBSource: "osv.dev",
 	}
+	if cfg.Offline {
+		prov.VulnDBSource = "" // Match API provenance when live OSV is disabled.
+	}
 	scmConnectorStore, scmErr := postgres.NewSCMConnectorRepository(pool, mustVaultCipher(cfg, log))
 	if scmErr != nil {
 		log.Error("source-control connector store init failed", "err", scmErr)
@@ -322,6 +386,10 @@ func main() {
 	scaService := scauc.NewService(repo, findingRepo, scanRepo, scanResultStore, scanJobStore, scanRunStore, evidenceService, ids, prov, clock, auditLog, shared.Severity(cfg.FindingMinSeverity), cfg.ScanTimeout, sourceupload.NewAcquirer(scaExecution.Acquirer, uploadedSources),
 		enry.New(), scaExecution.SBOMGen, scaExecution.Sources,
 		risk.New(cfg.KEVURL, cfg.EPSSURL, nil), license.New(), licensemeta.NewChain(licensemeta.NewOSMetadata(), licensemeta.New(cfg.DepsDevURL, nil), licensemeta.NewPyPI("", nil)))
+	if cfg.AssessmentSnapshotEnabled {
+		scaService.SetScanRunProvenance(scanRunStore, assessmentTransactions)
+		scaService.SetAssessmentCycleMembership(assessmentCycleStore, assessmentSnapshotStore)
+	}
 	scaService.SetImportedSBOMStore(importedSBOMStore)
 	scaService.SetUploadedSourceStore(uploadedSources)
 	configureCleanup := scacompose.Configure(scaService, cfg, scaExecution.Sandbox, log)
@@ -345,6 +413,27 @@ func main() {
 		log.Info("compliance report ENABLED (Synapse AppSec Baseline; deterministic, LLM-free)")
 	}
 	scaService.SetRunLock(postgres.NewLeaseRunLock(pool, ids.NewID().String(), cfg.ScanTimeout+time.Minute))
+	if cfg.AssessmentShadowEnabled {
+		shadowSnapshotService, shadowErr := snapshotuc.NewService(assessmentSnapshotStore, assessmentCycleStore, repo, scanRunStore, assessmentTransactions, ids, clock, auditLog)
+		if shadowErr != nil {
+			log.Error("worker assessment snapshot shadow init failed", "err", shadowErr)
+			os.Exit(1)
+		}
+		shadowProjector, shadowErr := lineageuc.NewShadowProjector(assessmentLineageService, assessmentCycleStore, assessmentSnapshotStore, findingRepo, cfg.AssessmentShadowForTenant)
+		if shadowErr != nil {
+			log.Error("worker assessment lineage shadow init failed", "err", shadowErr)
+			os.Exit(1)
+		}
+		shadowSnapshotService.SetFinalizationObserver(shadowProjector)
+		shadowProjector.SetNativeEvidence(scanRunStore, scanRunStore)
+		shadowCoordinator, shadowErr := lifecycleuc.NewShadowCoordinator(assessmentCycleStore, assessmentSnapshotStore, shadowSnapshotService, assessmentComparisonService, cfg.AssessmentShadowForTenant)
+		if shadowErr != nil {
+			log.Error("worker assessment lifecycle shadow coordinator init failed", "err", shadowErr)
+			os.Exit(1)
+		}
+		scaService.SetScanRunObserver(shadowCoordinator)
+		log.Info("worker assessment lifecycle shadow writers configured", "tenant_count", len(cfg.AssessmentShadowTenants))
+	}
 
 	// The sandbox is REQUIRED here – the worker exists to run recon contained.
 	sb, serr := sandbox.NewRunner(cfg.ReconTimeout, cfg.ReconMaxOutput, cfg.SandboxMemMax, cfg.SandboxPidsMax)
@@ -420,9 +509,11 @@ func main() {
 
 	maintenanceTasks := append([]func(context.Context){}, integrationMaintenanceTasks...)
 	handlers := map[string]worker.Handler{
-		reconuc.JobKind:       reconJobHandler{svc: reconService}, // Handle + OnDeadLetter (finalize the run)
-		scauc.ScanJobKind:     scaJobHandler{svc: scaService},
-		integrationuc.JobKind: integrationJobHandler{svc: integrationService},
+		reconuc.JobKind:                        reconJobHandler{svc: reconService}, // Handle + OnDeadLetter (finalize the run)
+		scauc.ScanJobKind:                      scaJobHandler{svc: scaService},
+		integrationuc.JobKind:                  integrationJobHandler{svc: integrationService},
+		comparisonuc.JobKind:                   assessmentComparisonJobHandler{svc: assessmentComparisonService},
+		cycleuc.AssessmentClosureReportJobKind: assessmentClosureReportJobHandler{svc: assessmentClosureReportService},
 	}
 	vulnerabilityRegistry := vulnerabilitymonitor.NewRegistry()
 	vulnerabilityRegistry.AllowPrivateNetworkSources(cfg.VulnerabilitySourceAllowPrivateNetwork)
@@ -978,6 +1069,22 @@ func (handler integrationJobHandler) Handle(ctx context.Context, job ports.Queue
 }
 
 func (handler integrationJobHandler) OnDeadLetter(ctx context.Context, job ports.QueuedJob, _ error) error {
+	return handler.svc.OnDeadLetter(ctx, job.Payload)
+}
+
+type assessmentComparisonJobHandler struct{ svc *comparisonuc.Service }
+
+type assessmentClosureReportJobHandler struct{ svc *cycleuc.ClosureReportService }
+
+func (handler assessmentClosureReportJobHandler) Handle(ctx context.Context, job ports.QueuedJob) error {
+	return handler.svc.HandleJob(ctx, job)
+}
+
+func (handler assessmentComparisonJobHandler) Handle(ctx context.Context, job ports.QueuedJob) error {
+	return handler.svc.HandleJob(ctx, job.Payload)
+}
+
+func (handler assessmentComparisonJobHandler) OnDeadLetter(ctx context.Context, job ports.QueuedJob, _ error) error {
 	return handler.svc.OnDeadLetter(ctx, job.Payload)
 }
 

--- a/internal/adapter/httpapi/assessment_closure_handler_test.go
+++ b/internal/adapter/httpapi/assessment_closure_handler_test.go
@@ -1,0 +1,344 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	closuredom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentclosure"
+	cmpdom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type closureHTTPDecisionReader struct{}
+
+func (closureHTTPDecisionReader) ListAssessmentClosureReferences(context.Context, shared.ID, ports.AssessmentClosureReferenceQuery) ([]closuredom.Reference, error) {
+	return nil, nil
+}
+
+func (closureHTTPDecisionReader) ResolveAssessmentClosureReference(context.Context, shared.ID, ports.AssessmentClosureReferenceQuery, closuredom.Reference) error {
+	return nil
+}
+
+func TestAssessmentClosureReportDownloadHTTP(t *testing.T) {
+	router, tenantID, cycleID, manifestID := newAssessmentClosureHTTPRouter(t)
+	handler := router.routes()
+	path := "/api/v1/assessment-cycles/" + cycleID.String() + "/closure-manifests/" + manifestID.String() + "/report"
+
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, cycleRequest(http.MethodGet, path, "", userdom.RoleReadOnly, tenantID.String()))
+	if response.Code != http.StatusOK || response.Header().Get("Content-Type") != "application/json" || response.Header().Get("X-Content-Type-Options") != "nosniff" {
+		t.Fatalf("download response=%d headers=%v body=%s", response.Code, response.Header(), response.Body.String())
+	}
+	if response.Header().Get("Content-Disposition") != `attachment; filename="assessment-cycle-closure-report.json"` || !strings.HasPrefix(response.Header().Get("ETag"), `"sha256:`) {
+		t.Fatalf("download headers=%v", response.Header())
+	}
+	var document cycleuc.ClosureReportDocument
+	if err := json.Unmarshal(response.Body.Bytes(), &document); err != nil || document.Report.Manifest.ID != manifestID.String() || document.Report.Cycle.ID != cycleID.String() {
+		t.Fatalf("report document=%+v err=%v", document, err)
+	}
+
+	notModifiedRequest := cycleRequest(http.MethodGet, path, "", userdom.RoleReadOnly, tenantID.String())
+	notModifiedRequest.Header.Set("If-None-Match", response.Header().Get("ETag"))
+	notModified := httptest.NewRecorder()
+	handler.ServeHTTP(notModified, notModifiedRequest)
+	if notModified.Code != http.StatusNotModified || notModified.Body.Len() != 0 {
+		t.Fatalf("not modified response=%d body=%q", notModified.Code, notModified.Body.String())
+	}
+
+	crossTenant := httptest.NewRecorder()
+	handler.ServeHTTP(crossTenant, cycleRequest(http.MethodGet, path, "", userdom.RoleReadOnly, "other-tenant"))
+	if crossTenant.Code != http.StatusNotFound {
+		t.Fatalf("cross-tenant response=%d body=%s", crossTenant.Code, crossTenant.Body.String())
+	}
+}
+
+func TestAssessmentClosureAndReopenHTTPConcurrencyContracts(t *testing.T) {
+	router, tenantID, cycleID, _ := newAssessmentClosureHTTPRouterState(t, false)
+	handler := router.routes()
+	base := "/api/v1/assessment-cycles/" + cycleID.String()
+
+	previewResponse := httptest.NewRecorder()
+	handler.ServeHTTP(previewResponse, cycleRequest(http.MethodPost, base+"/closure-previews", `{"reason":"release accepted"}`, userdom.RoleReviewer, tenantID.String()))
+	if previewResponse.Code != http.StatusOK {
+		t.Fatalf("closure preview=%d body=%s", previewResponse.Code, previewResponse.Body.String())
+	}
+	var preview cycleuc.ClosurePreview
+	if err := json.Unmarshal(previewResponse.Body.Bytes(), &preview); err != nil || preview.PreviewToken == "" {
+		t.Fatalf("closure preview=%+v err=%v", preview, err)
+	}
+	commitBody := `{"preview_token":"` + preview.PreviewToken + `","reason":"release accepted"}`
+
+	missingIfMatch := httptest.NewRecorder()
+	request := cycleRequest(http.MethodPost, base+"/closure-commits", commitBody, userdom.RoleReviewer, tenantID.String())
+	request.Header.Set("Idempotency-Key", "closure-http-missing-match")
+	handler.ServeHTTP(missingIfMatch, request)
+	assertAssessmentCycleHTTPError(t, missingIfMatch, http.StatusPreconditionRequired, "precondition_required")
+
+	missingIdempotency := httptest.NewRecorder()
+	request = cycleRequest(http.MethodPost, base+"/closure-commits", commitBody, userdom.RoleReviewer, tenantID.String())
+	request.Header.Set("If-Match", `"`+strconv.FormatInt(preview.CycleVersion, 10)+`"`)
+	handler.ServeHTTP(missingIdempotency, request)
+	assertAssessmentCycleHTTPError(t, missingIdempotency, http.StatusBadRequest, cycleuc.CodeIdempotencyKeyRequired)
+
+	tampered := httptest.NewRecorder()
+	tamperedBody := `{"preview_token":"` + preview.PreviewToken + `x","reason":"release accepted"}`
+	request = cycleRequest(http.MethodPost, base+"/closure-commits", tamperedBody, userdom.RoleReviewer, tenantID.String())
+	request.Header.Set("If-Match", strconv.FormatInt(preview.CycleVersion, 10))
+	request.Header.Set("Idempotency-Key", "closure-http-tampered")
+	handler.ServeHTTP(tampered, request)
+	assertAssessmentCycleHTTPError(t, tampered, http.StatusConflict, cycleuc.CodeClosurePreviewStale)
+
+	committed := httptest.NewRecorder()
+	request = cycleRequest(http.MethodPost, base+"/closure-commits", commitBody, userdom.RoleReviewer, tenantID.String())
+	request.Header.Set("If-Match", strconv.FormatInt(preview.CycleVersion, 10))
+	request.Header.Set("Idempotency-Key", "closure-http-commit-contract")
+	handler.ServeHTTP(committed, request)
+	if committed.Code != http.StatusCreated {
+		t.Fatalf("closure commit=%d body=%s", committed.Code, committed.Body.String())
+	}
+	var closureResult cycleuc.ClosureCommitResult
+	if err := json.Unmarshal(committed.Body.Bytes(), &closureResult); err != nil {
+		t.Fatal(err)
+	}
+
+	replayed := httptest.NewRecorder()
+	request = cycleRequest(http.MethodPost, base+"/closure-commits", commitBody, userdom.RoleReviewer, tenantID.String())
+	request.Header.Set("If-Match", strconv.FormatInt(preview.CycleVersion, 10))
+	request.Header.Set("Idempotency-Key", "closure-http-commit-contract")
+	handler.ServeHTTP(replayed, request)
+	if replayed.Code != http.StatusCreated || replayed.Header().Get("Idempotency-Replayed") != "true" || replayed.Body.String() != committed.Body.String() {
+		t.Fatalf("closure replay=%d headers=%v body=%s", replayed.Code, replayed.Header(), replayed.Body.String())
+	}
+
+	mismatchedBody := httptest.NewRecorder()
+	request = cycleRequest(http.MethodPost, base+"/closure-commits", strings.Replace(commitBody, "release accepted", "different reason", 1), userdom.RoleReviewer, tenantID.String())
+	request.Header.Set("If-Match", strconv.FormatInt(preview.CycleVersion, 10))
+	request.Header.Set("Idempotency-Key", "closure-http-commit-contract")
+	handler.ServeHTTP(mismatchedBody, request)
+	assertAssessmentCycleHTTPError(t, mismatchedBody, http.StatusConflict, cycleuc.CodeIdempotencyBodyMismatch)
+
+	reusedPreview := httptest.NewRecorder()
+	request = cycleRequest(http.MethodPost, base+"/closure-commits", commitBody, userdom.RoleReviewer, tenantID.String())
+	request.Header.Set("If-Match", strconv.FormatInt(preview.CycleVersion, 10))
+	request.Header.Set("Idempotency-Key", "closure-http-reused-preview")
+	handler.ServeHTTP(reusedPreview, request)
+	assertAssessmentCycleHTTPError(t, reusedPreview, http.StatusConflict, cycleuc.CodeClosurePreviewStale)
+
+	reopenPreviewResponse := httptest.NewRecorder()
+	handler.ServeHTTP(reopenPreviewResponse, cycleRequest(http.MethodPost, base+"/reopen-previews", `{}`, userdom.RoleReviewer, tenantID.String()))
+	if reopenPreviewResponse.Code != http.StatusOK {
+		t.Fatalf("reopen preview=%d body=%s", reopenPreviewResponse.Code, reopenPreviewResponse.Body.String())
+	}
+	var reopenPreview cycleuc.ReopenPreview
+	if err := json.Unmarshal(reopenPreviewResponse.Body.Bytes(), &reopenPreview); err != nil || reopenPreview.PreviewToken == "" || reopenPreview.Manifest.ID != closureResult.Manifest.ID {
+		t.Fatalf("reopen preview=%+v err=%v", reopenPreview, err)
+	}
+	reopenBody := `{"preview_token":"` + reopenPreview.PreviewToken + `","reason":"additional testing required"}`
+	reopened := httptest.NewRecorder()
+	request = cycleRequest(http.MethodPost, base+"/reopen-commits", reopenBody, userdom.RoleReviewer, tenantID.String())
+	request.Header.Set("If-Match", strconv.FormatInt(reopenPreview.CycleVersion, 10))
+	request.Header.Set("Idempotency-Key", "closure-http-reopen-contract")
+	handler.ServeHTTP(reopened, request)
+	if reopened.Code != http.StatusOK {
+		t.Fatalf("reopen commit=%d body=%s", reopened.Code, reopened.Body.String())
+	}
+
+	reopenReplay := httptest.NewRecorder()
+	request = cycleRequest(http.MethodPost, base+"/reopen-commits", reopenBody, userdom.RoleReviewer, tenantID.String())
+	request.Header.Set("If-Match", strconv.FormatInt(reopenPreview.CycleVersion, 10))
+	request.Header.Set("Idempotency-Key", "closure-http-reopen-contract")
+	handler.ServeHTTP(reopenReplay, request)
+	if reopenReplay.Code != http.StatusOK || reopenReplay.Header().Get("Idempotency-Replayed") != "true" || reopenReplay.Body.String() != reopened.Body.String() {
+		t.Fatalf("reopen replay=%d headers=%v body=%s", reopenReplay.Code, reopenReplay.Header(), reopenReplay.Body.String())
+	}
+}
+
+func newAssessmentClosureHTTPRouter(t *testing.T) (*Router, shared.ID, shared.ID, shared.ID) {
+	return newAssessmentClosureHTTPRouterState(t, true)
+}
+
+func newAssessmentClosureHTTPRouterState(t *testing.T, closeCycle bool) (*Router, shared.ID, shared.ID, shared.ID) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	tenantID := shared.ID("tenant-closure-http")
+	ids := &assessmentCycleHTTPIDs{}
+	clock := fixedClock{t: now}
+	audit := &fakeAudit{}
+	engagements := memory.NewEngagementRepository()
+	cycles := memory.NewAssessmentCycleRepository()
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	comparisons := memory.NewAssessmentComparisonRepository()
+	transactions := memory.NewTenantTransactionRunner()
+	queue := memory.NewJobQueue(ids, clock.Now)
+
+	root := completedClosureHTTPAssessment(t, tenantID, "closure-http-root", now)
+	final := completedClosureHTTPAssessment(t, tenantID, "closure-http-final", now)
+	for _, assessment := range []*engdom.Engagement{root, final} {
+		if err := engagements.Create(ctx, assessment); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cycle, err := cycledom.NewAssessmentCycle("closure-http-cycle", tenantID, "Closure HTTP", cycledom.BoundaryStandalone, "", "", root.ID, "owner", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cycle.AdvanceRetest(final.ID, root.ID, cycle.Version, "owner", now); err != nil {
+		t.Fatal(err)
+	}
+	rootMember, _ := cycledom.NewInitialMember(tenantID, cycle.ID, root.ID, "owner", now)
+	finalMember, _ := cycledom.NewRetestMember(tenantID, cycle.ID, final.ID, root.ID, 1, "owner", now)
+	if err := cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	for _, member := range []*cycledom.Member{rootMember, finalMember} {
+		if err := cycles.CreateMember(ctx, member); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rootSnapshot := closureHTTPSnapshot(t, tenantID, cycle.ID, root.ID, "closure-http-snapshot-root", "closure-http-run-root", now)
+	finalSnapshot := closureHTTPSnapshot(t, tenantID, cycle.ID, final.ID, "closure-http-snapshot-final", "closure-http-run-final", now)
+	for _, snapshot := range []*assessmentsnapshot.Snapshot{rootSnapshot, finalSnapshot} {
+		if _, _, err := snapshots.CreateFinalizedCAS(ctx, snapshot, 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	comparison := closureHTTPComparison(t, tenantID, cycle.ID, rootSnapshot, finalSnapshot, now)
+	if _, created, err := comparisons.CreateQueued(ctx, comparison); err != nil || !created {
+		t.Fatalf("create comparison created=%v err=%v", created, err)
+	}
+	if err := comparison.Start(comparison.Version, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := comparisons.UpdateCAS(ctx, comparison, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := comparison.Complete(nil, comparison.Version, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := comparisons.UpdateCAS(ctx, comparison, 2); err != nil {
+		t.Fatal(err)
+	}
+
+	engagementService := enguc.NewService(engagements, clock, ids, audit)
+	cycleService, err := cycleuc.NewService(cycles, engagements, nil, nil, transactions, ids, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	api, err := cycleuc.NewAPIService(cycleService, cycles, memory.NewAssessmentCycleRequestRepository(), engagementService, transactions, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := api.SetClosureDependencies(cycles, snapshots, comparisons, closureHTTPDecisionReader{}, queue, []byte("0123456789abcdef0123456789abcdef")); err != nil {
+		t.Fatal(err)
+	}
+	router := &Router{log: discardLog(), eng: engagementService}
+	router.SetAssessmentCycles(api, true, func(string) bool { return true })
+	router.SetAssessmentLifecycleRollout(func(string) bool { return true }, func(string) bool { return true })
+	if !closeCycle {
+		return router, tenantID, cycle.ID, ""
+	}
+	preview, err := api.PreviewClosure(ctx, cycleuc.ClosurePreviewInput{TenantID: tenantID, Actor: "reviewer", CycleID: cycle.ID, Reason: "release accepted"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	commit, err := api.CommitClosure(ctx, cycleuc.ClosureCommitInput{
+		Request: cycleuc.RetainedRequest{TenantID: tenantID, Actor: "reviewer", Route: "/closure-commits", IdempotencyKey: "closure-http-commit"},
+		CycleID: cycle.ID, ExpectedVersion: preview.CycleVersion, PreviewToken: preview.PreviewToken, Reason: "release accepted",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var result cycleuc.ClosureCommitResult
+	if err := json.Unmarshal(commit.Body, &result); err != nil {
+		t.Fatal(err)
+	}
+	return router, tenantID, cycle.ID, shared.ID(result.Manifest.ID)
+}
+
+func assertAssessmentCycleHTTPError(t *testing.T, response *httptest.ResponseRecorder, status int, code string) {
+	t.Helper()
+	var body errorBody
+	if err := json.Unmarshal(response.Body.Bytes(), &body); err != nil || response.Code != status || body.Error != code {
+		t.Fatalf("response=%d body=%s parsed=%+v err=%v want_status=%d want_code=%q", response.Code, response.Body.String(), body, err, status, code)
+	}
+}
+
+func completedClosureHTTPAssessment(t *testing.T, tenantID, id shared.ID, now time.Time) *engdom.Engagement {
+	t.Helper()
+	assessment, err := engdom.New(id, tenantID, id.String(), "client", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := assessment.Transition(engdom.StatusActive, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := assessment.Transition(engdom.StatusCompleted, now); err != nil {
+		t.Fatal(err)
+	}
+	return assessment
+}
+
+func closureHTTPSnapshot(t *testing.T, tenantID, cycleID, assessmentID, snapshotID shared.ID, runID string, now time.Time) *assessmentsnapshot.Snapshot {
+	t.Helper()
+	finished := now.Add(-time.Minute)
+	target, err := scanrun.CanonicalizeRepositoryTarget("https://example.com/repo.git", "0123456789abcdef0123456789abcdef01234567")
+	if err != nil {
+		t.Fatal(err)
+	}
+	lanes := []scanrun.Lane{{
+		TenantID: tenantID, EngagementID: assessmentID, ScanRunID: runID, LaneKey: runID + "-lane", Producer: "sca", TerminalStatus: scanrun.StatusSucceeded,
+		Target:                    target,
+		AuthoritativeFindingKinds: []string{"vulnerability"}, IncludedScope: []string{"src/**"}, ExcludedScope: []string{"vendor/**"},
+		StartedAt: finished.Add(-time.Minute), FinishedAt: &finished, ResultRef: "result:" + runID, EvidenceRef: "evidence:" + runID,
+		ResultSHA256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion, SealedAt: &finished,
+		Versions: []scanrun.LaneVersion{{VersionKind: scanrun.VersionScanner, Name: "sca", Version: "1"}}, Stages: []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSucceeded, StartedAt: finished.Add(-time.Minute), FinishedAt: &finished}},
+	}}
+	lanes[0].ManifestHash, err = scanrun.ComputeManifestHash(lanes[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestHash, err := scanrun.ComputeRunManifestHash(lanes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := assessmentsnapshot.NewFinalized(tenantID, snapshotID, cycleID, assessmentID, assessmentsnapshot.Boundary{Kind: cycledom.BoundaryStandalone}, "request-"+snapshotID.String(), "scanner", now, []assessmentsnapshot.SelectedRun{{
+		ID: runID, ManifestHash: manifestHash, Provenance: scanrun.ProvenanceNative, TerminalStatus: scanrun.StatusSucceeded, Trusted: true, Lanes: lanes,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return snapshot
+}
+
+func closureHTTPComparison(t *testing.T, tenantID, cycleID shared.ID, initial, final *assessmentsnapshot.Snapshot, now time.Time) cmpdom.Comparison {
+	t.Helper()
+	input := cmpdom.GenerationInput{
+		Mode: cmpdom.ModeLifecycle, Baseline: cmpdom.SnapshotHashRef{ID: initial.ID, ContentHash: initial.ContentHash}, Current: cmpdom.SnapshotHashRef{ID: final.ID, ContentHash: final.ContentHash},
+		AlgorithmVersion: 1, FingerprintVersion: 1, RiskModelVersion: 1, CoveragePolicyVersion: 1,
+	}
+	payload, inputHash, err := cmpdom.HashGenerationInput(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	comparison, err := cmpdom.NewQueued(tenantID, cycleID, "closure-http-comparison", input, payload, inputHash, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return comparison
+}

--- a/internal/adapter/httpapi/assessment_comparison_handler.go
+++ b/internal/adapter/httpapi/assessment_comparison_handler.go
@@ -1,0 +1,185 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	comparisonuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcomparison"
+)
+
+const assessmentComparisonBodyLimit = int64(16 << 10)
+
+type createAssessmentComparisonRequest struct {
+	BaselineSnapshotID string      `json:"baseline_snapshot_id"`
+	CurrentSnapshotID  string      `json:"current_snapshot_id"`
+	Mode               domain.Mode `json:"mode"`
+}
+
+func (rt *Router) createAssessmentComparison(w http.ResponseWriter, r *http.Request) {
+	var request createAssessmentComparisonRequest
+	if !decodeAssessmentComparisonJSON(w, r, &request) {
+		return
+	}
+	response, err := rt.assessmentComparisons.QueueRetained(r.Context(), comparisonuc.RetainedRequest{
+		TenantID: shared.ID(TenantFrom(r.Context())), Actor: PrincipalFrom(r.Context()), Route: "POST /api/v1/assessment-comparisons", IdempotencyKey: r.Header.Get("Idempotency-Key"),
+	}, comparisonuc.QueueInput{
+		BaselineSnapshotID: shared.ID(request.BaselineSnapshotID), CurrentSnapshotID: shared.ID(request.CurrentSnapshotID), Mode: request.Mode,
+		FingerprintVersion: 1, RiskModelVersion: comparisonuc.RiskModelVersionV1,
+	})
+	if err != nil {
+		writeAssessmentComparisonError(w, err)
+		return
+	}
+	writeAssessmentComparisonRetained(w, response)
+}
+
+func (rt *Router) getAssessmentComparison(w http.ResponseWriter, r *http.Request) {
+	view, err := rt.assessmentComparisons.Get(r.Context(), shared.ID(TenantFrom(r.Context())), shared.ID(r.PathValue("comparisonId")))
+	if err != nil {
+		writeAssessmentComparisonError(w, err)
+		return
+	}
+	w.Header().Set("ETag", relationshipETag(view.Version))
+	writeJSON(w, http.StatusOK, view)
+}
+
+func (rt *Router) getAssessmentComparisonSummary(w http.ResponseWriter, r *http.Request) {
+	summary, err := rt.assessmentComparisons.GetSummary(
+		r.Context(),
+		shared.ID(TenantFrom(r.Context())),
+		shared.ID(r.PathValue("comparisonId")),
+		domain.Scope(strings.TrimSpace(r.URL.Query().Get("scope"))),
+	)
+	if err != nil {
+		writeAssessmentComparisonError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, summary)
+}
+
+func (rt *Router) listAssessmentComparisonItems(w http.ResponseWriter, r *http.Request) {
+	limit := 0
+	if value := strings.TrimSpace(r.URL.Query().Get("limit")); value != "" {
+		parsed, err := strconv.Atoi(value)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_limit"})
+			return
+		}
+		limit = parsed
+	}
+	page, err := rt.assessmentComparisons.ListItems(r.Context(), comparisonuc.ListItemsInput{
+		TenantID: shared.ID(TenantFrom(r.Context())), ComparisonID: shared.ID(r.PathValue("comparisonId")), Cursor: r.URL.Query().Get("cursor"), Limit: limit,
+		Scope:    domain.Scope(strings.TrimSpace(r.URL.Query().Get("scope"))),
+		Presence: strings.TrimSpace(r.URL.Query().Get("presence")), ChangeFlag: domain.ChangeFlag(strings.TrimSpace(r.URL.Query().Get("change_flag"))),
+		Severity: shared.Severity(strings.TrimSpace(r.URL.Query().Get("severity"))), ProducerKind: r.URL.Query().Get("producer"), FindingKind: r.URL.Query().Get("finding_kind"),
+		Disposition: strings.TrimSpace(r.URL.Query().Get("disposition")), ReviewState: strings.TrimSpace(r.URL.Query().Get("review_state")),
+	})
+	if err != nil {
+		writeAssessmentComparisonError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, page)
+}
+
+type reviewAssessmentComparisonItemRequest struct {
+	CandidateID         string `json:"candidate_id"`
+	SourceObservationID string `json:"source_observation_id"`
+	TargetObservationID string `json:"target_observation_id,omitempty"`
+	Reason              string `json:"reason"`
+}
+
+func (rt *Router) confirmAssessmentComparisonItem(w http.ResponseWriter, r *http.Request) {
+	rt.reviewAssessmentComparisonItem(w, r, comparisonuc.ReviewConfirm)
+}
+
+func (rt *Router) unlinkAssessmentComparisonItem(w http.ResponseWriter, r *http.Request) {
+	rt.reviewAssessmentComparisonItem(w, r, comparisonuc.ReviewUnlink)
+}
+
+func (rt *Router) reviewAssessmentComparisonItem(w http.ResponseWriter, r *http.Request, action comparisonuc.ReviewAction) {
+	if strings.TrimSpace(r.Header.Get("If-Match")) == "" {
+		writeJSON(w, http.StatusPreconditionRequired, errorBody{Error: "precondition_required"})
+		return
+	}
+	expectedVersion, err := parseCycleIfMatch(r.Header.Get("If-Match"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_if_match"})
+		return
+	}
+	var request reviewAssessmentComparisonItemRequest
+	if !decodeAssessmentComparisonJSON(w, r, &request) {
+		return
+	}
+	response, err := rt.assessmentComparisons.Review(r.Context(), comparisonuc.ReviewInput{
+		Request: comparisonuc.RetainedRequest{
+			TenantID: shared.ID(TenantFrom(r.Context())), Actor: PrincipalFrom(r.Context()), Route: "POST /api/v1/assessment-comparisons/{comparisonId}/items/{itemId}/" + string(action), IdempotencyKey: r.Header.Get("Idempotency-Key"),
+		},
+		ComparisonID: shared.ID(r.PathValue("comparisonId")), ItemID: shared.ID(r.PathValue("itemId")), CandidateID: shared.ID(request.CandidateID),
+		SourceObservationID: shared.ID(request.SourceObservationID), TargetObservationID: shared.ID(request.TargetObservationID), ExpectedVersion: expectedVersion,
+		Action: action, Reason: request.Reason,
+	})
+	if err != nil {
+		writeAssessmentComparisonError(w, err)
+		return
+	}
+	writeAssessmentComparisonRetained(w, response)
+}
+
+func decodeAssessmentComparisonJSON(w http.ResponseWriter, r *http.Request, target any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, assessmentComparisonBodyLimit)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, errorBody{Error: "request_too_large"})
+		} else {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_request"})
+		}
+		return false
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_request"})
+		return false
+	}
+	return true
+}
+
+func writeAssessmentComparisonRetained(w http.ResponseWriter, response comparisonuc.RetainedResponse) {
+	if response.Replayed {
+		w.Header().Set("Idempotency-Replayed", "true")
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(response.StatusCode)
+	_, _ = w.Write(response.Body)
+}
+
+func writeAssessmentComparisonError(w http.ResponseWriter, err error) {
+	code := comparisonuc.ErrorCode(err)
+	if code == "" {
+		code = "assessment_comparison_error"
+	}
+	status := http.StatusInternalServerError
+	switch {
+	case errors.Is(err, shared.ErrNotFound):
+		status = http.StatusNotFound
+	case errors.Is(err, shared.ErrForbidden):
+		status = http.StatusForbidden
+	case errors.Is(err, shared.ErrConflict):
+		status = http.StatusConflict
+	case errors.Is(err, shared.ErrValidation):
+		status = http.StatusBadRequest
+	}
+	switch code {
+	case domain.ReasonLifecycleReverse, domain.ReasonLifecycleSibling, domain.ReasonLifecycleDirectionAvailable,
+		domain.ReasonSameSnapshot, domain.ReasonCrossCycle, domain.ReasonSnapshotNotFinalized, domain.ReasonMissingRelationship:
+		status = http.StatusUnprocessableEntity
+	}
+	writeJSON(w, status, errorBody{Error: code})
+}

--- a/internal/adapter/httpapi/assessment_comparison_handler_test.go
+++ b/internal/adapter/httpapi/assessment_comparison_handler_test.go
@@ -1,0 +1,210 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	comparisonuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcomparison"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
+)
+
+func TestAssessmentComparisonRoutesContractPermissionsAndIsolation(t *testing.T) {
+	router, service, baselineID, currentID := newAssessmentComparisonHTTPRouter(t)
+	handler := router.routes()
+	body := `{"baseline_snapshot_id":"` + baselineID.String() + `","current_snapshot_id":"` + currentID.String() + `","mode":"lifecycle"}`
+
+	forbidden := httptest.NewRecorder()
+	handler.ServeHTTP(forbidden, cycleRequest(http.MethodPost, "/api/v1/assessment-comparisons", body, userdom.RoleReviewer, "tenant-comparison-http"))
+	if forbidden.Code != http.StatusForbidden {
+		t.Fatalf("reviewer create=%d body=%s", forbidden.Code, forbidden.Body.String())
+	}
+
+	missingKey := httptest.NewRecorder()
+	handler.ServeHTTP(missingKey, cycleRequest(http.MethodPost, "/api/v1/assessment-comparisons", body, userdom.RoleConsultant, "tenant-comparison-http"))
+	if missingKey.Code != http.StatusBadRequest || !strings.Contains(missingKey.Body.String(), comparisonuc.CodeIdempotencyKeyRequired) {
+		t.Fatalf("missing key=%d body=%s", missingKey.Code, missingKey.Body.String())
+	}
+
+	create := cycleRequest(http.MethodPost, "/api/v1/assessment-comparisons", body, userdom.RoleConsultant, "tenant-comparison-http")
+	create.Header.Set("Idempotency-Key", "comparison-http-create")
+	created := httptest.NewRecorder()
+	handler.ServeHTTP(created, create)
+	if created.Code != http.StatusAccepted {
+		t.Fatalf("create=%d body=%s", created.Code, created.Body.String())
+	}
+	var queued comparisonuc.QueueResult
+	if err := json.Unmarshal(created.Body.Bytes(), &queued); err != nil || queued.Comparison.ID.IsZero() {
+		t.Fatalf("queued=%+v err=%v", queued, err)
+	}
+
+	replay := cycleRequest(http.MethodPost, "/api/v1/assessment-comparisons", body, userdom.RoleConsultant, "tenant-comparison-http")
+	replay.Header.Set("Idempotency-Key", "comparison-http-create")
+	replayed := httptest.NewRecorder()
+	handler.ServeHTTP(replayed, replay)
+	if replayed.Code != http.StatusAccepted || replayed.Header().Get("Idempotency-Replayed") != "true" || replayed.Body.String() != created.Body.String() {
+		t.Fatalf("replay=%d headers=%v body=%s", replayed.Code, replayed.Header(), replayed.Body.String())
+	}
+
+	crossTenant := httptest.NewRecorder()
+	handler.ServeHTTP(crossTenant, cycleRequest(http.MethodGet, "/api/v1/assessment-comparisons/"+queued.Comparison.ID.String(), "", userdom.RoleReadOnly, "tenant-other"))
+	if crossTenant.Code != http.StatusNotFound {
+		t.Fatalf("cross tenant get=%d body=%s", crossTenant.Code, crossTenant.Body.String())
+	}
+
+	completed, err := service.Generate(context.Background(), comparisonuc.WorkInput{TenantID: "tenant-comparison-http", ComparisonID: queued.Comparison.ID, Actor: "worker"})
+	if err != nil || completed.Status != domain.StatusComplete {
+		t.Fatalf("completed=%+v err=%v", completed, err)
+	}
+	get := httptest.NewRecorder()
+	handler.ServeHTTP(get, cycleRequest(http.MethodGet, "/api/v1/assessment-comparisons/"+completed.ID.String(), "", userdom.RoleReadOnly, "tenant-comparison-http"))
+	if get.Code != http.StatusOK || get.Header().Get("ETag") != `"3"` {
+		t.Fatalf("get=%d headers=%v body=%s", get.Code, get.Header(), get.Body.String())
+	}
+	summary := httptest.NewRecorder()
+	handler.ServeHTTP(summary, cycleRequest(http.MethodGet, "/api/v1/assessment-comparisons/"+completed.ID.String()+"/summary?scope=vulnerability", "", userdom.RoleReadOnly, "tenant-comparison-http"))
+	if summary.Code != http.StatusOK || !strings.Contains(summary.Body.String(), `"baseline_count":1`) || !strings.Contains(summary.Body.String(), `"current_count":1`) {
+		t.Fatalf("summary=%d body=%s", summary.Code, summary.Body.String())
+	}
+	invalidScope := httptest.NewRecorder()
+	handler.ServeHTTP(invalidScope, cycleRequest(http.MethodGet, "/api/v1/assessment-comparisons/"+completed.ID.String()+"/summary?scope=quality", "", userdom.RoleReadOnly, "tenant-comparison-http"))
+	if invalidScope.Code != http.StatusBadRequest {
+		t.Fatalf("invalid scope=%d body=%s", invalidScope.Code, invalidScope.Body.String())
+	}
+
+	items := httptest.NewRecorder()
+	handler.ServeHTTP(items, cycleRequest(http.MethodGet, "/api/v1/assessment-comparisons/"+completed.ID.String()+"/items?limit=1&scope=vulnerability", "", userdom.RoleReadOnly, "tenant-comparison-http"))
+	if items.Code != http.StatusOK || !strings.Contains(items.Body.String(), "comparison-item-") {
+		t.Fatalf("items=%d body=%s", items.Code, items.Body.String())
+	}
+	invalidCursor := httptest.NewRecorder()
+	handler.ServeHTTP(invalidCursor, cycleRequest(http.MethodGet, "/api/v1/assessment-comparisons/"+completed.ID.String()+"/items?cursor=not-base64", "", userdom.RoleReadOnly, "tenant-comparison-http"))
+	if invalidCursor.Code != http.StatusBadRequest || !strings.Contains(invalidCursor.Body.String(), "invalid_cursor") {
+		t.Fatalf("invalid cursor=%d body=%s", invalidCursor.Code, invalidCursor.Body.String())
+	}
+
+	reviewPath := "/api/v1/assessment-comparisons/" + completed.ID.String() + "/items/missing/confirm"
+	consultantReview := httptest.NewRecorder()
+	handler.ServeHTTP(consultantReview, cycleRequest(http.MethodPost, reviewPath, `{}`, userdom.RoleConsultant, "tenant-comparison-http"))
+	if consultantReview.Code != http.StatusForbidden {
+		t.Fatalf("consultant review=%d body=%s", consultantReview.Code, consultantReview.Body.String())
+	}
+	missingIfMatch := cycleRequest(http.MethodPost, reviewPath, `{}`, userdom.RoleReviewer, "tenant-comparison-http")
+	missingIfMatch.Header.Set("Idempotency-Key", "review-http")
+	missingIfMatchResponse := httptest.NewRecorder()
+	handler.ServeHTTP(missingIfMatchResponse, missingIfMatch)
+	if missingIfMatchResponse.Code != http.StatusPreconditionRequired {
+		t.Fatalf("missing If-Match=%d body=%s", missingIfMatchResponse.Code, missingIfMatchResponse.Body.String())
+	}
+}
+
+func newAssessmentComparisonHTTPRouter(t *testing.T) (*Router, *comparisonuc.Service, shared.ID, shared.ID) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Date(2026, 9, 1, 16, 0, 0, 0, time.UTC)
+	clock := fixedClock{t: now}
+	ids := &assessmentCycleHTTPIDs{}
+	audit := &fakeAudit{}
+	transactions := memory.NewTenantTransactionRunner()
+	cycles := memory.NewAssessmentCycleRepository()
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	lineage := memory.NewFindingLineageRepository()
+	comparisons := memory.NewAssessmentComparisonRepository()
+	cycle, err := assessmentcycle.NewAssessmentCycle("comparison-http-cycle", "tenant-comparison-http", "HTTP Cycle", assessmentcycle.BoundaryStandalone, "", "", "comparison-http-assessment", "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember("tenant-comparison-http", cycle.ID, "comparison-http-assessment", "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+	retest, err := assessmentcycle.NewRetestMember("tenant-comparison-http", cycle.ID, "comparison-http-retest", member.AssessmentID, 1, "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(ctx, retest); err != nil {
+		t.Fatal(err)
+	}
+	var baselineID, currentID shared.ID
+	for number, value := range []struct {
+		id, runID, assessmentID shared.ID
+		scope                   string
+	}{{"comparison-http-snapshot-1", "comparison-http-run-1", member.AssessmentID, "src/**"}, {"comparison-http-snapshot-2", "comparison-http-run-2", retest.AssessmentID, "src/**"}} {
+		snapshot, err := assessmentsnapshot.NewFinalized("tenant-comparison-http", value.id, cycle.ID, value.assessmentID,
+			assessmentsnapshot.Boundary{Kind: assessmentcycle.BoundaryStandalone}, "request-"+value.id.String(), "operator", now.Add(time.Duration(number)*time.Minute),
+			[]assessmentsnapshot.SelectedRun{assessmentRelationshipHTTPRun(t, value.runID.String(), value.scope, now.Add(time.Duration(number)*time.Minute))})
+		if err != nil {
+			t.Fatal(err)
+		}
+		stored, created, err := snapshots.CreateFinalizedCAS(ctx, snapshot, 0)
+		if err != nil || !created {
+			t.Fatalf("snapshot %d created=%v err=%v", number+1, created, err)
+		}
+		if number == 0 {
+			baselineID = stored.ID
+		} else {
+			currentID = stored.ID
+		}
+	}
+	canonical, err := findinglineage.CanonicalizeFingerprintV1(findinglineage.FingerprintCanonicalInputV1{
+		CanonicalizationVersion: 1, ProducerKind: "sca", TargetIdentitySchemaVersion: 1, TargetIdentityCanonical: "repository:https://example.com/repository.git@0123456789abcdef0123456789abcdef01234567",
+		IdentityFields: map[string]findinglineage.CanonicalValue{"rule_id": findinglineage.Text("rule-http")},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	risk := 5000
+	identity := findinglineage.Identity{
+		TenantID: "tenant-comparison-http", CycleID: cycle.ID, ID: "comparison-http-identity", ProducerKind: "sca", FindingKind: "vulnerability",
+		CanonicalizationVersion: 1, FingerprintSchemaVersion: 1, LineageFingerprint: canonical.Fingerprint, TargetIdentitySchemaVersion: 1,
+		TargetIdentityCanonical: "repository:https://example.com/repository.git@0123456789abcdef0123456789abcdef01234567", CanonicalIdentityFields: canonical.IdentityFields,
+		FirstSeenSnapshotID: baselineID, CreatedAt: now,
+	}
+	observation := func(id, snapshotID shared.ID, observedAt time.Time) findinglineage.Observation {
+		return findinglineage.Observation{
+			TenantID: identity.TenantID, CycleID: cycle.ID, ID: id, SnapshotID: snapshotID, IdentityID: identity.ID, ProducerKind: "sca", FindingKind: "vulnerability",
+			TargetCanonical: identity.TargetIdentityCanonical, SourceFindingID: "source-" + id.String(), Severity: shared.SeverityHigh, RiskScoreMilli: &risk,
+			ComponentVersion: "1.0.0", Location: "go.mod", Reachability: "reachable", EvidenceDigest: strings.Repeat("a", 64),
+			ScannerProvenance: findinglineage.ScannerProvenance{ToolName: "sca", ToolVersion: "1", LaneKey: "sca", RuleID: "rule-http"}, ObservedAt: observedAt,
+		}
+	}
+	if err := lineage.CreateIdentityWithObservation(ctx, identity, observation("comparison-http-observation-1", baselineID, now)); err != nil {
+		t.Fatal(err)
+	}
+	if err := lineage.AppendObservation(ctx, observation("comparison-http-observation-2", currentID, now.Add(time.Minute))); err != nil {
+		t.Fatal(err)
+	}
+	verification, err := comparisonuc.NewRetestVerificationReader(lineage, snapshots, memory.NewRetestRepository())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := comparisonuc.NewService(comparisons, snapshots, cycles, lineage, transactions, audit, clock, ids, verification, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineageService, err := lineageuc.NewService(lineage, transactions, audit, clock, ids, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service.SetAPIStores(memory.NewAssessmentCycleRequestRepository(), memory.NewJobQueue(ids, clock.Now), lineageService)
+	router := &Router{log: discardLog()}
+	router.SetAssessmentComparisons(service)
+	return router, service, baselineID, currentID
+}

--- a/internal/adapter/httpapi/assessment_cycle_handler.go
+++ b/internal/adapter/httpapi/assessment_cycle_handler.go
@@ -1,0 +1,486 @@
+package httpapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"strconv"
+	"strings"
+
+	cmpdom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+)
+
+const assessmentCycleRequestLimit = int64(1 << 20)
+
+type createAssessmentRetestRequest struct {
+	SourceStrategy          string      `json:"source_strategy"`
+	SourceVersionID         string      `json:"source_version_id"`
+	PlannedDate             string      `json:"planned_date"`
+	Name                    string      `json:"name"`
+	PredecessorAssessmentID string      `json:"predecessor_assessment_id"`
+	ScopeStrategy           string      `json:"scope_strategy"`
+	ProfileStrategy         string      `json:"profile_strategy"`
+	AuthorizedFrom          string      `json:"authorized_from"`
+	AuthorizedTo            string      `json:"authorized_to"`
+	Timezone                string      `json:"timezone"`
+	RoE                     *engdom.RoE `json:"roe"`
+}
+
+type assessmentRelationshipChangeRequest struct {
+	Command                    string `json:"command"`
+	AssessmentID               string `json:"assessment_id"`
+	NewPredecessorAssessmentID string `json:"new_predecessor_assessment_id"`
+	SelectedHeadAssessmentID   string `json:"selected_head_assessment_id"`
+	PreviewToken               string `json:"preview_token"`
+	Reason                     string `json:"reason"`
+}
+
+type assessmentClosureRequest struct {
+	PreviewToken       string   `json:"preview_token"`
+	Reason             string   `json:"reason"`
+	OverrideBlockerIDs []string `json:"override_blocker_ids"`
+	OverrideReason     string   `json:"override_reason"`
+}
+
+type assessmentReopenRequest struct {
+	PreviewToken string `json:"preview_token"`
+	Reason       string `json:"reason"`
+}
+
+func (rt *Router) createAssessmentRetest(w http.ResponseWriter, r *http.Request) {
+	var request createAssessmentRetestRequest
+	var source *cycleuc.SourceUpload
+	var sourceFile multipart.File
+	var body io.Reader
+	mediaType, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if mediaType == "multipart/form-data" {
+		r.Body = http.MaxBytesReader(w, r.Body, sourcepackage.MaxArchiveBytes+assessmentCycleRequestLimit)
+		if err := r.ParseMultipartForm(8 << 20); err != nil {
+			if r.MultipartForm != nil {
+				_ = r.MultipartForm.RemoveAll()
+			}
+			var tooLarge *http.MaxBytesError
+			status := http.StatusBadRequest
+			if errors.As(err, &tooLarge) {
+				status = http.StatusRequestEntityTooLarge
+			}
+			writeJSON(w, status, errorBody{Error: "invalid_or_oversized_source_upload"})
+			return
+		}
+		defer func() {
+			if r.MultipartForm != nil {
+				_ = r.MultipartForm.RemoveAll()
+			}
+		}()
+		metadata := r.FormValue("metadata")
+		if len(metadata) == 0 || int64(len(metadata)) > assessmentCycleRequestLimit {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_metadata"})
+			return
+		}
+		body = strings.NewReader(metadata)
+		var header *multipart.FileHeader
+		var err error
+		sourceFile, header, err = r.FormFile("source")
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: "source_upload_required"})
+			return
+		}
+		defer func() { _ = sourceFile.Close() }()
+		filename := sourcepackage.BaseFilename(header.Filename)
+		if !sourcepackage.ValidFilename(filename) {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_source_filename"})
+			return
+		}
+		size, digest, err := hashSourceUpload(sourceFile)
+		if err != nil {
+			if size > sourcepackage.MaxArchiveBytes {
+				writeJSON(w, http.StatusRequestEntityTooLarge, errorBody{Error: "source_upload_too_large"})
+			} else {
+				writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_source_upload"})
+			}
+			return
+		}
+		source = &cycleuc.SourceUpload{Filename: filename, Size: size, SHA256: digest, Reader: sourceFile}
+	} else {
+		body = http.MaxBytesReader(w, r.Body, assessmentCycleRequestLimit)
+	}
+	decoder := json.NewDecoder(body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_request"})
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_request"})
+		return
+	}
+	authorizedFrom, err := parseRFC3339Ptr(request.AuthorizedFrom)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_authorized_from"})
+		return
+	}
+	authorizedTo, err := parseRFC3339Ptr(request.AuthorizedTo)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_authorized_to"})
+		return
+	}
+	response, err := rt.assessmentCycles.CreateRetestAssessment(r.Context(), cycleuc.CreateRetestAssessmentInput{
+		Request: cycleuc.RetainedRequest{
+			TenantID: shared.ID(TenantFrom(r.Context())), Actor: PrincipalFrom(r.Context()), Route: r.URL.Path,
+			IdempotencyKey: r.Header.Get("Idempotency-Key"),
+		},
+		AssessmentID: shared.ID(r.PathValue("assessmentId")), Name: request.Name, Source: source,
+		SourceStrategy: request.SourceStrategy, SourceVersionID: shared.ID(request.SourceVersionID),
+		PredecessorAssessmentID: shared.ID(request.PredecessorAssessmentID), ScopeStrategy: request.ScopeStrategy,
+		ProfileStrategy: request.ProfileStrategy, AuthorizedFrom: authorizedFrom, AuthorizedTo: authorizedTo,
+		Timezone: request.Timezone, RoE: request.RoE, PlannedDate: request.PlannedDate,
+	})
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	var result cycleuc.CreateRetestResponse
+	if err := json.Unmarshal(response.Body, &result); err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeRetainedValue(w, response, struct {
+		Engagement      engagementView                 `json:"engagement"`
+		Cycle           cycleuc.CycleView              `json:"cycle"`
+		Member          cycleuc.MemberView             `json:"member"`
+		InheritanceDiff cycleuc.InheritanceDiff        `json:"inheritance_diff"`
+		Warnings        []string                       `json:"warnings"`
+		SourceSelection *cycleuc.RetestSourceSelection `json:"source_selection,omitempty"`
+	}{toEngagementView(result.Engagement), result.Cycle, result.Member, result.InheritanceDiff, result.Warnings, result.SourceSelection})
+}
+
+func (rt *Router) getAssessmentLifecycle(w http.ResponseWriter, r *http.Request) {
+	response, err := rt.assessmentCycles.GetLifecycle(r.Context(), shared.ID(TenantFrom(r.Context())), shared.ID(r.PathValue("assessmentId")))
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (rt *Router) getAssessmentCycle(w http.ResponseWriter, r *http.Request) {
+	response, err := rt.assessmentCycles.GetCycle(r.Context(), shared.ID(TenantFrom(r.Context())), shared.ID(r.PathValue("cycleId")))
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (rt *Router) listAssessmentCycles(w http.ResponseWriter, r *http.Request) {
+	limit := 0
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: cycleuc.CodeInvalidPageSize})
+			return
+		}
+		limit = parsed
+	}
+	response, err := rt.assessmentCycles.ListCycles(r.Context(), cycleuc.ListCyclesInput{
+		TenantID: shared.ID(TenantFrom(r.Context())), Status: cycledom.Status(r.URL.Query().Get("status")),
+		BoundaryKind: cycledom.BoundaryKind(r.URL.Query().Get("boundary_kind")), AssessmentStatus: engdom.Status(r.URL.Query().Get("assessment_status")),
+		SelectedHeadID: shared.ID(r.URL.Query().Get("selected_head_assessment_id")), AssessmentType: cycledom.AssessmentType(r.URL.Query().Get("assessment_type")),
+		ProducerKind: r.URL.Query().Get("producer"), FindingKind: r.URL.Query().Get("finding_kind"), ReviewState: r.URL.Query().Get("review_state"),
+		ChangePresence: cmpdom.Presence(r.URL.Query().Get("change_presence")), ChangeSeverity: shared.Severity(r.URL.Query().Get("change_severity")),
+		ScanStaleness: r.URL.Query().Get("scan_staleness"), Search: r.URL.Query().Get("q"), Cursor: r.URL.Query().Get("cursor"), Limit: limit,
+	})
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (rt *Router) listAssessmentCycleMembers(w http.ResponseWriter, r *http.Request) {
+	limit := 0
+	if value := strings.TrimSpace(r.URL.Query().Get("limit")); value != "" {
+		parsed, err := strconv.Atoi(value)
+		if err != nil || parsed < 1 {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: cycleuc.CodeInvalidPageSize})
+			return
+		}
+		limit = parsed
+	}
+	page, err := rt.assessmentCycles.ListCycleMembers(r.Context(), cycleuc.ListCycleMembersInput{
+		TenantID: shared.ID(TenantFrom(r.Context())), CycleID: shared.ID(r.PathValue("cycleId")), Cursor: r.URL.Query().Get("cursor"), Limit: limit,
+	})
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, page)
+}
+
+func (rt *Router) archiveAssessmentCycle(w http.ResponseWriter, r *http.Request) {
+	expectedVersion, err := parseCycleIfMatch(r.Header.Get("If-Match"))
+	if err != nil {
+		writeJSON(w, http.StatusPreconditionRequired, errorBody{Error: "precondition_required"})
+		return
+	}
+	response, err := rt.assessmentCycles.ArchiveCycle(r.Context(), cycleuc.ArchiveCycleRequest{
+		Request: cycleuc.RetainedRequest{
+			TenantID: shared.ID(TenantFrom(r.Context())), Actor: PrincipalFrom(r.Context()), Route: r.URL.Path,
+			IdempotencyKey: r.Header.Get("Idempotency-Key"),
+		},
+		CycleID: shared.ID(r.PathValue("cycleId")), ExpectedVersion: expectedVersion,
+	})
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeRetainedJSON(w, response)
+}
+
+func (rt *Router) reopenAssessmentCycle(w http.ResponseWriter, r *http.Request) {
+	expectedVersion, err := parseCycleIfMatch(r.Header.Get("If-Match"))
+	if err != nil {
+		writeJSON(w, http.StatusPreconditionRequired, errorBody{Error: "precondition_required"})
+		return
+	}
+	var request struct {
+		Reason string `json:"reason"`
+	}
+	if !decodeAssessmentCycleJSON(w, r, &request) {
+		return
+	}
+	response, err := rt.assessmentCycles.ReopenCycle(r.Context(), cycleuc.ReopenCycleRequest{
+		Request: cycleuc.RetainedRequest{
+			TenantID: shared.ID(TenantFrom(r.Context())), Actor: PrincipalFrom(r.Context()), Route: r.URL.Path,
+			IdempotencyKey: r.Header.Get("Idempotency-Key"),
+		},
+		CycleID: shared.ID(r.PathValue("cycleId")), ExpectedVersion: expectedVersion, Reason: request.Reason,
+	})
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeRetainedJSON(w, response)
+}
+
+func (rt *Router) previewAssessmentRelationshipChange(w http.ResponseWriter, r *http.Request) {
+	var request assessmentRelationshipChangeRequest
+	if !decodeAssessmentCycleJSON(w, r, &request) {
+		return
+	}
+	preview, err := rt.assessmentCycles.PreviewRelationshipChange(r.Context(), cycleuc.RelationshipPreviewInput{
+		TenantID: shared.ID(TenantFrom(r.Context())), Actor: PrincipalFrom(r.Context()), CycleID: shared.ID(r.PathValue("cycleId")),
+		Request: cycleuc.RelationshipChangeRequest{Command: request.Command, AssessmentID: shared.ID(request.AssessmentID), NewPredecessorAssessmentID: shared.ID(request.NewPredecessorAssessmentID), SelectedHeadAssessmentID: shared.ID(request.SelectedHeadAssessmentID)},
+	})
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, preview)
+}
+
+func (rt *Router) commitAssessmentRelationshipChange(w http.ResponseWriter, r *http.Request) {
+	expectedVersion, err := parseCycleIfMatch(r.Header.Get("If-Match"))
+	if err != nil {
+		writeJSON(w, http.StatusPreconditionRequired, errorBody{Error: "precondition_required"})
+		return
+	}
+	var request assessmentRelationshipChangeRequest
+	if !decodeAssessmentCycleJSON(w, r, &request) {
+		return
+	}
+	response, err := rt.assessmentCycles.CommitRelationshipChange(r.Context(), cycleuc.RelationshipCommitInput{
+		Request: cycleuc.RetainedRequest{TenantID: shared.ID(TenantFrom(r.Context())), Actor: PrincipalFrom(r.Context()), Route: r.URL.Path, IdempotencyKey: r.Header.Get("Idempotency-Key")},
+		CycleID: shared.ID(r.PathValue("cycleId")), ExpectedVersion: expectedVersion, PreviewToken: request.PreviewToken, Reason: request.Reason,
+		Change: cycleuc.RelationshipChangeRequest{Command: request.Command, AssessmentID: shared.ID(request.AssessmentID), NewPredecessorAssessmentID: shared.ID(request.NewPredecessorAssessmentID), SelectedHeadAssessmentID: shared.ID(request.SelectedHeadAssessmentID)},
+	})
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeRetainedJSON(w, response)
+}
+
+func (rt *Router) previewAssessmentClosure(w http.ResponseWriter, r *http.Request) {
+	var request assessmentClosureRequest
+	if !decodeAssessmentCycleJSON(w, r, &request) {
+		return
+	}
+	preview, err := rt.assessmentCycles.PreviewClosure(r.Context(), cycleuc.ClosurePreviewInput{
+		TenantID: shared.ID(TenantFrom(r.Context())), Actor: PrincipalFrom(r.Context()), CycleID: shared.ID(r.PathValue("cycleId")),
+		Reason: request.Reason, OverrideBlockerIDs: request.OverrideBlockerIDs, OverrideReason: request.OverrideReason,
+	})
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, preview)
+}
+
+func (rt *Router) commitAssessmentClosure(w http.ResponseWriter, r *http.Request) {
+	expectedVersion, err := parseCycleIfMatch(r.Header.Get("If-Match"))
+	if err != nil {
+		writeJSON(w, http.StatusPreconditionRequired, errorBody{Error: "precondition_required"})
+		return
+	}
+	var request assessmentClosureRequest
+	if !decodeAssessmentCycleJSON(w, r, &request) {
+		return
+	}
+	response, err := rt.assessmentCycles.CommitClosure(r.Context(), cycleuc.ClosureCommitInput{
+		Request: cycleuc.RetainedRequest{TenantID: shared.ID(TenantFrom(r.Context())), Actor: PrincipalFrom(r.Context()), Route: r.URL.Path, IdempotencyKey: r.Header.Get("Idempotency-Key")},
+		CycleID: shared.ID(r.PathValue("cycleId")), ExpectedVersion: expectedVersion, PreviewToken: request.PreviewToken,
+		Reason: request.Reason, OverrideBlockerIDs: request.OverrideBlockerIDs, OverrideReason: request.OverrideReason,
+	})
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeRetainedJSON(w, response)
+}
+
+func (rt *Router) previewAssessmentReopen(w http.ResponseWriter, r *http.Request) {
+	var request struct{}
+	if !decodeAssessmentCycleJSON(w, r, &request) {
+		return
+	}
+	preview, err := rt.assessmentCycles.PreviewReopen(r.Context(), cycleuc.ReopenPreviewInput{
+		TenantID: shared.ID(TenantFrom(r.Context())), Actor: PrincipalFrom(r.Context()), CycleID: shared.ID(r.PathValue("cycleId")),
+	})
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, preview)
+}
+
+func (rt *Router) commitAssessmentReopen(w http.ResponseWriter, r *http.Request) {
+	expectedVersion, err := parseCycleIfMatch(r.Header.Get("If-Match"))
+	if err != nil {
+		writeJSON(w, http.StatusPreconditionRequired, errorBody{Error: "precondition_required"})
+		return
+	}
+	var request assessmentReopenRequest
+	if !decodeAssessmentCycleJSON(w, r, &request) {
+		return
+	}
+	response, err := rt.assessmentCycles.CommitReopen(r.Context(), cycleuc.ReopenCommitInput{
+		Request: cycleuc.RetainedRequest{TenantID: shared.ID(TenantFrom(r.Context())), Actor: PrincipalFrom(r.Context()), Route: r.URL.Path, IdempotencyKey: r.Header.Get("Idempotency-Key")},
+		CycleID: shared.ID(r.PathValue("cycleId")), ExpectedVersion: expectedVersion, PreviewToken: request.PreviewToken, Reason: request.Reason,
+	})
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeRetainedJSON(w, response)
+}
+
+func (rt *Router) listAssessmentClosureManifests(w http.ResponseWriter, r *http.Request) {
+	manifests, err := rt.assessmentCycles.ListClosureManifests(r.Context(), shared.ID(TenantFrom(r.Context())), shared.ID(r.PathValue("cycleId")))
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": manifests})
+}
+
+func (rt *Router) getAssessmentClosureManifest(w http.ResponseWriter, r *http.Request) {
+	manifest, err := rt.assessmentCycles.GetClosureManifest(r.Context(), shared.ID(TenantFrom(r.Context())), shared.ID(r.PathValue("cycleId")), shared.ID(r.PathValue("manifestId")))
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, manifest)
+}
+
+func (rt *Router) downloadAssessmentClosureReport(w http.ResponseWriter, r *http.Request) {
+	report, err := rt.assessmentCycles.GetClosureReport(r.Context(), shared.ID(TenantFrom(r.Context())), shared.ID(r.PathValue("cycleId")), shared.ID(r.PathValue("manifestId")))
+	if err != nil {
+		writeAssessmentCycleError(w, rt.log, err)
+		return
+	}
+	etag := `"sha256:` + report.ContentHash + `"`
+	w.Header().Set("Cache-Control", "private, max-age=31536000, immutable")
+	w.Header().Set("Content-Disposition", `attachment; filename="assessment-cycle-closure-report.json"`)
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("ETag", etag)
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	if r.Header.Get("If-None-Match") == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(report.Content)
+}
+
+func decodeAssessmentCycleJSON(w http.ResponseWriter, r *http.Request, target any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, assessmentCycleRequestLimit)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_request"})
+		return false
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_request"})
+		return false
+	}
+	return true
+}
+
+func parseCycleIfMatch(value string) (int64, error) {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "W/") {
+		value = strings.TrimSpace(strings.TrimPrefix(value, "W/"))
+	}
+	value = strings.Trim(value, "\"")
+	version, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || version < 1 {
+		return 0, errors.New("invalid If-Match")
+	}
+	return version, nil
+}
+
+func writeRetainedJSON(w http.ResponseWriter, response cycleuc.RetainedResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	if response.Replayed {
+		w.Header().Set("Idempotency-Replayed", "true")
+	}
+	w.WriteHeader(response.StatusCode)
+	_, _ = io.Copy(w, bytes.NewReader(response.Body))
+}
+
+func writeRetainedValue(w http.ResponseWriter, response cycleuc.RetainedResponse, value any) {
+	if response.Replayed {
+		w.Header().Set("Idempotency-Replayed", "true")
+	}
+	writeJSON(w, response.StatusCode, value)
+}
+
+func writeAssessmentCycleError(w http.ResponseWriter, log *slog.Logger, err error) {
+	code := cycleuc.ErrorCode(err)
+	if code == "" {
+		writeError(w, log, err)
+		return
+	}
+	status := http.StatusBadRequest
+	switch {
+	case errors.Is(err, shared.ErrNotFound):
+		status = http.StatusNotFound
+	case errors.Is(err, shared.ErrForbidden):
+		status = http.StatusForbidden
+	case errors.Is(err, shared.ErrConflict):
+		status = http.StatusConflict
+	}
+	writeJSON(w, status, errorBody{Error: code})
+}

--- a/internal/adapter/httpapi/assessment_cycle_handler_test.go
+++ b/internal/adapter/httpapi/assessment_cycle_handler_test.go
@@ -1,0 +1,412 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	comparisonuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcomparison"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type assessmentCycleHTTPIDs struct{ next int }
+
+func (ids *assessmentCycleHTTPIDs) NewID() shared.ID {
+	ids.next++
+	return shared.ID("cycle-http-" + strconv.Itoa(ids.next))
+}
+
+type assessmentCycleHTTPObserver struct{ outcomes []string }
+
+func (*assessmentCycleHTTPObserver) ObserveHTTPRequest(string, string, string, time.Duration) {}
+
+func (observer *assessmentCycleHTTPObserver) ObserveAssessmentCycleDualWrite(outcome string) {
+	observer.outcomes = append(observer.outcomes, outcome)
+}
+
+func (observer *assessmentCycleHTTPObserver) count(outcome string) int {
+	count := 0
+	for _, observed := range observer.outcomes {
+		if observed == outcome {
+			count++
+		}
+	}
+	return count
+}
+
+func newAssessmentCycleHTTPRouter(t *testing.T, apiEnabled bool, dualWrite func(string) bool) (*Router, *memory.AssessmentCycleRepository, *assessmentCycleHTTPObserver) {
+	t.Helper()
+	clock := fixedClock{t: time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)}
+	ids := &assessmentCycleHTTPIDs{}
+	audit := &fakeAudit{}
+	engagements := memory.NewEngagementRepository()
+	cycles := memory.NewAssessmentCycleRepository()
+	transactions := memory.NewTenantTransactionRunner()
+	engagementService := enguc.NewService(engagements, clock, ids, audit)
+	cycleService, err := cycleuc.NewService(cycles, engagements, nil, nil, transactions, ids, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cycleAPI, err := cycleuc.NewAPIService(cycleService, cycles, memory.NewAssessmentCycleRequestRepository(), engagementService, transactions, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	comparisons := memory.NewAssessmentComparisonRepository()
+	lineage := memory.NewFindingLineageRepository()
+	verification, err := comparisonuc.NewRetestVerificationReader(lineage, snapshots, memory.NewRetestRepository())
+	if err != nil {
+		t.Fatal(err)
+	}
+	comparisonService, err := comparisonuc.NewService(comparisons, snapshots, cycles, lineage, transactions, audit, clock, ids, verification, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycleAPI.SetRelationshipChangeDependencies(snapshots, comparisons, lineage, memory.NewScanJobStore(), comparisonService, []byte("0123456789abcdef0123456789abcdef")); err != nil {
+		t.Fatal(err)
+	}
+	observer := &assessmentCycleHTTPObserver{}
+	router := &Router{log: discardLog(), eng: engagementService}
+	router.SetObservability(false, observer)
+	router.SetAssessmentCycles(cycleAPI, apiEnabled, dualWrite)
+	router.SetAssessmentLifecycleRollout(func(string) bool { return true }, func(string) bool { return true })
+	return router, cycles, observer
+}
+
+func TestAssessmentLifecycleReadGateIsTenantScopedAndFailClosed(t *testing.T) {
+	router, _, _ := newAssessmentCycleHTTPRouter(t, true, func(string) bool { return true })
+	router.SetAssessmentLifecycleRollout(func(tenantID string) bool { return tenantID == "tenant-canary" }, func(string) bool { return false })
+	handler := router.requireAssessmentLifecycleRead(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+
+	blocked := httptest.NewRecorder()
+	handler(blocked, cycleRequest(http.MethodGet, "/api/v1/assessment-cycles", "", userdom.RoleReadOnly, "tenant-other"))
+	if blocked.Code != http.StatusNotFound || !strings.Contains(blocked.Body.String(), "assessment_lifecycle_read_disabled") {
+		t.Fatalf("blocked lifecycle read = %d %s", blocked.Code, blocked.Body.String())
+	}
+
+	allowed := httptest.NewRecorder()
+	handler(allowed, cycleRequest(http.MethodGet, "/api/v1/assessment-cycles", "", userdom.RoleReadOnly, "tenant-canary"))
+	if allowed.Code != http.StatusNoContent {
+		t.Fatalf("allowed lifecycle read = %d", allowed.Code)
+	}
+}
+
+func TestAssessmentRelationshipChangeHTTPContract(t *testing.T) {
+	router, cycles, _ := newAssessmentCycleHTTPRouter(t, true, func(string) bool { return true })
+	ctx := context.Background()
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	tenantID := shared.ID("tenant-relationship-http")
+	cycle, err := cycledom.NewAssessmentCycle("cycle-relationship-http", tenantID, "Relationship HTTP", cycledom.BoundaryStandalone, "", "", "root", "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cycle.AdvanceRetest("head-a", "root", cycle.Version, "operator", now); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := cycle.AdvanceRetest("head-b", "root", cycle.Version, "operator", now); err != nil {
+		t.Fatal(err)
+	}
+	root, _ := cycledom.NewInitialMember(tenantID, cycle.ID, "root", "operator", now)
+	headA, _ := cycledom.NewRetestMember(tenantID, cycle.ID, "head-a", "root", 1, "operator", now)
+	headB, _ := cycledom.NewRetestMember(tenantID, cycle.ID, "head-b", "root", 2, "operator", now)
+	if err := cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	for _, member := range []*cycledom.Member{root, headA, headB} {
+		if err := cycles.CreateMember(ctx, member); err != nil {
+			t.Fatal(err)
+		}
+	}
+	handler := router.routes()
+	path := "/api/v1/assessment-cycles/" + cycle.ID.String()
+	changeBody := `{"command":"select_head","selected_head_assessment_id":"head-b"}`
+
+	denied := httptest.NewRecorder()
+	handler.ServeHTTP(denied, cycleRequest(http.MethodPost, path+"/relationship-previews", changeBody, userdom.RoleReadOnly, tenantID.String()))
+	if denied.Code != http.StatusForbidden {
+		t.Fatalf("permission response=%d body=%s", denied.Code, denied.Body.String())
+	}
+	crossTenant := httptest.NewRecorder()
+	handler.ServeHTTP(crossTenant, cycleRequest(http.MethodPost, path+"/relationship-previews", changeBody, userdom.RoleReviewer, "other-tenant"))
+	if crossTenant.Code != http.StatusNotFound {
+		t.Fatalf("cross-tenant response=%d body=%s", crossTenant.Code, crossTenant.Body.String())
+	}
+
+	previewResponse := httptest.NewRecorder()
+	handler.ServeHTTP(previewResponse, cycleRequest(http.MethodPost, path+"/relationship-previews", changeBody, userdom.RoleReviewer, tenantID.String()))
+	if previewResponse.Code != http.StatusOK {
+		t.Fatalf("preview response=%d body=%s", previewResponse.Code, previewResponse.Body.String())
+	}
+	var preview cycleuc.RelationshipPreview
+	if err := json.Unmarshal(previewResponse.Body.Bytes(), &preview); err != nil {
+		t.Fatal(err)
+	}
+	if !preview.CommitAllowed || preview.PreviewToken == "" || preview.NewSelectedHeadAssessmentID != "head-b" {
+		t.Fatalf("preview=%+v", preview)
+	}
+	commitBody := `{"command":"select_head","selected_head_assessment_id":"head-b","preview_token":"` + preview.PreviewToken + `"}`
+	missingPrecondition := httptest.NewRecorder()
+	handler.ServeHTTP(missingPrecondition, cycleRequest(http.MethodPost, path+"/relationship-commits", commitBody, userdom.RoleReviewer, tenantID.String()))
+	if missingPrecondition.Code != http.StatusPreconditionRequired {
+		t.Fatalf("missing If-Match response=%d body=%s", missingPrecondition.Code, missingPrecondition.Body.String())
+	}
+
+	commitRequest := cycleRequest(http.MethodPost, path+"/relationship-commits", commitBody, userdom.RoleReviewer, tenantID.String())
+	commitRequest.Header.Set("If-Match", strconv.FormatInt(preview.CycleVersion, 10))
+	commitRequest.Header.Set("Idempotency-Key", "relationship-http-commit")
+	committed := httptest.NewRecorder()
+	handler.ServeHTTP(committed, commitRequest)
+	if committed.Code != http.StatusOK {
+		t.Fatalf("commit response=%d body=%s", committed.Code, committed.Body.String())
+	}
+
+	replayRequest := cycleRequest(http.MethodPost, path+"/relationship-commits", commitBody, userdom.RoleReviewer, tenantID.String())
+	replayRequest.Header.Set("If-Match", strconv.FormatInt(preview.CycleVersion, 10))
+	replayRequest.Header.Set("Idempotency-Key", "relationship-http-commit")
+	replayed := httptest.NewRecorder()
+	handler.ServeHTTP(replayed, replayRequest)
+	if replayed.Code != http.StatusOK || replayed.Header().Get("Idempotency-Replayed") != "true" || replayed.Body.String() != committed.Body.String() {
+		t.Fatalf("replay response=%d headers=%v body=%s", replayed.Code, replayed.Header(), replayed.Body.String())
+	}
+
+	reusedRequest := cycleRequest(http.MethodPost, path+"/relationship-commits", commitBody, userdom.RoleReviewer, tenantID.String())
+	reusedRequest.Header.Set("If-Match", strconv.FormatInt(preview.CycleVersion, 10))
+	reusedRequest.Header.Set("Idempotency-Key", "relationship-http-reuse")
+	reused := httptest.NewRecorder()
+	handler.ServeHTTP(reused, reusedRequest)
+	if reused.Code != http.StatusConflict || !strings.Contains(reused.Body.String(), cycleuc.CodeRelationshipPreviewStale) {
+		t.Fatalf("reused token response=%d body=%s", reused.Code, reused.Body.String())
+	}
+}
+
+func TestAssessmentLifecycleWriteGateUsesTenantReadCanary(t *testing.T) {
+	router, _, _ := newAssessmentCycleHTTPRouter(t, true, func(string) bool { return true })
+	router.SetAssessmentLifecycleRollout(func(tenantID string) bool { return tenantID == "tenant-canary" }, func(string) bool { return false })
+	handler := router.requireAssessmentLifecycleWrite(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusNoContent) })
+
+	blocked := httptest.NewRecorder()
+	handler(blocked, cycleRequest(http.MethodPost, "/api/v1/engagements/a/retests", `{}`, userdom.RoleConsultant, "tenant-other"))
+	if blocked.Code != http.StatusNotFound || !strings.Contains(blocked.Body.String(), "assessment_lifecycle_write_disabled") {
+		t.Fatalf("blocked lifecycle write = %d %s", blocked.Code, blocked.Body.String())
+	}
+
+	allowed := httptest.NewRecorder()
+	handler(allowed, cycleRequest(http.MethodPost, "/api/v1/engagements/a/retests", `{}`, userdom.RoleConsultant, "tenant-canary"))
+	if allowed.Code != http.StatusNoContent {
+		t.Fatalf("allowed lifecycle write = %d", allowed.Code)
+	}
+}
+
+func TestAssessmentCycleRoutesPermissionAndIdempotency(t *testing.T) {
+	router, cycles, _ := newAssessmentCycleHTTPRouter(t, true, func(string) bool { return true })
+	handler := router.routes()
+
+	missingKey := cycleRequest(http.MethodPost, "/api/v1/engagements", `{"name":"Acme"}`, userdom.RoleConsultant, "tenant-1")
+	missingKeyResponse := httptest.NewRecorder()
+	handler.ServeHTTP(missingKeyResponse, missingKey)
+	if missingKeyResponse.Code != http.StatusCreated || missingKeyResponse.Header().Get("X-Synapse-Assessment-Cycle-Dual-Write") != "true" {
+		t.Fatalf("missing key response = %d %s", missingKeyResponse.Code, missingKeyResponse.Body.String())
+	}
+
+	create := cycleRequest(http.MethodPost, "/api/v1/engagements", `{"name":"Acme","in_scope":[{"kind":"domain","value":"app.example.com"}]}`, userdom.RoleConsultant, "tenant-1")
+	create.Header.Set("Idempotency-Key", "create-1")
+	created := httptest.NewRecorder()
+	handler.ServeHTTP(created, create)
+	if created.Code != http.StatusCreated {
+		t.Fatalf("create response = %d %s", created.Code, created.Body.String())
+	}
+	var engagement struct{ ID shared.ID }
+	if err := json.Unmarshal(created.Body.Bytes(), &engagement); err != nil {
+		t.Fatal(err)
+	}
+	var createdView engagementView
+	if err := json.Unmarshal(created.Body.Bytes(), &createdView); err != nil || createdView.ID == "" || createdView.Name != "Acme" || len(createdView.Scope.InScope) != 1 {
+		t.Fatalf("initial assessment wire contract=%+v err=%v", createdView, err)
+	}
+	if strings.Contains(created.Body.String(), `"Scope"`) || strings.Contains(created.Body.String(), `"Audit"`) {
+		t.Fatalf("domain representation leaked into initial assessment response: %s", created.Body.String())
+	}
+
+	replay := cycleRequest(http.MethodPost, "/api/v1/engagements", `{"name":"Acme","in_scope":[{"kind":"domain","value":"app.example.com"}]}`, userdom.RoleConsultant, "tenant-1")
+	replay.Header.Set("Idempotency-Key", "create-1")
+	replayed := httptest.NewRecorder()
+	handler.ServeHTTP(replayed, replay)
+	if replayed.Code != http.StatusCreated || replayed.Header().Get("Idempotency-Replayed") != "true" {
+		t.Fatalf("replay response = %d headers=%v", replayed.Code, replayed.Header())
+	}
+
+	lifecyclePath := "/api/v1/engagements/" + engagement.ID.String() + "/lifecycle"
+	crossTenant := cycleRequest(http.MethodGet, lifecyclePath, "", userdom.RoleReadOnly, "tenant-2")
+	crossTenantResponse := httptest.NewRecorder()
+	handler.ServeHTTP(crossTenantResponse, crossTenant)
+	if crossTenantResponse.Code != http.StatusNotFound {
+		t.Fatalf("cross-tenant lifecycle = %d %s", crossTenantResponse.Code, crossTenantResponse.Body.String())
+	}
+
+	retestPath := "/api/v1/engagements/" + engagement.ID.String() + "/retests"
+	for _, status := range []engdom.Status{engdom.StatusActive, engdom.StatusCompleted} {
+		if _, err := router.eng.Transition(context.Background(), "consultant", "tenant-1", engagement.ID, status); err != nil {
+			t.Fatal(err)
+		}
+	}
+	reviewerRetest := cycleRequest(http.MethodPost, retestPath, `{}`, userdom.RoleReviewer, "tenant-1")
+	reviewerRetest.Header.Set("Idempotency-Key", "retest-denied")
+	reviewerRetestResponse := httptest.NewRecorder()
+	handler.ServeHTTP(reviewerRetestResponse, reviewerRetest)
+	if reviewerRetestResponse.Code != http.StatusForbidden {
+		t.Fatalf("reviewer retest = %d", reviewerRetestResponse.Code)
+	}
+
+	retest := cycleRequest(http.MethodPost, retestPath, `{}`, userdom.RoleConsultant, "tenant-1")
+	retest.Header.Set("Idempotency-Key", "retest-1")
+	retestResponse := httptest.NewRecorder()
+	handler.ServeHTTP(retestResponse, retest)
+	if retestResponse.Code != http.StatusCreated {
+		t.Fatalf("retest response = %d %s", retestResponse.Code, retestResponse.Body.String())
+	}
+	var retestView struct {
+		Engagement engagementView `json:"engagement"`
+	}
+	if err := json.Unmarshal(retestResponse.Body.Bytes(), &retestView); err != nil || retestView.Engagement.ID == "" || len(retestView.Engagement.Scope.InScope) != 1 || !retestView.Engagement.RequiresExplicitExecutionAuthorization {
+		t.Fatalf("re-test wire contract=%+v err=%v", retestView, err)
+	}
+
+	lifecycle := cycleRequest(http.MethodGet, lifecyclePath, "", userdom.RoleReadOnly, "tenant-1")
+	lifecycleResponse := httptest.NewRecorder()
+	handler.ServeHTTP(lifecycleResponse, lifecycle)
+	if lifecycleResponse.Code != http.StatusOK {
+		t.Fatalf("lifecycle response = %d %s", lifecycleResponse.Code, lifecycleResponse.Body.String())
+	}
+	var lifecycleBody cycleuc.LifecycleView
+	if err := json.Unmarshal(lifecycleResponse.Body.Bytes(), &lifecycleBody); err != nil {
+		t.Fatal(err)
+	}
+	storedCycle, err := cycles.GetCycle(context.Background(), "tenant-1", shared.ID(lifecycleBody.Cycle.ID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := storedCycle.Transition(cycledom.StatusCompleted, storedCycle.Version, "reviewer", time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.UpdateCycleCAS(context.Background(), storedCycle, lifecycleBody.Cycle.Version); err != nil {
+		t.Fatal(err)
+	}
+	reopenPath := "/api/v1/assessment-cycles/" + lifecycleBody.Cycle.ID + "/reopen"
+	missingReason := cycleRequest(http.MethodPost, reopenPath, `{}`, userdom.RoleReviewer, "tenant-1")
+	missingReason.Header.Set("Idempotency-Key", "reopen-missing-reason")
+	missingReason.Header.Set("If-Match", strconv.FormatInt(storedCycle.Version, 10))
+	missingReasonResponse := httptest.NewRecorder()
+	handler.ServeHTTP(missingReasonResponse, missingReason)
+	if missingReasonResponse.Code != http.StatusBadRequest || !strings.Contains(missingReasonResponse.Body.String(), "reopen_reason_required") {
+		t.Fatalf("missing reopen reason = %d %s", missingReasonResponse.Code, missingReasonResponse.Body.String())
+	}
+	reopen := cycleRequest(http.MethodPost, reopenPath, `{"reason":"continue remediation verification"}`, userdom.RoleReviewer, "tenant-1")
+	reopen.Header.Set("Idempotency-Key", "reopen-1")
+	reopen.Header.Set("If-Match", strconv.FormatInt(storedCycle.Version, 10))
+	reopenResponse := httptest.NewRecorder()
+	handler.ServeHTTP(reopenResponse, reopen)
+	if reopenResponse.Code != http.StatusOK {
+		t.Fatalf("reopen response = %d %s", reopenResponse.Code, reopenResponse.Body.String())
+	}
+	var reopened cycleuc.CycleDetail
+	if err := json.Unmarshal(reopenResponse.Body.Bytes(), &reopened); err != nil || reopened.Cycle.Status != cycledom.StatusOpen {
+		t.Fatalf("reopened cycle = %+v err=%v", reopened, err)
+	}
+	lifecycleBody.Cycle = reopened.Cycle
+
+	archivePath := "/api/v1/assessment-cycles/" + lifecycleBody.Cycle.ID + "/archive"
+	consultantArchive := cycleRequest(http.MethodPost, archivePath, "", userdom.RoleConsultant, "tenant-1")
+	consultantArchive.Header.Set("Idempotency-Key", "archive-denied")
+	consultantArchive.Header.Set("If-Match", strconv.FormatInt(lifecycleBody.Cycle.Version, 10))
+	consultantArchiveResponse := httptest.NewRecorder()
+	handler.ServeHTTP(consultantArchiveResponse, consultantArchive)
+	if consultantArchiveResponse.Code != http.StatusForbidden {
+		t.Fatalf("consultant archive = %d", consultantArchiveResponse.Code)
+	}
+
+	archive := cycleRequest(http.MethodPost, archivePath, "", userdom.RoleReviewer, "tenant-1")
+	archive.Header.Set("Idempotency-Key", "archive-1")
+	archive.Header.Set("If-Match", `"`+strconv.FormatInt(lifecycleBody.Cycle.Version, 10)+`"`)
+	archiveResponse := httptest.NewRecorder()
+	handler.ServeHTTP(archiveResponse, archive)
+	if archiveResponse.Code != http.StatusOK {
+		t.Fatalf("archive response = %d %s", archiveResponse.Code, archiveResponse.Body.String())
+	}
+}
+
+func TestAssessmentCycleDualWriteTenantRollout(t *testing.T) {
+	router, cycles, observer := newAssessmentCycleHTTPRouter(t, false, func(tenantID string) bool { return tenantID == "tenant-a" })
+	handler := router.routes()
+	body := `{"name":"Acme","in_scope":[{"kind":"domain","value":"app.example.com"}]}`
+
+	missingKey := cycleRequest(http.MethodPost, "/api/v1/engagements", body, userdom.RoleConsultant, "tenant-a")
+	missingKeyResponse := httptest.NewRecorder()
+	handler.ServeHTTP(missingKeyResponse, missingKey)
+	if missingKeyResponse.Code != http.StatusCreated || observer.count("created") != 1 {
+		t.Fatalf("tenant-a missing key = %d outcomes=%v body=%s", missingKeyResponse.Code, observer.outcomes, missingKeyResponse.Body.String())
+	}
+
+	tenantA := cycleRequest(http.MethodPost, "/api/v1/engagements", body, userdom.RoleConsultant, "tenant-a")
+	tenantAResponse := httptest.NewRecorder()
+	handler.ServeHTTP(tenantAResponse, tenantA)
+	if tenantAResponse.Code != http.StatusCreated || tenantAResponse.Header().Get("Idempotency-Replayed") != "true" || tenantAResponse.Body.String() != missingKeyResponse.Body.String() || observer.count("replayed") != 1 {
+		t.Fatalf("tenant-a create = %d headers=%v outcomes=%v body=%s", tenantAResponse.Code, tenantAResponse.Header(), observer.outcomes, tenantAResponse.Body.String())
+	}
+
+	tenantB := cycleRequest(http.MethodPost, "/api/v1/engagements", body, userdom.RoleConsultant, "tenant-b")
+	tenantBResponse := httptest.NewRecorder()
+	handler.ServeHTTP(tenantBResponse, tenantB)
+	if tenantBResponse.Code != http.StatusCreated || tenantBResponse.Header().Get("X-Synapse-Assessment-Cycle-Dual-Write") != "" || observer.count("legacy") != 1 {
+		t.Fatalf("tenant-b legacy create = %d headers=%v outcomes=%v body=%s", tenantBResponse.Code, tenantBResponse.Header(), observer.outcomes, tenantBResponse.Body.String())
+	}
+
+	for tenantID, want := range map[shared.ID]int{"tenant-a": 1, "tenant-b": 0} {
+		records, err := cycles.ListCycles(context.Background(), ports.AssessmentCycleListQuery{TenantID: tenantID, Limit: 10})
+		if err != nil || len(records) != want {
+			t.Fatalf("tenant %s cycle count = %d, want %d, err=%v", tenantID, len(records), want, err)
+		}
+	}
+}
+
+func TestAssessmentCycleDualWriteDisabledPreservesLegacyResponse(t *testing.T) {
+	configured, cycles, observer := newAssessmentCycleHTTPRouter(t, false, func(string) bool { return false })
+	legacy, _, _ := newAssessmentCycleHTTPRouter(t, false, func(string) bool { return false })
+	legacy.assessmentCycles = nil
+	legacy.assessmentCycleDualWrite = nil
+
+	body := `{"name":"Acme","in_scope":[{"kind":"domain","value":"app.example.com"}]}`
+	configuredResponse := httptest.NewRecorder()
+	configured.routes().ServeHTTP(configuredResponse, cycleRequest(http.MethodPost, "/api/v1/engagements", body, userdom.RoleConsultant, "tenant-a"))
+	legacyResponse := httptest.NewRecorder()
+	legacy.routes().ServeHTTP(legacyResponse, cycleRequest(http.MethodPost, "/api/v1/engagements", body, userdom.RoleConsultant, "tenant-a"))
+
+	if configuredResponse.Code != legacyResponse.Code || configuredResponse.Body.String() != legacyResponse.Body.String() {
+		t.Fatalf("disabled dual-write response changed: configured=(%d,%q) legacy=(%d,%q)", configuredResponse.Code, configuredResponse.Body.String(), legacyResponse.Code, legacyResponse.Body.String())
+	}
+	if configuredResponse.Header().Get("X-Synapse-Assessment-Cycle-Dual-Write") != "" || observer.count("legacy") != 1 {
+		t.Fatalf("disabled dual-write headers=%v outcomes=%v", configuredResponse.Header(), observer.outcomes)
+	}
+	records, err := cycles.ListCycles(context.Background(), ports.AssessmentCycleListQuery{TenantID: "tenant-a", Limit: 10})
+	if err != nil || len(records) != 0 {
+		t.Fatalf("disabled dual-write cycle count = %d, err=%v", len(records), err)
+	}
+}
+
+func cycleRequest(method, target, body string, role userdom.Role, tenantID string) *http.Request {
+	request := httptest.NewRequest(method, target, strings.NewReader(body))
+	request.Header.Set("Content-Type", "application/json")
+	principal := Principal{ID: "actor-1", Role: string(role), TenantID: tenantID}
+	return request.WithContext(context.WithValue(request.Context(), principalKey, principal))
+}

--- a/internal/adapter/httpapi/assessment_relationship_handler.go
+++ b/internal/adapter/httpapi/assessment_relationship_handler.go
@@ -1,0 +1,137 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentrelationship"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	relationshipuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentrelationship"
+)
+
+const assessmentRelationshipBodyLimit = int64(16 << 10)
+
+type generateAssessmentRelationshipRequest struct {
+	PredecessorCycleID    string `json:"predecessor_cycle_id"`
+	SuccessorCycleID      string `json:"successor_cycle_id"`
+	ImportedReferenceHash string `json:"imported_reference_hash,omitempty"`
+	ExpiresInDays         int    `json:"expires_in_days,omitempty"`
+}
+
+func (rt *Router) generateAssessmentRelationshipCandidate(w http.ResponseWriter, r *http.Request) {
+	var request generateAssessmentRelationshipRequest
+	if !decodeAssessmentRelationshipJSON(w, r, &request) {
+		return
+	}
+	view, created, err := rt.assessmentRelationships.Generate(r.Context(), relationshipuc.GenerateInput{
+		TenantID: shared.ID(TenantFrom(r.Context())), PredecessorCycleID: shared.ID(request.PredecessorCycleID),
+		SuccessorCycleID: shared.ID(request.SuccessorCycleID), ImportedReferenceHash: request.ImportedReferenceHash,
+		ExpiresIn: time.Duration(request.ExpiresInDays) * 24 * time.Hour, Actor: PrincipalFrom(r.Context()),
+	})
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	w.Header().Set("ETag", relationshipETag(view.Version))
+	status := http.StatusOK
+	if created {
+		status = http.StatusCreated
+	}
+	writeJSON(w, status, view)
+}
+
+func (rt *Router) listAssessmentRelationshipCandidates(w http.ResponseWriter, r *http.Request) {
+	limit := 0
+	if value := strings.TrimSpace(r.URL.Query().Get("limit")); value != "" {
+		parsed, err := strconv.Atoi(value)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_limit"})
+			return
+		}
+		limit = parsed
+	}
+	views, err := rt.assessmentRelationships.List(r.Context(), shared.ID(TenantFrom(r.Context())), r.URL.Query().Get("status"), limit)
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": views})
+}
+
+func (rt *Router) getAssessmentRelationshipCandidate(w http.ResponseWriter, r *http.Request) {
+	view, err := rt.assessmentRelationships.Get(r.Context(), shared.ID(TenantFrom(r.Context())), shared.ID(r.PathValue("candidateId")))
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	w.Header().Set("ETag", relationshipETag(view.Version))
+	writeJSON(w, http.StatusOK, view)
+}
+
+type decideAssessmentRelationshipRequest struct {
+	Action domain.DecisionAction `json:"action"`
+	Reason string                `json:"reason"`
+}
+
+func (rt *Router) decideAssessmentRelationshipCandidate(w http.ResponseWriter, r *http.Request) {
+	if strings.TrimSpace(r.Header.Get("If-Match")) == "" {
+		writeJSON(w, http.StatusPreconditionRequired, errorBody{Error: "precondition_required"})
+		return
+	}
+	expectedVersion, err := parseCycleIfMatch(r.Header.Get("If-Match"))
+	if err != nil {
+		writeJSON(w, http.StatusPreconditionRequired, errorBody{Error: "precondition_required"})
+		return
+	}
+	key := strings.TrimSpace(r.Header.Get("Idempotency-Key"))
+	if key == "" {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "idempotency_key_required"})
+		return
+	}
+	var request decideAssessmentRelationshipRequest
+	if !decodeAssessmentRelationshipJSON(w, r, &request) {
+		return
+	}
+	view, replayed, err := rt.assessmentRelationships.Decide(r.Context(), relationshipuc.DecideInput{
+		TenantID: shared.ID(TenantFrom(r.Context())), CandidateID: shared.ID(r.PathValue("candidateId")),
+		ExpectedVersion: expectedVersion, IdempotencyKey: key, Action: request.Action,
+		Reason: request.Reason, Actor: PrincipalFrom(r.Context()),
+	})
+	if err != nil {
+		writeError(w, rt.log, err)
+		return
+	}
+	if replayed {
+		w.Header().Set("Idempotency-Replayed", "true")
+	}
+	w.Header().Set("ETag", relationshipETag(view.Version))
+	writeJSON(w, http.StatusOK, view)
+}
+
+func decodeAssessmentRelationshipJSON(w http.ResponseWriter, r *http.Request, target any) bool {
+	r.Body = http.MaxBytesReader(w, r.Body, assessmentRelationshipBodyLimit)
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		var tooLarge *http.MaxBytesError
+		if errors.As(err, &tooLarge) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, errorBody{Error: "request_too_large"})
+		} else {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_request"})
+		}
+		return false
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_request"})
+		return false
+	}
+	return true
+}
+
+func relationshipETag(version int64) string { return fmt.Sprintf("\"%d\"", version) }

--- a/internal/adapter/httpapi/assessment_relationship_handler_test.go
+++ b/internal/adapter/httpapi/assessment_relationship_handler_test.go
@@ -1,0 +1,203 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	relationshipuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentrelationship"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestAssessmentRelationshipRoutesEnforceReviewContractsAndIsolation(t *testing.T) {
+	router, cycles := newAssessmentRelationshipHTTPRouter(t)
+	handler := router.routes()
+	generatePath := "/api/v1/assessment-relationship-candidates/generate"
+	generateBody := `{"predecessor_cycle_id":"relationship-http-predecessor","successor_cycle_id":"relationship-http-successor","imported_reference_hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}`
+
+	forbidden := httptest.NewRecorder()
+	handler.ServeHTTP(forbidden, cycleRequest(http.MethodPost, generatePath, generateBody, userdom.RoleConsultant, "tenant-relationship-http"))
+	if forbidden.Code != http.StatusForbidden {
+		t.Fatalf("consultant generate=%d body=%s", forbidden.Code, forbidden.Body.String())
+	}
+
+	unknownMetadata := httptest.NewRecorder()
+	handler.ServeHTTP(unknownMetadata, cycleRequest(http.MethodPost, generatePath, `{"predecessor_cycle_id":"relationship-http-predecessor","successor_cycle_id":"relationship-http-successor","imported_reference":{"raw":"secret"}}`, userdom.RoleReviewer, "tenant-relationship-http"))
+	if unknownMetadata.Code != http.StatusBadRequest || strings.Contains(unknownMetadata.Body.String(), "secret") {
+		t.Fatalf("raw imported metadata=%d body=%s", unknownMetadata.Code, unknownMetadata.Body.String())
+	}
+
+	created := httptest.NewRecorder()
+	handler.ServeHTTP(created, cycleRequest(http.MethodPost, generatePath, generateBody, userdom.RoleReviewer, "tenant-relationship-http"))
+	if created.Code != http.StatusCreated || created.Header().Get("ETag") != `"1"` || strings.Contains(created.Body.String(), "imported_reference_hash") {
+		t.Fatalf("generate=%d headers=%v body=%s", created.Code, created.Header(), created.Body.String())
+	}
+	var candidate relationshipuc.View
+	if err := json.Unmarshal(created.Body.Bytes(), &candidate); err != nil || candidate.ID.IsZero() || candidate.Status != relationshipuc.StatusOpen {
+		t.Fatalf("candidate=%+v err=%v", candidate, err)
+	}
+
+	crossTenant := httptest.NewRecorder()
+	handler.ServeHTTP(crossTenant, cycleRequest(http.MethodGet, "/api/v1/assessment-relationship-candidates/"+candidate.ID.String(), "", userdom.RoleReviewer, "other-tenant"))
+	if crossTenant.Code != http.StatusNotFound {
+		t.Fatalf("cross-tenant get=%d body=%s", crossTenant.Code, crossTenant.Body.String())
+	}
+
+	decisionPath := "/api/v1/assessment-relationship-candidates/" + candidate.ID.String() + "/decisions"
+	decisionBody := `{"action":"confirm","reason":"Reviewed deterministic migration evidence"}`
+	missingIfMatch := cycleRequest(http.MethodPost, decisionPath, decisionBody, userdom.RoleReviewer, "tenant-relationship-http")
+	missingIfMatch.Header.Set("Idempotency-Key", "relationship-http-confirm")
+	missingIfMatchResponse := httptest.NewRecorder()
+	handler.ServeHTTP(missingIfMatchResponse, missingIfMatch)
+	if missingIfMatchResponse.Code != http.StatusPreconditionRequired {
+		t.Fatalf("missing If-Match=%d body=%s", missingIfMatchResponse.Code, missingIfMatchResponse.Body.String())
+	}
+
+	missingKey := cycleRequest(http.MethodPost, decisionPath, decisionBody, userdom.RoleReviewer, "tenant-relationship-http")
+	missingKey.Header.Set("If-Match", `"1"`)
+	missingKeyResponse := httptest.NewRecorder()
+	handler.ServeHTTP(missingKeyResponse, missingKey)
+	if missingKeyResponse.Code != http.StatusBadRequest || !strings.Contains(missingKeyResponse.Body.String(), "idempotency_key_required") {
+		t.Fatalf("missing idempotency=%d body=%s", missingKeyResponse.Code, missingKeyResponse.Body.String())
+	}
+
+	oversized := cycleRequest(http.MethodPost, decisionPath, `{"action":"confirm","reason":"`+strings.Repeat("x", int(assessmentRelationshipBodyLimit))+`"}`, userdom.RoleReviewer, "tenant-relationship-http")
+	oversized.Header.Set("If-Match", `"1"`)
+	oversized.Header.Set("Idempotency-Key", "relationship-http-oversized")
+	oversizedResponse := httptest.NewRecorder()
+	handler.ServeHTTP(oversizedResponse, oversized)
+	if oversizedResponse.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("oversized decision=%d body=%s", oversizedResponse.Code, oversizedResponse.Body.String())
+	}
+
+	predecessorBefore, _ := cycles.GetCycle(context.Background(), "tenant-relationship-http", "relationship-http-predecessor")
+	successorBefore, _ := cycles.GetCycle(context.Background(), "tenant-relationship-http", "relationship-http-successor")
+	predecessorMembersBefore, _ := cycles.ListMembers(context.Background(), "tenant-relationship-http", "relationship-http-predecessor")
+	successorMembersBefore, _ := cycles.ListMembers(context.Background(), "tenant-relationship-http", "relationship-http-successor")
+
+	confirm := cycleRequest(http.MethodPost, decisionPath, decisionBody, userdom.RoleReviewer, "tenant-relationship-http")
+	confirm.Header.Set("If-Match", `W/"1"`)
+	confirm.Header.Set("Idempotency-Key", "relationship-http-confirm")
+	confirmed := httptest.NewRecorder()
+	handler.ServeHTTP(confirmed, confirm)
+	if confirmed.Code != http.StatusOK || confirmed.Header().Get("ETag") != `"2"` || confirmed.Header().Get("Idempotency-Replayed") != "" || !strings.Contains(confirmed.Body.String(), `"execution":"blocked"`) {
+		t.Fatalf("confirm=%d headers=%v body=%s", confirmed.Code, confirmed.Header(), confirmed.Body.String())
+	}
+
+	replay := cycleRequest(http.MethodPost, decisionPath, decisionBody, userdom.RoleReviewer, "tenant-relationship-http")
+	replay.Header.Set("If-Match", `"1"`)
+	replay.Header.Set("Idempotency-Key", "relationship-http-confirm")
+	replayed := httptest.NewRecorder()
+	handler.ServeHTTP(replayed, replay)
+	if replayed.Code != http.StatusOK || replayed.Header().Get("Idempotency-Replayed") != "true" || replayed.Body.String() != confirmed.Body.String() {
+		t.Fatalf("replay=%d headers=%v body=%s", replayed.Code, replayed.Header(), replayed.Body.String())
+	}
+
+	predecessorAfter, _ := cycles.GetCycle(context.Background(), "tenant-relationship-http", "relationship-http-predecessor")
+	successorAfter, _ := cycles.GetCycle(context.Background(), "tenant-relationship-http", "relationship-http-successor")
+	predecessorMembersAfter, _ := cycles.ListMembers(context.Background(), "tenant-relationship-http", "relationship-http-predecessor")
+	successorMembersAfter, _ := cycles.ListMembers(context.Background(), "tenant-relationship-http", "relationship-http-successor")
+	if !reflect.DeepEqual(predecessorBefore, predecessorAfter) || !reflect.DeepEqual(successorBefore, successorAfter) || !reflect.DeepEqual(predecessorMembersBefore, predecessorMembersAfter) || !reflect.DeepEqual(successorMembersBefore, successorMembersAfter) {
+		t.Fatal("HTTP confirmation changed the Assessment Cycle graph")
+	}
+}
+
+func newAssessmentRelationshipHTTPRouter(t *testing.T) (*Router, *memory.AssessmentCycleRepository) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Date(2026, 9, 1, 15, 0, 0, 0, time.UTC)
+	clock := relationshipHTTPClock{now: now}
+	ids := &relationshipHTTPIDs{}
+	cycles := memory.NewAssessmentCycleRepository()
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	for _, subject := range []struct {
+		cycleID, assessmentID, snapshotID shared.ID
+		runID                             string
+		scope                             string
+	}{
+		{"relationship-http-predecessor", "relationship-http-assessment-predecessor", "relationship-http-snapshot-predecessor", "relationship-http-run-predecessor", "src/**"},
+		{"relationship-http-successor", "relationship-http-assessment-successor", "relationship-http-snapshot-successor", "relationship-http-run-successor", "app/**"},
+	} {
+		cycle, err := assessmentcycle.NewAssessmentCycle(subject.cycleID, "tenant-relationship-http", subject.cycleID.String(), assessmentcycle.BoundaryProject, "", "relationship-http-project", subject.assessmentID, "operator", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		member, err := assessmentcycle.NewInitialMember("tenant-relationship-http", subject.cycleID, subject.assessmentID, "operator", now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := cycles.CreateCycle(ctx, cycle); err != nil {
+			t.Fatal(err)
+		}
+		if err := cycles.CreateMember(ctx, member); err != nil {
+			t.Fatal(err)
+		}
+		snapshot, err := assessmentsnapshot.NewFinalized("tenant-relationship-http", subject.snapshotID, subject.cycleID, subject.assessmentID,
+			assessmentsnapshot.Boundary{Kind: assessmentcycle.BoundaryProject, ProjectID: "relationship-http-project"}, "request-"+subject.snapshotID.String(), "operator", now,
+			[]assessmentsnapshot.SelectedRun{assessmentRelationshipHTTPRun(t, subject.runID, subject.scope, now)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, created, err := snapshots.CreateFinalizedCAS(ctx, snapshot, 0); err != nil || !created {
+			t.Fatalf("snapshot created=%v err=%v", created, err)
+		}
+	}
+	service, err := relationshipuc.NewService(memory.NewAssessmentRelationshipRepository(), cycles, snapshots, memory.NewFindingLineageRepository(), memory.NewTenantTransactionRunner(), ids, clock, relationshipHTTPAudit{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := &Router{log: discardLog()}
+	router.SetAssessmentRelationships(service)
+	return router, cycles
+}
+
+func assessmentRelationshipHTTPRun(t *testing.T, runID, scope string, now time.Time) assessmentsnapshot.SelectedRun {
+	t.Helper()
+	target, err := scanrun.CanonicalizeRepositoryTarget("https://example.com/repository.git", "0123456789abcdef0123456789abcdef01234567")
+	if err != nil {
+		t.Fatal(err)
+	}
+	finished := now.Add(time.Minute)
+	lanes := []scanrun.Lane{{
+		TenantID: "tenant-relationship-http", EngagementID: "assessment", ScanRunID: runID, LaneKey: "sca", Producer: "sca", TerminalStatus: scanrun.StatusSucceeded, Target: target,
+		AuthoritativeFindingKinds: []string{"vulnerability"}, IncludedScope: []string{scope}, StartedAt: now, FinishedAt: &finished,
+		ResultRef: "result:" + runID, EvidenceRef: "evidence:" + runID, ResultSHA256: strings.Repeat("b", 64), ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion, SealedAt: &finished,
+		Versions: []scanrun.LaneVersion{{VersionKind: scanrun.VersionScanner, Name: "sca", Version: "1"}}, Stages: []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSucceeded, StartedAt: now, FinishedAt: &finished}},
+	}}
+	lanes[0].ManifestHash, err = scanrun.ComputeManifestHash(lanes[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestHash, err := scanrun.ComputeRunManifestHash(lanes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return assessmentsnapshot.SelectedRun{ID: runID, ManifestHash: manifestHash, Provenance: scanrun.ProvenanceNative, TerminalStatus: scanrun.StatusSucceeded, Trusted: true, Lanes: lanes}
+}
+
+type relationshipHTTPClock struct{ now time.Time }
+
+func (clock relationshipHTTPClock) Now() time.Time { return clock.now }
+
+type relationshipHTTPIDs struct{ next atomic.Int64 }
+
+func (ids *relationshipHTTPIDs) NewID() shared.ID {
+	return shared.ID(fmt.Sprintf("relationship-http-%d", ids.next.Add(1)))
+}
+
+type relationshipHTTPAudit struct{}
+
+func (relationshipHTTPAudit) Record(context.Context, ports.AuditEntry) error { return nil }

--- a/internal/adapter/httpapi/assessment_retest_upload_test.go
+++ b/internal/adapter/httpapi/assessment_retest_upload_test.go
@@ -1,0 +1,179 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/blob"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sourceupload"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+)
+
+func TestAssessmentRetestUploadedRevisionIsExplicitOwnedAndIdempotent(t *testing.T) {
+	router, _, _ := newAssessmentCycleHTTPRouter(t, true, func(string) bool { return true })
+	sources := sourceupload.NewStore(blob.NewMemory(), 0)
+	router.eng.SetSourceStore(sources)
+	handler := router.routes()
+	upload := func(path, key, tenant, metadata, content string) *httptest.ResponseRecorder {
+		t.Helper()
+		var body bytes.Buffer
+		form := multipart.NewWriter(&body)
+		if err := form.WriteField("metadata", metadata); err != nil {
+			t.Fatal(err)
+		}
+		file, err := form.CreateFormFile("source", "source.zip")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := io.WriteString(file, content); err != nil {
+			t.Fatal(err)
+		}
+		if err := form.Close(); err != nil {
+			t.Fatal(err)
+		}
+		request := cycleRequest(http.MethodPost, path, "", userdom.RoleConsultant, tenant)
+		request.Body = io.NopCloser(bytes.NewReader(body.Bytes()))
+		request.ContentLength = int64(body.Len())
+		request.Header.Set("Content-Type", form.FormDataContentType())
+		request.Header.Set("Idempotency-Key", key)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+		return response
+	}
+	created := upload("/api/v1/engagements", "root-source", "source-tenant", `{"name":"Uploaded root"}`, "original revision")
+	if created.Code != http.StatusCreated {
+		t.Fatalf("initial=%d %s", created.Code, created.Body.String())
+	}
+	var root engagementView
+	if err := json.Unmarshal(created.Body.Bytes(), &root); err != nil {
+		t.Fatal(err)
+	}
+	for _, status := range []engdom.Status{engdom.StatusActive, engdom.StatusCompleted} {
+		if _, err := router.eng.Transition(context.Background(), "consultant", "source-tenant", shared.ID(root.ID), status); err != nil {
+			t.Fatal(err)
+		}
+	}
+	path := "/api/v1/engagements/" + root.ID + "/retests"
+	jsonRequest := func(key, tenant, body string) *httptest.ResponseRecorder {
+		t.Helper()
+		request := cycleRequest(http.MethodPost, path, body, userdom.RoleConsultant, tenant)
+		request.Header.Set("Idempotency-Key", key)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, request)
+		return response
+	}
+	original, err := sources.Get(context.Background(), "source-tenant", shared.ID(root.ID))
+	if err != nil || original.VersionID.IsZero() {
+		t.Fatalf("initial source has no immutable version: %+v err=%v", original, err)
+	}
+	decodeResult := func(response *httptest.ResponseRecorder) struct {
+		Engagement      engagementView                 `json:"engagement"`
+		SourceSelection *cycleuc.RetestSourceSelection `json:"source_selection"`
+	} {
+		t.Helper()
+		var result struct {
+			Engagement      engagementView                 `json:"engagement"`
+			SourceSelection *cycleuc.RetestSourceSelection `json:"source_selection"`
+		}
+		if response.Code != http.StatusCreated {
+			t.Fatalf("create=%d %s", response.Code, response.Body.String())
+		}
+		if err := json.Unmarshal(response.Body.Bytes(), &result); err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(response.Body.String(), "engagement-sources/") || strings.Contains(response.Body.String(), "Locator") {
+			t.Fatal("retained response exposed internal storage locator")
+		}
+		return result
+	}
+	for _, test := range []struct {
+		key, body, code string
+		status          int
+	}{
+		{"unknown-strategy", `{"source_strategy":"other"}`, "invalid_source_strategy", http.StatusBadRequest},
+		{"empty-reuse", `{"source_strategy":"reuse_current","scope_strategy":"empty"}`, "source_selection_requires_copied_scope", http.StatusBadRequest},
+		{"missing-new-file", `{"source_strategy":"upload_new"}`, "source_upload_required", http.StatusBadRequest},
+		{"stale-version", `{"source_strategy":"reuse_current","source_version_id":"stale"}`, "source_version_mismatch", http.StatusConflict},
+		{"wrong-predecessor", `{"source_strategy":"reuse_current","predecessor_assessment_id":"other"}`, "invalid_predecessor_assessment", http.StatusBadRequest},
+	} {
+		response := jsonRequest(test.key, "source-tenant", test.body)
+		if response.Code != test.status || !strings.Contains(response.Body.String(), test.code) {
+			t.Fatalf("%s=%d %s", test.key, response.Code, response.Body.String())
+		}
+	}
+	contradictory := upload(path, "reuse-with-file", "source-tenant", `{"source_strategy":"reuse_current"}`, "unused archive")
+	if contradictory.Code != http.StatusBadRequest || !strings.Contains(contradictory.Body.String(), "source_strategy_file_conflict") {
+		t.Fatalf("file+reuse=%d %s", contradictory.Code, contradictory.Body.String())
+	}
+	defaultReuse := jsonRequest("default-reuse", "source-tenant", `{}`)
+	defaultResult := decodeResult(defaultReuse)
+	if defaultResult.SourceSelection == nil || defaultResult.SourceSelection.Strategy != "reuse_current" || defaultResult.SourceSelection.ReusedFromVersionID != original.VersionID || defaultResult.SourceSelection.SourceAssessmentID != shared.ID(root.ID) || defaultResult.SourceSelection.SHA256 != original.SHA256 {
+		t.Fatalf("default source reuse not explicit in response: %+v", defaultResult.SourceSelection)
+	}
+	reusedSource, err := sources.Get(context.Background(), "source-tenant", shared.ID(defaultResult.Engagement.ID))
+	if err != nil || reusedSource.VersionID == original.VersionID || reusedSource.VersionID != defaultResult.SourceSelection.VersionID || reusedSource.EngagementID == original.EngagementID || reusedSource.Locator == original.Locator || reusedSource.SHA256 != original.SHA256 || reusedSource.CreatedBy != original.CreatedBy || !reusedSource.CreatedAt.Equal(original.CreatedAt) {
+		t.Fatalf("reused source is not child owned: %+v err=%v", reusedSource, err)
+	}
+	defaultReplay := jsonRequest("default-reuse", "source-tenant", `{}`)
+	if defaultReplay.Code != http.StatusCreated || defaultReplay.Body.String() != defaultReuse.Body.String() || defaultReplay.Header().Get("Idempotency-Replayed") != "true" {
+		t.Fatalf("reuse replay=%d %s", defaultReplay.Code, defaultReplay.Body.String())
+	}
+	changedSelection := jsonRequest("default-reuse", "source-tenant", `{"source_strategy":"upload_new"}`)
+	if changedSelection.Code != http.StatusConflict {
+		t.Fatalf("source strategy change reused idempotency key: %d", changedSelection.Code)
+	}
+	explicit := jsonRequest("explicit-reuse", "source-tenant", `{"source_strategy":"reuse_current","source_version_id":"`+original.VersionID.String()+`"}`)
+	if result := decodeResult(explicit); result.SourceSelection == nil || result.SourceSelection.ReusedFromVersionID != original.VersionID {
+		t.Fatalf("explicit version not pinned: %+v", result)
+	}
+	foreignReuse := jsonRequest("foreign-reuse", "other-tenant", `{"source_strategy":"reuse_current","source_version_id":"`+original.VersionID.String()+`"}`)
+	if foreignReuse.Code != http.StatusNotFound {
+		t.Fatalf("foreign version accessible: %d %s", foreignReuse.Code, foreignReuse.Body.String())
+	}
+	foreignVersion := jsonRequest("child-version", "source-tenant", `{"source_strategy":"reuse_current","source_version_id":"`+reusedSource.VersionID.String()+`"}`)
+	if foreignVersion.Code != http.StatusConflict {
+		t.Fatalf("sibling version selected from predecessor: %d %s", foreignVersion.Code, foreignVersion.Body.String())
+	}
+	wrongUploadVersion := upload(path, "new-file-wrong-parent-version", "source-tenant", `{"source_strategy":"upload_new","source_version_id":"`+reusedSource.VersionID.String()+`"}`, "new source")
+	if wrongUploadVersion.Code != http.StatusConflict {
+		t.Fatalf("new archive bypassed predecessor version pin: %d %s", wrongUploadVersion.Code, wrongUploadVersion.Body.String())
+	}
+	if len(defaultResult.Engagement.Scope.InScope) != 1 || defaultResult.Engagement.Scope.InScope[0].Value != original.Target() || defaultResult.Engagement.Status != string(engdom.StatusDraft) {
+		t.Fatalf("reuse changed source scope or draft state: %+v", defaultResult.Engagement)
+	}
+	metadata := `{"name":"Updated revision","planned_date":"2026-09-08"}`
+	retest := upload(path, "new-revision", "source-tenant", metadata, "updated revision")
+	if retest.Code != http.StatusCreated {
+		t.Fatalf("retest=%d %s", retest.Code, retest.Body.String())
+	}
+	result := decodeResult(retest)
+	stored, err := sources.Get(context.Background(), "source-tenant", shared.ID(result.Engagement.ID))
+	if err != nil || len(result.Engagement.Scope.InScope) != 1 || result.Engagement.Scope.InScope[0].Value != stored.Target() || stored.Target() == root.Scope.InScope[0].Value {
+		t.Fatalf("new source not bound: %+v err=%v", result, err)
+	}
+	if result.SourceSelection == nil || result.SourceSelection.Strategy != "upload_new" || result.SourceSelection.VersionID != stored.VersionID || result.SourceSelection.SHA256 != stored.SHA256 || !result.SourceSelection.ReusedFromVersionID.IsZero() {
+		t.Fatalf("uploaded revision selection missing: %+v", result.SourceSelection)
+	}
+	replayed := upload(path, "new-revision", "source-tenant", metadata, "updated revision")
+	if replayed.Code != http.StatusCreated || replayed.Header().Get("Idempotency-Replayed") != "true" || replayed.Body.String() != retest.Body.String() {
+		t.Fatalf("replay=%d %s", replayed.Code, replayed.Body.String())
+	}
+	changed := upload(path, "new-revision", "source-tenant", metadata, "different bytes")
+	if changed.Code != http.StatusConflict {
+		t.Fatalf("changed digest replay=%d %s", changed.Code, changed.Body.String())
+	}
+	other := upload(path, "foreign", "other-tenant", metadata, "updated revision")
+	if other.Code != http.StatusNotFound {
+		t.Fatalf("cross tenant=%d %s", other.Code, other.Body.String())
+	}
+}

--- a/internal/adapter/httpapi/assessment_snapshot_handler.go
+++ b/internal/adapter/httpapi/assessment_snapshot_handler.go
@@ -1,0 +1,200 @@
+package httpapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	domain "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+)
+
+const assessmentSnapshotRequestLimit = int64(64 << 10)
+
+type finalizeAssessmentSnapshotRequest struct {
+	SelectedRuns []finalizeAssessmentSnapshotRun `json:"selected_runs"`
+}
+
+type finalizeAssessmentSnapshotRun struct {
+	RunID    string   `json:"run_id"`
+	LaneKeys []string `json:"lane_keys,omitempty"`
+}
+
+type assessmentSnapshotResponse struct {
+	ID             shared.ID             `json:"id"`
+	CycleID        shared.ID             `json:"cycle_id"`
+	AssessmentID   shared.ID             `json:"assessment_id"`
+	SnapshotNumber int                   `json:"snapshot_number"`
+	Lifecycle      domain.Lifecycle      `json:"lifecycle"`
+	Provenance     domain.Provenance     `json:"provenance"`
+	Boundary       domain.Boundary       `json:"boundary"`
+	RunReferences  []domain.RunReference `json:"run_references"`
+	Dimensions     []domain.Dimension    `json:"dimensions"`
+	SchemaVersion  int                   `json:"schema_version"`
+	ContentHash    string                `json:"content_hash"`
+	CreatedAt      time.Time             `json:"created_at"`
+	CreatedBy      string                `json:"created_by"`
+	FinalizedAt    *time.Time            `json:"finalized_at"`
+	FinalizedBy    string                `json:"finalized_by"`
+	SupersededAt   *time.Time            `json:"superseded_at,omitempty"`
+	SupersededBy   string                `json:"superseded_by,omitempty"`
+}
+
+type finalizedAssessmentSnapshotResponse struct {
+	Snapshot       assessmentSnapshotResponse `json:"snapshot"`
+	DefaultVersion int64                      `json:"default_version"`
+}
+
+type assessmentSnapshotListResponse struct {
+	Items             []assessmentSnapshotResponse `json:"items"`
+	NextCursor        string                       `json:"next_cursor,omitempty"`
+	DefaultSnapshotID shared.ID                    `json:"default_snapshot_id,omitempty"`
+	DefaultVersion    int64                        `json:"default_version"`
+}
+
+func (rt *Router) finalizeAssessmentSnapshot(w http.ResponseWriter, r *http.Request) {
+	requestKey := strings.TrimSpace(r.Header.Get("Idempotency-Key"))
+	if requestKey == "" {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "idempotency_key_required"})
+		return
+	}
+	if strings.TrimSpace(r.Header.Get("If-Match")) == "" {
+		writeJSON(w, http.StatusPreconditionRequired, errorBody{Error: "precondition_required"})
+		return
+	}
+	expectedVersion, err := parseSnapshotIfMatch(r.Header.Get("If-Match"))
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_if_match"})
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, assessmentSnapshotRequestLimit)
+	var request finalizeAssessmentSnapshotRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&request); err != nil {
+		var sizeErr *http.MaxBytesError
+		if errors.As(err, &sizeErr) {
+			writeJSON(w, http.StatusRequestEntityTooLarge, errorBody{Error: "request_too_large"})
+			return
+		}
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_request"})
+		return
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_request"})
+		return
+	}
+	selectedRuns := make([]snapshotuc.RunSelection, len(request.SelectedRuns))
+	for index, selected := range request.SelectedRuns {
+		selectedRuns[index] = snapshotuc.RunSelection{RunID: selected.RunID, LaneKeys: selected.LaneKeys}
+	}
+	snapshot, created, err := rt.assessmentSnapshots.Finalize(r.Context(), snapshotuc.FinalizeInput{
+		TenantID: shared.ID(TenantFrom(r.Context())), AssessmentID: shared.ID(r.PathValue("id")), SelectedRuns: selectedRuns,
+		RequestKey: requestKey, ExpectedDefaultVersion: expectedVersion, Actor: PrincipalFrom(r.Context()),
+	})
+	if err != nil {
+		writeAssessmentSnapshotError(w, rt.log, err)
+		return
+	}
+	if !created {
+		w.Header().Set("Idempotency-Replayed", "true")
+	}
+	w.Header().Set("ETag", snapshotETag(snapshot.DefaultVersion))
+	writeJSON(w, http.StatusCreated, finalizedAssessmentSnapshotResponse{Snapshot: newAssessmentSnapshotResponse(snapshot), DefaultVersion: snapshot.DefaultVersion})
+}
+
+func (rt *Router) listAssessmentSnapshots(w http.ResponseWriter, r *http.Request) {
+	tenantID := shared.ID(TenantFrom(r.Context()))
+	assessmentID := shared.ID(r.PathValue("id"))
+	limit := 0
+	if raw := strings.TrimSpace(r.URL.Query().Get("limit")); raw != "" {
+		parsed, err := strconv.Atoi(raw)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, errorBody{Error: "invalid_page_size"})
+			return
+		}
+		limit = parsed
+	}
+	page, err := rt.assessmentSnapshots.ListByAssessment(r.Context(), tenantID, assessmentID, r.URL.Query().Get("cursor"), limit)
+	if err != nil {
+		writeAssessmentSnapshotError(w, rt.log, err)
+		return
+	}
+	response := assessmentSnapshotListResponse{Items: make([]assessmentSnapshotResponse, 0, len(page.Items)), NextCursor: page.NextCursor}
+	for index := range page.Items {
+		response.Items = append(response.Items, newAssessmentSnapshotResponse(&page.Items[index]))
+	}
+	if len(page.Items) > 0 {
+		_, pointer, err := rt.assessmentSnapshots.GetDefault(r.Context(), tenantID, assessmentID)
+		if err != nil && !errors.Is(err, shared.ErrNotFound) {
+			writeAssessmentSnapshotError(w, rt.log, err)
+			return
+		}
+		if err == nil {
+			response.DefaultSnapshotID, response.DefaultVersion = pointer.SnapshotID, pointer.Version
+		}
+	}
+	w.Header().Set("ETag", snapshotETag(response.DefaultVersion))
+	writeJSON(w, http.StatusOK, response)
+}
+
+func (rt *Router) getAssessmentSnapshot(w http.ResponseWriter, r *http.Request) {
+	snapshot, err := rt.assessmentSnapshots.Get(r.Context(), shared.ID(TenantFrom(r.Context())), shared.ID(r.PathValue("snapshotId")))
+	if err != nil {
+		writeAssessmentSnapshotError(w, rt.log, err)
+		return
+	}
+	w.Header().Set("ETag", fmt.Sprintf("\"sha256:%s\"", snapshot.ContentHash))
+	writeJSON(w, http.StatusOK, newAssessmentSnapshotResponse(snapshot))
+}
+
+func parseSnapshotIfMatch(value string) (int64, error) {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "W/") {
+		value = strings.TrimSpace(strings.TrimPrefix(value, "W/"))
+	}
+	value = strings.Trim(value, "\"")
+	version, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || version < 0 {
+		return 0, errors.New("invalid If-Match")
+	}
+	return version, nil
+}
+
+func snapshotETag(version int64) string { return fmt.Sprintf("\"%d\"", version) }
+
+func newAssessmentSnapshotResponse(snapshot *domain.Snapshot) assessmentSnapshotResponse {
+	return assessmentSnapshotResponse{
+		ID: snapshot.ID, CycleID: snapshot.CycleID, AssessmentID: snapshot.AssessmentID, SnapshotNumber: snapshot.SnapshotNumber,
+		Lifecycle: snapshot.Lifecycle, Provenance: snapshot.Provenance, Boundary: snapshot.Boundary,
+		RunReferences: snapshot.RunReferences, Dimensions: snapshot.Dimensions, SchemaVersion: snapshot.SchemaVersion,
+		ContentHash: snapshot.ContentHash, CreatedAt: snapshot.CreatedAt, CreatedBy: snapshot.CreatedBy,
+		FinalizedAt: snapshot.FinalizedAt, FinalizedBy: snapshot.FinalizedBy, SupersededAt: snapshot.SupersededAt, SupersededBy: snapshot.SupersededBy,
+	}
+}
+
+func writeAssessmentSnapshotError(w http.ResponseWriter, log *slog.Logger, err error) {
+	status, code := http.StatusInternalServerError, "internal_error"
+	switch {
+	case errors.Is(err, snapshotuc.ErrIdempotencyBodyMismatch):
+		status, code = http.StatusConflict, "idempotency_body_mismatch"
+	case errors.Is(err, shared.ErrValidation):
+		status, code = http.StatusBadRequest, "invalid_request"
+	case errors.Is(err, shared.ErrConflict):
+		status, code = http.StatusConflict, "snapshot_conflict"
+	case errors.Is(err, shared.ErrNotFound):
+		status, code = http.StatusNotFound, "not_found"
+	case errors.Is(err, shared.ErrForbidden):
+		status, code = http.StatusForbidden, "forbidden"
+	default:
+		requestLogger(w, log).Error("assessment snapshot request failed", "err", err)
+	}
+	writeJSON(w, status, errorBody{Error: code})
+}

--- a/internal/adapter/httpapi/assessment_snapshot_handler_test.go
+++ b/internal/adapter/httpapi/assessment_snapshot_handler_test.go
@@ -1,0 +1,227 @@
+package httpapi
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestAssessmentSnapshotRoutesContractsPermissionsAndTenantIsolation(t *testing.T) {
+	router := newAssessmentSnapshotHTTPRouter(t)
+	handler := router.routes()
+	path := "/api/v1/engagements/assessment-snapshot-http/snapshots/finalize"
+	body := `{"selected_runs":[{"run_id":"snapshot-http-run","lane_keys":["sca"]}]}`
+
+	reviewer := cycleRequest(http.MethodPost, path, body, userdom.RoleReviewer, "tenant-snapshot-http")
+	reviewer.Header.Set("Idempotency-Key", "snapshot-http-reviewer")
+	reviewer.Header.Set("If-Match", "0")
+	reviewerResponse := httptest.NewRecorder()
+	handler.ServeHTTP(reviewerResponse, reviewer)
+	if reviewerResponse.Code != http.StatusForbidden {
+		t.Fatalf("reviewer finalize=%d body=%s", reviewerResponse.Code, reviewerResponse.Body.String())
+	}
+
+	missingKey := cycleRequest(http.MethodPost, path, body, userdom.RoleConsultant, "tenant-snapshot-http")
+	missingKey.Header.Set("If-Match", "0")
+	missingKeyResponse := httptest.NewRecorder()
+	handler.ServeHTTP(missingKeyResponse, missingKey)
+	if missingKeyResponse.Code != http.StatusBadRequest || !strings.Contains(missingKeyResponse.Body.String(), "idempotency_key_required") {
+		t.Fatalf("missing key=%d body=%s", missingKeyResponse.Code, missingKeyResponse.Body.String())
+	}
+
+	missingIfMatch := cycleRequest(http.MethodPost, path, body, userdom.RoleConsultant, "tenant-snapshot-http")
+	missingIfMatch.Header.Set("Idempotency-Key", "snapshot-http-missing-if-match")
+	missingIfMatchResponse := httptest.NewRecorder()
+	handler.ServeHTTP(missingIfMatchResponse, missingIfMatch)
+	if missingIfMatchResponse.Code != http.StatusPreconditionRequired || !strings.Contains(missingIfMatchResponse.Body.String(), "precondition_required") {
+		t.Fatalf("missing If-Match=%d body=%s", missingIfMatchResponse.Code, missingIfMatchResponse.Body.String())
+	}
+
+	create := cycleRequest(http.MethodPost, path, body, userdom.RoleConsultant, "tenant-snapshot-http")
+	create.Header.Set("Idempotency-Key", "snapshot-http-create")
+	create.Header.Set("If-Match", `W/"0"`)
+	created := httptest.NewRecorder()
+	handler.ServeHTTP(created, create)
+	if created.Code != http.StatusCreated || created.Header().Get("ETag") != `"1"` || strings.Contains(created.Body.String(), "snapshot-http-create") || strings.Contains(created.Body.String(), "request_hash") {
+		t.Fatalf("create=%d headers=%v body=%s", created.Code, created.Header(), created.Body.String())
+	}
+	var finalized finalizedAssessmentSnapshotResponse
+	if err := json.Unmarshal(created.Body.Bytes(), &finalized); err != nil || finalized.Snapshot.ID.IsZero() || finalized.DefaultVersion != 1 {
+		t.Fatalf("decode finalized=%+v err=%v", finalized, err)
+	}
+
+	replay := cycleRequest(http.MethodPost, path, body, userdom.RoleConsultant, "tenant-snapshot-http")
+	replay.Header.Set("Idempotency-Key", "snapshot-http-create")
+	replay.Header.Set("If-Match", "0")
+	replayed := httptest.NewRecorder()
+	handler.ServeHTTP(replayed, replay)
+	if replayed.Code != http.StatusCreated || replayed.Header().Get("Idempotency-Replayed") != "true" || replayed.Body.String() != created.Body.String() {
+		t.Fatalf("replay=%d headers=%v body=%s", replayed.Code, replayed.Header(), replayed.Body.String())
+	}
+
+	staleReplay := cycleRequest(http.MethodPost, path, body, userdom.RoleConsultant, "tenant-snapshot-http")
+	staleReplay.Header.Set("Idempotency-Key", "snapshot-http-create")
+	staleReplay.Header.Set("If-Match", "77")
+	staleReplayResponse := httptest.NewRecorder()
+	handler.ServeHTTP(staleReplayResponse, staleReplay)
+	if staleReplayResponse.Code != http.StatusConflict || !strings.Contains(staleReplayResponse.Body.String(), "snapshot_conflict") {
+		t.Fatalf("stale replay=%d body=%s", staleReplayResponse.Code, staleReplayResponse.Body.String())
+	}
+
+	mismatch := cycleRequest(http.MethodPost, path, `{"selected_runs":[{"run_id":"snapshot-http-run","lane_keys":["other"]}]}`, userdom.RoleConsultant, "tenant-snapshot-http")
+	mismatch.Header.Set("Idempotency-Key", "snapshot-http-create")
+	mismatch.Header.Set("If-Match", "0")
+	mismatchResponse := httptest.NewRecorder()
+	handler.ServeHTTP(mismatchResponse, mismatch)
+	if mismatchResponse.Code != http.StatusConflict || !strings.Contains(mismatchResponse.Body.String(), "idempotency_body_mismatch") {
+		t.Fatalf("mismatch=%d body=%s", mismatchResponse.Code, mismatchResponse.Body.String())
+	}
+
+	listPath := "/api/v1/engagements/assessment-snapshot-http/snapshots"
+	list := httptest.NewRecorder()
+	handler.ServeHTTP(list, cycleRequest(http.MethodGet, listPath, "", userdom.RoleReadOnly, "tenant-snapshot-http"))
+	if list.Code != http.StatusOK || list.Header().Get("ETag") != `"1"` {
+		t.Fatalf("list=%d headers=%v body=%s", list.Code, list.Header(), list.Body.String())
+	}
+	var page assessmentSnapshotListResponse
+	if err := json.Unmarshal(list.Body.Bytes(), &page); err != nil || len(page.Items) != 1 || page.DefaultSnapshotID != finalized.Snapshot.ID || page.DefaultVersion != 1 {
+		t.Fatalf("list page=%+v err=%v", page, err)
+	}
+
+	get := httptest.NewRecorder()
+	handler.ServeHTTP(get, cycleRequest(http.MethodGet, "/api/v1/assessment-snapshots/"+finalized.Snapshot.ID.String(), "", userdom.RoleReadOnly, "tenant-snapshot-http"))
+	if get.Code != http.StatusOK || get.Header().Get("ETag") != `"sha256:`+finalized.Snapshot.ContentHash+`"` {
+		t.Fatalf("get=%d headers=%v body=%s", get.Code, get.Header(), get.Body.String())
+	}
+
+	crossTenantList := httptest.NewRecorder()
+	handler.ServeHTTP(crossTenantList, cycleRequest(http.MethodGet, listPath, "", userdom.RoleReadOnly, "tenant-other"))
+	if crossTenantList.Code != http.StatusNotFound {
+		t.Fatalf("cross-tenant list=%d body=%s", crossTenantList.Code, crossTenantList.Body.String())
+	}
+	crossTenantGet := httptest.NewRecorder()
+	handler.ServeHTTP(crossTenantGet, cycleRequest(http.MethodGet, "/api/v1/assessment-snapshots/"+finalized.Snapshot.ID.String(), "", userdom.RoleReadOnly, "tenant-other"))
+	if crossTenantGet.Code != http.StatusNotFound || !strings.Contains(crossTenantGet.Body.String(), "not_found") {
+		t.Fatalf("cross-tenant get=%d body=%s", crossTenantGet.Code, crossTenantGet.Body.String())
+	}
+}
+
+func TestAssessmentSnapshotFinalizeRejectsOversizedBody(t *testing.T) {
+	router := newAssessmentSnapshotHTTPRouter(t)
+	request := cycleRequest(http.MethodPost, "/api/v1/engagements/assessment-snapshot-http/snapshots/finalize", `{"selected_runs":[{"run_id":"`+strings.Repeat("a", int(assessmentSnapshotRequestLimit))+`"}]}`, userdom.RoleConsultant, "tenant-snapshot-http")
+	request.Header.Set("Idempotency-Key", "snapshot-http-oversized")
+	request.Header.Set("If-Match", "0")
+	response := httptest.NewRecorder()
+	router.routes().ServeHTTP(response, request)
+	if response.Code != http.StatusRequestEntityTooLarge || !strings.Contains(response.Body.String(), "request_too_large") {
+		t.Fatalf("oversized=%d body=%s", response.Code, response.Body.String())
+	}
+}
+
+func newAssessmentSnapshotHTTPRouter(t *testing.T) *Router {
+	t.Helper()
+	ctx := context.Background()
+	clock := fixedClock{t: time.Date(2026, 9, 1, 14, 0, 0, 0, time.UTC)}
+	ids := &assessmentCycleHTTPIDs{}
+	audit := &fakeAudit{}
+	engagements := memory.NewEngagementRepository()
+	assessment, err := engagement.New("assessment-snapshot-http", "tenant-snapshot-http", "Snapshot API", "", clock.t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := assessment.Transition(engagement.StatusActive, clock.t); err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(ctx, assessment); err != nil {
+		t.Fatal(err)
+	}
+	cycles := memory.NewAssessmentCycleRepository()
+	cycle, err := assessmentcycle.NewAssessmentCycle("cycle-snapshot-http", "tenant-snapshot-http", "Snapshot API", assessmentcycle.BoundaryStandalone, "", "", assessment.ID, "operator", clock.t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember("tenant-snapshot-http", cycle.ID, assessment.ID, "operator", clock.t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+	runs := memory.NewScanRunStore()
+	run := assessmentSnapshotHTTPRun(t, clock.t)
+	building := run
+	building.Lanes, building.ManifestHash, building.SealedAt = nil, "", nil
+	if run.Provenance == scanrun.ProvenanceNative {
+		building.TerminalStatus = scanrun.StatusBuilding
+	}
+	if err := runs.SaveScanRun(ctx, building); err != nil {
+		t.Fatal(err)
+	}
+	if run.SealedAt != nil {
+		if err := runs.SealScanRun(ctx, ports.SealScanRunCommand{
+			TenantID: run.TenantID, RunID: run.ID, TerminalStatus: run.TerminalStatus,
+			Lanes: run.Lanes, ManifestSchemaVersion: run.ManifestSchemaVersion, ManifestHash: run.ManifestHash, SealedAt: *run.SealedAt,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	transactions := memory.NewTenantTransactionRunner()
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	service, err := snapshotuc.NewService(snapshots, cycles, engagements, runs, transactions, ids, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	engagementService := enguc.NewService(engagements, clock, ids, audit)
+	router := &Router{log: discardLog(), eng: engagementService}
+	router.SetAssessmentLifecycleRollout(func(string) bool { return true }, func(string) bool { return true })
+	router.SetAssessmentSnapshots(service)
+	return router
+}
+
+func assessmentSnapshotHTTPRun(t *testing.T, now time.Time) scanrun.ScanRun {
+	t.Helper()
+	target, err := scanrun.CanonicalizeRepositoryTarget("https://example.com/repo.git", "0123456789abcdef0123456789abcdef01234567")
+	if err != nil {
+		t.Fatal(err)
+	}
+	finished := now.Add(time.Minute)
+	run := scanrun.ScanRun{
+		TenantID: "tenant-snapshot-http", ID: "snapshot-http-run", EngagementID: "assessment-snapshot-http", CreatedAt: now, UpdatedAt: now,
+		Provenance: scanrun.ProvenanceNative, TerminalStatus: scanrun.StatusSucceeded, ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion,
+		Lanes: []scanrun.Lane{{
+			TenantID: "tenant-snapshot-http", EngagementID: "assessment-snapshot-http", ScanRunID: "snapshot-http-run",
+			LaneKey: "sca", Producer: "sca", TerminalStatus: scanrun.StatusSucceeded, Target: target,
+			AuthoritativeFindingKinds: []string{"vulnerability"}, IncludedScope: []string{"src/**"}, StartedAt: now, FinishedAt: &finished,
+			ResultRef: "result:snapshot-http", EvidenceRef: "evidence:snapshot-http", ResultSHA256: strings.Repeat("a", 64), ManifestSchemaVersion: 1,
+			Versions: []scanrun.LaneVersion{{VersionKind: scanrun.VersionScanner, Name: "sca", Version: "1"}},
+			Stages:   []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSucceeded, StartedAt: now, FinishedAt: &finished}},
+		}},
+	}
+	run.Lanes[0].SealedAt = &finished
+	run.Lanes[0].ManifestHash, err = scanrun.ComputeManifestHash(run.Lanes[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.ManifestHash, err = scanrun.ComputeRunManifestHash(run.Lanes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.SealedAt, run.UpdatedAt = &finished, finished
+	return run
+}

--- a/internal/adapter/httpapi/bodylimit.go
+++ b/internal/adapter/httpapi/bodylimit.go
@@ -34,6 +34,7 @@ const (
 // runs. An unknown pattern falls back to the default, so a new route is bounded from the
 // moment it is registered.
 var routeBodyLimits = map[string]int64{
+	"POST /api/v1/engagements/{assessmentId}/retests":  sourceUploadBodyLimit,
 	"POST /api/v1/projects/{key}/analyses/{id}/source": sourceUploadBodyLimit,
 	// Engagement and project creation both accept a multipart source archive on the same
 	// route that otherwise takes a small JSON body. The JSON branch of each handler bounds

--- a/internal/adapter/httpapi/engagement_handler.go
+++ b/internal/adapter/httpapi/engagement_handler.go
@@ -18,6 +18,7 @@ import (
 	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
 	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
@@ -30,14 +31,15 @@ type scopeTargetDTO struct {
 }
 
 type createEngagementRequest struct {
-	Name           string           `json:"name"`
-	Client         string           `json:"client"`
-	InScope        []scopeTargetDTO `json:"in_scope"`
-	OutOfScope     []scopeTargetDTO `json:"out_of_scope"`
-	AuthorizedFrom string           `json:"authorized_from"` // RFC3339, optional
-	AuthorizedTo   string           `json:"authorized_to"`   // RFC3339, optional
-	Timezone       string           `json:"timezone"`        // IANA, optional (display)
-	AssetID        string           `json:"asset_id"`
+	Name                string           `json:"name"`
+	Client              string           `json:"client"`
+	InScope             []scopeTargetDTO `json:"in_scope"`
+	OutOfScope          []scopeTargetDTO `json:"out_of_scope"`
+	AuthorizedFrom      string           `json:"authorized_from"` // RFC3339, optional
+	AuthorizedTo        string           `json:"authorized_to"`   // RFC3339, optional
+	Timezone            string           `json:"timezone"`        // IANA, optional (display)
+	AssetID             string           `json:"asset_id"`
+	AssessmentProjectID string           `json:"assessment_project_id"`
 }
 
 // parseRFC3339Ptr parses an optional RFC3339 timestamp. Empty -> (nil, nil).
@@ -188,16 +190,73 @@ func (rt *Router) createEngagement(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	input := enguc.CreateInput{
-		TenantID:        tenantID,
-		BusinessAssetID: shared.ID(req.AssetID),
-		CreatedBy:       PrincipalFrom(r.Context()), // engagement owner (ownership)
-		Name:            req.Name,
-		Client:          req.Client,
-		InScope:         toTargets(req.InScope),
-		OutOfScope:      toTargets(req.OutOfScope),
-		AuthorizedFrom:  from,
-		AuthorizedTo:    to,
-		Timezone:        req.Timezone,
+		AssessmentProjectID: shared.ID(req.AssessmentProjectID),
+		TenantID:            tenantID,
+		BusinessAssetID:     shared.ID(req.AssetID),
+		CreatedBy:           PrincipalFrom(r.Context()), // engagement owner (ownership)
+		Name:                req.Name,
+		Client:              req.Client,
+		InScope:             toTargets(req.InScope),
+		OutOfScope:          toTargets(req.OutOfScope),
+		AuthorizedFrom:      from,
+		AuthorizedTo:        to,
+		Timezone:            req.Timezone,
+	}
+	dualWrite := rt.assessmentCycles != nil && rt.assessmentCycleDualWrite != nil && rt.assessmentCycleDualWrite(tenantID.String())
+	if req.AssessmentProjectID != "" && !dualWrite {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "assessment_project_association_disabled"})
+		return
+	}
+	if dualWrite {
+		idempotencyKey := strings.TrimSpace(r.Header.Get("Idempotency-Key"))
+		if idempotencyKey == "" {
+			canonical, marshalErr := json.Marshal(struct {
+				Engagement     enguc.CreateInput `json:"engagement"`
+				SourceFilename string            `json:"source_filename,omitempty"`
+				SourceSize     int64             `json:"source_size,omitempty"`
+				SourceSHA256   string            `json:"source_sha256,omitempty"`
+			}{Engagement: input, SourceFilename: sourceFilename, SourceSize: sourceSize, SourceSHA256: sourceSHA256})
+			if marshalErr != nil {
+				writeError(w, rt.log, fmt.Errorf("derive assessment creation idempotency key: %w", marshalErr))
+				return
+			}
+			digest := sha256.Sum256(canonical)
+			idempotencyKey = "server-" + hex.EncodeToString(digest[:])
+		}
+		cycleInput := cycleuc.CreateInitialAssessmentInput{
+			Request: cycleuc.RetainedRequest{
+				TenantID: tenantID, Actor: PrincipalFrom(r.Context()), Route: "/api/v1/engagements",
+				IdempotencyKey: idempotencyKey,
+			},
+			Engagement: input,
+		}
+		if sourceFile != nil {
+			cycleInput.Source = &cycleuc.SourceUpload{Filename: sourceFilename, Size: sourceSize, SHA256: sourceSHA256, Reader: sourceFile}
+		}
+		response, err := rt.assessmentCycles.CreateInitialAssessment(r.Context(), cycleInput)
+		if err != nil {
+			rt.observeAssessmentCycleDualWrite("failed")
+			writeAssessmentCycleError(w, rt.log, err)
+			return
+		}
+		if response.Replayed {
+			rt.observeAssessmentCycleDualWrite("replayed")
+		} else {
+			rt.observeAssessmentCycleDualWrite("created")
+		}
+		w.Header().Set("X-Synapse-Assessment-Cycle-Dual-Write", "true")
+		// Retention stores an immutable application result, not the transport
+		// representation. Use the same view as the ordinary engagement endpoints.
+		var assessment engdom.Engagement
+		if err := json.Unmarshal(response.Body, &assessment); err != nil {
+			writeError(w, rt.log, err)
+			return
+		}
+		writeRetainedValue(w, response, toEngagementView(&assessment))
+		return
+	}
+	if rt.assessmentCycles != nil {
+		rt.observeAssessmentCycleDualWrite("legacy")
 	}
 	var e *engdom.Engagement
 	if sourceFile != nil {
@@ -210,6 +269,16 @@ func (rt *Router) createEngagement(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusCreated, toEngagementView(e))
+}
+
+type assessmentCycleDualWriteObserver interface {
+	ObserveAssessmentCycleDualWrite(outcome string)
+}
+
+func (rt *Router) observeAssessmentCycleDualWrite(outcome string) {
+	if observer, ok := rt.httpObserver.(assessmentCycleDualWriteObserver); ok {
+		observer.ObserveAssessmentCycleDualWrite(outcome)
+	}
 }
 
 func (rt *Router) listEngagements(w http.ResponseWriter, r *http.Request) {

--- a/internal/adapter/httpapi/harness_test.go
+++ b/internal/adapter/httpapi/harness_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/agent"
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	snapshotdom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
 	ap "github.com/KKloudTarus/synapse-ce/internal/domain/attackpath"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/dastrun"
@@ -24,12 +26,15 @@ import (
 	projectdom "github.com/KKloudTarus/synapse-ce/internal/domain/project"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/purplecoverage"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/rule"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/threatmodel"
 	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/writeupdraft"
 	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
 	analysisuc "github.com/KKloudTarus/synapse-ce/internal/usecase/analysis"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
 	attackpathuc "github.com/KKloudTarus/synapse-ce/internal/usecase/attackpath"
 	chainrehearsaluc "github.com/KKloudTarus/synapse-ce/internal/usecase/chainrehearsal"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/dastrunner"
@@ -418,9 +423,51 @@ func TestHostileHarness(t *testing.T) {
 	if _, _, err := usersSvc.CreateUser(context.Background(), platform, "tenantB", "B Member", userdom.RoleMember); err != nil {
 		t.Fatalf("seed tenantB member: %v", err)
 	}
+	lifecycleClock := fixedClock{t: time.Unix(1, 0).UTC()}
+	lifecycleIDs := engIDs{}
+	lifecycleTransactions := memory.NewTenantTransactionRunner()
+	lifecycleCycles := memory.NewAssessmentCycleRepository()
+	lifecycleCycle, err := cycledom.NewAssessmentCycle("cycle-A", "tenantA", "tenant-A-cycle-marker", cycledom.BoundaryStandalone, "", "", "engA", "p", lifecycleClock.Now())
+	if err != nil {
+		t.Fatalf("seed assessment cycle: %v", err)
+	}
+	lifecycleMember, err := cycledom.NewInitialMember("tenantA", lifecycleCycle.ID, "engA", "p", lifecycleClock.Now())
+	if err != nil {
+		t.Fatalf("seed assessment cycle member: %v", err)
+	}
+	if err := lifecycleCycles.CreateCycle(context.Background(), lifecycleCycle); err != nil {
+		t.Fatalf("store assessment cycle: %v", err)
+	}
+	if err := lifecycleCycles.CreateMember(context.Background(), lifecycleMember); err != nil {
+		t.Fatalf("store assessment cycle member: %v", err)
+	}
+	engagementService := enguc.NewService(engRepo, lifecycleClock, lifecycleIDs, audit)
+	lifecycleService, err := cycleuc.NewService(lifecycleCycles, engRepo, nil, nil, lifecycleTransactions, lifecycleIDs, lifecycleClock, audit)
+	if err != nil {
+		t.Fatalf("assessment cycle service: %v", err)
+	}
+	lifecycleAPI, err := cycleuc.NewAPIService(lifecycleService, lifecycleCycles, memory.NewAssessmentCycleRequestRepository(), engagementService, lifecycleTransactions, lifecycleClock, audit)
+	if err != nil {
+		t.Fatalf("assessment cycle API: %v", err)
+	}
+	lifecycleSnapshots := memory.NewAssessmentSnapshotRepository()
+	lifecycleRuns := memory.NewScanRunStore()
+	lifecycleSnapshotService, err := snapshotuc.NewService(lifecycleSnapshots, lifecycleCycles, engRepo, lifecycleRuns, lifecycleTransactions, lifecycleIDs, lifecycleClock, audit)
+	if err != nil {
+		t.Fatalf("assessment snapshot service: %v", err)
+	}
+	legacySnapshot, err := snapshotdom.NewFinalized("tenantA", "snapshot-A", lifecycleCycle.ID, "engA", snapshotdom.Boundary{Kind: cycledom.BoundaryStandalone}, "legacy-snapshot-A", "p", lifecycleClock.Now(), []snapshotdom.SelectedRun{{
+		ID: "legacy-run-A", ManifestHash: strings.Repeat("a", 64), Provenance: scanrun.ProvenanceLegacy, TerminalStatus: scanrun.StatusUnknown,
+	}})
+	if err != nil {
+		t.Fatalf("seed assessment snapshot: %v", err)
+	}
+	if _, _, err := lifecycleSnapshots.CreateLegacyProjection(context.Background(), legacySnapshot); err != nil {
+		t.Fatalf("store assessment snapshot: %v", err)
+	}
 	rt := &Router{
 		log:      discardLog(),
-		eng:      enguc.NewService(engRepo, fixedClock{}, engIDs{}, &fakeAudit{}),
+		eng:      engagementService,
 		projects: projectSvc,
 		users:    usersSvc,
 	}
@@ -472,6 +519,9 @@ func TestHostileHarness(t *testing.T) {
 	}
 	rt.SetHostVulnerabilities(hostVulns)
 	rt.SetFleetRolloutAdmin(harnessRollout{})
+	rt.SetAssessmentCycles(lifecycleAPI, true, func(string) bool { return true })
+	rt.SetAssessmentLifecycleRollout(func(string) bool { return true }, func(string) bool { return true })
+	rt.SetAssessmentSnapshots(lifecycleSnapshotService)
 	// A real approval store, not nil: the generated sweep below reads the approvals route as the
 	// owning tenant, so the handler must run rather than dereference a nil dependency.
 	rt.EnableAgent(nil, memory.NewAgentSessionStore(), nil, memory.NewApprovalStore(), nil, 1, 8)
@@ -530,6 +580,17 @@ func TestHostileHarness(t *testing.T) {
 	verifyPromotion := func(role, tenant string) (int, string) {
 		req := httptest.NewRequest(http.MethodPost, "/api/v1/engagements/engA/judgments/eng-1/verify", strings.NewReader(`{"score":75,"rationale":"hostile verification","version":1}`))
 		req = req.WithContext(context.WithValue(req.Context(), principalKey, Principal{ID: "p", Role: role, TenantID: tenant}))
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		return rec.Code, rec.Body.String()
+	}
+
+	sendLifecycleWrite := func(role, tenant, method, path, body string, headers map[string]string) (int, string) {
+		req := httptest.NewRequest(method, path, strings.NewReader(body))
+		req = req.WithContext(context.WithValue(req.Context(), principalKey, Principal{ID: "p", Role: role, TenantID: tenant}))
+		for name, value := range headers {
+			req.Header.Set(name, value)
+		}
 		rec := httptest.NewRecorder()
 		mux.ServeHTTP(rec, req)
 		return rec.Code, rec.Body.String()
@@ -622,6 +683,11 @@ func TestHostileHarness(t *testing.T) {
 		// 403 that would reveal the engagement exists.
 		{"cross-tenant engagement read → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA", http.StatusNotFound},
 		{"cross-tenant child resource → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA/findings", http.StatusNotFound},
+		{"cross-tenant assessment lifecycle → 404", "readonly", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA/lifecycle", http.StatusNotFound},
+		{"cross-tenant assessment cycle → 404", "readonly", "tenantB", true, http.MethodGet, "/api/v1/assessment-cycles/cycle-A", http.StatusNotFound},
+		{"cross-tenant assessment cycle members → 404", "readonly", "tenantB", true, http.MethodGet, "/api/v1/assessment-cycles/cycle-A/members", http.StatusNotFound},
+		{"cross-tenant assessment snapshots → 404", "readonly", "tenantB", true, http.MethodGet, "/api/v1/engagements/engA/snapshots", http.StatusNotFound},
+		{"cross-tenant assessment snapshot → 404", "readonly", "tenantB", true, http.MethodGet, "/api/v1/assessment-snapshots/snapshot-A", http.StatusNotFound},
 		// Same-tenant read still works (isolation does not over-block).
 		{"same-tenant engagement read → 200", "consultant", "tenantA", true, http.MethodGet, "/api/v1/engagements/engA", http.StatusOK},
 		{"cross-tenant project read → 404", "consultant", "tenantB", true, http.MethodGet, "/api/v1/projects/project-a", http.StatusNotFound},
@@ -736,6 +802,26 @@ func TestHostileHarness(t *testing.T) {
 		if got, body := send(c.role, c.tenant, c.method, c.path, c.authed); got != c.want {
 			t.Errorf("%s: %s %s (role=%q tenant=%q) → %d, body: %s, want %d", c.name, c.method, c.path, c.role, c.tenant, got, body, c.want)
 		}
+	}
+
+	for _, probe := range []struct {
+		name, role, method, path, body string
+		headers                        map[string]string
+	}{
+		{"cross-tenant assessment retest", "consultant", http.MethodPost, "/api/v1/engagements/engA/retests", `{}`, map[string]string{"Idempotency-Key": "hostile-retest"}},
+		{"cross-tenant assessment cycle archive", "reviewer", http.MethodPost, "/api/v1/assessment-cycles/cycle-A/archive", `{}`, map[string]string{"Idempotency-Key": "hostile-archive", "If-Match": `"1"`}},
+		{"cross-tenant assessment cycle reopen", "reviewer", http.MethodPost, "/api/v1/assessment-cycles/cycle-A/reopen", `{"reason":"hostile probe"}`, map[string]string{"Idempotency-Key": "hostile-reopen", "If-Match": `"1"`}},
+		{"cross-tenant assessment snapshot finalize", "consultant", http.MethodPost, "/api/v1/engagements/engA/snapshots/finalize", `{"selected_run_ids":["legacy-run-A"]}`, map[string]string{"Idempotency-Key": "hostile-finalize", "If-Match": `"0"`}},
+	} {
+		if code, body := sendLifecycleWrite(probe.role, "tenantB", probe.method, probe.path, probe.body, probe.headers); code != http.StatusNotFound || strings.Contains(body, "tenant-A-cycle-marker") || strings.Contains(body, "snapshot-A") {
+			t.Errorf("%s leaked tenantA lifecycle state: code=%d body=%s", probe.name, code, body)
+		}
+	}
+	if code, body := send("readonly", "tenantA", http.MethodGet, "/api/v1/assessment-cycles", true); code != http.StatusOK || !strings.Contains(body, "tenant-A-cycle-marker") {
+		t.Fatalf("tenantA must see its assessment cycle marker (code=%d body=%s)", code, body)
+	}
+	if code, body := send("readonly", "tenantB", http.MethodGet, "/api/v1/assessment-cycles", true); code != http.StatusOK || strings.Contains(body, "tenant-A-cycle-marker") || strings.Contains(body, "cycle-A") {
+		t.Errorf("tenantB assessment cycle list leaked tenantA data (code=%d body=%s)", code, body)
 	}
 
 	if code, body := send("readonly", "tenantA", http.MethodGet, "/api/v1/attack-paths", true); code != http.StatusOK || !strings.Contains(body, "tenant-A-secret-marker") {

--- a/internal/adapter/httpapi/resource_view.go
+++ b/internal/adapter/httpapi/resource_view.go
@@ -34,20 +34,22 @@ type roeView struct {
 
 // engagementView is the serialized shape of an engagement.
 type engagementView struct {
-	ID              string    `json:"id"`
-	TenantID        string    `json:"tenant_id"`
-	ProjectID       string    `json:"project_id,omitempty"`
-	BusinessAssetID string    `json:"business_asset_id,omitempty"`
-	Name            string    `json:"name"`
-	Client          string    `json:"client"`
-	Status          string    `json:"status"`
-	Scope           scopeView `json:"scope"`
-	RoE             roeView   `json:"roe"`
+	ID                  string    `json:"id"`
+	TenantID            string    `json:"tenant_id"`
+	ProjectID           string    `json:"project_id,omitempty"`
+	AssessmentProjectID string    `json:"assessment_project_id,omitempty"`
+	BusinessAssetID     string    `json:"business_asset_id,omitempty"`
+	Name                string    `json:"name"`
+	Client              string    `json:"client"`
+	Status              string    `json:"status"`
+	Scope               scopeView `json:"scope"`
+	RoE                 roeView   `json:"roe"`
 	// AuthorizedFrom and AuthorizedTo bound legal testing. A null bound is open on that side.
-	AuthorizedFrom   *time.Time `json:"authorized_from"`
-	AuthorizedTo     *time.Time `json:"authorized_to"`
-	Timezone         string     `json:"timezone,omitempty"`
-	LiveReconEnabled bool       `json:"live_recon_enabled"`
+	AuthorizedFrom                         *time.Time `json:"authorized_from"`
+	AuthorizedTo                           *time.Time `json:"authorized_to"`
+	Timezone                               string     `json:"timezone,omitempty"`
+	LiveReconEnabled                       bool       `json:"live_recon_enabled"`
+	RequiresExplicitExecutionAuthorization bool       `json:"requires_explicit_execution_authorization"`
 	// OffensiveRoE is the rules of engagement the offensive governance policy requires before adversary
 	// emulation or exploitation chains may run. Distinct from RoE above (allowed tool classes + blackouts).
 	OffensiveRoE offensiveRoEView `json:"offensive_roe"`
@@ -104,22 +106,24 @@ func toEngagementView(e *engdom.Engagement) engagementView {
 		return engagementView{}
 	}
 	return engagementView{
-		ID:              e.ID.String(),
-		TenantID:        e.TenantID.String(),
-		ProjectID:       e.ProjectID.String(),
-		BusinessAssetID: e.BusinessAssetID.String(),
-		Name:            e.Name,
-		Client:          e.Client,
-		Status:          string(e.Status),
+		AssessmentProjectID: e.AssessmentProjectID.String(),
+		ID:                  e.ID.String(),
+		TenantID:            e.TenantID.String(),
+		ProjectID:           e.ProjectID.String(),
+		BusinessAssetID:     e.BusinessAssetID.String(),
+		Name:                e.Name,
+		Client:              e.Client,
+		Status:              string(e.Status),
 		Scope: scopeView{
 			InScope:    toTargetViews(e.Scope.InScope),
 			OutOfScope: toTargetViews(e.Scope.OutOfScope),
 		},
-		RoE:              toRoEView(e.RoE),
-		AuthorizedFrom:   e.AuthorizedFrom,
-		AuthorizedTo:     e.AuthorizedTo,
-		Timezone:         e.Timezone,
-		LiveReconEnabled: e.LiveReconEnabled,
+		RoE:                                    toRoEView(e.RoE),
+		AuthorizedFrom:                         e.AuthorizedFrom,
+		AuthorizedTo:                           e.AuthorizedTo,
+		Timezone:                               e.Timezone,
+		LiveReconEnabled:                       e.LiveReconEnabled,
+		RequiresExplicitExecutionAuthorization: e.RequiresExplicitExecutionAuthorization,
 		OffensiveRoE: offensiveRoEView{
 			CustomerContact:   e.CustomerContact,
 			EmergencyContact:  e.EmergencyContact,

--- a/internal/adapter/httpapi/resource_view_contract_test.go
+++ b/internal/adapter/httpapi/resource_view_contract_test.go
@@ -19,8 +19,8 @@ import (
 // or renaming one all fail here and force the web client and the OpenAPI document to move with it.
 var wireContract = map[string][]string{
 	"engagementView": {
-		"id", "tenant_id", "project_id", "business_asset_id", "name", "client", "status",
-		"scope", "roe", "authorized_from", "authorized_to", "timezone", "live_recon_enabled",
+		"id", "tenant_id", "project_id", "assessment_project_id", "business_asset_id", "name", "client", "status",
+		"scope", "roe", "authorized_from", "authorized_to", "timezone", "live_recon_enabled", "requires_explicit_execution_authorization",
 		"offensive_roe", "created_at", "updated_at",
 		// list enrichment, present only on listEngagements rows with the stores wired
 		"findings_count", "last_scan_date", "last_scan_status",

--- a/internal/adapter/httpapi/router.go
+++ b/internal/adapter/httpapi/router.go
@@ -17,6 +17,10 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	userdom "github.com/KKloudTarus/synapse-ce/internal/domain/user"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/writeupdraft"
+	comparisonuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcomparison"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	relationshipuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentrelationship"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
 	audituc "github.com/KKloudTarus/synapse-ce/internal/usecase/audit"
 	aupuc "github.com/KKloudTarus/synapse-ce/internal/usecase/aup"
 	credentialsuc "github.com/KKloudTarus/synapse-ce/internal/usecase/credentials"
@@ -46,96 +50,104 @@ import (
 
 // Router wires HTTP routes to use case services.
 type Router struct {
-	log                    *slog.Logger
-	accessLogEnabled       bool
-	httpObserver           HTTPObserver
-	auth                   *Authenticator
-	oidc                   OIDCService
-	oidcFrontendURL        string
-	eng                    *enguc.Service
-	sca                    *scauc.Service
-	aup                    *aupuc.Service
-	findings               *findingsuc.Service
-	export                 *exportuc.Service
-	report                 *reportuc.Service
-	evidence               *evidenceuc.Service
-	recon                  *reconuc.Service
-	logs                   ports.LogStream
-	transfer               *transferuc.Service
-	audit                  *audituc.Service
-	vex                    *vexuc.Service
-	users                  *usersuc.Service
-	credentials            *credentialsuc.Service
-	integrations           *integrationuc.Service
-	dastVerifier           runtimeVerifierService
-	dastWorkflow           dastWorkflowService
-	dastRun                dastRunService              // optional; nil ⇒ DAST verification runs execute synchronously in-process
-	agent                  *agentDeps                  // optional; nil ⇒ agent routes are not registered
-	exploitation           findingVerifier             // optional; nil ⇒ the verify route is not registered
-	judgments              judgmentService             // optional; nil ⇒ judgment routes are not registered
-	autoVerifier           autoVerifierService         // optional; nil ⇒ the LLM auto-verify route is not registered
-	threatModels           threatModelService          // optional; nil ⇒ threat-model routes are not registered
-	drafts                 writeupDraftService         // optional; nil ⇒ writeup-draft sign-off routes are not registered
-	aiTriageReviews        aiTriageReviewService       // optional; nil ⇒ AI-triage review queue routes are not registered
-	projects               projectService              // optional; nil ⇒ project routes are not registered
-	assets                 assetService                // optional; nil ⇒ fleet asset routes are not registered
-	hostVulns              hostVulnerabilityService    // optional; nil ⇒ host vulnerability routes are not registered (#820)
-	findingSummaries       ports.FindingSummaryReader  // optional; nil ⇒ engagement list rows carry no finding counts
-	scanJobs               ports.ScanJobStore          // optional; nil ⇒ engagement list rows carry no last scan
-	scanRunHistory         scanRunHistoryReader        // optional; normalized provenance read side for the existing scan-runs route
-	alerts                 alertService                // optional; nil ⇒ operator alerting routes are not registered
-	offensivePolicy        *offensivepolicy.Register   // optional; nil ⇒ the policy register route is not registered
-	responses              responseService             // optional; nil ⇒ governed defensive-response routes are not registered (#425)
-	responseIDs            ports.IDGenerator           // set with responses; mints the server-authoritative action id
-	incidentResponses      incidentResponseCoordinator // optional; nil ⇒ incident-scoped governed response route is not registered
-	connectors             connectorService            // optional; nil ⇒ source-control connector routes are not registered
-	cspm                   *cspm.Service               // optional; nil ⇒ CSPM routes are not registered
-	businessAssets         businessAssetService        // optional; nil ⇒ business-level Asset routes are not registered
-	attackPaths            attackPathService           // optional; nil ⇒ attack-path routes are not registered
-	coverage               coverageService             // optional; nil ⇒ fleet coverage/agent-view routes are not registered
-	coverageWindows        coverageWindowReader        // optional; nil ⇒ immutable telemetry coverage-window routes are not registered
-	privacyPolicies        privacyPolicyService        // optional; nil ⇒ tenant source-privacy policy routes are not registered
-	incidents              incidentReader              // optional; nil ⇒ incident read routes are not registered (#594 C7)
-	incidentTriage         incidentTriager             // optional; nil ⇒ incident triage routes are not registered (#594 C5)
-	incidentRiskReassessor incidentRiskReassessor      // optional; nil ⇒ the tri-score reassess route is not registered (#594 C3/D/X5)
-	incidentCorrelator     incidentCorrelator          // optional; nil ⇒ the correlation route is not registered (#594 C2/C3)
-	endpointProcesses      endpointProcessStore        // optional; nil ⇒ the process-report routes are not registered (#594 B5)
-	processLearner         processLearner              // optional; nil ⇒ reported processes are not folded into the behavior baseline (#594 D)
-	behaviorRebaseliner    behaviorRebaseliner         // optional; nil ⇒ the behavior-baseline re-baseline route is not registered (#594 D)
-	hostAssets             hostAssetVerifier           // optional; verifies an id is a live host asset before the operator process/rebaseline routes mutate state
-	desiredCapabilities    desiredCapabilityService    // optional; nil ⇒ the desired-vs-observed routes are not registered (#633)
-	legalHolds             legalHoldService            // optional; nil ⇒ the legal-hold routes are not registered (#635)
-	privacyExport          privacyExporter             // optional; nil ⇒ the data-export route is not registered (#635)
-	dataPurge              dataPurger                  // optional; nil ⇒ the on-demand data-deletion route is not registered (#635)
-	endpointTimeline       endpointTimelineReader      // optional; nil ⇒ the State-Timeline read route is not registered (#594 B7)
-	retroHunter            retroHunter                 // optional; nil ⇒ the retro-hunt route is not registered (#594 B7)
-	sarif                  sarifIngester               // optional; nil ⇒ the third-party SARIF import route is not registered
-	importedFindings       sarifReader                 // optional read side for imported findings
-	fleetRolloutAdmin      fleetRolloutService         // optional; nil ⇒ the operator rollout routes are not served
-	offensiveHalt          offensiveKillSwitch         // optional; nil ⇒ the red-team halt route is not served
-	detections             detectionReader             // optional read side for the detection ledger (#423)
-	detectionProvenance    detectionProvenanceReader   // optional read side for durable detection provenance (#610)
-	riskStories            riskStoryReader             // optional read side for the unified per-asset risk story (#427)
-	purpleCoverage         purpleCoverageReader        // optional read side for purple-team coverage (#426)
-	purpleTeam             purpleTeamRunner            // optional producer: runs governed emulation → coverage (#426)
-	chainRehearsal         chainRehearser              // optional: governed exploitation chain rehearsal (simulation)
-	fleet                  *fleetRouter                // optional; nil ⇒ agent transport plane is not served
-	fleetAdmin             fleetAdminService           // optional; nil ⇒ operator agent-admin routes not registered
-	fleetKeys              fleetKeyAdmin               // optional; nil ⇒ operator signing-key routes not registered (A4 #625)
-	responseObservers      responseObserverAdmin       // optional; nil ⇒ response-observer assignment route is not registered
-	qualityGates           qualityGateService          // optional; nil ⇒ quality-gate routes are not registered
-	qualityProfiles        qualityProfileService       // optional; nil ⇒ quality-profile routes are not registered
-	rules                  rulesService                // optional; nil ⇒ rule catalog routes are not registered
-	dastScan               dastScanService
-	vulnerabilitySources   *vulnerabilitysourceuc.Service
-	vulnerabilityMonitor   *vulnerabilitymonitor.Service
-	vulnerabilityReconcile *vulnerabilityreconciliation.Service
-	vulnerabilityAudit     ports.AuditLogger
-	vulnerabilityRead      *vulnerabilityinteluc.Service
-	vulnerabilityActions   *vulnerabilityactionuc.Service
-	sla                    *slauc.Service
-	capabilities           capabilityCatalog // optional; nil ⇒ the capability catalog route is not registered
-	readiness              readinessConfig
+	log                      *slog.Logger
+	accessLogEnabled         bool
+	httpObserver             HTTPObserver
+	auth                     *Authenticator
+	oidc                     OIDCService
+	oidcFrontendURL          string
+	eng                      *enguc.Service
+	sca                      *scauc.Service
+	aup                      *aupuc.Service
+	findings                 *findingsuc.Service
+	export                   *exportuc.Service
+	report                   *reportuc.Service
+	evidence                 *evidenceuc.Service
+	recon                    *reconuc.Service
+	logs                     ports.LogStream
+	transfer                 *transferuc.Service
+	audit                    *audituc.Service
+	vex                      *vexuc.Service
+	users                    *usersuc.Service
+	credentials              *credentialsuc.Service
+	integrations             *integrationuc.Service
+	dastVerifier             runtimeVerifierService
+	dastWorkflow             dastWorkflowService
+	dastRun                  dastRunService             // optional; nil ⇒ DAST verification runs execute synchronously in-process
+	agent                    *agentDeps                 // optional; nil ⇒ agent routes are not registered
+	exploitation             findingVerifier            // optional; nil ⇒ the verify route is not registered
+	judgments                judgmentService            // optional; nil ⇒ judgment routes are not registered
+	autoVerifier             autoVerifierService        // optional; nil ⇒ the LLM auto-verify route is not registered
+	threatModels             threatModelService         // optional; nil ⇒ threat-model routes are not registered
+	drafts                   writeupDraftService        // optional; nil ⇒ writeup-draft sign-off routes are not registered
+	aiTriageReviews          aiTriageReviewService      // optional; nil ⇒ AI-triage review queue routes are not registered
+	projects                 projectService             // optional; nil ⇒ project routes are not registered
+	assets                   assetService               // optional; nil ⇒ fleet asset routes are not registered
+	hostVulns                hostVulnerabilityService   // optional; nil ⇒ host vulnerability routes are not registered (#820)
+	findingSummaries         ports.FindingSummaryReader // optional; nil ⇒ engagement list rows carry no finding counts
+	scanJobs                 ports.ScanJobStore         // optional; nil ⇒ engagement list rows carry no last scan
+	scanRunHistory           scanRunHistoryReader       // optional; normalized provenance read side for the existing scan-runs route
+	alerts                   alertService               // optional; nil ⇒ operator alerting routes are not registered
+	offensivePolicy          *offensivepolicy.Register  // optional; nil ⇒ the policy register route is not registered
+	responses                responseService            // optional; nil ⇒ governed defensive-response routes are not registered (#425)
+	responseIDs              ports.IDGenerator          // set with responses; mints the server-authoritative action id
+	connectors               connectorService           // optional; nil ⇒ source-control connector routes are not registered
+	cspm                     *cspm.Service              // optional; nil ⇒ CSPM routes are not registered
+	businessAssets           businessAssetService       // optional; nil ⇒ business-level Asset routes are not registered
+	attackPaths              attackPathService          // optional; nil ⇒ attack-path routes are not registered
+	coverage                 coverageService            // optional; nil ⇒ fleet coverage/agent-view routes are not registered
+	coverageWindows          coverageWindowReader       // optional; nil ⇒ immutable telemetry coverage-window routes are not registered
+	privacyPolicies          privacyPolicyService       // optional; nil ⇒ tenant source-privacy policy routes are not registered
+	incidents                incidentReader             // optional; nil ⇒ incident read routes are not registered (#594 C7)
+	incidentTriage           incidentTriager            // optional; nil ⇒ incident triage routes are not registered (#594 C5)
+	incidentRiskReassessor   incidentRiskReassessor     // optional; nil ⇒ the tri-score reassess route is not registered (#594 C3/D/X5)
+	incidentCorrelator       incidentCorrelator         // optional; nil ⇒ the correlation route is not registered (#594 C2/C3)
+	endpointProcesses        endpointProcessStore       // optional; nil ⇒ the process-report routes are not registered (#594 B5)
+	processLearner           processLearner             // optional; nil ⇒ reported processes are not folded into the behavior baseline (#594 D)
+	behaviorRebaseliner      behaviorRebaseliner        // optional; nil ⇒ the behavior-baseline re-baseline route is not registered (#594 D)
+	hostAssets               hostAssetVerifier          // optional; verifies an id is a live host asset before the operator process/rebaseline routes mutate state
+	desiredCapabilities      desiredCapabilityService   // optional; nil ⇒ the desired-vs-observed routes are not registered (#633)
+	legalHolds               legalHoldService           // optional; nil ⇒ the legal-hold routes are not registered (#635)
+	privacyExport            privacyExporter            // optional; nil ⇒ the data-export route is not registered (#635)
+	dataPurge                dataPurger                 // optional; nil ⇒ the on-demand data-deletion route is not registered (#635)
+	endpointTimeline         endpointTimelineReader     // optional; nil ⇒ the State-Timeline read route is not registered (#594 B7)
+	retroHunter              retroHunter                // optional; nil ⇒ the retro-hunt route is not registered (#594 B7)
+	sarif                    sarifIngester              // optional; nil ⇒ the third-party SARIF import route is not registered
+	importedFindings         sarifReader                // optional read side for imported findings
+	fleetRolloutAdmin        fleetRolloutService        // optional; nil ⇒ the operator rollout routes are not served
+	offensiveHalt            offensiveKillSwitch        // optional; nil ⇒ the red-team halt route is not served
+	detections               detectionReader            // optional read side for the detection ledger (#423)
+	detectionProvenance      detectionProvenanceReader  // optional read side for durable detection provenance (#610)
+	riskStories              riskStoryReader            // optional read side for the unified per-asset risk story (#427)
+	purpleCoverage           purpleCoverageReader       // optional read side for purple-team coverage (#426)
+	purpleTeam               purpleTeamRunner           // optional producer: runs governed emulation → coverage (#426)
+	chainRehearsal           chainRehearser             // optional: governed exploitation chain rehearsal (simulation)
+	fleet                    *fleetRouter               // optional; nil ⇒ agent transport plane is not served
+	fleetAdmin               fleetAdminService          // optional; nil ⇒ operator agent-admin routes not registered
+	fleetKeys                fleetKeyAdmin              // optional; nil ⇒ operator signing-key routes not registered (A4 #625)
+	qualityGates             qualityGateService         // optional; nil ⇒ quality-gate routes are not registered
+	qualityProfiles          qualityProfileService      // optional; nil ⇒ quality-profile routes are not registered
+	rules                    rulesService               // optional; nil ⇒ rule catalog routes are not registered
+	dastScan                 dastScanService
+	vulnerabilitySources     *vulnerabilitysourceuc.Service
+	vulnerabilityMonitor     *vulnerabilitymonitor.Service
+	vulnerabilityReconcile   *vulnerabilityreconciliation.Service
+	vulnerabilityAudit       ports.AuditLogger
+	vulnerabilityRead        *vulnerabilityinteluc.Service
+	vulnerabilityActions     *vulnerabilityactionuc.Service
+	sla                      *slauc.Service
+	capabilities             capabilityCatalog // optional; nil ⇒ the capability catalog route is not registered
+	readiness                readinessConfig
+	assessmentCycles         *cycleuc.APIService
+	assessmentSnapshots      *snapshotuc.Service
+	assessmentComparisons    *comparisonuc.Service
+	assessmentRelationships  *relationshipuc.Service
+	assessmentCycleAPI       bool
+	assessmentCycleDualWrite func(string) bool
+	assessmentLifecycleRead  func(string) bool
+	assessmentLifecycleUI    func(string) bool
+	incidentResponses        incidentResponseCoordinator // optional; nil ⇒ incident-scoped governed response route is not registered
+	responseObservers        responseObserverAdmin       // optional; nil ⇒ response-observer assignment route is not registered
 }
 
 // findingVerifier is the narrow slice of the exploitation use-case the verify endpoint needs:
@@ -262,6 +274,49 @@ func (rt *Router) SetVulnerabilityReadModel(service *vulnerabilityinteluc.Servic
 
 func (rt *Router) SetVulnerabilityActions(actions *vulnerabilityactionuc.Service) {
 	rt.vulnerabilityActions = actions
+}
+
+func (rt *Router) SetAssessmentCycles(service *cycleuc.APIService, apiEnabled bool, dualWrite func(string) bool) {
+	rt.assessmentCycles = service
+	rt.assessmentCycleAPI = apiEnabled
+	rt.assessmentCycleDualWrite = dualWrite
+}
+
+func (rt *Router) SetAssessmentLifecycleRollout(readEnabled, uiEnabled func(string) bool) {
+	rt.assessmentLifecycleRead = readEnabled
+	rt.assessmentLifecycleUI = uiEnabled
+}
+
+func (rt *Router) SetAssessmentSnapshots(service *snapshotuc.Service) {
+	rt.assessmentSnapshots = service
+}
+
+func (rt *Router) SetAssessmentComparisons(service *comparisonuc.Service) {
+	rt.assessmentComparisons = service
+}
+
+func (rt *Router) SetAssessmentRelationships(service *relationshipuc.Service) {
+	rt.assessmentRelationships = service
+}
+
+func (rt *Router) requireAssessmentLifecycleRead(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if rt.assessmentLifecycleRead != nil && !rt.assessmentLifecycleRead(TenantFrom(r.Context())) {
+			writeJSON(w, http.StatusNotFound, errorBody{Error: "assessment_lifecycle_read_disabled"})
+			return
+		}
+		next(w, r)
+	}
+}
+
+func (rt *Router) requireAssessmentLifecycleWrite(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if rt.assessmentLifecycleRead == nil || !rt.assessmentLifecycleRead(TenantFrom(r.Context())) {
+			writeJSON(w, http.StatusNotFound, errorBody{Error: "assessment_lifecycle_write_disabled"})
+			return
+		}
+		next(w, r)
+	}
 }
 
 // SetSLA wires the opt-in risk-based remediation governance API.
@@ -586,6 +641,43 @@ func (rt *Router) routes() *http.ServeMux {
 		mux.HandleFunc("GET /api/v1/projects/{key}/analysis", rt.authz(userdom.PermView, rt.latestProjectAnalysis))
 	}
 	mux.HandleFunc("POST /api/v1/engagements", rt.authz(userdom.PermOperate, rt.createEngagement))
+	if rt.assessmentCycles != nil && rt.assessmentCycleAPI {
+		mux.HandleFunc("POST /api/v1/engagements/{assessmentId}/retests", rt.authz(userdom.PermOperate, rt.requireAssessmentLifecycleWrite(rt.createAssessmentRetest)))
+		mux.HandleFunc("GET /api/v1/engagements/{assessmentId}/lifecycle", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.getAssessmentLifecycle)))
+		mux.HandleFunc("GET /api/v1/assessment-cycles/{cycleId}", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.getAssessmentCycle)))
+		mux.HandleFunc("GET /api/v1/assessment-cycles/{cycleId}/members", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.listAssessmentCycleMembers)))
+		mux.HandleFunc("GET /api/v1/assessment-cycles", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.listAssessmentCycles)))
+		mux.HandleFunc("POST /api/v1/assessment-cycles/{cycleId}/archive", rt.authz(userdom.PermReview, rt.requireAssessmentLifecycleWrite(rt.archiveAssessmentCycle)))
+		mux.HandleFunc("POST /api/v1/assessment-cycles/{cycleId}/reopen", rt.authz(userdom.PermReview, rt.requireAssessmentLifecycleWrite(rt.reopenAssessmentCycle)))
+		mux.HandleFunc("POST /api/v1/assessment-cycles/{cycleId}/relationship-previews", rt.authz(userdom.PermReview, rt.requireAssessmentLifecycleWrite(rt.previewAssessmentRelationshipChange)))
+		mux.HandleFunc("POST /api/v1/assessment-cycles/{cycleId}/relationship-commits", rt.authz(userdom.PermReview, rt.requireAssessmentLifecycleWrite(rt.commitAssessmentRelationshipChange)))
+		mux.HandleFunc("POST /api/v1/assessment-cycles/{cycleId}/closure-previews", rt.authz(userdom.PermReview, rt.requireAssessmentLifecycleWrite(rt.previewAssessmentClosure)))
+		mux.HandleFunc("POST /api/v1/assessment-cycles/{cycleId}/closure-commits", rt.authz(userdom.PermReview, rt.requireAssessmentLifecycleWrite(rt.commitAssessmentClosure)))
+		mux.HandleFunc("POST /api/v1/assessment-cycles/{cycleId}/reopen-previews", rt.authz(userdom.PermReview, rt.requireAssessmentLifecycleWrite(rt.previewAssessmentReopen)))
+		mux.HandleFunc("POST /api/v1/assessment-cycles/{cycleId}/reopen-commits", rt.authz(userdom.PermReview, rt.requireAssessmentLifecycleWrite(rt.commitAssessmentReopen)))
+		mux.HandleFunc("GET /api/v1/assessment-cycles/{cycleId}/closure-manifests", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.listAssessmentClosureManifests)))
+		mux.HandleFunc("GET /api/v1/assessment-cycles/{cycleId}/closure-manifests/{manifestId}", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.getAssessmentClosureManifest)))
+		mux.HandleFunc("GET /api/v1/assessment-cycles/{cycleId}/closure-manifests/{manifestId}/report", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.downloadAssessmentClosureReport)))
+	}
+	if rt.assessmentSnapshots != nil {
+		mux.HandleFunc("POST /api/v1/engagements/{id}/snapshots/finalize", rt.authz(userdom.PermOperate, rt.requireAssessmentLifecycleWrite(rt.withEngTenant(rt.finalizeAssessmentSnapshot))))
+		mux.HandleFunc("GET /api/v1/engagements/{id}/snapshots", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.withEngTenant(rt.listAssessmentSnapshots))))
+		mux.HandleFunc("GET /api/v1/assessment-snapshots/{snapshotId}", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.getAssessmentSnapshot)))
+	}
+	if rt.assessmentComparisons != nil {
+		mux.HandleFunc("POST /api/v1/assessment-comparisons", rt.authz(userdom.PermOperate, rt.requireAssessmentLifecycleRead(rt.createAssessmentComparison)))
+		mux.HandleFunc("GET /api/v1/assessment-comparisons/{comparisonId}", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.getAssessmentComparison)))
+		mux.HandleFunc("GET /api/v1/assessment-comparisons/{comparisonId}/summary", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.getAssessmentComparisonSummary)))
+		mux.HandleFunc("GET /api/v1/assessment-comparisons/{comparisonId}/items", rt.authz(userdom.PermView, rt.requireAssessmentLifecycleRead(rt.listAssessmentComparisonItems)))
+		mux.HandleFunc("POST /api/v1/assessment-comparisons/{comparisonId}/items/{itemId}/confirm", rt.authz(userdom.PermReview, rt.requireAssessmentLifecycleRead(rt.confirmAssessmentComparisonItem)))
+		mux.HandleFunc("POST /api/v1/assessment-comparisons/{comparisonId}/items/{itemId}/unlink", rt.authz(userdom.PermReview, rt.requireAssessmentLifecycleRead(rt.unlinkAssessmentComparisonItem)))
+	}
+	if rt.assessmentRelationships != nil {
+		mux.HandleFunc("POST /api/v1/assessment-relationship-candidates/generate", rt.authz(userdom.PermReview, rt.generateAssessmentRelationshipCandidate))
+		mux.HandleFunc("GET /api/v1/assessment-relationship-candidates", rt.authz(userdom.PermReview, rt.listAssessmentRelationshipCandidates))
+		mux.HandleFunc("GET /api/v1/assessment-relationship-candidates/{candidateId}", rt.authz(userdom.PermReview, rt.getAssessmentRelationshipCandidate))
+		mux.HandleFunc("POST /api/v1/assessment-relationship-candidates/{candidateId}/decisions", rt.authz(userdom.PermReview, rt.decideAssessmentRelationshipCandidate))
+	}
 	if rt.fleetRolloutAdmin != nil {
 		// These are OPERATOR routes and they live under /api/v1/agents, not /api/v1/fleet.
 		// Handler() mounts /api/v1/fleet/ on the untrusted AGENT auth plane, which deliberately

--- a/internal/adapter/httpapi/sca_handler.go
+++ b/internal/adapter/httpapi/sca_handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
 )
@@ -22,23 +23,35 @@ import (
 var scanImageRefRE = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._/:@-]*$`)
 
 type scaScanRequest struct {
-	EngagementID string `json:"engagement_id"`
-	Target       string `json:"target"`
-	Kind         string `json:"kind"`         // local (default) | git | archive | upload | image
-	Ref          string `json:"ref"`          // optional git branch/tag
-	Mode         string `json:"mode"`         // full (default) | vulnerabilities | licenses
-	CodeQuality  bool   `json:"code_quality"` // include first-party code-quality findings
+	SourceVersionID string `json:"source_version_id,omitempty"`
+	EngagementID    string `json:"engagement_id"`
+	Target          string `json:"target"`
+	Kind            string `json:"kind"`         // local (default) | git | archive | upload | image
+	Ref             string `json:"ref"`          // optional git branch/tag
+	Mode            string `json:"mode"`         // full (default) | vulnerabilities | licenses
+	CodeQuality     bool   `json:"code_quality"` // include first-party code-quality findings
 }
 
 type uploadedSourceResponse struct {
-	Filename   string    `json:"filename"`
-	Size       int64     `json:"size"`
-	SHA256     string    `json:"sha256"`
-	Target     string    `json:"target"`
-	UploadedBy string    `json:"uploaded_by"`
-	UploadedAt time.Time `json:"uploaded_at"`
+	VersionID           shared.ID `json:"version_id,omitempty"`
+	ReusedFromVersionID shared.ID `json:"reused_from_version_id,omitempty"`
+	AssociatedBy        string    `json:"associated_by,omitempty"`
+	AssociatedAt        time.Time `json:"associated_at,omitempty"`
+	Filename            string    `json:"filename"`
+	Size                int64     `json:"size"`
+	SHA256              string    `json:"sha256"`
+	Target              string    `json:"target"`
+	UploadedBy          string    `json:"uploaded_by"`
+	UploadedAt          time.Time `json:"uploaded_at"`
 }
 
+func uploadedSourceView(item sourcepackage.Package) uploadedSourceResponse {
+	return uploadedSourceResponse{
+		VersionID: item.VersionID, ReusedFromVersionID: item.ReusedFromVersionID,
+		AssociatedBy: item.AssociatedBy, AssociatedAt: item.AssociatedAt,
+		Filename: item.Filename, Size: item.Size, SHA256: item.SHA256, Target: item.Target(), UploadedBy: item.CreatedBy, UploadedAt: item.CreatedAt,
+	}
+}
 
 // scanRunHistoryReader is the normalized, tenant-scoped provenance read side.
 // It deliberately excludes mutation methods: this existing HTTP route is view-only.
@@ -50,25 +63,38 @@ type scanRunHistoryReader interface {
 func (rt *Router) SetScanRunHistory(history scanRunHistoryReader) { rt.scanRunHistory = history }
 
 type scanRunHistoryResponse struct {
-	ID               string            `json:"id"`
-	EngagementID     string            `json:"engagement_id"`
-	CreatedAt        time.Time         `json:"created_at"`
-	Manifest         ports.ScanManifest `json:"manifest"`
-	FindingKeys      []string          `json:"finding_keys"`
-	Provenance       string            `json:"provenance"`
-	TerminalStatus   string            `json:"terminal_status"`
-	SealedAt         *time.Time        `json:"sealed_at,omitempty"`
-	ManifestHash     string            `json:"manifest_hash,omitempty"`
-	LaneCount        int               `json:"lane_count"`
-	CompleteCoverage bool              `json:"complete_coverage"`
+	SourcePackage    *uploadedSourceResponse `json:"source_package,omitempty"`
+	TargetKind       string                  `json:"target_kind,omitempty"`
+	Target           string                  `json:"target,omitempty"`
+	ID               string                  `json:"id"`
+	EngagementID     string                  `json:"engagement_id"`
+	CreatedAt        time.Time               `json:"created_at"`
+	Manifest         ports.ScanManifest      `json:"manifest"`
+	FindingKeys      []string                `json:"finding_keys"`
+	Provenance       string                  `json:"provenance"`
+	TerminalStatus   string                  `json:"terminal_status"`
+	SealedAt         *time.Time              `json:"sealed_at,omitempty"`
+	ManifestHash     string                  `json:"manifest_hash,omitempty"`
+	LaneCount        int                     `json:"lane_count"`
+	CompleteCoverage bool                    `json:"complete_coverage"`
 }
 
 func legacyScanRunResponse(run ports.ScanRun) scanRunHistoryResponse {
-	return scanRunHistoryResponse{
+	view := scanRunHistoryResponse{
 		ID: run.ID, EngagementID: run.EngagementID, CreatedAt: run.CreatedAt,
 		Manifest: run.Manifest, FindingKeys: run.FindingKeys,
 		Provenance: "legacy", TerminalStatus: "unknown",
 	}
+	attachScanSource(&view, run.Manifest.SourcePackage)
+	return view
+}
+
+func attachScanSource(view *scanRunHistoryResponse, item *sourcepackage.Package) {
+	if item == nil {
+		return
+	}
+	source := uploadedSourceView(*item)
+	view.SourcePackage, view.TargetKind, view.Target = &source, ports.TargetUpload, item.Target()
 }
 
 func mergeScanRunHistory(legacy []ports.ScanRun, normalized []scanrun.ScanRun) []scanRunHistoryResponse {
@@ -87,7 +113,15 @@ func mergeScanRunHistory(legacy []ports.ScanRun, normalized []scanrun.ScanRun) [
 		}
 		if legacyRun, ok := legacyByID[run.ID]; ok {
 			view.Manifest, view.FindingKeys = legacyRun.Manifest, legacyRun.FindingKeys
+		} else if len(run.LegacyManifest) > 0 {
+			// The normalized read side also retains this run's immutable
+			// manifest; never substitute engagement-level current metadata.
+			var manifest ports.ScanManifest
+			if json.Unmarshal(run.LegacyManifest, &manifest) == nil {
+				view.Manifest = manifest
+			}
 		}
+		attachScanSource(&view, view.Manifest.SourcePackage)
 		out = append(out, view)
 		seen[run.ID] = struct{}{}
 	}
@@ -182,12 +216,16 @@ func (rt *Router) runSCAScan(w http.ResponseWriter, r *http.Request) {
 			writeJSON(w, http.StatusBadRequest, errorBody{Error: msg})
 			return
 		}
-		job, err := rt.sca.StartUploadedSourceScanWithOptions(r.Context(), PrincipalFrom(r.Context()), tenantID, engagementID, scauc.ScanOptions{Mode: req.Mode, CodeQuality: req.CodeQuality})
+		job, err := rt.sca.StartUploadedSourceVersionScanWithOptions(r.Context(), PrincipalFrom(r.Context()), tenantID, engagementID, shared.ID(req.SourceVersionID), scauc.ScanOptions{Mode: req.Mode, CodeQuality: req.CodeQuality})
 		if err != nil {
 			writeError(w, rt.log, err)
 			return
 		}
 		writeJSON(w, http.StatusAccepted, job)
+		return
+	}
+	if req.SourceVersionID != "" {
+		writeJSON(w, http.StatusBadRequest, errorBody{Error: "source_version_id requires an upload target"})
 		return
 	}
 	usingImportedSBOM := false
@@ -233,9 +271,7 @@ func (rt *Router) uploadedSource(w http.ResponseWriter, r *http.Request) {
 		writeError(w, rt.log, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, uploadedSourceResponse{
-		Filename: item.Filename, Size: item.Size, SHA256: item.SHA256, Target: item.Target(), UploadedBy: item.CreatedBy, UploadedAt: item.CreatedAt,
-	})
+	writeJSON(w, http.StatusOK, uploadedSourceView(item))
 }
 
 // evidenceLedger returns the engagement's hash-chained evidence + verification.
@@ -285,7 +321,7 @@ func (rt *Router) compareScanRuns(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, errorBody{Error: "both run ids (a, b) are required"})
 		return
 	}
-	drift, err := rt.sca.CompareRuns(r.Context(), a, b)
+	drift, err := rt.sca.CompareRuns(r.Context(), shared.ID(r.PathValue("id")), a, b)
 	if err != nil {
 		writeError(w, rt.log, err)
 		return

--- a/internal/adapter/httpapi/scan_run_history_test.go
+++ b/internal/adapter/httpapi/scan_run_history_test.go
@@ -1,11 +1,14 @@
 package httpapi
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -35,5 +38,42 @@ func TestMergeScanRunHistoryPreservesLegacyAndAddsNormalizedProvenance(t *testin
 	}
 	if got[1].ID != "legacy-1" || got[1].Provenance != "legacy" || got[1].TerminalStatus != "unknown" {
 		t.Fatalf("legacy response = %+v", got[1])
+	}
+}
+
+func TestScanRunHistoryRetainsExactUploadedSourceAndHidesStorageKeys(t *testing.T) {
+	now := time.Date(2026, 9, 8, 10, 0, 0, 0, time.UTC)
+	first := sourcepackage.Package{TenantID: "tenant", EngagementID: "initial", VersionID: "version-1", Filename: "source-v1.zip", Size: 100, SHA256: strings.Repeat("a", 64), CreatedBy: "uploader", CreatedAt: now, AssociatedBy: "uploader", AssociatedAt: now, Locator: "private-locator", ObjectKey: "private-object-key"}
+	second := first
+	second.EngagementID, second.VersionID, second.Filename, second.SHA256 = "retest", "version-2", "source-v2.zip", strings.Repeat("b", 64)
+	runs := []ports.ScanRun{
+		{ID: "initial-run", EngagementID: "initial", CreatedAt: now, Manifest: ports.ScanManifest{SourcePackage: &first}},
+		{ID: "retest-run", EngagementID: "retest", CreatedAt: now.Add(time.Hour), Manifest: ports.ScanManifest{SourcePackage: &second}},
+		{ID: "legacy-run", EngagementID: "initial", CreatedAt: now.Add(-time.Hour)},
+	}
+	views := mergeScanRunHistory(runs, []scanrun.ScanRun{{ID: "initial-run", EngagementID: "initial", Provenance: scanrun.ProvenanceNative}, {ID: "retest-run", EngagementID: "retest", Provenance: scanrun.ProvenanceNative}})
+	if len(views) != 3 || views[0].SourcePackage == nil || views[1].SourcePackage == nil {
+		t.Fatalf("source metadata missing from history: %+v", views)
+	}
+	if views[0].SourcePackage.VersionID != "version-1" || views[0].SourcePackage.Filename != "source-v1.zip" || views[1].SourcePackage.VersionID != "version-2" || views[1].SourcePackage.SHA256 == views[0].SourcePackage.SHA256 {
+		t.Fatalf("historical file versions were overwritten: %+v", views)
+	}
+	if views[2].SourcePackage != nil || views[2].TargetKind != "" {
+		t.Fatal("legacy source metadata must not be invented from a later source")
+	}
+	data, err := json.Marshal(views)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "private-locator") || strings.Contains(string(data), "private-object-key") {
+		t.Fatal("private storage location exposed in source history")
+	}
+	manifest, err := json.Marshal(runs[0].Manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nativeOnly := mergeScanRunHistory(nil, []scanrun.ScanRun{{ID: "initial-run", EngagementID: "initial", Provenance: scanrun.ProvenanceNative, LegacyManifest: manifest}})
+	if len(nativeOnly) != 1 || nativeOnly[0].SourcePackage == nil || nativeOnly[0].SourcePackage.VersionID != first.VersionID {
+		t.Fatalf("normalized-only history lost its own immutable source: %+v", nativeOnly)
 	}
 }

--- a/internal/adapter/httpapi/user_handler.go
+++ b/internal/adapter/httpapi/user_handler.go
@@ -37,7 +37,13 @@ func actorFrom(r *http.Request) usersuc.Actor {
 // the logged-in consultant and gate admin-only surfaces.
 func (rt *Router) currentUser(w http.ResponseWriter, r *http.Request) {
 	p, _ := principalObj(r.Context())
-	writeJSON(w, http.StatusOK, map[string]any{"id": p.ID, "name": p.Name, "role": p.Role})
+	tenantID := TenantFrom(r.Context())
+	readEnabled := rt.assessmentLifecycleRead != nil && rt.assessmentLifecycleRead(tenantID)
+	uiEnabled := rt.assessmentLifecycleUI != nil && rt.assessmentLifecycleUI(tenantID)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"id": p.ID, "name": p.Name, "role": p.Role,
+		"features": map[string]bool{"assessment_lifecycle_read": readEnabled, "assessment_lifecycle_ui_default": uiEnabled},
+	})
 }
 
 // listUsers returns the team roster of the caller's own tenant (admin only).

--- a/internal/adapter/httpapi/user_handler_test.go
+++ b/internal/adapter/httpapi/user_handler_test.go
@@ -71,6 +71,29 @@ func TestCreateUserAdminOnly(t *testing.T) {
 	}
 }
 
+func TestCurrentUserReportsTenantLifecycleRollout(t *testing.T) {
+	router := newUsersRouter(t)
+	router.SetAssessmentLifecycleRollout(
+		func(tenantID string) bool { return tenantID == "tenant-canary" },
+		func(tenantID string) bool { return tenantID == "tenant-canary" },
+	)
+	request := httptest.NewRequest(http.MethodGet, "/api/v1/me", nil).WithContext(context.WithValue(
+		context.Background(), principalKey,
+		Principal{ID: "p1", Name: "P", Role: "member", TenantID: "tenant-other"},
+	))
+	recorder := httptest.NewRecorder()
+	router.currentUser(recorder, request)
+	var response struct {
+		Features map[string]bool `json:"features"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatal(err)
+	}
+	if response.Features["assessment_lifecycle_read"] || response.Features["assessment_lifecycle_ui_default"] {
+		t.Fatalf("non-canary features = %v", response.Features)
+	}
+}
+
 func TestListUsersAdminOnly(t *testing.T) {
 	rt := newUsersRouter(t)
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/users", nil).WithContext(ctxAs("member"))

--- a/internal/adapter/observability/prometheus.go
+++ b/internal/adapter/observability/prometheus.go
@@ -4,6 +4,8 @@ package observability
 import (
 	"context"
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,6 +27,16 @@ type Collectors struct {
 	integrationOperations *prometheus.CounterVec
 	queueReader           ports.AggregateJobQueueStatsReader
 	now                   func() time.Time
+	findingLineage                   *prometheus.CounterVec
+	findingLineageBackfillItems      *prometheus.CounterVec
+	findingLineageBackfillRuns       *prometheus.CounterVec
+	assessmentComparisons            *prometheus.CounterVec
+	assessmentComparisonBacklog      *prometheus.GaugeVec
+	assessmentComparisonOldestAge    *prometheus.GaugeVec
+	assessmentComparisonDuration     *prometheus.HistogramVec
+	assessmentRelationshipCandidates *prometheus.CounterVec
+	assessmentRelationshipDecisions  *prometheus.CounterVec
+	assessmentClosureReports         *prometheus.CounterVec
 }
 
 // New constructs the bounded Prometheus collectors used by the API metrics listener.
@@ -54,8 +66,50 @@ func New(queueReader ports.AggregateJobQueueStatsReader, pool ports.PoolStatsRea
 			Namespace: "synapse", Subsystem: "integration", Name: "operations_total",
 			Help: "Terminal external integration operation outcomes.",
 		}, []string{"provider", "operation", "outcome"}),
+
+		findingLineage: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "synapse", Subsystem: "finding_lineage", Name: "operations_total",
+			Help: "Finding lineage correlation and review outcomes.",
+		}, []string{"outcome", "method", "reason"}),
+		findingLineageBackfillItems: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "synapse", Subsystem: "finding_lineage", Name: "backfill_items_total",
+			Help: "Legacy Finding lineage backfill item outcomes.",
+		}, []string{"outcome"}),
+		findingLineageBackfillRuns: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "synapse", Subsystem: "finding_lineage", Name: "backfill_runs_total",
+			Help: "Legacy Finding lineage backfill terminal run states.",
+		}, []string{"state"}),
+		assessmentComparisons: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "synapse", Subsystem: "assessment_comparison", Name: "operations_total",
+			Help: "Assessment comparison generation and lifecycle outcomes.",
+		}, []string{"status", "mode", "reason"}),
+		assessmentComparisonBacklog: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "synapse", Subsystem: "assessment_comparison", Name: "backlog",
+			Help: "Current tenant-scoped Assessment comparison backlog by state.",
+		}, []string{"tenant_id", "state"}),
+		assessmentComparisonOldestAge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: "synapse", Subsystem: "assessment_comparison", Name: "oldest_active_age_seconds",
+			Help: "Age in seconds of the oldest queued or generating Assessment comparison by tenant.",
+		}, []string{"tenant_id"}),
+		assessmentComparisonDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "synapse", Subsystem: "assessment_comparison", Name: "generation_duration_seconds",
+			Help:    "Assessment comparison worker generation duration by tenant, immutable versions, and bounded item-count band.",
+			Buckets: []float64{0.1, 0.25, 0.5, 1, 2, 5, 10, 30, 60, 120, 300, 600},
+		}, []string{"tenant_id", "mode", "status", "fingerprint_version", "risk_model_version", "item_count_band"}),
+		assessmentRelationshipCandidates: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "synapse", Subsystem: "assessment_relationship", Name: "candidates_total",
+			Help: "Historical Assessment relationship candidate generation outcomes.",
+		}, []string{"outcome", "confidence"}),
+		assessmentRelationshipDecisions: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "synapse", Subsystem: "assessment_relationship", Name: "decisions_total",
+			Help: "Historical Assessment relationship review decision outcomes.",
+		}, []string{"action", "outcome"}),
+		assessmentClosureReports: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "synapse", Subsystem: "assessment_closure", Name: "reports_total",
+			Help: "Deterministic Assessment closure report outcomes.",
+		}, []string{"outcome", "reason"}),
 	}
-	c.registry.MustRegister(c.httpRequests, c.httpDuration, c.scaDuration, c.scaOutcomes, c.integrationOperations)
+	c.registry.MustRegister(c.httpRequests, c.httpDuration, c.scaDuration, c.scaOutcomes, c.integrationOperations, c.findingLineage, c.findingLineageBackfillItems, c.findingLineageBackfillRuns, c.assessmentComparisons, c.assessmentComparisonBacklog, c.assessmentComparisonOldestAge, c.assessmentComparisonDuration, c.assessmentRelationshipCandidates, c.assessmentRelationshipDecisions, c.assessmentClosureReports)
 	if queueReader != nil {
 		queue := newQueueCollector(queueReader, c.now)
 		c.registry.MustRegister(queue)
@@ -208,6 +262,193 @@ func (c *Collectors) ObserveIntegrationOperation(provider, operation, outcome st
 	c.integrationOperations.WithLabelValues(provider, operation, outcome).Inc()
 }
 
+
+func (c *Collectors) ObserveFindingLineage(outcome, method, reason string) {
+	c.findingLineage.WithLabelValues(boundedLineageOutcome(outcome), boundedLineageMethod(method), boundedLineageReason(reason)).Inc()
+}
+
+func (c *Collectors) ObserveFindingLineageBackfillItem(outcome string) {
+	switch outcome {
+	case "observation_created", "provisional_candidate_created", "skipped":
+	default:
+		outcome = "unknown"
+	}
+	c.findingLineageBackfillItems.WithLabelValues(outcome).Inc()
+}
+
+func (c *Collectors) ObserveFindingLineageBackfillRun(state string) {
+	switch state {
+	case "completed", "cancelled", "failed":
+	default:
+		state = "unknown"
+	}
+	c.findingLineageBackfillRuns.WithLabelValues(state).Inc()
+}
+
+func (c *Collectors) ObserveAssessmentComparison(status, mode, reason string) {
+	c.assessmentComparisons.WithLabelValues(boundedComparisonStatus(status), boundedComparisonMode(mode), boundedComparisonReason(reason)).Inc()
+}
+
+func (c *Collectors) ObserveAssessmentComparisonBacklog(tenantID string, backlog ports.AssessmentComparisonBacklog, observedAt time.Time) {
+	tenantID = boundedMetricTenant(tenantID)
+	c.assessmentComparisonBacklog.WithLabelValues(tenantID, "queued").Set(float64(backlog.Queued))
+	c.assessmentComparisonBacklog.WithLabelValues(tenantID, "generating").Set(float64(backlog.Generating))
+	c.assessmentComparisonBacklog.WithLabelValues(tenantID, "failed").Set(float64(backlog.Failed))
+	c.assessmentComparisonBacklog.WithLabelValues(tenantID, "dead_lettered").Set(float64(backlog.DeadLettered))
+	age := 0.0
+	if backlog.OldestActiveAt != nil && observedAt.After(*backlog.OldestActiveAt) {
+		age = observedAt.Sub(*backlog.OldestActiveAt).Seconds()
+	}
+	c.assessmentComparisonOldestAge.WithLabelValues(tenantID).Set(age)
+}
+
+func (c *Collectors) ObserveAssessmentComparisonGeneration(tenantID, mode, status string, fingerprintVersion, riskModelVersion, itemCount int, duration time.Duration) {
+	c.assessmentComparisonDuration.WithLabelValues(
+		boundedMetricTenant(tenantID), boundedComparisonMode(mode), boundedComparisonStatus(status), boundedMetricVersion(fingerprintVersion), boundedMetricVersion(riskModelVersion), comparisonItemCountBand(itemCount),
+	).Observe(duration.Seconds())
+}
+
+func (c *Collectors) ObserveAssessmentRelationshipCandidate(outcome, confidence string) {
+	switch outcome {
+	case "created", "existing", "failed":
+	default:
+		outcome = "unknown"
+	}
+	switch confidence {
+	case "medium", "high":
+	default:
+		confidence = "unknown"
+	}
+	c.assessmentRelationshipCandidates.WithLabelValues(outcome, confidence).Inc()
+}
+
+func (c *Collectors) ObserveAssessmentRelationshipDecision(action, outcome string) {
+	switch action {
+	case "confirm", "reject", "dismiss":
+	default:
+		action = "unknown"
+	}
+	switch outcome {
+	case "applied", "replayed", "failed":
+	default:
+		outcome = "unknown"
+	}
+	c.assessmentRelationshipDecisions.WithLabelValues(action, outcome).Inc()
+}
+
+func (c *Collectors) ObserveAssessmentClosureReport(outcome, reason string) {
+	switch outcome {
+	case "generated", "cached", "failed":
+	default:
+		outcome = "unknown"
+	}
+	switch reason {
+	case "none", "manifest_read", "audit", "artifact_read", "render", "artifact_write", "invalid_job", "closure_reference_missing", "closure_reference_integrity_failed":
+	default:
+		reason = "unknown"
+	}
+	c.assessmentClosureReports.WithLabelValues(outcome, reason).Inc()
+}
+
+func boundedMetricTenant(tenantID string) string {
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" || len(tenantID) > 128 {
+		return "unknown"
+	}
+	return tenantID
+}
+
+func boundedMetricVersion(version int) string {
+	if version < 1 || version > 99 {
+		return "unknown"
+	}
+	return strconv.Itoa(version)
+}
+
+func comparisonItemCountBand(itemCount int) string {
+	switch {
+	case itemCount < 0:
+		return "unknown"
+	case itemCount < 1000:
+		return "lt_1k"
+	case itemCount < 10000:
+		return "1k_10k"
+	case itemCount < 100000:
+		return "10k_100k"
+	default:
+		return "gte_100k"
+	}
+}
+
+func boundedComparisonStatus(value string) string {
+	switch value {
+	case "queued", "generating", "complete", "needs_review", "failed", "superseded", "rejected":
+		return value
+	case "":
+		return "none"
+	default:
+		return "unknown"
+	}
+}
+
+func boundedComparisonMode(value string) string {
+	switch value {
+	case "lifecycle", "neutral_diff":
+		return value
+	case "":
+		return "none"
+	default:
+		return "unknown"
+	}
+}
+
+func boundedComparisonReason(value string) string {
+	switch value {
+	case "created", "replayed", "generated", "worker_recovered", "input_changed", "input_missing", "invalid_input", "worker_cancelled", "generation_failed",
+		"directed", "neutral_sibling", "neutral_reverse", "same_snapshot", "cross_cycle", "snapshot_not_finalized", "lifecycle_reverse", "lifecycle_sibling", "lifecycle_direction_available", "missing_relationship":
+		return value
+	case "":
+		return "none"
+	default:
+		return "unknown"
+	}
+}
+
+func boundedLineageOutcome(value string) string {
+	switch value {
+	case "matched", "created", "needs_review", "skipped", "resolved", "override":
+		return value
+	case "":
+		return "none"
+	default:
+		return "unknown"
+	}
+}
+
+func boundedLineageMethod(value string) string {
+	switch value {
+	case "override", "producer_id", "fingerprint", "alias", "matcher", "manual", "new_identity":
+		return value
+	case "":
+		return "none"
+	default:
+		return "unknown"
+	}
+}
+
+func boundedLineageReason(value string) string {
+	switch value {
+	case "observation_replay", "active_override", "trusted_producer_id", "exact_fingerprint", "approved_alias", "new_identity",
+		"fingerprint_collision", "split", "merge", "insufficient_anchor", "legacy_ambiguous",
+		"invalid_trust", "invalid_ownership", "redaction_required", "confirm_existing", "create_distinct_identity",
+		"unlink", "dismiss", "supersede", "confirm":
+		return value
+	case "":
+		return "none"
+	default:
+		return "unknown"
+	}
+}
 // Handler returns the private-registry Prometheus metrics endpoint.
 func (c *Collectors) Handler() http.Handler {
 	return promhttp.HandlerFor(c.registry, promhttp.HandlerOpts{})
@@ -215,3 +456,10 @@ func (c *Collectors) Handler() http.Handler {
 
 var _ ports.SCAObserver = (*Collectors)(nil)
 var _ ports.IntegrationObserver = (*Collectors)(nil)
+
+var _ ports.FindingLineageObserver = (*Collectors)(nil)
+var _ ports.AssessmentComparisonObserver = (*Collectors)(nil)
+var _ ports.AssessmentComparisonBacklogObserver = (*Collectors)(nil)
+var _ ports.AssessmentComparisonGenerationObserver = (*Collectors)(nil)
+var _ ports.AssessmentRelationshipObserver = (*Collectors)(nil)
+var _ ports.AssessmentClosureReportObserver = (*Collectors)(nil)

--- a/internal/adapter/observability/prometheus_test.go
+++ b/internal/adapter/observability/prometheus_test.go
@@ -48,6 +48,17 @@ func TestCollectorsScrapeOutput(t *testing.T) {
 	c.ObserveSCAScan(time.Second, "success")
 	c.ObserveIntegrationOperation("jenkins", "test", "succeeded")
 
+	c.ObserveFindingLineage("matched", "fingerprint", "exact_fingerprint")
+	c.ObserveFindingLineageBackfillItem("observation_created")
+	c.ObserveFindingLineageBackfillRun("completed")
+	c.ObserveAssessmentComparison("complete", "lifecycle", "generated")
+	oldest := time.Now().Add(-10 * time.Minute)
+	c.ObserveAssessmentComparisonBacklog("tenant-a", ports.AssessmentComparisonBacklog{Queued: 2, OldestActiveAt: &oldest}, time.Now())
+	c.ObserveAssessmentComparisonGeneration("tenant-a", "lifecycle", "complete", 1, 1, 1000, time.Second)
+	c.ObserveAssessmentRelationshipCandidate("created", "medium")
+	c.ObserveAssessmentRelationshipDecision("confirm", "applied")
+	c.ObserveAssessmentClosureReport("generated", "none")
+
 	rec := httptest.NewRecorder()
 	c.Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
 
@@ -57,6 +68,16 @@ func TestCollectorsScrapeOutput(t *testing.T) {
 		"synapse_http_request_duration_seconds",
 		"synapse_sca_scan_duration_seconds",
 		"synapse_sca_scan_outcomes_total",
+		"synapse_finding_lineage_operations_total",
+		"synapse_finding_lineage_backfill_items_total",
+		"synapse_finding_lineage_backfill_runs_total",
+		"synapse_assessment_comparison_operations_total",
+		"synapse_assessment_comparison_backlog",
+		"synapse_assessment_comparison_oldest_active_age_seconds",
+		"synapse_assessment_comparison_generation_duration_seconds",
+		"synapse_assessment_relationship_candidates_total",
+		"synapse_assessment_relationship_decisions_total",
+		"synapse_assessment_closure_reports_total",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("scrape output missing metric %q", want)
@@ -80,6 +101,67 @@ func TestCollectorsIntegrationMetricsUseOnlyBoundedLabels(t *testing.T) {
 	}
 }
 
+
+func TestCollectorsAssessmentLifecycleUsesBoundedLabels(t *testing.T) {
+	c := New(nil, nil)
+	c.ObserveAssessmentComparison("complete", "lifecycle", "generated")
+	c.ObserveAssessmentComparison("comparison-secret", "finding-secret", "raw-secret")
+	c.ObserveAssessmentRelationshipCandidate("created", "high")
+	c.ObserveAssessmentRelationshipCandidate("candidate-secret", "tenant-secret")
+	c.ObserveAssessmentRelationshipDecision("dismiss", "replayed")
+	c.ObserveAssessmentClosureReport("generated", "none")
+	c.ObserveAssessmentClosureReport("manifest-secret", "tenant-secret")
+
+	recorder := httptest.NewRecorder()
+	c.Handler().ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := recorder.Body.String()
+	for _, expected := range []string{
+		`synapse_assessment_comparison_operations_total{mode="lifecycle",reason="generated",status="complete"} 1`,
+		`synapse_assessment_comparison_operations_total{mode="unknown",reason="unknown",status="unknown"} 1`,
+		`synapse_assessment_relationship_candidates_total{confidence="unknown",outcome="unknown"} 1`,
+		`synapse_assessment_closure_reports_total{outcome="unknown",reason="unknown"} 1`,
+	} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("assessment lifecycle metric missing %q: %s", expected, body)
+		}
+	}
+	for _, forbidden := range []string{"comparison-secret", "finding-secret", "raw-secret", "candidate-secret", "manifest-secret", "tenant-secret"} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("assessment lifecycle metric leaked %q: %s", forbidden, body)
+		}
+	}
+}
+
+func TestCollectorsFindingLineageMetricsUseOnlyBoundedLabels(t *testing.T) {
+	c := New(nil, nil)
+	c.ObserveFindingLineage("matched", "fingerprint", "exact_fingerprint")
+	c.ObserveFindingLineage("tenant-a", "source-123", "raw-finding-id")
+	c.ObserveFindingLineageBackfillItem("observation_created")
+	c.ObserveFindingLineageBackfillItem("source-finding-id")
+	c.ObserveFindingLineageBackfillRun("completed")
+	c.ObserveFindingLineageBackfillRun("tenant-a")
+
+	recorder := httptest.NewRecorder()
+	c.Handler().ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := recorder.Body.String()
+	for _, expected := range []string{
+		`synapse_finding_lineage_operations_total{method="fingerprint",outcome="matched",reason="exact_fingerprint"} 1`,
+		`synapse_finding_lineage_operations_total{method="unknown",outcome="unknown",reason="unknown"} 1`,
+		`synapse_finding_lineage_backfill_items_total{outcome="observation_created"} 1`,
+		`synapse_finding_lineage_backfill_items_total{outcome="unknown"} 1`,
+		`synapse_finding_lineage_backfill_runs_total{state="completed"} 1`,
+		`synapse_finding_lineage_backfill_runs_total{state="unknown"} 1`,
+	} {
+		if !strings.Contains(body, expected) {
+			t.Fatalf("finding lineage metric missing %q: %s", expected, body)
+		}
+	}
+	for _, forbidden := range []string{"source-123", "raw-finding-id", "source-finding-id", "tenant-a"} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("finding lineage metric leaked %q: %s", forbidden, body)
+		}
+	}
+}
 // TestCollectorsQueueGaugesReflectAggregateStats covers the aggregate queue gauges:
 // they must reflect the reader's totals and report no tenant label anywhere.
 func TestCollectorsQueueGaugesReflectAggregateStats(t *testing.T) {

--- a/internal/infrastructure/persistence/memory/assessment_transaction_test.go
+++ b/internal/infrastructure/persistence/memory/assessment_transaction_test.go
@@ -1,0 +1,71 @@
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+)
+
+func TestAssessmentTransactionPublishesJobsOnlyAfterCommit(t *testing.T) {
+	ctx := context.Background()
+	queue := NewJobQueue(idgen.RandomID{}, time.Now)
+	tx := NewTenantTransactionRunner()
+	failure := errors.New("audit unavailable")
+	for _, fail := range []bool{true, false} {
+		err := tx.Run(ctx, "tenant", func(txCtx context.Context) error {
+			if _, err := queue.Enqueue(txCtx, "assessment-comparison", []byte(`{}`)); err != nil {
+				return err
+			}
+			job, err := queue.Claim(ctx, time.Minute)
+			if err != nil || job != nil {
+				t.Fatalf("uncommitted job visible: %+v err=%v", job, err)
+			}
+			if fail {
+				return failure
+			}
+			return nil
+		})
+		if fail && !errors.Is(err, failure) || !fail && err != nil {
+			t.Fatal(err)
+		}
+		job, err := queue.Claim(ctx, time.Minute)
+		if err != nil || fail && job != nil || !fail && job == nil {
+			t.Fatalf("post-transaction visibility (fail=%v): %+v err=%v", fail, job, err)
+		}
+	}
+}
+
+func TestAssessmentTransactionRollsBackWithoutAliasingEngagement(t *testing.T) {
+	ctx := context.Background()
+	repo := NewEngagementRepository()
+	item, err := engagement.New("assessment", "tenant", "Initial", "", time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.Create(ctx, item); err != nil {
+		t.Fatal(err)
+	}
+	item.Name = "caller mutation"
+	if err := NewTenantTransactionRunner().Run(ctx, "tenant", func(txCtx context.Context) error {
+		got, err := repo.GetByIDInTenant(txCtx, "tenant", item.ID)
+		if err != nil {
+			return err
+		}
+		got.Name = "uncommitted"
+		if err := repo.Update(txCtx, got); err != nil {
+			return err
+		}
+		return shared.ErrConflict
+	}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatal(err)
+	}
+	got, err := repo.GetByIDInTenant(ctx, "tenant", item.ID)
+	if err != nil || got.Name != "Initial" {
+		t.Fatalf("rollback aliased: %+v err=%v", got, err)
+	}
+}

--- a/internal/infrastructure/persistence/memory/jobqueue.go
+++ b/internal/infrastructure/persistence/memory/jobqueue.go
@@ -55,10 +55,16 @@ func (q *JobQueue) Enqueue(ctx context.Context, kind string, payload []byte) (st
 		return "", fmt.Errorf("%w: tenant context is required for durable job", shared.ErrValidation)
 	}
 	id := q.ids.NewID().String()
-	q.mu.Lock()
-	defer q.mu.Unlock()
-	q.jobs[id] = &memJob{id: id, tenantID: tenantID, kind: kind, payload: payload, status: "queued", availableAt: q.now()}
-	q.order = append(q.order, id)
+	job := &memJob{id: id, tenantID: tenantID, kind: kind, payload: append([]byte(nil), payload...), status: "queued", availableAt: q.now()}
+	publish := func() {
+		q.mu.Lock()
+		defer q.mu.Unlock()
+		q.jobs[id] = job
+		q.order = append(q.order, id)
+	}
+	if !registerTenantCommit(ctx, publish) {
+		publish()
+	}
 	return id, nil
 }
 

--- a/internal/infrastructure/persistence/memory/judgment_store.go
+++ b/internal/infrastructure/persistence/memory/judgment_store.go
@@ -60,6 +60,18 @@ func (s *JudgmentStore) ListByEngagement(_ context.Context, engagementID shared.
 	return out, nil
 }
 
+// GetByID provides a bounded lookup for migration/backfill consumers.
+func (s *JudgmentStore) GetByID(_ context.Context, engagementID, id shared.ID) (judgment.Judgment, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, item := range s.byEng[engagementID] {
+		if item.ID == id {
+			return item, nil
+		}
+	}
+	return judgment.Judgment{}, shared.ErrNotFound
+}
+
 // ListBySubject returns the engagement's judgments about a given subject id.
 func (s *JudgmentStore) ListBySubject(_ context.Context, engagementID, subjectID shared.ID) ([]judgment.Judgment, error) {
 	s.mu.Lock()

--- a/internal/infrastructure/persistence/postgres/assessment_scale_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_scale_test.go
@@ -1,0 +1,140 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	cmp "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	comparisonuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcomparison"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/jackc/pgx/v5"
+)
+
+// Run explicitly against disposable PostgreSQL with SYNAPSE_ASSESSMENT_SCALE_TEST=1.
+// Setup uses COPY for validated synthetic artifacts; measurements exercise the
+// real comparison service and repositories, not a domain-only benchmark.
+func TestPostgresAssessmentComparisonScale100K(t *testing.T) {
+	if os.Getenv("SYNAPSE_ASSESSMENT_SCALE_TEST") != "1" {
+		t.Skip("opt-in 100k PostgreSQL validation")
+	}
+	ctx, pool := setupTestDB(t)
+	ctx, cancel := context.WithTimeout(ctx, 8*time.Minute)
+	defer cancel()
+	const count = 100_000
+	tenantID := shared.ID("assessment-scale")
+	cycleID, baseline, current := createAssessmentComparisonSnapshots(t, ctx, pool, tenantID, "scale")
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	identities := make([]findinglineage.Identity, count)
+	for index := range identities {
+		identity, observation := postgresFindingLineagePair(t, tenantID, cycleID, baseline.ID,
+			fmt.Sprintf("identity-%06d", index), fmt.Sprintf("observation-%06d", index), fmt.Sprintf("finding-%06d", index), fmt.Sprintf("CVE-2026-%06d", index), now)
+		if err := identity.Validate(); err != nil {
+			t.Fatal(err)
+		}
+		if err := observation.Validate(); err != nil {
+			t.Fatal(err)
+		}
+		identities[index] = identity
+	}
+	columns := func(value string) []string {
+		result := strings.Split(value, ",")
+		for index := range result {
+			result[index] = strings.TrimSpace(result[index])
+		}
+		return result
+	}
+	seedAt := time.Now()
+	err := WithTenant(ctx, pool, tenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.CopyFrom(ctx, pgx.Identifier{"finding_identities"}, columns(findingIdentityColumns), pgx.CopyFromSlice(count, func(index int) ([]any, error) {
+			value := identities[index]
+			return []any{value.TenantID.String(), value.CycleID.String(), value.ID.String(), value.ProducerKind, value.FindingKind, value.CanonicalizationVersion, value.FingerprintSchemaVersion, value.LineageFingerprint, value.TargetIdentitySchemaVersion, value.TargetIdentityCanonical, value.CanonicalIdentityFields, value.FirstSeenSnapshotID.String(), value.CreatedAt}, nil
+		})); err != nil {
+			return err
+		}
+		for _, snapshotID := range []shared.ID{baseline.ID, current.ID} {
+			if _, err := tx.CopyFrom(ctx, pgx.Identifier{"finding_observations"}, columns(findingObservationColumns), pgx.CopyFromSlice(count, func(index int) ([]any, error) {
+				value := identities[index]
+				return []any{tenantID.String(), cycleID.String(), snapshotID.String() + value.ID.String(), snapshotID.String(), value.ID.String(), "sca", "vulnerability", value.TargetIdentityCanonical, fmt.Sprintf("finding-%06d", index), "", "high", nil, "1.0.0", "", "", "", json.RawMessage(`{"tool_name":"scanner"}`), now}, nil
+			})); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("seed: %d identities / %d observations in %s", count, 2*count, time.Since(seedAt))
+	lineage := NewFindingLineageRepository(pool)
+	snapshots := NewAssessmentSnapshotRepository(pool)
+	comparisons := NewAssessmentComparisonRepository(pool)
+	verification, err := comparisonuc.NewRetestVerificationReader(lineage, snapshots, NewRetestRepository(pool))
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := comparisonuc.NewService(comparisons, snapshots, NewAssessmentCycleRepository(pool), lineage, NewTenantTransactionRunner(pool), postgresLineageAudit{}, postgresLineageClock{now: now.Add(time.Second)}, &postgresLineageIDs{prefix: "scale"}, verification, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now()
+	queued, created, decision, err := service.Queue(ctx, comparisonuc.QueueInput{TenantID: tenantID, BaselineSnapshotID: baseline.ID, CurrentSnapshotID: current.ID, Mode: cmp.ModeLifecycle, FingerprintVersion: 1, RiskModelVersion: 1, Actor: "scale-test"})
+	if err != nil || !created || !decision.Allowed {
+		t.Fatalf("queue created=%v allowed=%v err=%v", created, decision.Allowed, err)
+	}
+	queuedAfter := time.Since(started)
+	result, err := service.Generate(ctx, comparisonuc.WorkInput{TenantID: tenantID, ComparisonID: queued.ID, Actor: "scale-worker"})
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(result.Items) != count || result.Summary.BaselineCount != count || result.Summary.CurrentCount != count {
+		t.Fatalf("scale counts: items=%d summary=%+v", len(result.Items), result.Summary)
+	}
+	t.Logf("queue=%s generation+queue=%s items=%d", queuedAfter, elapsed, len(result.Items))
+	if elapsed > 5*time.Minute {
+		t.Fatalf("100k generation exceeded five minutes: %s", elapsed)
+	}
+	latencies := make([]time.Duration, 20)
+	for index := range latencies {
+		started := time.Now()
+		page, err := comparisons.ListItems(ctx, tenantID, result.ID, ports.AssessmentComparisonItemFilter{AfterPosition: index*100 - 1, Limit: 100, ProducerKind: "sca", FindingKind: "vulnerability"})
+		if err != nil || len(page.Items) != 100 || !page.HasMore {
+			t.Fatalf("page count=%d err=%v", len(page.Items), err)
+		}
+		latencies[index] = time.Since(started)
+	}
+	sort.Slice(latencies, func(i, j int) bool { return latencies[i] < latencies[j] })
+	t.Logf("filtered 100-item pages: n=20 p50=%s p95=%s max=%s", latencies[9], latencies[18], latencies[19])
+	if latencies[18] > 2*time.Second {
+		t.Fatalf("100k filtered page p95 exceeded two seconds: %s", latencies[18])
+	}
+	reader, err := cycleuc.NewClosureDecisionReader(lineage, snapshots, NewRetestRepository(pool), NewSLAStore(pool))
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := ports.AssessmentClosureReferenceQuery{CycleID: cycleID, SnapshotIDs: []shared.ID{baseline.ID, current.ID}, AsOfAt: now.Add(time.Minute)}
+	started = time.Now()
+	references, err := reader.ListAssessmentClosureReferences(ctx, tenantID, query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(references)
+	if err != nil || len(references) != 1 || references[0].Kind != "finding_observation_set" || len(encoded) > 1024 {
+		t.Fatalf("closure references=%d bytes=%d err=%v", len(references), len(encoded), err)
+	}
+	t.Logf("closure source collection: %s; %d observations bound in %d-byte reference set", time.Since(started), 2*count, len(encoded))
+	started = time.Now()
+	if err := reader.ResolveAssessmentClosureReferences(ctx, tenantID, query, references); err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("historical closure source resolution: %s", time.Since(started))
+}

--- a/internal/infrastructure/persistence/postgres/assessment_source_transaction_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_source_transaction_test.go
@@ -1,0 +1,210 @@
+package postgres
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/blob"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sourceupload"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	enguc "github.com/KKloudTarus/synapse-ce/internal/usecase/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type retainedSourceFailure struct {
+	ports.AssessmentCycleRequestStore
+	fail bool
+}
+
+var errSourceRetainedCompletion = errors.New("injected retained source completion failure")
+
+func (s *retainedSourceFailure) CompleteAssessmentCycleRequest(ctx context.Context, scope ports.AssessmentCycleRequestScope, hash string, status int, body []byte, at time.Time) error {
+	if s.fail {
+		s.fail = false
+		return errSourceRetainedCompletion
+	}
+	return s.AssessmentCycleRequestStore.CompleteAssessmentCycleRequest(ctx, scope, hash, status, body, at)
+}
+
+type committedSourceFailure struct {
+	ports.TenantTransactionRunner
+	fail bool
+}
+
+func (s *committedSourceFailure) Run(ctx context.Context, tenant shared.ID, operation func(context.Context) error) error {
+	err := s.TenantTransactionRunner.Run(ctx, tenant, operation)
+	if err == nil && s.fail {
+		s.fail = false
+		return ErrTenantCommit // Simulate losing acknowledgement of a real commit.
+	}
+	return err
+}
+
+type trackedSourceObjects struct {
+	*blob.Memory
+	keys []string
+}
+
+func (s *trackedSourceObjects) PutObject(ctx context.Context, key string, data io.Reader, size int64) error {
+	s.keys = append(s.keys, key)
+	return s.Memory.PutObject(ctx, key, data, size)
+}
+
+func (s *trackedSourceObjects) live(t *testing.T, ctx context.Context) int {
+	t.Helper()
+	count := 0
+	for _, key := range s.keys {
+		reader, err := s.OpenObject(ctx, key)
+		if errors.Is(err, shared.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = reader.Close()
+		count++
+	}
+	return count
+}
+
+type sourceTransactionFixture struct {
+	ctx         context.Context
+	tenant      shared.ID
+	api         *cycleuc.APIService
+	engagements *EngagementRepository
+	sources     *sourceupload.Store
+	objects     *trackedSourceObjects
+	completion  *retainedSourceFailure
+	commit      *committedSourceFailure
+}
+
+func newSourceTransactionFixture(t *testing.T) *sourceTransactionFixture {
+	t.Helper()
+	ctx, pool := setupTestDB(t)
+	tenant := shared.ID("source-transaction-tenant")
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES($1,$1)`, tenant); err != nil {
+		t.Fatal(err)
+	}
+	ctx = shared.WithTenant(ctx, tenant)
+	repo := NewEngagementRepository(pool)
+	cycles := NewAssessmentCycleRepository(pool)
+	transactions := NewTenantTransactionRunner(pool)
+	clock, ids, audit := idgen.SystemClock{}, idgen.RandomID{}, assessmentCycleNoopAudit{}
+	objects := &trackedSourceObjects{Memory: blob.NewMemory()}
+	sources := sourceupload.NewStoreWithRepository(objects, NewEngagementSourceRepository(pool), 0)
+	engagements := enguc.NewService(repo, clock, ids, audit)
+	engagements.SetSourceStore(sources)
+	cycleService, err := cycleuc.NewService(cycles, repo, nil, nil, transactions, ids, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	completion := &retainedSourceFailure{AssessmentCycleRequestStore: NewAssessmentCycleRequestRepository(pool)}
+	commit := &committedSourceFailure{TenantTransactionRunner: transactions}
+	api, err := cycleuc.NewAPIService(cycleService, cycles, completion, engagements, commit, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &sourceTransactionFixture{ctx: ctx, tenant: tenant, api: api, engagements: repo, sources: sources, objects: objects, completion: completion, commit: commit}
+}
+
+func transactionUpload(data string) *cycleuc.SourceUpload {
+	return &cycleuc.SourceUpload{Filename: "source.zip", Size: int64(len(data)), SHA256: sourceDigest([]byte(data)), Reader: bytes.NewBufferString(data)}
+}
+
+func (f *sourceTransactionFixture) initial(key string) cycleuc.CreateInitialAssessmentInput {
+	return cycleuc.CreateInitialAssessmentInput{Request: cycleuc.RetainedRequest{TenantID: f.tenant, Actor: "alice", Route: "/api/v1/engagements", IdempotencyKey: key}, Engagement: enguc.CreateInput{Name: key}, Source: transactionUpload("source archive A")}
+}
+
+func TestPostgresAssessmentSourceAPIRollbackDiscardsOnlyUnpublishedUploads(t *testing.T) {
+	f := newSourceTransactionFixture(t)
+	f.completion.fail = true
+	if _, err := f.api.CreateInitialAssessment(f.ctx, f.initial("initial")); !errors.Is(err, errSourceRetainedCompletion) {
+		t.Fatalf("initial completion failure = %v", err)
+	}
+	if live := f.objects.live(t, f.ctx); live != 0 {
+		t.Fatalf("failed initial transaction left %d unpublished source objects", live)
+	}
+	list, err := f.engagements.List(f.ctx, f.tenant)
+	if err != nil || len(list) != 0 {
+		t.Fatalf("failed initial retained assessments: %d %v", len(list), err)
+	}
+	created, err := f.api.CreateInitialAssessment(f.ctx, f.initial("initial"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root engdom.Engagement
+	if err := json.Unmarshal(created.Body, &root); err != nil {
+		t.Fatal(err)
+	}
+	root.Status = engdom.StatusCompleted
+	if err := f.engagements.Update(f.ctx, &root); err != nil {
+		t.Fatal(err)
+	}
+	parent, err := f.sources.Get(f.ctx, f.tenant, root.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, strategy := range []string{"upload_new", "reuse_current"} {
+		f.completion.fail = true
+		input := cycleuc.CreateRetestAssessmentInput{Request: cycleuc.RetainedRequest{TenantID: f.tenant, Actor: "bob", Route: "/api/v1/engagements/" + root.ID.String() + "/retests", IdempotencyKey: strategy}, AssessmentID: root.ID, SourceStrategy: strategy}
+		if strategy == "upload_new" {
+			input.Source = transactionUpload("source archive B")
+		} else {
+			input.SourceVersionID = parent.VersionID
+		}
+		if _, err := f.api.CreateRetestAssessment(f.ctx, input); !errors.Is(err, errSourceRetainedCompletion) {
+			t.Fatalf("%s completion failure = %v", strategy, err)
+		}
+		if live := f.objects.live(t, f.ctx); live != 1 {
+			t.Fatalf("%s rollback left %d live archives, want only parent", strategy, live)
+		}
+		got, err := f.sources.GetByVersion(f.ctx, f.tenant, root.ID, parent.VersionID)
+		if err != nil || got != parent {
+			t.Fatalf("%s rollback changed parent source: %+v %v", strategy, got, err)
+		}
+		lifecycle, err := f.api.GetLifecycle(f.ctx, f.tenant, root.ID)
+		if err != nil || len(lifecycle.Members) != 1 || lifecycle.Cycle.Version != 1 {
+			t.Fatalf("%s rollback changed cycle: %+v %v", strategy, lifecycle, err)
+		}
+	}
+}
+
+func TestPostgresAssessmentSourceAPIUnknownCommitRetainsReplayAndArchive(t *testing.T) {
+	f := newSourceTransactionFixture(t)
+	f.commit.fail = true
+	if _, err := f.api.CreateInitialAssessment(f.ctx, f.initial("unknown-commit")); !errors.Is(err, ErrTenantCommit) {
+		t.Fatalf("simulated lost commit acknowledgement = %v", err)
+	}
+	if live := f.objects.live(t, f.ctx); live != 1 {
+		t.Fatalf("unknown successful commit retained %d archive objects", live)
+	}
+	replayed, err := f.api.CreateInitialAssessment(f.ctx, f.initial("unknown-commit"))
+	if err != nil || !replayed.Replayed || replayed.StatusCode != 201 {
+		t.Fatalf("unknown commit replay = %+v %v", replayed, err)
+	}
+	var root engdom.Engagement
+	if err := json.Unmarshal(replayed.Body, &root); err != nil {
+		t.Fatal(err)
+	}
+	item, err := f.sources.Get(f.ctx, f.tenant, root.ID)
+	if err != nil || item.VersionID.IsZero() || len(f.objects.keys) != 1 {
+		t.Fatalf("replay lost source or uploaded twice: %+v %v count=%d", item, err, len(f.objects.keys))
+	}
+	reader, err := f.objects.OpenObject(f.ctx, item.ObjectKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := io.ReadAll(reader)
+	_ = reader.Close()
+	if err != nil || string(data) != "source archive A" {
+		t.Fatalf("retained source = %q %v", data, err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/assessment_ui_worker_test.go
+++ b/internal/infrastructure/persistence/postgres/assessment_ui_worker_test.go
@@ -1,0 +1,76 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	comparisonuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcomparison"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/worker"
+)
+
+// Explicit browser-QA helper for macOS hosts, where the all-purpose production
+// worker correctly refuses to boot without Linux/amd64 bubblewrap. This uses the
+// same durable claim loop and application handlers, but registers NO executable
+// scan/recon/integration jobs. It can only connect to an isolated local UI test DB.
+// It does not replace production-worker sandbox conformance testing.
+func TestAssessmentUIWorker(t *testing.T) {
+	dsn := os.Getenv("SYNAPSE_ASSESSMENT_UI_WORKER_DSN")
+	if dsn == "" {
+		t.Skip("explicit local browser-QA helper")
+	}
+	parsed, err := url.Parse(dsn)
+	if err != nil || parsed.Hostname() != "127.0.0.1" || !strings.HasPrefix(parsed.Path, "/assessment_cycle_ui_") {
+		t.Fatal("browser-QA worker requires an isolated loopback assessment_cycle_ui_ database")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if err := CheckRLSRuntimeRole(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+	clock, ids := idgen.SystemClock{}, idgen.RandomID{}
+	audit, tx := NewAuditLog(pool), NewTenantTransactionRunner(pool)
+	queue, cycles := NewJobQueue(pool, ids), NewAssessmentCycleRepository(pool)
+	snapshots, lineageStore, comparisons := NewAssessmentSnapshotRepository(pool), NewFindingLineageRepository(pool), NewAssessmentComparisonRepository(pool)
+	verification, err := comparisonuc.NewRetestVerificationReader(lineageStore, snapshots, NewRetestRepository(pool))
+	if err != nil {
+		t.Fatal(err)
+	}
+	comparison, err := comparisonuc.NewService(comparisons, snapshots, cycles, lineageStore, tx, audit, clock, ids, verification, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lineage, err := lineageuc.NewService(lineageStore, tx, audit, clock, ids, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	comparison.SetAPIStores(nil, queue, lineage)
+	decisions, err := cycleuc.NewClosureDecisionReader(lineageStore, snapshots, NewRetestRepository(pool), NewSLAStore(pool))
+	if err != nil {
+		t.Fatal(err)
+	}
+	reports, err := cycleuc.NewClosureReportService(cycles, cycles, snapshots, comparisons, decisions, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jobs := worker.New(queue, map[string]worker.Handler{
+		comparisonuc.JobKind:                   worker.HandlerFunc(func(ctx context.Context, job ports.QueuedJob) error { return comparison.HandleJob(ctx, job.Payload) }),
+		cycleuc.AssessmentClosureReportJobKind: worker.HandlerFunc(reports.HandleJob),
+	}, worker.Config{Poll: 250 * time.Millisecond, Visibility: 2 * time.Minute, MaxAttempts: 3}, nil)
+	if err := jobs.Run(ctx); err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatal(err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/judgment_repo.go
+++ b/internal/infrastructure/persistence/postgres/judgment_repo.go
@@ -90,6 +90,24 @@ func (r *JudgmentRepository) ListByEngagement(ctx context.Context, engagementID 
 	return out, err
 }
 
+// GetByID provides a bounded engagement-scoped lookup for migration/backfill
+// consumers without loading every judgment into process memory.
+func (r *JudgmentRepository) GetByID(ctx context.Context, engagementID, id shared.ID) (out judgment.Judgment, err error) {
+	err = WithContextTenant(ctx, r.pool, func(tx pgx.Tx) error {
+		var scanErr error
+		out, scanErr = scanJudgment(tx.QueryRow(ctx,
+			`SELECT `+judgmentCols+` FROM judgments WHERE engagement_id=$1 AND id=$2`, engagementID.String(), id.String()))
+		if errors.Is(scanErr, pgx.ErrNoRows) {
+			return shared.ErrNotFound
+		}
+		if scanErr != nil {
+			return fmt.Errorf("get judgment: %w", scanErr)
+		}
+		return nil
+	})
+	return out, err
+}
+
 // ListBySubject returns the engagement's judgments about a given subject id, oldest first.
 // RLS scopes the query to the context tenant.
 func (r *JudgmentRepository) ListBySubject(ctx context.Context, engagementID, subjectID shared.ID) ([]judgment.Judgment, error) {

--- a/internal/infrastructure/persistence/postgres/migration_0151_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0151_test.go
@@ -1,0 +1,65 @@
+package postgres
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func TestMigration0151EmptyRoundTrip(t *testing.T) {
+	db, _ := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 151); err != nil {
+		t.Fatalf("up to 0151: %v", err)
+	}
+	if err := goose.DownTo(db, ".", 150); err != nil {
+		t.Fatalf("empty rollback to 0150: %v", err)
+	}
+	var exists bool
+	if err := db.QueryRowContext(context.Background(), `SELECT to_regclass('public.finding_identities') IS NOT NULL`).Scan(&exists); err != nil || exists {
+		t.Fatalf("finding identities after rollback exists=%v err=%v", exists, err)
+	}
+	if err := goose.UpTo(db, ".", 151); err != nil {
+		t.Fatalf("reapply 0143: %v", err)
+	}
+}
+
+func TestMigration0151UpgradeFixtureAndRollbackGuard(t *testing.T) {
+	ctx := context.Background()
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 150); err != nil {
+		t.Fatalf("up to 0150: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenantID := shared.ID("m135-tenant")
+	cycleID, snapshotID := createFindingLineageSnapshot(t, ctx, pool, tenantID, "m135")
+	pool.Close()
+
+	if err := goose.UpTo(db, ".", 151); err != nil {
+		t.Fatalf("upgrade fixture to 0151: %v", err)
+	}
+	pool, err = Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, observation := postgresFindingLineagePair(t, tenantID, cycleID, snapshotID, "m135-identity", "m135-observation", "m135-source", "m135-rule", time.Now().UTC())
+	if err := NewFindingLineageRepository(pool).CreateIdentityWithObservation(ctx, identity, observation); err != nil {
+		pool.Close()
+		t.Fatal(err)
+	}
+	pool.Close()
+	if err := goose.DownTo(db, ".", 150); err == nil || !strings.Contains(err.Error(), "cannot roll back finding lineage while lineage rows exist") {
+		t.Fatalf("rollback with lineage rows error=%v", err)
+	}
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT count(*) FROM finding_identities`).Scan(&count); err != nil || count != 1 {
+		t.Fatalf("finding identities after refused rollback count=%d err=%v", count, err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/migration_0153_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0153_test.go
@@ -1,0 +1,22 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+)
+
+func TestMigration0153EmptyRoundTrip(t *testing.T) {
+	db, _ := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 153); err != nil {
+		t.Fatalf("up to 0153: %v", err)
+	}
+	if err := goose.DownTo(db, ".", 152); err != nil {
+		t.Fatalf("rollback to 0152: %v", err)
+	}
+	var exists bool
+	if err := db.QueryRowContext(context.Background(), `SELECT to_regclass('public.assessment_comparisons') IS NOT NULL`).Scan(&exists); err != nil || exists {
+		t.Fatalf("assessment comparisons after rollback exists=%v err=%v", exists, err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/migration_0154_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0154_test.go
@@ -1,0 +1,279 @@
+package postgres
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestMigration0154EmptyRoundTrip(t *testing.T) {
+	db, _ := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 154); err != nil {
+		t.Fatalf("up to 0154: %v", err)
+	}
+
+	ctx := context.Background()
+	for _, table := range []string{
+		"assessment_cycle_closure_manifests",
+		"assessment_cycle_closure_path_members",
+		"assessment_cycle_closure_references",
+	} {
+		var exists, forcedRLS bool
+		if err := db.QueryRowContext(ctx, `SELECT to_regclass('public.' || $1) IS NOT NULL`, table).Scan(&exists); err != nil || !exists {
+			t.Fatalf("%s exists=%v err=%v", table, exists, err)
+		}
+		if err := db.QueryRowContext(ctx, `SELECT relforcerowsecurity FROM pg_class WHERE oid=$1::regclass`, table).Scan(&forcedRLS); err != nil || !forcedRLS {
+			t.Fatalf("%s FORCE RLS=%v err=%v", table, forcedRLS, err)
+		}
+	}
+
+	var activeManifestColumn bool
+	if err := db.QueryRowContext(ctx, `SELECT EXISTS (
+		SELECT 1 FROM information_schema.columns
+		WHERE table_schema='public' AND table_name='assessment_cycles' AND column_name='active_closure_manifest_id'
+	)`).Scan(&activeManifestColumn); err != nil || !activeManifestColumn {
+		t.Fatalf("active closure manifest column exists=%v err=%v", activeManifestColumn, err)
+	}
+
+	if err := goose.DownTo(db, ".", 153); err != nil {
+		t.Fatalf("rollback to 0153: %v", err)
+	}
+	var exists bool
+	if err := db.QueryRowContext(ctx, `SELECT to_regclass('public.assessment_cycle_closure_manifests') IS NOT NULL`).Scan(&exists); err != nil || exists {
+		t.Fatalf("closure manifests after rollback exists=%v err=%v", exists, err)
+	}
+}
+
+func TestMigration0154UpgradePaths(t *testing.T) {
+	for _, from := range []int64{137, 144, 145, 153} {
+		t.Run(strconv.FormatInt(from, 10), func(t *testing.T) {
+			db, _ := newAssessmentMigrationDB(t)
+			if err := goose.UpTo(db, ".", from); err != nil {
+				t.Fatalf("up to %d: %v", from, err)
+			}
+			if err := goose.UpTo(db, ".", 154); err != nil {
+				t.Fatalf("upgrade %d to 154: %v", from, err)
+			}
+		})
+	}
+}
+
+func TestMigration0154ClosureManifestGuards(t *testing.T) {
+	ctx := context.Background()
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 154); err != nil {
+		t.Fatalf("up to 0154: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tenantID := shared.ID("m138-tenant")
+	cycleID, baseline, current := createAssessmentComparisonSnapshots(t, ctx, pool, tenantID, "m138")
+	comparison := postgresQueuedComparison(t, tenantID, cycleID, "m138-comparison", baseline, current, 1, time.Now().UTC())
+	if _, created, err := NewAssessmentComparisonRepository(pool).CreateQueued(ctx, comparison); err != nil || !created {
+		t.Fatalf("create comparison created=%v err=%v", created, err)
+	}
+	assessmentID := shared.ID("lineage-assessment-m138")
+	manifestID := shared.ID("m138-manifest")
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	if err := WithTenant(ctx, pool, tenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `INSERT INTO assessment_cycle_closure_manifests (
+			tenant_id,cycle_id,id,manifest_version,lifecycle,cycle_version,root_assessment_id,final_assessment_id,
+			initial_snapshot_id,final_snapshot_id,comparison_id,initial_snapshot_hash,final_snapshot_hash,comparison_hash,
+			canonical_input_hash,policy_version,algorithm_version,fingerprint_version,risk_version,renderer_contract_version,
+			as_of_at,created_at,created_by
+		) VALUES ($1,$2,$3,1,'building',1,$4,$4,$5,$6,$7,$8,$9,$10,$11,'policy-v1','comparison-v1','fingerprint-v1','risk-v1','renderer-v1',$12,$12,'reviewer')`,
+			tenantID.String(), cycleID.String(), manifestID.String(), assessmentID.String(), baseline.ID.String(), current.ID.String(), comparison.ID.String(),
+			baseline.ContentHash, current.ContentHash, strings.Repeat("c", 64), comparison.InputHash, now)
+		return err
+	}); err != nil {
+		pool.Close()
+		t.Fatal(err)
+	}
+	if err := WithTenant(ctx, pool, tenantID.String(), func(tx pgx.Tx) error {
+		if _, err := tx.Exec(ctx, `INSERT INTO assessment_cycle_closure_path_members
+			(tenant_id,cycle_id,manifest_id,path_position,assessment_id,assessment_type,retest_number,relationship_version,snapshot_id)
+			VALUES ($1,$2,$3,0,$4,'initial',0,1,$5)`, tenantID.String(), cycleID.String(), manifestID.String(), assessmentID.String(), baseline.ID.String()); err != nil {
+			return err
+		}
+		_, err := tx.Exec(ctx, `INSERT INTO assessment_cycle_closure_references
+			(tenant_id,cycle_id,manifest_id,reference_kind,reference_id,reference_version,content_hash)
+			VALUES ($1,$2,$3,'policy_input','policy-v1',1,$4)`, tenantID.String(), cycleID.String(), manifestID.String(), strings.Repeat("d", 64))
+		return err
+	}); err != nil {
+		pool.Close()
+		t.Fatal(err)
+	}
+	if err := WithTenant(ctx, pool, tenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `UPDATE assessment_cycle_closure_manifests
+			SET lifecycle='active',content_hash=$4,sealed_at=$5,sealed_by='reviewer'
+			WHERE tenant_id=$1 AND cycle_id=$2 AND id=$3`, tenantID.String(), cycleID.String(), manifestID.String(), strings.Repeat("e", 64), now)
+		return err
+	}); err != nil {
+		pool.Close()
+		t.Fatal(err)
+	}
+	if err := WithTenant(ctx, pool, tenantID.String(), func(tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `UPDATE assessment_cycles SET active_closure_manifest_id=$3,active_closure_cycle_version=version
+			WHERE tenant_id=$1 AND id=$2`, tenantID.String(), cycleID.String(), manifestID.String())
+		return err
+	}); err != nil {
+		pool.Close()
+		t.Fatal(err)
+	}
+
+	for name, statement := range map[string]string{
+		"manifest mutation": `UPDATE assessment_cycle_closure_manifests SET reason='mutated' WHERE tenant_id=$1 AND cycle_id=$2 AND id=$3`,
+		"late child": `INSERT INTO assessment_cycle_closure_references
+			(tenant_id,cycle_id,manifest_id,reference_kind,reference_id,reference_version)
+			VALUES ($1,$2,$3,'waiver','late',1)`,
+		"cycle version drift": `UPDATE assessment_cycles SET version=version+1 WHERE tenant_id=$1 AND id=$2`,
+	} {
+		err := WithTenant(ctx, pool, tenantID.String(), func(tx pgx.Tx) error {
+			_, err := tx.Exec(ctx, statement, tenantID.String(), cycleID.String(), manifestID.String())
+			return err
+		})
+		if err == nil {
+			pool.Close()
+			t.Fatalf("%s unexpectedly succeeded", name)
+		}
+	}
+
+	const rlsRole = "synapse_m138_rls"
+	if _, err := pool.Exec(ctx, `CREATE ROLE `+rlsRole+` NOLOGIN NOSUPERUSER NOBYPASSRLS`); err != nil {
+		pool.Close()
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `GRANT USAGE ON SCHEMA public TO `+rlsRole); err != nil {
+		pool.Close()
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `GRANT SELECT ON assessment_cycle_closure_manifests TO `+rlsRole); err != nil {
+		pool.Close()
+		t.Fatal(err)
+	}
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		pool.Close()
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(ctx, `SET LOCAL ROLE `+rlsRole); err != nil {
+		_ = tx.Rollback(ctx)
+		pool.Close()
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(ctx, `SELECT set_config('app.current_tenant','m138-other-tenant',true)`); err != nil {
+		_ = tx.Rollback(ctx)
+		pool.Close()
+		t.Fatal(err)
+	}
+	var crossTenantCount int
+	if err := tx.QueryRow(ctx, `SELECT count(*) FROM assessment_cycle_closure_manifests`).Scan(&crossTenantCount); err != nil || crossTenantCount != 0 {
+		_ = tx.Rollback(ctx)
+		pool.Close()
+		t.Fatalf("cross-tenant manifest count=%d err=%v", crossTenantCount, err)
+	}
+	_ = tx.Rollback(ctx)
+	_, _ = pool.Exec(ctx, `DROP OWNED BY `+rlsRole)
+	_, _ = pool.Exec(ctx, `DROP ROLE IF EXISTS `+rlsRole)
+	pool.Close()
+
+	if err := goose.DownTo(db, ".", 153); err == nil || !strings.Contains(err.Error(), "cannot roll back assessment closure manifests") {
+		t.Fatalf("rollback guard error=%v", err)
+	}
+}
+
+func TestAssessmentCycleScaleTargets(t *testing.T) {
+	ctx := context.Background()
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 154); err != nil {
+		t.Fatalf("up to 0154: %v", err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+
+	const cycleCount = 10_000
+	tenantID := shared.ID("m138-scale-tenant")
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, `INSERT INTO tenants (id,name) VALUES ($1,'Assessment scale tenant')`, tenantID.String()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(ctx, `INSERT INTO engagements (id,tenant_id,name,created_at,updated_at)
+		SELECT 'm138-scale-eng-' || lpad(n::text,5,'0'),$1,'Scale assessment ' || n,
+		       clock_timestamp() - make_interval(secs => $2 - n),clock_timestamp() - make_interval(secs => $2 - n)
+		FROM generate_series(1,$2) AS n`, tenantID.String(), cycleCount); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(ctx, `INSERT INTO assessment_cycles
+		(tenant_id,id,name,boundary_kind,status,root_assessment_id,selected_head_assessment_id,next_retest_number,version,created_at,updated_at,created_by,updated_by)
+		SELECT $1,'m138-scale-cycle-' || lpad(n::text,5,'0'),'Scale cycle ' || n,'standalone','open',
+		       'm138-scale-eng-' || lpad(n::text,5,'0'),'m138-scale-eng-' || lpad(n::text,5,'0'),1,1,
+		       clock_timestamp() - make_interval(secs => $2 - n),clock_timestamp() - make_interval(secs => $2 - n),'scale','scale'
+		FROM generate_series(1,$2) AS n`, tenantID.String(), cycleCount); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tx.Exec(ctx, `INSERT INTO assessment_cycle_members
+		(tenant_id,cycle_id,assessment_id,assessment_type,retest_number,relationship_version,created_at,created_by)
+		SELECT $1,'m138-scale-cycle-' || lpad(n::text,5,'0'),'m138-scale-eng-' || lpad(n::text,5,'0'),'initial',0,1,
+		       clock_timestamp() - make_interval(secs => $2 - n),'scale'
+		FROM generate_series(1,$2) AS n`, tenantID.String(), cycleCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `ANALYZE engagements; ANALYZE assessment_cycles; ANALYZE assessment_cycle_members`); err != nil {
+		t.Fatal(err)
+	}
+
+	repository := NewAssessmentCycleRepository(pool)
+	listDurations := make([]time.Duration, 0, 20)
+	detailDurations := make([]time.Duration, 0, 20)
+	for range 20 {
+		started := time.Now()
+		records, err := repository.ListCycles(ctx, ports.AssessmentCycleListQuery{TenantID: tenantID, Limit: 100})
+		listDurations = append(listDurations, time.Since(started))
+		if err != nil || len(records) != 100 {
+			t.Fatalf("scale list records=%d err=%v", len(records), err)
+		}
+		started = time.Now()
+		cycle, err := repository.GetCycle(ctx, tenantID, records[0].Cycle.ID)
+		if err == nil {
+			_, err = repository.ListMembers(ctx, tenantID, cycle.ID)
+		}
+		detailDurations = append(detailDurations, time.Since(started))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	assertP95Within(t, "Cycle list", listDurations, 500*time.Millisecond)
+	assertP95Within(t, "Cycle detail", detailDurations, 750*time.Millisecond)
+}
+
+func assertP95Within(t *testing.T, label string, durations []time.Duration, limit time.Duration) {
+	t.Helper()
+	sort.Slice(durations, func(left, right int) bool { return durations[left] < durations[right] })
+	p95 := durations[(len(durations)*95+99)/100-1]
+	if p95 > limit {
+		t.Fatalf("%s p95=%s exceeds %s (%v)", label, p95, limit, durations)
+	}
+	t.Logf("%s p95=%s at %d rows", label, p95, 10_000)
+}

--- a/internal/infrastructure/persistence/postgres/migration_0155_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0155_test.go
@@ -1,0 +1,85 @@
+package postgres
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/migrations"
+)
+
+func TestMigration0155DefinesAppendOnlyTenantSafeReviewArtifacts(t *testing.T) {
+	data, err := migrations.FS.ReadFile("0155_assessment_relationship_candidates.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql := string(data)
+	for _, required := range []string{
+		"assessment_relationship_candidates", "assessment_relationship_repair_plans", "assessment_relationship_decisions",
+		"FOREIGN KEY (tenant_id, predecessor_cycle_id, predecessor_assessment_id, predecessor_snapshot_id)",
+		"FOREIGN KEY (tenant_id, successor_cycle_id, successor_assessment_id, successor_snapshot_id)",
+		"body          BYTEA NOT NULL", "execution' = 'blocked'", "separately_approved_move_merge_command", "synapse_forbid_mutation",
+		"synapse_enable_tenant_rls('assessment_relationship_candidates')", "cannot roll back assessment relationship review while artifacts exist",
+	} {
+		if !strings.Contains(sql, required) {
+			t.Errorf("migration missing %q", required)
+		}
+	}
+}
+
+func TestMigration0155EmptyRoundTrip(t *testing.T) {
+	db, _ := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 155); err != nil {
+		t.Fatalf("up to 0155: %v", err)
+	}
+	ctx := context.Background()
+	for _, table := range []string{"assessment_relationship_candidates", "assessment_relationship_repair_plans", "assessment_relationship_decisions"} {
+		var exists, forcedRLS bool
+		if err := db.QueryRowContext(ctx, `SELECT to_regclass('public.' || $1) IS NOT NULL`, table).Scan(&exists); err != nil || !exists {
+			t.Fatalf("%s exists=%v err=%v", table, exists, err)
+		}
+		if err := db.QueryRowContext(ctx, `SELECT relforcerowsecurity FROM pg_class WHERE oid=$1::regclass`, table).Scan(&forcedRLS); err != nil || !forcedRLS {
+			t.Fatalf("%s FORCE RLS=%v err=%v", table, forcedRLS, err)
+		}
+	}
+	if err := goose.DownTo(db, ".", 154); err != nil {
+		t.Fatalf("rollback to 0154: %v", err)
+	}
+}
+
+func TestMigration0155UpgradePaths(t *testing.T) {
+	for _, from := range []int64{137, 144, 145, 154} {
+		t.Run(strconv.FormatInt(from, 10), func(t *testing.T) {
+			db, _ := newAssessmentMigrationDB(t)
+			if err := goose.UpTo(db, ".", from); err != nil {
+				t.Fatalf("up to %d: %v", from, err)
+			}
+			if err := goose.UpTo(db, ".", 155); err != nil {
+				t.Fatalf("upgrade %d to 155: %v", from, err)
+			}
+		})
+	}
+}
+
+func TestMigration0155RollbackGuard(t *testing.T) {
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 155); err != nil {
+		t.Fatalf("up to 0155: %v", err)
+	}
+	pool, err := Connect(context.Background(), dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenantID, candidate := seedPostgresRelationshipSubjects(t, context.Background(), pool, "migration-0155")
+	if _, created, err := NewAssessmentRelationshipRepository(pool).CreateCandidate(context.Background(), candidate); err != nil || !created {
+		pool.Close()
+		t.Fatalf("seed candidate tenant=%s created=%v err=%v", tenantID, created, err)
+	}
+	pool.Close()
+	if err := goose.DownTo(db, ".", 154); err == nil || !strings.Contains(err.Error(), "cannot roll back assessment relationship review while artifacts exist") {
+		t.Fatalf("rollback guard error=%v", err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/migration_0156_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0156_test.go
@@ -1,0 +1,63 @@
+package postgres
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/migrations"
+)
+
+func TestMigration0156DefinesImmutableTenantSafeClosureReports(t *testing.T) {
+	data, err := migrations.FS.ReadFile("0156_assessment_closure_reports.sql")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql := string(data)
+	for _, required := range []string{
+		"assessment_cycle_closure_reports", "PRIMARY KEY (tenant_id, cycle_id, manifest_id, renderer_contract_version)",
+		"REFERENCES assessment_cycle_closure_manifests(tenant_id, cycle_id, id) ON DELETE RESTRICT",
+		"content_hash ~ '^[0-9a-f]{64}$'", "octet_length(content) BETWEEN 2 AND 16777216",
+		"synapse_forbid_mutation", "synapse_enable_tenant_rls('assessment_cycle_closure_reports')",
+		"cannot roll back assessment closure reports while report rows exist",
+	} {
+		if !strings.Contains(sql, required) {
+			t.Errorf("migration missing %q", required)
+		}
+	}
+}
+
+func TestMigration0156EmptyRoundTrip(t *testing.T) {
+	db, _ := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 156); err != nil {
+		t.Fatalf("up to 0156: %v", err)
+	}
+	ctx := context.Background()
+	var exists, forcedRLS bool
+	if err := db.QueryRowContext(ctx, `SELECT to_regclass('public.assessment_cycle_closure_reports') IS NOT NULL`).Scan(&exists); err != nil || !exists {
+		t.Fatalf("closure report table exists=%v err=%v", exists, err)
+	}
+	if err := db.QueryRowContext(ctx, `SELECT relforcerowsecurity FROM pg_class WHERE oid='assessment_cycle_closure_reports'::regclass`).Scan(&forcedRLS); err != nil || !forcedRLS {
+		t.Fatalf("closure report FORCE RLS=%v err=%v", forcedRLS, err)
+	}
+	if err := goose.DownTo(db, ".", 155); err != nil {
+		t.Fatalf("rollback to 0155: %v", err)
+	}
+}
+
+func TestMigration0156UpgradePaths(t *testing.T) {
+	for _, from := range []int64{137, 144, 145, 155} {
+		t.Run(strconv.FormatInt(from, 10), func(t *testing.T) {
+			db, _ := newAssessmentMigrationDB(t)
+			if err := goose.UpTo(db, ".", from); err != nil {
+				t.Fatalf("up to %d: %v", from, err)
+			}
+			if err := goose.UpTo(db, ".", 156); err != nil {
+				t.Fatalf("upgrade %d to 156: %v", from, err)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/persistence/postgres/migration_0157_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0157_test.go
@@ -1,0 +1,108 @@
+package postgres
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pressly/goose/v3"
+
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/project"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestMigration0157VisibleProjectBoundaryAndRollbackGuard(t *testing.T) {
+	ctx := context.Background()
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 157); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if _, err := pool.Exec(ctx, `INSERT INTO tenants(id,name) VALUES ('visible','Visible'),('other','Other')`); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	p, err := project.New("project", "visible", "Project", "project", project.SourceBinding{Kind: project.SourceGit, Value: "https://github.com/example/project"}, nil, "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projects := NewProjectRepository(pool)
+	if err := projects.Create(ctx, p); err != nil {
+		t.Fatal(err)
+	}
+	engagements := NewEngagementRepository(pool)
+	root, err := engdom.New("assessment", "visible", "Visible assessment", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root.AssessmentProjectID = p.ID
+	if err := engagements.Create(ctx, root); err != nil {
+		t.Fatal(err)
+	}
+	got, err := engagements.GetByIDInTenant(ctx, root.TenantID, root.ID)
+	if err != nil || got.Internal() || got.AssessmentProjectID != p.ID {
+		t.Fatalf("visible association: %+v err=%v", got, err)
+	}
+	cycles := NewAssessmentCycleRepository(pool)
+	pending, total, err := cycles.ListMigrationPendingAssessments(ctx, ports.AssessmentCycleListQuery{TenantID: root.TenantID, Limit: 10, BoundaryKind: cycledom.BoundaryProject})
+	if err != nil || total != 1 || len(pending) != 1 || pending[0].AssessmentID != root.ID || pending[0].BoundaryKind != cycledom.BoundaryProject {
+		t.Fatalf("visible Project pending projection: %+v total=%d err=%v", pending, total, err)
+	}
+	service, err := cycleuc.NewService(cycles, engagements, nil, projects, NewTenantTransactionRunner(pool), idgen.RandomID{}, idgen.SystemClock{}, assessmentCycleNoopAudit{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cycle, _, err := service.CreateInitialCycle(ctx, cycleuc.CreateInitialCycleInput{TenantID: root.TenantID, Name: "Project cycle", BoundaryKind: cycledom.BoundaryProject, ProjectID: p.ID, RootAssessmentID: root.ID, Actor: "tester"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		`UPDATE engagements SET assessment_project_id=NULL WHERE id='assessment'`,
+		`UPDATE engagements SET project_id='project',assessment_project_id=NULL WHERE id='assessment'`,
+		`UPDATE assessment_cycles SET project_id=NULL,boundary_kind='standalone' WHERE id=$1`,
+		`UPDATE assessment_cycles SET root_assessment_id='other' WHERE id=$1`,
+	} {
+		var err error
+		if strings.Contains(statement, "$1") {
+			_, err = pool.Exec(ctx, statement, cycle.ID.String())
+		} else {
+			_, err = pool.Exec(ctx, statement)
+		}
+		if err == nil {
+			t.Fatalf("frozen boundary update accepted: %s", statement)
+		}
+	}
+	wrong, err := engdom.New("wrong", "other", "Cross tenant", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrong.AssessmentProjectID = p.ID
+	if err := engagements.Create(ctx, wrong); err == nil {
+		t.Fatal("cross-tenant Project FK not enforced")
+	}
+	if err := goose.DownTo(db, ".", 156); err == nil || !strings.Contains(err.Error(), "associations exist") {
+		t.Fatalf("unsafe rollback accepted: %v", err)
+	}
+}
+
+func TestMigrations0157And0158EmptyRoundTrip(t *testing.T) {
+	db, _ := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 158); err != nil {
+		t.Fatal(err)
+	}
+	if err := goose.DownTo(db, ".", 156); err != nil {
+		t.Fatal(err)
+	}
+	if err := goose.UpTo(db, ".", 158); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/migration_0158_test.go
+++ b/internal/infrastructure/persistence/postgres/migration_0158_test.go
@@ -1,0 +1,88 @@
+package postgres
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestMigration0158EvidenceImmutabilityTenantBindingAndRollback(t *testing.T) {
+	ctx := context.Background()
+	db, dsn := newAssessmentMigrationDB(t)
+	if err := goose.UpTo(db, ".", 158); err != nil {
+		t.Fatal(err)
+	}
+	pool, err := Connect(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	ensureScanRunTenantAndEngagement(t, ctx, pool, "evidence-tenant", "assessment")
+	store := NewScanRunStore(pool)
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	run := scanrun.ScanRun{TenantID: "evidence-tenant", EngagementID: "assessment", ID: "evidence-run", Provenance: scanrun.ProvenanceNative, TerminalStatus: scanrun.StatusBuilding, ManifestSchemaVersion: 1, CreatedAt: now, UpdatedAt: now}
+	payload := []byte(`{"version":1,"records":[]}`)
+	hash := sha256.Sum256(payload)
+	evidence := ports.ScanRunEvidence{TenantID: run.TenantID, RunID: run.ID, Payload: payload, ContentHash: hex.EncodeToString(hash[:])}
+	failure := errors.New("audit unavailable")
+	if err := NewTenantTransactionRunner(pool).Run(ctx, run.TenantID, func(txCtx context.Context) error {
+		if err := store.SaveScanRun(txCtx, run); err != nil {
+			return err
+		}
+		if err := store.SaveScanRunEvidence(txCtx, evidence); err != nil {
+			return err
+		}
+		return failure
+	}); !errors.Is(err, failure) {
+		t.Fatal(err)
+	}
+	if _, err := store.GetScanRunEvidence(ctx, run.TenantID, run.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("evidence survived rollback: %v", err)
+	}
+	if err := store.SaveScanRun(ctx, run); err != nil {
+		t.Fatal(err)
+	}
+	for range 2 {
+		if err := store.SaveScanRunEvidence(ctx, evidence); err != nil {
+			t.Fatalf("save/replay: %v", err)
+		}
+	}
+	if _, err := store.GetScanRunEvidence(ctx, "other", run.ID); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross-tenant evidence read: %v", err)
+	}
+	bad := evidence
+	bad.Payload = []byte(`{"version":2}`)
+	if err := store.SaveScanRunEvidence(ctx, bad); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("hash mismatch accepted: %v", err)
+	}
+	badHash := sha256.Sum256(bad.Payload)
+	bad.ContentHash = hex.EncodeToString(badHash[:])
+	if err := store.SaveScanRunEvidence(ctx, bad); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("different replay accepted: %v", err)
+	}
+	for _, statement := range []string{
+		`UPDATE scan_run_comparison_evidence SET payload='changed' WHERE run_id='evidence-run'`,
+		`DELETE FROM scan_run_comparison_evidence WHERE run_id='evidence-run'`,
+	} {
+		if _, err := pool.Exec(ctx, statement); err == nil {
+			t.Fatalf("immutable evidence changed: %s", statement)
+		}
+	}
+	var enabled, forced bool
+	if err := pool.QueryRow(ctx, `SELECT relrowsecurity,relforcerowsecurity FROM pg_class WHERE oid='scan_run_comparison_evidence'::regclass`).Scan(&enabled, &forced); err != nil || !enabled || !forced {
+		t.Fatalf("RLS not enforced: %v %v %v", enabled, forced, err)
+	}
+	if err := goose.DownTo(db, ".", 157); err == nil || !strings.Contains(err.Error(), "evidence exists") {
+		t.Fatalf("unsafe evidence rollback: %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/postgres/sla_store_test.go
+++ b/internal/infrastructure/persistence/postgres/sla_store_test.go
@@ -170,6 +170,25 @@ func TestPostgresSLAStore(t *testing.T) {
 	if err != nil || len(events) != 1 || events[0].ID != event.ID {
 		t.Fatalf("events=%+v err=%v", events, err)
 	}
+	batch, err := store.SLAHistories(ctx, tenantID, engagementID, []shared.ID{findingID, "missing"})
+	if err != nil || len(batch.Assessments) != 1 || len(batch.Assessments[findingID]) != len(history) || len(batch.Events[findingID]) != len(events) {
+		t.Fatalf("closure history batch=%+v err=%v", batch, err)
+	}
+	for i := range history {
+		if batch.Assessments[findingID][i].ID != history[i].ID || batch.Assessments[findingID][i].InputHash != history[i].InputHash {
+			t.Fatal("batch lost immutable SLA provenance")
+		}
+	}
+	if batch.Events[findingID][0].Reason != events[0].Reason || !batch.Events[findingID][0].AcceptanceExpiresAt.Equal(*events[0].AcceptanceExpiresAt) {
+		t.Fatal("batch lost SLA decision/expiry")
+	}
+	foreignBatch, err := store.SLAHistories(shared.WithTenant(ctx, "other"), "other", engagementID, []shared.ID{findingID})
+	if err != nil || len(foreignBatch.Assessments)+len(foreignBatch.Events) != 0 {
+		t.Fatalf("cross-tenant SLA batch=%+v err=%v", foreignBatch, err)
+	}
+	if _, err := store.SLAHistories(ctx, tenantID, engagementID, make([]shared.ID, 1001)); !errors.Is(err, shared.ErrValidation) {
+		t.Fatalf("unbounded SLA batch=%v", err)
+	}
 	third, err := sla.Evaluate(sla.AssessmentInput{
 		TenantID: tenantID, EngagementID: engagementID, FindingID: findingID,
 		Risk: sla.Inputs{Severity: shared.SeverityMedium, CVSSScore: 5.5, EPSS: 0.04, PublicPoC: true, Feasibility: sla.FeasibilityChangeWindow},

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -15,6 +15,13 @@ import (
 const (
 	defaultWorkerConcurrency       = 1
 	maxWorkerConcurrency           = 64
+	defaultAssessmentBatchSize     = 500
+	maxAssessmentBatchSize         = 2000
+	defaultAssessmentTenantJobs    = 4
+	maxAssessmentTenantJobs        = 4
+	defaultComparisonBacklogWarn   = 500
+	defaultComparisonBacklogHard   = 1000
+	maxComparisonBacklogHard       = 1000
 	defaultFPTriageMaxFindings     = 100
 	maxFPTriageMaxFindings         = 1000
 	defaultFPTriageConcurrency     = 6
@@ -135,6 +142,9 @@ type Config struct {
 	MaxWorkspaceBytes int64
 	// ProjectUploadDir retains uploaded Project source archives for repeat analysis.
 	ProjectUploadDir string
+	// EngagementSourceDir is the durable operator-owned upload object root used
+	// when MinIO/S3 is not configured. API and workers must share the same root.
+	EngagementSourceDir string
 	// ProjectSourceArtifactDir retains immutable, analysis-owned Code source snapshots.
 	// It must be operator-owned; source contents are never fetched again at read time.
 	ProjectSourceArtifactDir  string
@@ -424,6 +434,24 @@ type Config struct {
 	// SLAEnabled turns on durable risk-based remediation deadlines, versioned tenant policy, and
 	// human lifecycle APIs. Default false until an operator explicitly opts into the new schema/path.
 	SLAEnabled bool
+	// Assessment lifecycle gates default off and use explicit tenant allowlists for staged rollout.
+	AssessmentCycleAPIEnabled           bool
+	AssessmentCycleDualWriteEnabled     bool
+	AssessmentCycleDualWriteTenants     []string
+	AssessmentSnapshotEnabled           bool
+	AssessmentSnapshotCompletionEnabled bool
+	AssessmentSnapshotCompletionTenants []string
+	AssessmentShadowEnabled             bool
+	AssessmentShadowTenants             []string
+	AssessmentLifecycleReadEnabled      bool
+	AssessmentLifecycleReadTenants      []string
+	AssessmentLifecycleUIDefault        bool
+	AssessmentLifecycleUITenants        []string
+	AssessmentClosureEnabled            bool
+	AssessmentBatchSize                 int
+	AssessmentTenantJobs                int
+	AssessmentBacklogWarning            int
+	AssessmentBacklogHardLimit          int
 	// SASTEnabled turns on the deterministic pattern-SAST analyzer in the scan pipeline; off by default.
 	SASTEnabled bool
 	// SecretScanEnabled turns on the deterministic secret scanner in the scan pipeline; off by default.
@@ -740,6 +768,7 @@ func Load() Config {
 		Offline:                   getbool("SYNAPSE_OFFLINE", false),
 		MaxWorkspaceBytes:         getint64("SYNAPSE_MAX_WORKSPACE_BYTES", 2<<30),
 		ProjectUploadDir:          getenv("SYNAPSE_PROJECT_UPLOAD_DIR", "data/project-uploads"),
+		EngagementSourceDir:       engagementSourceDir(),
 		ProjectSourceArtifactDir:  projectSourceArtifactDir(),
 		ProjectSourceRetention:    getduration("SYNAPSE_PROJECT_SOURCE_RETENTION", 90*24*time.Hour),
 		ProjectSourceMaxFileBytes: getint64("SYNAPSE_PROJECT_SOURCE_MAX_FILE_BYTES", 2<<20),
@@ -811,7 +840,6 @@ func Load() Config {
 		TriScoreReassessEnabled:                     getbool("SYNAPSE_TRISCORE_REASSESS_ENABLED", false),
 		FleetCorrelationEnabled:                     getbool("SYNAPSE_FLEET_CORRELATION_ENABLED", false),
 		FleetCorrelationWindow:                      getduration("SYNAPSE_FLEET_CORRELATION_WINDOW", 30*time.Minute),
-		FleetCorrelationAllowedLateness:             getduration("SYNAPSE_FLEET_CORRELATION_ALLOWED_LATENESS", 5*time.Minute),
 		FleetCorrelationMaxPerIncident:              getint("SYNAPSE_FLEET_CORRELATION_MAX_PER_INCIDENT", 100),
 		FleetCorrelationPageSize:                    getint("SYNAPSE_FLEET_CORRELATION_PAGE_SIZE", 100),
 		FleetCorrelationMaxActiveSessions:           getint("SYNAPSE_FLEET_CORRELATION_MAX_ACTIVE_SESSIONS", 500),
@@ -844,16 +872,10 @@ func Load() Config {
 		FleetAgentStaleAfter:                        getduration("SYNAPSE_FLEET_STALE_AFTER", 10*time.Minute),
 		FleetCoverageFreshnessTarget:                getduration("SYNAPSE_FLEET_COVERAGE_FRESHNESS_TARGET", 24*time.Hour),
 		FleetSignerKey:                              getenv("SYNAPSE_FLEET_SIGNER_KEY", ""),
-		ResponseExecutionEnabled:                    getbool("SYNAPSE_RESPONSE_EXECUTION_ENABLED", false),
-		ResponseCommandSigningKeyFile:               strings.TrimSpace(os.Getenv("SYNAPSE_RESPONSE_COMMAND_SIGNING_KEY_FILE")),
-		ResponseCommandTTL:                          getduration("SYNAPSE_RESPONSE_COMMAND_TTL", 2*time.Minute),
-		ResponseExecutionPollInterval:               getduration("SYNAPSE_RESPONSE_EXECUTION_POLL_INTERVAL", 100*time.Millisecond),
 		FleetCACertPEM:                              getenv("SYNAPSE_FLEET_CA_CERT", ""),
 		FleetCAKeyPEM:                               getenv("SYNAPSE_FLEET_CA_KEY", ""),
 		FleetCertTTL:                                getduration("SYNAPSE_FLEET_CERT_TTL", 720*time.Hour),
 		FleetClientCertHeader:                       getenv("SYNAPSE_FLEET_CLIENT_CERT_HEADER", ""),
-		FleetClientCertHost:                         getenv("SYNAPSE_FLEET_CLIENT_CERT_HOST", ""),
-		FleetEnrollmentHost:                         getenv("SYNAPSE_FLEET_ENROLLMENT_HOST", ""),
 		LeaderElectionEnabled:                       getbool("SYNAPSE_LEADER_ENABLED", false),
 		LeaderResource:                              getenv("SYNAPSE_LEADER_RESOURCE", "scheduler"),
 		LeaderTerm:                                  getduration("SYNAPSE_LEADER_TERM", 15*time.Second),
@@ -937,6 +959,30 @@ func Load() Config {
 		AlertWebhookAllowPrivate:                    getbool("SYNAPSE_ALERT_WEBHOOK_ALLOW_PRIVATE", false),
 		AlertWebhookAllowUnsigned:                   getbool("SYNAPSE_ALERT_WEBHOOK_ALLOW_UNSIGNED", false),
 		VulnerabilitySourceAllowPrivateNetwork:      getbool("SYNAPSE_VULNERABILITY_SOURCE_ALLOW_PRIVATE_NETWORK", false),
+		AssessmentCycleAPIEnabled:                   getbool("SYNAPSE_ASSESSMENT_CYCLE_API_ENABLED", false),
+		AssessmentCycleDualWriteEnabled:             getbool("SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_ENABLED", false),
+		AssessmentCycleDualWriteTenants:             splitList(getenv("SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_TENANTS", "")),
+		AssessmentSnapshotEnabled:                   getbool("SYNAPSE_ASSESSMENT_SNAPSHOT_ENABLED", false),
+		AssessmentSnapshotCompletionEnabled:         getbool("SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_ENABLED", false),
+		AssessmentSnapshotCompletionTenants:         splitList(getenv("SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_TENANTS", "")),
+		AssessmentShadowEnabled:                     getbool("SYNAPSE_ASSESSMENT_IDENTITY_COMPARISON_SHADOW_ENABLED", false),
+		AssessmentShadowTenants:                     splitList(getenv("SYNAPSE_ASSESSMENT_IDENTITY_COMPARISON_SHADOW_TENANTS", "")),
+		AssessmentLifecycleReadEnabled:              getbool("SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED", false),
+		AssessmentLifecycleReadTenants:              splitList(getenv("SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS", "")),
+		AssessmentLifecycleUIDefault:                getbool("SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_ENABLED", false),
+		AssessmentLifecycleUITenants:                splitList(getenv("SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_TENANTS", "")),
+		AssessmentClosureEnabled:                    getbool("SYNAPSE_ASSESSMENT_CLOSURE_REPORT_ENABLED", false),
+		AssessmentBatchSize:                         getint("SYNAPSE_ASSESSMENT_MIGRATION_BATCH_SIZE", defaultAssessmentBatchSize),
+		AssessmentTenantJobs:                        getint("SYNAPSE_ASSESSMENT_PROCESS_TENANT_JOBS", defaultAssessmentTenantJobs),
+		AssessmentBacklogWarning:                    getint("SYNAPSE_ASSESSMENT_COMPARISON_BACKLOG_WARNING", defaultComparisonBacklogWarn),
+		AssessmentBacklogHardLimit:                  getint("SYNAPSE_ASSESSMENT_COMPARISON_BACKLOG_HARD_LIMIT", defaultComparisonBacklogHard),
+		FleetCorrelationAllowedLateness:             getduration("SYNAPSE_FLEET_CORRELATION_ALLOWED_LATENESS", 5*time.Minute),
+		ResponseExecutionEnabled:                    getbool("SYNAPSE_RESPONSE_EXECUTION_ENABLED", false),
+		ResponseCommandSigningKeyFile:               strings.TrimSpace(os.Getenv("SYNAPSE_RESPONSE_COMMAND_SIGNING_KEY_FILE")),
+		ResponseCommandTTL:                          getduration("SYNAPSE_RESPONSE_COMMAND_TTL", 2*time.Minute),
+		ResponseExecutionPollInterval:               getduration("SYNAPSE_RESPONSE_EXECUTION_POLL_INTERVAL", 100*time.Millisecond),
+		FleetClientCertHost:                         getenv("SYNAPSE_FLEET_CLIENT_CERT_HOST", ""),
+		FleetEnrollmentHost:                         getenv("SYNAPSE_FLEET_ENROLLMENT_HOST", ""),
 
 		AgentApprovalMode:    getenv("SYNAPSE_AGENT_APPROVAL_MODE", "manual"),
 		AgentApprovalTimeout: getduration("SYNAPSE_AGENT_APPROVAL_TIMEOUT", 30*time.Minute),
@@ -1163,22 +1209,23 @@ type WorkerProfile string
 const (
 	WorkerProfileAll          WorkerProfile = "all"
 	WorkerProfileIntegrations WorkerProfile = "integrations"
+	WorkerProfileLifecycle    WorkerProfile = "lifecycle"
 )
 
 func (c Config) ValidateWorkerProfile() error {
 	switch c.WorkerProfile {
-	case WorkerProfileAll, WorkerProfileIntegrations:
+	case WorkerProfileAll, WorkerProfileIntegrations, WorkerProfileLifecycle:
 		return nil
 	default:
-		return fmt.Errorf("SYNAPSE_WORKER_PROFILE must be %q or %q (got %q)", WorkerProfileAll, WorkerProfileIntegrations, c.WorkerProfile)
+		return fmt.Errorf("SYNAPSE_WORKER_PROFILE must be %q, %q, or %q (got %q)", WorkerProfileAll, WorkerProfileIntegrations, WorkerProfileLifecycle, c.WorkerProfile)
 	}
 }
 
 // ValidateWorkerSandboxPosture preserves the scanner worker's production fail-closed
-// sandbox gate while allowing the integration-only worker, which never constructs or
-// claims an executable-tool handler.
+// sandbox gate while allowing data-only workers, which never construct or claim an
+// executable-tool handler.
 func (c Config) ValidateWorkerSandboxPosture() error {
-	if c.WorkerProfile == WorkerProfileIntegrations {
+	if c.WorkerProfile == WorkerProfileIntegrations || c.WorkerProfile == WorkerProfileLifecycle {
 		return nil
 	}
 	return c.ValidateSandboxPosture()
@@ -1201,7 +1248,7 @@ func (c Config) ResolveToolExecution(role ProcessRole) (ToolExecution, error) {
 		if c.DBDSN == "" {
 			return "", errors.New("synapse-worker requires SYNAPSE_DB_DSN: queued execution cannot use process-local persistence")
 		}
-		if c.IsProduction() && !c.SandboxEnabled && c.WorkerProfile != WorkerProfileIntegrations {
+		if c.IsProduction() && !c.SandboxEnabled && c.WorkerProfile != WorkerProfileIntegrations && c.WorkerProfile != WorkerProfileLifecycle {
 			return "", errors.New("production synapse-worker requires SYNAPSE_SANDBOX_ENABLED=true")
 		}
 		return ToolExecutionWorker, nil
@@ -1336,6 +1383,116 @@ func (c Config) ValidateWorkerConcurrency() error {
 		return fmt.Errorf("SYNAPSE_WORKER_CONCURRENCY must be between 1 and %d (got %d)", maxWorkerConcurrency, c.WorkerConcurrency)
 	}
 	return nil
+}
+
+// ValidateAssessmentLifecycleRollout rejects rollout settings that can create
+// unbounded migration work or expose UI/closure paths before their read inputs.
+func (c Config) ValidateAssessmentLifecycleRollout() error {
+	if c.AssessmentCycleDualWriteEnabled && len(c.AssessmentCycleDualWriteTenants) == 0 {
+		return errors.New("SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_ENABLED requires SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_TENANTS")
+	}
+	if c.AssessmentBatchSize < 1 || c.AssessmentBatchSize > maxAssessmentBatchSize {
+		return fmt.Errorf("SYNAPSE_ASSESSMENT_MIGRATION_BATCH_SIZE must be between 1 and %d (got %d)", maxAssessmentBatchSize, c.AssessmentBatchSize)
+	}
+	if c.AssessmentTenantJobs < 1 || c.AssessmentTenantJobs > maxAssessmentTenantJobs {
+		return fmt.Errorf("SYNAPSE_ASSESSMENT_PROCESS_TENANT_JOBS must be between 1 and %d (got %d)", maxAssessmentTenantJobs, c.AssessmentTenantJobs)
+	}
+	if c.AssessmentBacklogWarning < 1 || c.AssessmentBacklogWarning > defaultComparisonBacklogWarn {
+		return fmt.Errorf("SYNAPSE_ASSESSMENT_COMPARISON_BACKLOG_WARNING must be between 1 and %d (got %d)", defaultComparisonBacklogWarn, c.AssessmentBacklogWarning)
+	}
+	if c.AssessmentBacklogHardLimit < c.AssessmentBacklogWarning || c.AssessmentBacklogHardLimit > maxComparisonBacklogHard {
+		return fmt.Errorf("SYNAPSE_ASSESSMENT_COMPARISON_BACKLOG_HARD_LIMIT must be between warning threshold %d and %d (got %d)", c.AssessmentBacklogWarning, maxComparisonBacklogHard, c.AssessmentBacklogHardLimit)
+	}
+	if c.AssessmentShadowEnabled && !c.AssessmentSnapshotEnabled {
+		return errors.New("SYNAPSE_ASSESSMENT_IDENTITY_COMPARISON_SHADOW_ENABLED requires SYNAPSE_ASSESSMENT_SNAPSHOT_ENABLED=true")
+	}
+	if c.AssessmentShadowEnabled && len(c.AssessmentShadowTenants) == 0 {
+		return errors.New("SYNAPSE_ASSESSMENT_IDENTITY_COMPARISON_SHADOW_ENABLED requires SYNAPSE_ASSESSMENT_IDENTITY_COMPARISON_SHADOW_TENANTS")
+	}
+	if c.AssessmentLifecycleReadEnabled && (!c.AssessmentShadowEnabled || len(c.AssessmentLifecycleReadTenants) == 0) {
+		return errors.New("SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED requires shadow generation and SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS")
+	}
+	if !tenantAllowlistCovers(c.AssessmentShadowTenants, c.AssessmentLifecycleReadTenants) {
+		return errors.New("SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS must be a subset of SYNAPSE_ASSESSMENT_IDENTITY_COMPARISON_SHADOW_TENANTS")
+	}
+	if c.AssessmentSnapshotCompletionEnabled && !c.AssessmentSnapshotEnabled {
+		return errors.New("SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_ENABLED requires SYNAPSE_ASSESSMENT_SNAPSHOT_ENABLED=true")
+	}
+	if c.AssessmentSnapshotCompletionEnabled && len(c.AssessmentSnapshotCompletionTenants) == 0 {
+		return errors.New("SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_ENABLED requires SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_TENANTS")
+	}
+	if c.AssessmentSnapshotCompletionEnabled && !c.AssessmentLifecycleReadEnabled {
+		return errors.New("SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_ENABLED requires SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED=true")
+	}
+	if !tenantAllowlistCovers(c.AssessmentLifecycleReadTenants, c.AssessmentSnapshotCompletionTenants) {
+		return errors.New("SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_TENANTS must be a subset of SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS")
+	}
+	if c.AssessmentLifecycleUIDefault && !c.AssessmentLifecycleReadEnabled {
+		return errors.New("SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_ENABLED requires SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED=true")
+	}
+	if c.AssessmentLifecycleUIDefault && len(c.AssessmentLifecycleUITenants) == 0 {
+		return errors.New("SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_ENABLED requires SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_TENANTS")
+	}
+	if !tenantAllowlistCovers(c.AssessmentLifecycleReadTenants, c.AssessmentLifecycleUITenants) {
+		return errors.New("SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_TENANTS must be a subset of SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS")
+	}
+	if c.AssessmentClosureEnabled && (!c.AssessmentLifecycleReadEnabled || !c.AssessmentSnapshotEnabled || !c.AssessmentShadowEnabled) {
+		return errors.New("SYNAPSE_ASSESSMENT_CLOSURE_REPORT_ENABLED requires lifecycle read, snapshots, and identity/comparison shadow generation")
+	}
+	return nil
+}
+
+func (c Config) AssessmentCycleDualWriteForTenant(tenantID string) bool {
+	return tenantFeatureEnabled(c.AssessmentCycleDualWriteEnabled, c.AssessmentCycleDualWriteTenants, tenantID)
+}
+
+func (c Config) AssessmentShadowForTenant(tenantID string) bool {
+	return tenantFeatureEnabled(c.AssessmentShadowEnabled, c.AssessmentShadowTenants, tenantID)
+}
+
+func (c Config) AssessmentLifecycleReadForTenant(tenantID string) bool {
+	return tenantFeatureEnabled(c.AssessmentLifecycleReadEnabled, c.AssessmentLifecycleReadTenants, tenantID)
+}
+
+func (c Config) AssessmentSnapshotCompletionForTenant(tenantID string) bool {
+	return tenantFeatureEnabled(c.AssessmentSnapshotCompletionEnabled, c.AssessmentSnapshotCompletionTenants, tenantID)
+}
+
+func (c Config) AssessmentLifecycleUIForTenant(tenantID string) bool {
+	return tenantFeatureEnabled(c.AssessmentLifecycleUIDefault, c.AssessmentLifecycleUITenants, tenantID)
+}
+
+func tenantFeatureEnabled(enabled bool, allowlist []string, tenantID string) bool {
+	if !enabled {
+		return false
+	}
+	tenantID = strings.TrimSpace(tenantID)
+	for _, allowed := range allowlist {
+		if allowed == "*" || strings.TrimSpace(allowed) == tenantID {
+			return true
+		}
+	}
+	return false
+}
+
+func tenantAllowlistCovers(superset, subset []string) bool {
+	if len(subset) == 0 {
+		return true
+	}
+	allowed := make(map[string]struct{}, len(superset))
+	for _, tenantID := range superset {
+		tenantID = strings.TrimSpace(tenantID)
+		if tenantID == "*" {
+			return true
+		}
+		allowed[tenantID] = struct{}{}
+	}
+	for _, tenantID := range subset {
+		if _, ok := allowed[strings.TrimSpace(tenantID)]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 // ValidateOIDCPosture fails closed when the browser OIDC BFF cannot bind identity/session state to a fixed tenant.

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -114,6 +115,7 @@ func TestResolveToolExecution(t *testing.T) {
 		{name: "production worker requires sandbox", cfg: Config{Environment: "production", DBDSN: "postgres://runtime"}, role: ProcessRoleWorker, wantErr: true},
 		{name: "production worker accepts sandbox", cfg: Config{Environment: "production", DBDSN: "postgres://runtime", SandboxEnabled: true}, role: ProcessRoleWorker, want: ToolExecutionWorker},
 		{name: "production integration worker needs no tool sandbox", cfg: Config{Environment: "production", DBDSN: "postgres://runtime", WorkerProfile: WorkerProfileIntegrations}, role: ProcessRoleWorker, want: ToolExecutionWorker},
+		{name: "production lifecycle worker needs no tool sandbox", cfg: Config{Environment: "production", DBDSN: "postgres://runtime", WorkerProfile: WorkerProfileLifecycle}, role: ProcessRoleWorker, want: ToolExecutionWorker},
 		{name: "worker refuses other mode", cfg: Config{Environment: "development", DBDSN: "postgres://runtime", ToolExecutionMode: "dispatch-only"}, role: ProcessRoleWorker, wantErr: true},
 		{name: "CLI defaults in process", cfg: Config{}, role: ProcessRoleCLI, want: ToolExecutionInProcess},
 		{name: "CLI refuses other mode", cfg: Config{ToolExecutionMode: "worker"}, role: ProcessRoleCLI, wantErr: true},
@@ -141,6 +143,7 @@ func TestWorkerProfileValidation(t *testing.T) {
 		{value: "", valid: true},
 		{value: "all", valid: true},
 		{value: " INTEGRATIONS ", valid: true},
+		{value: " LIFECYCLE ", valid: true},
 		{value: "scanner", valid: false},
 	} {
 		t.Run(test.value, func(t *testing.T) {
@@ -156,6 +159,9 @@ func TestWorkerProfileValidation(t *testing.T) {
 func TestValidateWorkerSandboxPosture(t *testing.T) {
 	if err := (Config{Environment: "production", WorkerProfile: WorkerProfileIntegrations}).ValidateWorkerSandboxPosture(); err != nil {
 		t.Fatalf("integration-only worker must not require executable-tool sandbox: %v", err)
+	}
+	if err := (Config{Environment: "production", WorkerProfile: WorkerProfileLifecycle}).ValidateWorkerSandboxPosture(); err != nil {
+		t.Fatalf("lifecycle-only worker must not require executable-tool sandbox: %v", err)
 	}
 	if err := (Config{Environment: "production", WorkerProfile: WorkerProfileAll}).ValidateWorkerSandboxPosture(); err == nil {
 		t.Fatal("full production worker must still require the sandbox")
@@ -768,6 +774,22 @@ func TestProjectSourceCaptureDefaults(t *testing.T) {
 	}
 }
 
+func TestEngagementSourceArchiveRootIsPersistentAndExplicit(t *testing.T) {
+	t.Setenv("SYNAPSE_ENGAGEMENT_SOURCE_DIR", "")
+	root := Load().EngagementSourceDir
+	if !filepath.IsAbs(root) || !strings.HasSuffix(root, filepath.Join("synapse", "engagement-sources")) {
+		t.Fatalf("uploaded archive root must be persistent absolute application data: %q", root)
+	}
+	t.Setenv("SYNAPSE_ENGAGEMENT_SOURCE_DIR", "/operator/source-archives")
+	if got := Load().EngagementSourceDir; got != "/operator/source-archives" {
+		t.Fatalf("explicit archive root ignored: %q", got)
+	}
+	t.Setenv("SYNAPSE_ENGAGEMENT_SOURCE_DIR", "relative/source-archives")
+	if got := Load().EngagementSourceDir; got != "relative/source-archives" {
+		t.Fatal("unsafe relative configuration must be rejected by the adapter, not silently rebased")
+	}
+}
+
 func TestProjectAnalysisCompletionTimeout(t *testing.T) {
 	t.Setenv("SYNAPSE_SCAN_TIMEOUT", "2m")
 	t.Setenv("SYNAPSE_PROJECT_ANALYSIS_COMPLETION_TIMEOUT", "")
@@ -914,5 +936,137 @@ func TestPythonTaintDefaultsOn(t *testing.T) {
 	t.Setenv("SYNAPSE_PYTAINT_ENABLED", "false")
 	if Load().PythonTaintEnabled {
 		t.Error("SYNAPSE_PYTAINT_ENABLED=false must disable Python taint")
+	}
+}
+
+func TestLoadAssessmentLifecycleDefaultsFailClosed(t *testing.T) {
+	for _, key := range []string{
+		"SYNAPSE_ASSESSMENT_CYCLE_API_ENABLED",
+		"SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_ENABLED",
+		"SYNAPSE_ASSESSMENT_CYCLE_DUAL_WRITE_TENANTS",
+		"SYNAPSE_ASSESSMENT_SNAPSHOT_ENABLED",
+		"SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_ENABLED",
+		"SYNAPSE_ASSESSMENT_SNAPSHOT_COMPLETION_TENANTS",
+		"SYNAPSE_ASSESSMENT_IDENTITY_COMPARISON_SHADOW_ENABLED",
+		"SYNAPSE_ASSESSMENT_IDENTITY_COMPARISON_SHADOW_TENANTS",
+		"SYNAPSE_ASSESSMENT_LIFECYCLE_READ_ENABLED",
+		"SYNAPSE_ASSESSMENT_LIFECYCLE_READ_TENANTS",
+		"SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_ENABLED",
+		"SYNAPSE_ASSESSMENT_LIFECYCLE_UI_DEFAULT_TENANTS",
+		"SYNAPSE_ASSESSMENT_CLOSURE_REPORT_ENABLED",
+		"SYNAPSE_ASSESSMENT_MIGRATION_BATCH_SIZE",
+		"SYNAPSE_ASSESSMENT_PROCESS_TENANT_JOBS",
+		"SYNAPSE_ASSESSMENT_COMPARISON_BACKLOG_WARNING",
+		"SYNAPSE_ASSESSMENT_COMPARISON_BACKLOG_HARD_LIMIT",
+	} {
+		t.Setenv(key, "")
+	}
+	cfg := Load()
+	if cfg.AssessmentCycleAPIEnabled || cfg.AssessmentCycleDualWriteEnabled || cfg.AssessmentSnapshotEnabled || cfg.AssessmentSnapshotCompletionEnabled || cfg.AssessmentShadowEnabled || cfg.AssessmentLifecycleReadEnabled || cfg.AssessmentLifecycleUIDefault || cfg.AssessmentClosureEnabled {
+		t.Fatal("assessment lifecycle flags must remain disabled by default")
+	}
+	if cfg.AssessmentBatchSize != 500 || cfg.AssessmentTenantJobs != 4 || cfg.AssessmentBacklogWarning != 500 || cfg.AssessmentBacklogHardLimit != 1000 {
+		t.Fatalf("assessment lifecycle limits = (%d,%d,%d,%d)", cfg.AssessmentBatchSize, cfg.AssessmentTenantJobs, cfg.AssessmentBacklogWarning, cfg.AssessmentBacklogHardLimit)
+	}
+}
+
+func TestValidateAssessmentLifecycleRollout(t *testing.T) {
+	valid := Config{
+		AssessmentCycleDualWriteEnabled:     true,
+		AssessmentCycleDualWriteTenants:     []string{"tenant-a"},
+		AssessmentSnapshotEnabled:           true,
+		AssessmentShadowEnabled:             true,
+		AssessmentShadowTenants:             []string{"tenant-a", "tenant-b"},
+		AssessmentLifecycleReadEnabled:      true,
+		AssessmentLifecycleReadTenants:      []string{"tenant-a", "tenant-b"},
+		AssessmentLifecycleUIDefault:        true,
+		AssessmentLifecycleUITenants:        []string{"tenant-a"},
+		AssessmentSnapshotCompletionEnabled: true,
+		AssessmentSnapshotCompletionTenants: []string{"tenant-a"},
+		AssessmentBatchSize:                 500,
+		AssessmentTenantJobs:                4,
+		AssessmentBacklogWarning:            500,
+		AssessmentBacklogHardLimit:          1000,
+		AssessmentClosureEnabled:            true,
+	}
+	if err := valid.ValidateAssessmentLifecycleRollout(); err != nil {
+		t.Fatalf("valid assessment lifecycle rollout: %v", err)
+	}
+
+	invalid := valid
+	invalid.AssessmentCycleDualWriteTenants = nil
+	if err := invalid.ValidateAssessmentLifecycleRollout(); err == nil {
+		t.Fatal("dual-write without a tenant allowlist must fail")
+	}
+	invalid = valid
+	invalid.AssessmentShadowTenants = nil
+	if err := invalid.ValidateAssessmentLifecycleRollout(); err == nil {
+		t.Fatal("shadow generation without a tenant allowlist must fail")
+	}
+	invalid = valid
+	invalid.AssessmentSnapshotEnabled = false
+	if err := invalid.ValidateAssessmentLifecycleRollout(); err == nil {
+		t.Fatal("shadow generation without snapshots must fail")
+	}
+	invalid = valid
+	invalid.AssessmentLifecycleUITenants = []string{"tenant-c"}
+	if err := invalid.ValidateAssessmentLifecycleRollout(); err == nil {
+		t.Fatal("UI tenant outside read allowlist must fail")
+	}
+	invalid = valid
+	invalid.AssessmentSnapshotCompletionTenants = []string{"tenant-c"}
+	if err := invalid.ValidateAssessmentLifecycleRollout(); err == nil {
+		t.Fatal("Snapshot completion tenant outside read allowlist must fail")
+	}
+
+	invalid = valid
+	invalid.AssessmentLifecycleReadTenants = []string{"tenant-c"}
+	if err := invalid.ValidateAssessmentLifecycleRollout(); err == nil {
+		t.Fatal("read tenant outside shadow allowlist must fail")
+	}
+	invalid = valid
+	invalid.AssessmentBatchSize = 2001
+	if err := invalid.ValidateAssessmentLifecycleRollout(); err == nil {
+		t.Fatal("unbounded assessment batch size must fail")
+	}
+	invalid = valid
+	invalid.AssessmentTenantJobs = 5
+	if err := invalid.ValidateAssessmentLifecycleRollout(); err == nil {
+		t.Fatal("unbounded assessment tenant concurrency must fail")
+	}
+	invalid = valid
+	invalid.AssessmentBacklogHardLimit = 499
+	if err := invalid.ValidateAssessmentLifecycleRollout(); err == nil {
+		t.Fatal("hard backlog limit below warning threshold must fail")
+	}
+	invalid = valid
+	invalid.AssessmentSnapshotEnabled = false
+	if err := invalid.ValidateAssessmentLifecycleRollout(); err == nil {
+		t.Fatal("closure without snapshots must fail")
+	}
+}
+
+func TestAssessmentLifecycleTenantGates(t *testing.T) {
+	cfg := Config{
+		AssessmentCycleDualWriteEnabled:     true,
+		AssessmentCycleDualWriteTenants:     []string{"tenant-a"},
+		AssessmentShadowEnabled:             true,
+		AssessmentShadowTenants:             []string{"tenant-a"},
+		AssessmentLifecycleReadEnabled:      true,
+		AssessmentLifecycleReadTenants:      []string{"*"},
+		AssessmentSnapshotCompletionEnabled: true,
+		AssessmentSnapshotCompletionTenants: []string{"tenant-a"},
+	}
+	if !cfg.AssessmentCycleDualWriteForTenant("tenant-a") || cfg.AssessmentCycleDualWriteForTenant("tenant-b") {
+		t.Fatal("tenant-scoped cycle dual-write allowlist mismatch")
+	}
+	if !cfg.AssessmentShadowForTenant("tenant-a") || cfg.AssessmentShadowForTenant("tenant-b") {
+		t.Fatal("tenant-scoped identity shadow allowlist mismatch")
+	}
+	if !cfg.AssessmentLifecycleReadForTenant("tenant-b") || cfg.AssessmentLifecycleUIForTenant("tenant-b") {
+		t.Fatal("read wildcard or fail-closed UI gate mismatch")
+	}
+	if !cfg.AssessmentSnapshotCompletionForTenant("tenant-a") || cfg.AssessmentSnapshotCompletionForTenant("tenant-b") {
+		t.Fatal("Snapshot completion tenant gate mismatch")
 	}
 }

--- a/internal/platform/config/project_source_artifact_dir.go
+++ b/internal/platform/config/project_source_artifact_dir.go
@@ -6,6 +6,20 @@ import (
 	"strings"
 )
 
+// Uploaded archives are original evidence, not a disposable source-preview cache.
+// Keep the default in persistent application data outside scanned workspaces.
+func engagementSourceDir() string {
+	if configured := strings.TrimSpace(os.Getenv("SYNAPSE_ENGAGEMENT_SOURCE_DIR")); configured != "" {
+		return configured
+	}
+	if root, err := os.UserConfigDir(); err == nil && filepath.IsAbs(root) {
+		return filepath.Join(root, "synapse", "engagement-sources")
+	}
+	// No temporary-directory fallback: an unavailable durable root must surface
+	// as a configuration error, not silently lose uploads on restart.
+	return ""
+}
+
 // projectSourceArtifactDir returns an operator-owned absolute default outside the process working
 // tree. An explicit environment value is preserved so write adapters can fail closed on a relative
 // configuration instead of silently rebasing it into an attacker-controlled checkout.

--- a/internal/usecase/assessmentlifecycle/shadow.go
+++ b/internal/usecase/assessmentlifecycle/shadow.go
@@ -1,0 +1,107 @@
+package assessmentlifecycle
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	cmpdom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	comparisonuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcomparison"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// ShadowCoordinator turns a sealed native scan run into a Snapshot and queues
+// the directed lifecycle comparison, without exposing lifecycle reads. Tenant
+// rollout is checked on every callback so wiring it does not broaden rollout.
+type ShadowCoordinator struct {
+	cycles      ports.AssessmentCycleRepository
+	snapshots   ports.AssessmentSnapshotRepository
+	finalizer   *snapshotuc.Service
+	comparisons *comparisonuc.Service
+	enabled     func(string) bool
+}
+
+func NewShadowCoordinator(cycles ports.AssessmentCycleRepository, snapshots ports.AssessmentSnapshotRepository, finalizer *snapshotuc.Service, comparisons *comparisonuc.Service, enabled func(string) bool) (*ShadowCoordinator, error) {
+	if cycles == nil || snapshots == nil || finalizer == nil || comparisons == nil || enabled == nil {
+		return nil, fmt.Errorf("%w: assessment lifecycle shadow dependencies are required", shared.ErrValidation)
+	}
+	return &ShadowCoordinator{cycles: cycles, snapshots: snapshots, finalizer: finalizer, comparisons: comparisons, enabled: enabled}, nil
+}
+
+func (coordinator *ShadowCoordinator) AssessmentScanRunSealed(ctx context.Context, tenantID, assessmentID, runID shared.ID) error {
+	tenantID = shared.TenantOrDefault(tenantID)
+	if !coordinator.enabled(tenantID.String()) {
+		return nil
+	}
+	cycle, err := coordinator.cycles.GetCycleByAssessment(ctx, tenantID, assessmentID)
+	if errors.Is(err, shared.ErrNotFound) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	baseline, pointer, err := coordinator.snapshots.GetDefault(ctx, tenantID, assessmentID)
+	if errors.Is(err, shared.ErrNotFound) {
+		baseline, pointer, err = nil, ports.AssessmentSnapshotDefault{}, nil
+	}
+	if err != nil {
+		return err
+	}
+	var current *assessmentsnapshot.Snapshot
+	created := false
+	for attempt := 0; attempt < 3; attempt++ {
+		current, created, err = coordinator.finalizer.Finalize(ctx, snapshotuc.FinalizeInput{
+			TenantID: tenantID, CycleID: cycle.ID, AssessmentID: assessmentID,
+			SelectedRunIDs: []string{runID.String()}, RequestKey: "shadow:scan:" + runID.String(),
+			ExpectedDefaultVersion: pointer.Version, Actor: "system:assessment-lifecycle-shadow",
+		})
+		if err == nil || !errors.Is(err, shared.ErrConflict) {
+			break
+		}
+		baseline, pointer, err = coordinator.snapshots.GetDefault(ctx, tenantID, assessmentID)
+		if err != nil {
+			return err
+		}
+	}
+	if err != nil || current == nil {
+		return err
+	}
+	if !created && baseline != nil && baseline.ID == current.ID {
+		baseline = nil
+		items, listErr := snapshotuc.ReadComparisonHistory(ctx, coordinator.snapshots, tenantID, assessmentID)
+		if listErr != nil {
+			return listErr
+		}
+		for index := range items {
+			candidate := &items[index]
+			if candidate.SnapshotNumber < current.SnapshotNumber && (baseline == nil || candidate.SnapshotNumber > baseline.SnapshotNumber) {
+				baseline = candidate
+			}
+		}
+	}
+	if baseline == nil {
+		member, memberErr := coordinator.cycles.GetMember(ctx, tenantID, cycle.ID, assessmentID)
+		if memberErr != nil {
+			return memberErr
+		}
+		if member.PredecessorAssessmentID.IsZero() {
+			return nil
+		}
+		baseline, _, err = coordinator.snapshots.GetDefault(ctx, tenantID, member.PredecessorAssessmentID)
+		if errors.Is(err, shared.ErrNotFound) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
+	_, _, _, err = coordinator.comparisons.Queue(ctx, comparisonuc.QueueInput{
+		TenantID: tenantID, BaselineSnapshotID: baseline.ID, CurrentSnapshotID: current.ID,
+		Mode: cmpdom.ModeLifecycle, FingerprintVersion: 1, RiskModelVersion: comparisonuc.RiskModelVersionV1,
+		Actor: "system:assessment-lifecycle-shadow",
+	})
+	return err
+}

--- a/internal/usecase/assessmentlifecycle/shadow_test.go
+++ b/internal/usecase/assessmentlifecycle/shadow_test.go
@@ -1,0 +1,186 @@
+package assessmentlifecycle
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	comparisonuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcomparison"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type shadowClock struct{ now time.Time }
+
+func (clock *shadowClock) Now() time.Time {
+	clock.now = clock.now.Add(time.Second)
+	return clock.now
+}
+
+type shadowIDs struct{ next int }
+
+func (ids *shadowIDs) NewID() shared.ID {
+	ids.next++
+	return shared.ID(fmt.Sprintf("shadow-%d", ids.next))
+}
+
+type shadowAudit struct{}
+
+func (shadowAudit) Record(context.Context, ports.AuditEntry) error { return nil }
+
+type shadowVerificationReader struct{}
+
+func (shadowVerificationReader) ListEffectiveComparisonVerifications(context.Context, shared.ID, shared.ID, []shared.ID) ([]ports.AssessmentComparisonVerification, error) {
+	return nil, nil
+}
+
+func TestShadowCoordinatorContinuouslyProjectsScanRuns(t *testing.T) {
+	ctx := context.Background()
+	tenantID, cycleID, assessmentID := shared.ID("tenant"), shared.ID("cycle"), shared.ID("assessment")
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	clock, ids := &shadowClock{now: now}, &shadowIDs{}
+
+	engagements := memory.NewEngagementRepository()
+	assessment, err := engagement.New(assessmentID, tenantID, "Assessment", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := assessment.Transition(engagement.StatusActive, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(ctx, assessment); err != nil {
+		t.Fatal(err)
+	}
+
+	cycles := memory.NewAssessmentCycleRepository()
+	cycle, err := assessmentcycle.NewAssessmentCycle(cycleID, tenantID, "Cycle", assessmentcycle.BoundaryStandalone, "", "", assessmentID, "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember(tenantID, cycleID, assessmentID, "operator", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+
+	runs := memory.NewScanRunStore()
+	saveShadowRun(t, runs, shadowRun(t, tenantID, assessmentID, "run-1", "0123456789abcdef0123456789abcdef01234567"))
+	saveShadowRun(t, runs, shadowRun(t, tenantID, assessmentID, "run-2", "1123456789abcdef0123456789abcdef01234567"))
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	transactions := memory.NewTenantTransactionRunner()
+	finalizer, err := snapshotuc.NewService(snapshots, cycles, engagements, runs, transactions, ids, clock, shadowAudit{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	comparisons := memory.NewAssessmentComparisonRepository()
+	comparisonService, err := comparisonuc.NewService(comparisons, snapshots, cycles, memory.NewFindingLineageRepository(), transactions, shadowAudit{}, clock, ids, shadowVerificationReader{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	enabled := false
+	coordinator, err := NewShadowCoordinator(cycles, snapshots, finalizer, comparisonService, func(string) bool { return enabled })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := coordinator.AssessmentScanRunSealed(ctx, tenantID, assessmentID, "run-1"); err != nil {
+		t.Fatal(err)
+	}
+	if items, err := snapshots.ListByAssessment(ctx, tenantID, assessmentID); err != nil || len(items) != 0 {
+		t.Fatalf("disabled snapshots=%d err=%v", len(items), err)
+	}
+
+	enabled = true
+	if err := coordinator.AssessmentScanRunSealed(ctx, tenantID, assessmentID, "run-1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := coordinator.AssessmentScanRunSealed(ctx, tenantID, assessmentID, "run-2"); err != nil {
+		t.Fatal(err)
+	}
+	items, err := snapshots.ListByAssessment(ctx, tenantID, assessmentID)
+	if err != nil || len(items) != 2 {
+		t.Fatalf("snapshots=%d err=%v", len(items), err)
+	}
+	queued, err := comparisons.ListMetadataByCycle(ctx, tenantID, cycleID)
+	if err != nil || len(queued) != 1 {
+		t.Fatalf("comparisons=%d err=%v", len(queued), err)
+	}
+	if queued[0].Mode != assessmentcomparison.ModeLifecycle || queued[0].BaselineSnapshotID != items[0].ID || queued[0].CurrentSnapshotID != items[1].ID {
+		t.Fatalf("unexpected lifecycle comparison: %+v snapshots=%+v", queued[0], items)
+	}
+
+	if err := coordinator.AssessmentScanRunSealed(ctx, tenantID, assessmentID, "run-2"); err != nil {
+		t.Fatal(err)
+	}
+	items, _ = snapshots.ListByAssessment(ctx, tenantID, assessmentID)
+	queued, _ = comparisons.ListMetadataByCycle(ctx, tenantID, cycleID)
+	if len(items) != 2 || len(queued) != 1 {
+		t.Fatalf("replay created duplicate artifacts: snapshots=%d comparisons=%d", len(items), len(queued))
+	}
+}
+
+func saveShadowRun(t *testing.T, store *memory.ScanRunStore, run scanrun.ScanRun) {
+	t.Helper()
+	building := run
+	building.Lanes, building.ManifestHash, building.SealedAt = nil, "", nil
+	if run.Provenance == scanrun.ProvenanceNative {
+		building.TerminalStatus = scanrun.StatusBuilding
+	}
+	if err := store.SaveScanRun(context.Background(), building); err != nil {
+		t.Fatal(err)
+	}
+	if run.SealedAt != nil {
+		if err := store.SealScanRun(context.Background(), ports.SealScanRunCommand{
+			TenantID: run.TenantID, RunID: run.ID, TerminalStatus: run.TerminalStatus,
+			Lanes: run.Lanes, ManifestSchemaVersion: run.ManifestSchemaVersion, ManifestHash: run.ManifestHash, SealedAt: *run.SealedAt,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func shadowRun(t *testing.T, tenantID, assessmentID shared.ID, id, revision string) scanrun.ScanRun {
+	t.Helper()
+	started := time.Date(2026, 9, 4, 11, 0, 0, 0, time.UTC)
+	finished := started.Add(time.Minute)
+	target, err := scanrun.CanonicalizeRepositoryTarget("https://example.com/repo.git", revision)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run := scanrun.ScanRun{
+		TenantID: tenantID, ID: id, EngagementID: assessmentID, CreatedAt: started, UpdatedAt: started,
+		Provenance: scanrun.ProvenanceNative, TerminalStatus: scanrun.StatusBuilding,
+		ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion,
+		Lanes: []scanrun.Lane{{
+			TenantID: tenantID, EngagementID: assessmentID, ScanRunID: id, LaneKey: "sca", Producer: "sca", TerminalStatus: scanrun.StatusSucceeded, Target: target,
+			AuthoritativeFindingKinds: []string{"vulnerability"}, IncludedScope: []string{"src/**"}, ExcludedScope: []string{"vendor/**"},
+			StartedAt: started, FinishedAt: &finished, ResultRef: "result:" + id, EvidenceRef: "evidence:" + id,
+			ResultSHA256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion,
+			Versions: []scanrun.LaneVersion{{VersionKind: scanrun.VersionScanner, Name: "sca", Version: "1"}, {VersionKind: scanrun.VersionRulePack, Name: "rules", Version: "1"}},
+			Stages:   []scanrun.LaneStage{{StageKey: "scan", Status: scanrun.StageSucceeded, StartedAt: started, FinishedAt: &finished}},
+		}},
+	}
+	run.Lanes[0].SealedAt = &finished
+	run.Lanes[0].ManifestHash, err = scanrun.ComputeManifestHash(run.Lanes[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.ManifestHash, err = scanrun.ComputeRunManifestHash(run.Lanes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run.TerminalStatus, run.SealedAt, run.UpdatedAt = scanrun.StatusSucceeded, &finished, finished
+	return run
+}

--- a/internal/usecase/assessmentrollout/gate.go
+++ b/internal/usecase/assessmentrollout/gate.go
@@ -1,0 +1,200 @@
+package assessmentrollout
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+type Phase string
+
+const (
+	PhaseInternalCanary Phase = "internal_canary"
+	PhaseOptInCanary    Phase = "opt_in_canary"
+	PhaseReadCutover    Phase = "read_cutover"
+	PhaseUIDefault      Phase = "ui_default"
+	PhaseRollbackDrill  Phase = "rollback_drill"
+)
+
+func (phase Phase) Valid() bool {
+	switch phase {
+	case PhaseInternalCanary, PhaseOptInCanary, PhaseReadCutover, PhaseUIDefault, PhaseRollbackDrill:
+		return true
+	default:
+		return false
+	}
+}
+
+type Snapshot struct {
+	TenantID                           string `json:"tenant_id"`
+	IntegrityViolations                int    `json:"integrity_violations"`
+	AutomaticFixedPartialUnknown       int    `json:"automatic_fixed_partial_unknown"`
+	ComparableItems                    int    `json:"comparable_items"`
+	SemanticMismatches                 int    `json:"semantic_mismatches"`
+	ProducerItems                      int    `json:"producer_items"`
+	ReviewCandidates                   int    `json:"review_candidates"`
+	SevenDayReviewCandidateBaselineBPS int    `json:"seven_day_review_candidate_baseline_bps"`
+	APIRequests                        int    `json:"api_requests"`
+	APIErrors                          int    `json:"api_errors"`
+	APIWindowMinutes                   int    `json:"api_window_minutes"`
+	LatencyWindowMinutes               int    `json:"latency_window_minutes"`
+	CycleListP95Millis                 int    `json:"cycle_list_p95_millis"`
+	CycleDetailP95Millis               int    `json:"cycle_detail_p95_millis"`
+	ComparisonPageP95Millis            int    `json:"comparison_page_p95_millis"`
+	ProductionSLOContinuousMinutes     int    `json:"production_slo_continuous_minutes"`
+	TargetCardinality                  bool   `json:"target_cardinality"`
+	ComparisonBacklog                  int    `json:"comparison_backlog"`
+	OldestComparisonAgeSeconds         int    `json:"oldest_comparison_age_seconds"`
+	Comparison100KDurationSeconds      int    `json:"comparison_100k_duration_seconds"`
+	DeadLetterGrowth10Minutes          int    `json:"dead_letter_growth_10_minutes"`
+	SuccessfulRepairs10Minutes         int    `json:"successful_repairs_10_minutes"`
+	MetricsRecorded                    bool   `json:"metrics_recorded"`
+	ApprovalRecorded                   bool   `json:"approval_recorded"`
+	ReadCutoverApproved                bool   `json:"read_cutover_approved"`
+	LifecycleReadEnabled               bool   `json:"lifecycle_read_enabled"`
+	LifecycleUIDefaultEnabled          bool   `json:"lifecycle_ui_default_enabled"`
+	SourceRowsPreserved                bool   `json:"source_rows_preserved"`
+	ImmutableArtifactsPreserved        bool   `json:"immutable_artifacts_preserved"`
+	RollbackDrillPassed                bool   `json:"rollback_drill_passed"`
+}
+
+type Finding struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type Decision struct {
+	Phase    Phase     `json:"phase"`
+	TenantID string    `json:"tenant_id"`
+	Allowed  bool      `json:"allowed"`
+	Blockers []Finding `json:"blockers"`
+	Warnings []Finding `json:"warnings"`
+}
+
+func Evaluate(phase Phase, snapshot Snapshot) (Decision, error) {
+	snapshot.TenantID = strings.TrimSpace(snapshot.TenantID)
+	if !phase.Valid() || snapshot.TenantID == "" || len(snapshot.TenantID) > 128 || invalidSnapshotCounts(snapshot) {
+		return Decision{}, fmt.Errorf("%w: assessment rollout gate input is invalid", shared.ErrValidation)
+	}
+	decision := Decision{Phase: phase, TenantID: snapshot.TenantID, Blockers: []Finding{}, Warnings: []Finding{}}
+	block := func(code, message string) {
+		decision.Blockers = append(decision.Blockers, Finding{Code: code, Message: message})
+	}
+	warn := func(code, message string) {
+		decision.Warnings = append(decision.Warnings, Finding{Code: code, Message: message})
+	}
+
+	if phase == PhaseRollbackDrill {
+		if snapshot.LifecycleReadEnabled || snapshot.LifecycleUIDefaultEnabled {
+			block("rollback_flags_enabled", "rollback must disable lifecycle reads and lifecycle UI")
+		}
+		if !snapshot.SourceRowsPreserved {
+			block("rollback_source_not_preserved", "rollback must preserve source rows")
+		}
+		if !snapshot.ImmutableArtifactsPreserved {
+			block("rollback_artifacts_not_preserved", "rollback must preserve immutable lifecycle artifacts")
+		}
+		if !snapshot.RollbackDrillPassed {
+			block("rollback_drill_not_passed", "rollback drill evidence is not recorded as passed")
+		}
+		if !snapshot.MetricsRecorded || !snapshot.ApprovalRecorded {
+			block("phase_record_missing", "phase metrics and approval must both be recorded")
+		}
+		return finalize(decision), nil
+	}
+
+	if snapshot.IntegrityViolations > 0 {
+		block("integrity_violation", "tenant, boundary, root, member, snapshot hash, and ownership integrity violations must be zero")
+	}
+	if snapshot.AutomaticFixedPartialUnknown > 0 {
+		block("automatic_fixed_without_coverage", "automatic Fixed claims from partial or unknown coverage must be zero")
+	}
+	if snapshot.ComparableItems >= 1000 {
+		if snapshot.SemanticMismatches*10000 > snapshot.ComparableItems*50 {
+			block("semantic_mismatch_rate", "shadow semantic mismatch rate exceeds 0.5 percent")
+		}
+	} else if phase == PhaseReadCutover || phase == PhaseUIDefault {
+		block("comparable_sample_insufficient", "read cutover requires at least 1000 comparable items")
+	} else {
+		warn("comparable_sample_insufficient", "semantic mismatch rate is not authoritative before 1000 comparable items")
+	}
+	if snapshot.ProducerItems > 0 {
+		rateBPS := snapshot.ReviewCandidates * 10000 / snapshot.ProducerItems
+		thresholdBPS := 1000
+		if snapshot.SevenDayReviewCandidateBaselineBPS > 0 && snapshot.SevenDayReviewCandidateBaselineBPS*2 < thresholdBPS {
+			thresholdBPS = snapshot.SevenDayReviewCandidateBaselineBPS * 2
+		}
+		if rateBPS > thresholdBPS {
+			warn("review_candidate_rate", "producer review-candidate rate exceeds its rollout alert threshold")
+		}
+	}
+	if snapshot.APIWindowMinutes < 15 || snapshot.APIRequests == 0 {
+		block("api_window_insufficient", "API error gate requires at least 15 minutes with requests")
+	} else if snapshot.APIErrors*100 > snapshot.APIRequests {
+		block("api_error_rate", "API error rate exceeds 1 percent over the measured window")
+	}
+	if snapshot.LatencyWindowMinutes < 15 {
+		block("latency_window_insufficient", "latency safety gate requires at least 15 minutes")
+	}
+	if snapshot.CycleListP95Millis > 750 || snapshot.CycleDetailP95Millis > 1000 || snapshot.ComparisonPageP95Millis > 1000 {
+		block("canary_latency_ceiling", "early-canary latency safety ceiling is exceeded")
+	}
+	if snapshot.ComparisonBacklog > 1000 {
+		block("comparison_backlog_hard_limit", "tenant comparison backlog exceeds 1000")
+	} else if snapshot.ComparisonBacklog >= 500 {
+		warn("comparison_backlog_warning", "tenant comparison backlog is at or above 500")
+	}
+	if snapshot.OldestComparisonAgeSeconds > 900 {
+		block("comparison_oldest_age", "oldest queued or generating comparison exceeds 15 minutes")
+	}
+	if snapshot.Comparison100KDurationSeconds > 600 {
+		block("comparison_100k_duration", "100000-item comparison exceeds 10 minutes")
+	}
+	if snapshot.DeadLetterGrowth10Minutes > 0 && snapshot.SuccessfulRepairs10Minutes == 0 {
+		block("dead_letter_growth", "dead-letter count increased for 10 minutes without successful repair")
+	}
+	if !snapshot.MetricsRecorded || !snapshot.ApprovalRecorded {
+		block("phase_record_missing", "phase metrics and approval must both be recorded")
+	}
+	if phase == PhaseReadCutover || phase == PhaseUIDefault {
+		if !snapshot.TargetCardinality {
+			block("target_cardinality_missing", "production SLO must be measured at target cardinality")
+		}
+		if snapshot.CycleListP95Millis > 500 || snapshot.CycleDetailP95Millis > 750 || snapshot.ComparisonPageP95Millis > 750 {
+			block("production_latency_slo", "production 500/750 millisecond read SLO is not met")
+		}
+		if snapshot.ProductionSLOContinuousMinutes < 30 {
+			block("production_slo_window", "production read SLO must hold continuously for 30 minutes")
+		}
+	}
+	if phase == PhaseUIDefault && !snapshot.ReadCutoverApproved {
+		block("read_cutover_not_approved", "lifecycle UI default requires approved read cutover")
+	}
+	return finalize(decision), nil
+}
+
+func invalidSnapshotCounts(snapshot Snapshot) bool {
+	values := []int{
+		snapshot.IntegrityViolations, snapshot.AutomaticFixedPartialUnknown, snapshot.ComparableItems, snapshot.SemanticMismatches,
+		snapshot.ProducerItems, snapshot.ReviewCandidates, snapshot.SevenDayReviewCandidateBaselineBPS, snapshot.APIRequests,
+		snapshot.APIErrors, snapshot.APIWindowMinutes, snapshot.LatencyWindowMinutes, snapshot.CycleListP95Millis,
+		snapshot.CycleDetailP95Millis, snapshot.ComparisonPageP95Millis, snapshot.ProductionSLOContinuousMinutes,
+		snapshot.ComparisonBacklog, snapshot.OldestComparisonAgeSeconds, snapshot.Comparison100KDurationSeconds,
+		snapshot.DeadLetterGrowth10Minutes, snapshot.SuccessfulRepairs10Minutes,
+	}
+	for _, value := range values {
+		if value < 0 {
+			return true
+		}
+	}
+	return snapshot.SemanticMismatches > snapshot.ComparableItems || snapshot.ReviewCandidates > snapshot.ProducerItems || snapshot.APIErrors > snapshot.APIRequests || snapshot.SevenDayReviewCandidateBaselineBPS > 10000
+}
+
+func finalize(decision Decision) Decision {
+	sort.Slice(decision.Blockers, func(left, right int) bool { return decision.Blockers[left].Code < decision.Blockers[right].Code })
+	sort.Slice(decision.Warnings, func(left, right int) bool { return decision.Warnings[left].Code < decision.Warnings[right].Code })
+	decision.Allowed = len(decision.Blockers) == 0
+	return decision
+}

--- a/internal/usecase/assessmentrollout/gate_test.go
+++ b/internal/usecase/assessmentrollout/gate_test.go
@@ -1,0 +1,64 @@
+package assessmentrollout
+
+import "testing"
+
+func TestEvaluateReadCutoverRequiresProductionSLOGate(t *testing.T) {
+	snapshot := passingSnapshot()
+	snapshot.CycleListP95Millis = 600
+	decision, err := Evaluate(PhaseReadCutover, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.Allowed || !hasFinding(decision.Blockers, "production_latency_slo") {
+		t.Fatalf("safety ceiling must not authorize cutover: %+v", decision)
+	}
+	snapshot.CycleListP95Millis = 500
+	decision, err = Evaluate(PhaseReadCutover, snapshot)
+	if err != nil || !decision.Allowed {
+		t.Fatalf("expected cutover approval, decision=%+v err=%v", decision, err)
+	}
+}
+
+func TestEvaluateCanaryAndRollbackAbortConditions(t *testing.T) {
+	snapshot := passingSnapshot()
+	snapshot.IntegrityViolations = 1
+	snapshot.ComparisonBacklog = 1001
+	snapshot.DeadLetterGrowth10Minutes = 1
+	decision, err := Evaluate(PhaseInternalCanary, snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, code := range []string{"integrity_violation", "comparison_backlog_hard_limit", "dead_letter_growth"} {
+		if !hasFinding(decision.Blockers, code) {
+			t.Fatalf("missing blocker %s in %+v", code, decision)
+		}
+	}
+	rollback := passingSnapshot()
+	rollback.LifecycleReadEnabled = false
+	rollback.LifecycleUIDefaultEnabled = false
+	rollback.SourceRowsPreserved = true
+	rollback.ImmutableArtifactsPreserved = true
+	rollback.RollbackDrillPassed = true
+	decision, err = Evaluate(PhaseRollbackDrill, rollback)
+	if err != nil || !decision.Allowed {
+		t.Fatalf("expected rollback drill approval, decision=%+v err=%v", decision, err)
+	}
+}
+
+func passingSnapshot() Snapshot {
+	return Snapshot{
+		TenantID: "tenant-a", ComparableItems: 1000, ProducerItems: 1000, APIRequests: 1000,
+		APIWindowMinutes: 15, LatencyWindowMinutes: 15, CycleListP95Millis: 500, CycleDetailP95Millis: 750,
+		ComparisonPageP95Millis: 750, ProductionSLOContinuousMinutes: 30, TargetCardinality: true,
+		Comparison100KDurationSeconds: 300, MetricsRecorded: true, ApprovalRecorded: true, ReadCutoverApproved: true,
+	}
+}
+
+func hasFinding(findings []Finding, code string) bool {
+	for _, finding := range findings {
+		if finding.Code == code {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/usecase/businessassetuc/service.go
+++ b/internal/usecase/businessassetuc/service.go
@@ -27,6 +27,11 @@ type Service struct {
 	audit     ports.AuditLogger
 	clock     ports.Clock
 	ids       ports.IDGenerator
+	cycles    ports.AssessmentCycleRepository
+}
+
+func (s *Service) SetAssessmentCycleReader(cycles ports.AssessmentCycleRepository) {
+	s.cycles = cycles
 }
 
 func NewService(repo ports.BusinessAssetRepository, findings ports.FindingRepository, imported ports.ImportedFindingStore, judgments ports.JudgmentStore, retests ports.RetestRepository, audit ports.AuditLogger, clock ports.Clock, ids ports.IDGenerator) (*Service, error) {
@@ -198,6 +203,13 @@ func (s *Service) TechnicalAssets(ctx context.Context, tenantID, id shared.ID) (
 
 func (s *Service) AssignEngagement(ctx context.Context, tenantID, engagementID, assetID shared.ID, actor string) error {
 	tenantID = shared.TenantOrDefault(tenantID)
+	if s.cycles != nil {
+		if _, err := s.cycles.GetCycleByAssessment(ctx, tenantID, engagementID); err == nil {
+			return fmt.Errorf("%w: an Assessment Cycle freezes its Business Asset boundary", shared.ErrConflict)
+		} else if !errors.Is(err, shared.ErrNotFound) {
+			return err
+		}
+	}
 	if !assetID.IsZero() {
 		a, err := s.resolveAsset(ctx, tenantID, assetID)
 		if err != nil {

--- a/internal/usecase/businessassetuc/service_test.go
+++ b/internal/usecase/businessassetuc/service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/asset"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
@@ -108,6 +109,50 @@ func TestCoverageAndRetiredAssignment(t *testing.T) {
 	}
 	if err := service.AssignEngagement(ctx, "t1", e.ID, updated.ID, "alice"); !errors.Is(err, shared.ErrValidation) {
 		t.Fatalf("retired assignment error=%v", err)
+	}
+}
+
+func TestAssignEngagementRejectsFrozenAssessmentCycleBoundary(t *testing.T) {
+	service, _, engagements, _, _, _, clock := newBusinessAssetService(t)
+	ctx := context.Background()
+	first, err := service.Create(ctx, CreateInput{TenantID: "t1", Key: "first", Name: "First", Type: asset.BusinessAssetApplication, Criticality: asset.CriticalityHigh, Owner: "team", Actor: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := service.Create(ctx, CreateInput{TenantID: "t1", Key: "second", Name: "Second", Type: asset.BusinessAssetApplication, Criticality: asset.CriticalityHigh, Owner: "team", Actor: "alice"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assessment, err := engagement.New("assessment-frozen", "t1", "Frozen", "", clock.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assessment.BusinessAssetID = first.ID
+	if err := engagements.Create(ctx, assessment); err != nil {
+		t.Fatal(err)
+	}
+	cycles := memory.NewAssessmentCycleRepository()
+	cycle, err := assessmentcycle.NewAssessmentCycle("cycle-frozen", "t1", "Frozen", assessmentcycle.BoundaryAsset, first.ID, "", assessment.ID, "alice", clock.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	member, err := assessmentcycle.NewInitialMember("t1", cycle.ID, assessment.ID, "alice", clock.now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateCycle(ctx, cycle); err != nil {
+		t.Fatal(err)
+	}
+	if err := cycles.CreateMember(ctx, member); err != nil {
+		t.Fatal(err)
+	}
+	service.SetAssessmentCycleReader(cycles)
+	if err := service.AssignEngagement(ctx, "t1", assessment.ID, second.ID, "alice"); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("frozen boundary reassignment=%v", err)
+	}
+	stored, err := engagements.GetByIDInTenant(ctx, "t1", assessment.ID)
+	if err != nil || stored.BusinessAssetID != first.ID {
+		t.Fatalf("frozen boundary changed: assessment=%+v err=%v", stored, err)
 	}
 }
 

--- a/internal/usecase/execution/guard.go
+++ b/internal/usecase/execution/guard.go
@@ -50,7 +50,11 @@ func (g *Guard) Authorize(ctx context.Context, req Request) (time.Time, error) {
 	}
 	now := g.clock.Now()
 	if !eng.AllowsExecution() {
-		g.auditDenied(ctx, req, now, "engagement_inactive")
+		reason := "engagement_inactive"
+		if eng.RequiresExplicitExecutionAuthorization && eng.Status != engagement.StatusCompleted && eng.Status != engagement.StatusArchived {
+			reason = "explicit_authorization_required"
+		}
+		g.auditDenied(ctx, req, now, reason)
 		return time.Time{}, fmt.Errorf("%w: engagement %s is not in an executable state", shared.ErrForbidden, req.EngagementID)
 	}
 	if !eng.IsAuthorizedAt(now) {
@@ -90,7 +94,11 @@ func (g *Guard) AuthorizeEngagementArtifact(ctx context.Context, req Request) (t
 	}
 	now := g.clock.Now()
 	if !eng.AllowsExecution() {
-		g.auditDenied(ctx, req, now, "engagement_inactive")
+		reason := "engagement_inactive"
+		if eng.RequiresExplicitExecutionAuthorization && eng.Status != engagement.StatusCompleted && eng.Status != engagement.StatusArchived {
+			reason = "explicit_authorization_required"
+		}
+		g.auditDenied(ctx, req, now, reason)
 		return time.Time{}, fmt.Errorf("%w: engagement %s is not in an executable state", shared.ErrForbidden, req.EngagementID)
 	}
 	if !eng.IsAuthorizedAt(now) {

--- a/internal/usecase/execution/guard_test.go
+++ b/internal/usecase/execution/guard_test.go
@@ -172,6 +172,22 @@ func TestAuthorizeDeniesTerminalEngagement(t *testing.T) {
 	}
 }
 
+func TestAuthorizeDeniesRetestWithoutExplicitAuthorization(t *testing.T) {
+	now := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	audit := &fakeAudit{}
+	eng := engAt(now, false)
+	eng.RequiresExplicitExecutionAuthorization = true
+	eng.RoE = engagement.RoE{}
+	guard, _ := NewGuard(&fakeEngRepo{eng: eng}, fakeClock{now}, audit)
+
+	if _, err := guard.Authorize(context.Background(), newReq("app.acme.io")); !errors.Is(err, shared.ErrForbidden) {
+		t.Fatalf("Re-test without explicit RoE must be forbidden, got %v", err)
+	}
+	if got := audit.entries[len(audit.entries)-1].Metadata["reason"]; got != "explicit_authorization_required" {
+		t.Fatalf("deny reason = %q, want explicit_authorization_required", got)
+	}
+}
+
 func TestAuthorizeRoEDenies(t *testing.T) {
 	now := time.Date(2026, 6, 21, 12, 0, 0, 0, time.UTC)
 	// In-window, in-scope, active – but RoE blocks the recon tool class.

--- a/internal/usecase/exploitation/service.go
+++ b/internal/usecase/exploitation/service.go
@@ -49,12 +49,20 @@ type evidenceSealer interface {
 
 // Service runs the evidence-gated exploitation-finding lifecycle.
 type Service struct {
-	findings   FindingStore
-	evidence   evidenceSealer
-	audit      ports.AuditLogger
-	clock      ports.Clock
-	ids        ports.IDGenerator
-	attributor ports.FindingAttributor
+	findings    FindingStore
+	evidence    evidenceSealer
+	audit       ports.AuditLogger
+	clock       ports.Clock
+	ids         ports.IDGenerator
+	attributor  ports.FindingAttributor
+	shadowTx    ports.TenantTransactionRunner
+	shadow      CreatedFindingProjector
+	shadowOn    func(string) bool
+	engagements ports.EngagementTenantResolver
+}
+
+type CreatedFindingProjector interface {
+	ProjectCreatedFinding(context.Context, shared.ID, finding.Finding, string) error
 }
 
 // NewService validates its dependencies (all required; the evidence sealer is mandatory
@@ -69,6 +77,16 @@ func NewService(findings FindingStore, ev evidenceSealer, audit ports.AuditLogge
 // SetAttributor wires explicit producer-owned bindings; nil preserves deployments without fleet assets.
 func (s *Service) SetAttributor(a ports.FindingAttributor) { s.attributor = a }
 
+// SetLifecycleShadow makes a newly proposed offensive Finding, its attribution,
+// audit entry, and native lineage projection one tenant-local transaction.
+func (s *Service) SetLifecycleShadow(tx ports.TenantTransactionRunner, projector CreatedFindingProjector, enabled func(string) bool, engagements ports.EngagementTenantResolver) error {
+	if tx == nil || projector == nil || enabled == nil || engagements == nil {
+		return fmt.Errorf("%w: exploitation lifecycle shadow dependencies are required", shared.ErrValidation)
+	}
+	s.shadowTx, s.shadow, s.shadowOn, s.engagements = tx, projector, enabled, engagements
+	return nil
+}
+
 // Propose creates an AI/exploitation finding at EvidenceScore 0. proposer is the actor that
 // proposed it (an agent session – attribution only; it confers no power to confirm).
 func (s *Service) Propose(ctx context.Context, proposer string, engagementID shared.ID, in finding.ExploitationInput) (finding.Finding, error) {
@@ -81,27 +99,36 @@ func (s *Service) Propose(ctx context.Context, proposer string, engagementID sha
 	if err := s.validateExplicitAsset(ctx, engagementID, in.AssetID); err != nil {
 		return finding.Finding{}, err
 	}
-	f, err := s.findOrCreate(ctx, engagementID, exploitationKey(proposer, engagementID, in), func(id shared.ID) (finding.Finding, error) {
-		f, err := finding.NewExploitation(id, engagementID, in, proposer, s.clock.Now())
-		f.DedupKey = exploitationKey(proposer, engagementID, in)
-		return f, err
+	var f finding.Finding
+	err := s.withCreationBoundary(ctx, engagementID, func(writeCtx context.Context, tenantID shared.ID, project bool) error {
+		var created bool
+		var err error
+		f, created, err = s.findOrCreate(writeCtx, engagementID, exploitationKey(proposer, engagementID, in), func(id shared.ID) (finding.Finding, error) {
+			f, err := finding.NewExploitation(id, engagementID, in, proposer, s.clock.Now())
+			f.DedupKey = exploitationKey(proposer, engagementID, in)
+			return f, err
+		})
+		if err != nil {
+			return err
+		}
+		if err := s.recordAttribution(writeCtx, engagementID, in.AssetID, shared.ID("exploitation:"+f.ID.String()), f.ID); err != nil {
+			return &ports.PartialWriteError{Operation: "exploitation finding", IDs: []shared.ID{f.ID}, Err: err}
+		}
+		if err := s.audit.Record(writeCtx, ports.AuditEntry{
+			Actor:    proposer,
+			Action:   "finding.proposed",
+			Target:   f.ID.String(),
+			Metadata: map[string]string{"engagement": engagementID.String(), "kind": string(f.Kind), "severity": string(f.Severity)},
+			At:       s.clock.Now(),
+		}); err != nil {
+			return fmt.Errorf("audit proposal: %w", err)
+		}
+		if created && project {
+			return s.shadow.ProjectCreatedFinding(writeCtx, tenantID, f, proposer)
+		}
+		return nil
 	})
-	if err != nil {
-		return f, err
-	}
-	if err := s.recordAttribution(ctx, engagementID, in.AssetID, shared.ID("exploitation:"+f.ID.String()), f.ID); err != nil {
-		return f, &ports.PartialWriteError{Operation: "exploitation finding", IDs: []shared.ID{f.ID}, Err: err}
-	}
-	if err := s.audit.Record(ctx, ports.AuditEntry{
-		Actor:    proposer,
-		Action:   "finding.proposed",
-		Target:   f.ID.String(),
-		Metadata: map[string]string{"engagement": engagementID.String(), "kind": string(f.Kind), "severity": string(f.Severity)},
-		At:       s.clock.Now(),
-	}); err != nil {
-		return finding.Finding{}, fmt.Errorf("audit proposal: %w", err)
-	}
-	return f, nil
+	return f, err
 }
 
 // ProposeHypothesis creates an AI attack-chain hypothesis finding (Kind=hypothesis) at EvidenceScore
@@ -122,7 +149,7 @@ func (s *Service) ProposeHypothesis(ctx context.Context, proposer string, engage
 	if err != nil {
 		return finding.Finding{}, err
 	}
-	f, err := s.findOrCreate(ctx, engagementID, hypothesisKey(in), func(id shared.ID) (finding.Finding, error) {
+	f, _, err := s.findOrCreate(ctx, engagementID, hypothesisKey(in), func(id shared.ID) (finding.Finding, error) {
 		return finding.NewHypothesis(id, engagementID, in, proposer, s.clock.Now())
 	})
 	if err != nil {
@@ -143,33 +170,50 @@ func (s *Service) ProposeHypothesis(ctx context.Context, proposer string, engage
 	return f, nil
 }
 
-func (s *Service) findOrCreate(ctx context.Context, engagementID shared.ID, key string, create func(shared.ID) (finding.Finding, error)) (finding.Finding, error) {
+func (s *Service) findOrCreate(ctx context.Context, engagementID shared.ID, key string, create func(shared.ID) (finding.Finding, error)) (finding.Finding, bool, error) {
 	all, err := s.findings.ListByEngagement(ctx, engagementID)
 	if err != nil {
-		return finding.Finding{}, fmt.Errorf("list findings: %w", err)
+		return finding.Finding{}, false, fmt.Errorf("list findings: %w", err)
 	}
 	for _, f := range all {
 		if f.DedupKey == key {
-			return f, nil
+			return f, false, nil
 		}
 	}
 	f, err := create(s.ids.NewID())
 	if err != nil {
-		return finding.Finding{}, err
+		return finding.Finding{}, false, err
 	}
 	if err := s.findings.Upsert(ctx, []finding.Finding{f}); err != nil {
-		return f, fmt.Errorf("persist finding: %w", err)
+		return f, false, fmt.Errorf("persist finding: %w", err)
 	}
 	all, err = s.findings.ListByEngagement(ctx, engagementID)
 	if err != nil {
-		return f, fmt.Errorf("list persisted findings: %w", err)
+		return f, false, fmt.Errorf("list persisted findings: %w", err)
 	}
 	for _, stored := range all {
 		if stored.DedupKey == key {
-			return stored, nil
+			return stored, true, nil
 		}
 	}
-	return f, nil
+	return f, true, nil
+}
+
+func (s *Service) withCreationBoundary(ctx context.Context, engagementID shared.ID, write func(context.Context, shared.ID, bool) error) error {
+	if s.shadowTx == nil || s.shadow == nil || s.shadowOn == nil || s.engagements == nil {
+		return write(ctx, "", false)
+	}
+	engagement, err := s.engagements.GetByID(ctx, engagementID)
+	if err != nil {
+		return err
+	}
+	tenantID := shared.TenantOrDefault(engagement.TenantID)
+	if !s.shadowOn(tenantID.String()) {
+		return write(ctx, tenantID, false)
+	}
+	return s.shadowTx.Run(ctx, tenantID, func(txCtx context.Context) error {
+		return write(txCtx, tenantID, true)
+	})
 }
 
 func exploitationKey(proposer string, engagementID shared.ID, in finding.ExploitationInput) string {

--- a/internal/usecase/exploitation/service_test.go
+++ b/internal/usecase/exploitation/service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	evdom "github.com/KKloudTarus/synapse-ce/internal/domain/evidence"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -56,6 +57,18 @@ type seqIDs struct{ n int }
 
 func (g *seqIDs) NewID() shared.ID { g.n++; return shared.ID("f-" + strconv.Itoa(g.n)) }
 
+type captureFindingProjector struct {
+	calls    int
+	tenantID shared.ID
+	item     finding.Finding
+}
+
+func (projector *captureFindingProjector) ProjectCreatedFinding(_ context.Context, tenantID shared.ID, item finding.Finding, _ string) error {
+	projector.calls++
+	projector.tenantID, projector.item = tenantID, item
+	return nil
+}
+
 func newSvc(t *testing.T) (*Service, *memory.FindingRepository, *fakeSealer, *capAudit) {
 	t.Helper()
 	repo := memory.NewFindingRepository()
@@ -99,6 +112,37 @@ func TestProposeStartsUnproven(t *testing.T) {
 	}
 	if !audit.has("finding.proposed") {
 		t.Error("proposal must be audited")
+	}
+}
+
+func TestProposeProjectsOffensiveFindingOnceForShadowTenant(t *testing.T) {
+	svc, _, _, _ := newSvc(t)
+	engagements := memory.NewEngagementRepository()
+	item, err := engagement.New("eng-1", "tenant-a", "Assessment", "", time.Unix(1_000_000, 0).UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(context.Background(), item); err != nil {
+		t.Fatal(err)
+	}
+	projector := &captureFindingProjector{}
+	if err := svc.SetLifecycleShadow(memory.NewTenantTransactionRunner(), projector, func(tenant string) bool { return tenant == "tenant-a" }, engagements); err != nil {
+		t.Fatal(err)
+	}
+	input := finding.ExploitationInput{Title: "RCE", Severity: shared.SeverityCritical}
+	first, err := svc.Propose(context.Background(), "agent:s1", "eng-1", input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if projector.calls != 1 || projector.tenantID != "tenant-a" || projector.item.ID != first.ID || projector.item.Kind != finding.KindExploitation {
+		t.Fatalf("offensive projection=%+v calls=%d tenant=%s", projector.item, projector.calls, projector.tenantID)
+	}
+	second, err := svc.Propose(context.Background(), "agent:s1", "eng-1", input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.ID != first.ID || projector.calls != 1 {
+		t.Fatalf("replay finding=%s want=%s projection calls=%d", second.ID, first.ID, projector.calls)
 	}
 }
 

--- a/internal/usecase/findings/attribution_test.go
+++ b/internal/usecase/findings/attribution_test.go
@@ -74,6 +74,40 @@ func TestCreateAttributedRetryUsesCanonicalFinding(t *testing.T) {
 	}
 }
 
+func TestCreateAttributedReportsPartialWriteOutsideShadowTransaction(t *testing.T) {
+	repo := &fakeRepo{}
+	svc := newSvc(repo, &fakeComments{}, &fakeAudit{})
+	svc.SetAttributor(&projectionAttributor{asset: "asset-1", recordErr: errors.New("attribution unavailable")})
+	created, err := svc.CreateAttributed(context.Background(), "human:alice", "eng-1", "asset-1", finding.ManualInput{Title: "manual"})
+	var partial *ports.PartialWriteError
+	if !errors.As(err, &partial) || len(partial.IDs) != 1 || partial.IDs[0] != created.ID || len(repo.upserted) != 1 {
+		t.Fatalf("created=%+v partial=%+v err=%v upserts=%d", created, partial, err, len(repo.upserted))
+	}
+}
+
+func TestCreateAttributedDedupReplayDoesNotReproject(t *testing.T) {
+	repository := &fakeRepo{}
+	projector := &lifecycleProjector{}
+	service := newSvc(repository, &fakeComments{}, &fakeAudit{})
+	service.SetAttributor(&projectionAttributor{asset: "asset-1"})
+	service.SetEngagementTenantResolver(lifecycleEngagementResolver{tenantID: "tenant"})
+	if err := service.SetLifecycleShadow(rollbackFindingTransaction{repository: repository}, projector, func(string) bool { return true }); err != nil {
+		t.Fatal(err)
+	}
+	input := finding.ManualInput{Title: "manual", Severity: shared.SeverityHigh}
+	first, err := service.CreateAttributed(context.Background(), "human:alice", "eng-1", "asset-1", input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replayed, err := service.CreateAttributed(context.Background(), "human:alice", "eng-1", "asset-1", input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ID != replayed.ID || projector.calls != 1 || len(repository.upserted) != 1 {
+		t.Fatalf("first=%s replay=%s projection calls=%d upserts=%d", first.ID, replayed.ID, projector.calls, len(repository.upserted))
+	}
+}
+
 func TestVerifiedProjectionRetryUsesCanonicalFinding(t *testing.T) {
 	ctx := context.Background()
 	for _, tc := range []struct {

--- a/internal/usecase/findings/service.go
+++ b/internal/usecase/findings/service.go
@@ -36,6 +36,13 @@ type Service struct {
 	clock       ports.Clock
 	ids         ports.IDGenerator
 	attributor  ports.FindingAttributor
+	shadowTx    ports.TenantTransactionRunner
+	shadow      CreatedFindingProjector
+	shadowOn    func(string) bool
+}
+
+type CreatedFindingProjector interface {
+	ProjectCreatedFinding(context.Context, shared.ID, finding.Finding, string) error
 }
 
 // NewService wires the findings workflow service.
@@ -50,6 +57,16 @@ func (s *Service) SetEngagementTenantResolver(r ports.EngagementTenantResolver) 
 // SetAttributor wires authoritative asset-to-finding bindings; nil preserves legacy internal callers.
 func (s *Service) SetAttributor(a ports.FindingAttributor) { s.attributor = a }
 
+// SetLifecycleShadow makes a newly-authored Finding, its audit/attribution, and
+// its shadow lineage Observation one tenant-local transaction.
+func (s *Service) SetLifecycleShadow(tx ports.TenantTransactionRunner, projector CreatedFindingProjector, enabled func(string) bool) error {
+	if tx == nil || projector == nil || enabled == nil || s.engagements == nil {
+		return fmt.Errorf("%w: finding lifecycle shadow dependencies are required", shared.ErrValidation)
+	}
+	s.shadowTx, s.shadow, s.shadowOn = tx, projector, enabled
+	return nil
+}
+
 // CreateAttributed requires an explicit asset for a new externally-authored finding.
 func (s *Service) CreateAttributed(ctx context.Context, actor string, engagementID, assetID shared.ID, in finding.ManualInput) (finding.Finding, error) {
 	if s.attributor == nil {
@@ -59,42 +76,59 @@ func (s *Service) CreateAttributed(ctx context.Context, actor string, engagement
 		return finding.Finding{}, err
 	}
 	key := attributedManualKey(actor, engagementID, assetID, in)
-	f, err := s.findByDedupKey(ctx, engagementID, key)
-	if err != nil {
-		return finding.Finding{}, err
-	}
-	created := f.ID.IsZero()
-	if created {
-		if v := strings.TrimSpace(in.CVSSVector); v != "" {
-			score, ok := shared.CVSSv3BaseScore(v)
-			if !ok {
-				return finding.Finding{}, fmt.Errorf("%w: invalid CVSS v3.1 vector", shared.ErrValidation)
-			}
-			in.Severity = shared.SeverityFromScore(score)
-		}
-		f, err = finding.NewManual(s.ids.NewID(), engagementID, in, s.clock.Now())
+	var f finding.Finding
+	err := s.withCreationBoundary(ctx, engagementID, func(writeCtx context.Context, tenantID shared.ID, project bool) error {
+		var err error
+		f, err = s.findByDedupKey(writeCtx, engagementID, key)
 		if err != nil {
-			return finding.Finding{}, err
+			return err
 		}
-		f.DedupKey = key
-		if err := s.repo.Upsert(ctx, []finding.Finding{f}); err != nil {
-			return f, fmt.Errorf("persist finding: %w", err)
+		created := f.ID.IsZero()
+		if created {
+			if v := strings.TrimSpace(in.CVSSVector); v != "" {
+				score, ok := shared.CVSSv3BaseScore(v)
+				if !ok {
+					return fmt.Errorf("%w: invalid CVSS v3.1 vector", shared.ErrValidation)
+				}
+				in.Severity = shared.SeverityFromScore(score)
+			}
+			f, err = finding.NewManual(s.ids.NewID(), engagementID, in, s.clock.Now())
+			if err != nil {
+				return err
+			}
+			f.DedupKey = key
+			if err := s.repo.Upsert(writeCtx, []finding.Finding{f}); err != nil {
+				return fmt.Errorf("persist finding: %w", err)
+			}
+			if stored, err := s.findByDedupKey(writeCtx, engagementID, key); err != nil {
+				return creationFollowupError(project, f.ID, err)
+			} else if !stored.ID.IsZero() {
+				f = stored
+			}
+			if err := s.record(writeCtx, actor, "finding.created", engagementID, f.ID, map[string]string{"severity": string(f.Severity), "kind": string(f.Kind)}); err != nil {
+				return creationFollowupError(project, f.ID, err)
+			}
 		}
-		if stored, err := s.findByDedupKey(ctx, engagementID, key); err != nil {
-			return f, err
-		} else if !stored.ID.IsZero() {
-			f = stored
+		if err := s.attributor.Record(writeCtx, engagementID, assetID, "manual:"+f.ID, "manual:"+f.ID, asset.EdgeObserved, []shared.ID{f.ID}); err != nil {
+			err = fmt.Errorf("record finding attribution: %w", err)
+			if created {
+				return creationFollowupError(project, f.ID, err)
+			}
+			return err
 		}
+		if created && project {
+			return s.shadow.ProjectCreatedFinding(writeCtx, tenantID, f, actor)
+		}
+		return nil
+	})
+	return f, err
+}
+
+func creationFollowupError(transactional bool, findingID shared.ID, err error) error {
+	if err == nil || transactional {
+		return err
 	}
-	if created {
-		if err := s.record(ctx, actor, "finding.created", engagementID, f.ID, map[string]string{"severity": string(f.Severity), "kind": string(f.Kind)}); err != nil {
-			return f, &ports.PartialWriteError{Operation: "manual finding", IDs: []shared.ID{f.ID}, Err: err}
-		}
-	}
-	if err := s.attributor.Record(ctx, engagementID, assetID, "manual:"+f.ID, "manual:"+f.ID, asset.EdgeObserved, []shared.ID{f.ID}); err != nil {
-		return f, &ports.PartialWriteError{Operation: "manual finding", IDs: []shared.ID{f.ID}, Err: fmt.Errorf("record finding attribution: %w", err)}
-	}
-	return f, nil
+	return &ports.PartialWriteError{Operation: "manual finding", IDs: []shared.ID{findingID}, Err: err}
 }
 
 func attributedManualKey(actor string, engagementID, assetID shared.ID, in finding.ManualInput) string {
@@ -403,19 +437,43 @@ func (s *Service) Create(ctx context.Context, actor string, engagementID shared.
 		}
 		in.Severity = shared.SeverityFromScore(score)
 	}
-	now := s.clock.Now()
-	f, err := finding.NewManual(s.ids.NewID(), engagementID, in, now)
+	var f finding.Finding
+	err := s.withCreationBoundary(ctx, engagementID, func(writeCtx context.Context, tenantID shared.ID, project bool) error {
+		var err error
+		f, err = finding.NewManual(s.ids.NewID(), engagementID, in, s.clock.Now())
+		if err != nil {
+			return err
+		}
+		if err := s.repo.Upsert(writeCtx, []finding.Finding{f}); err != nil {
+			return fmt.Errorf("persist finding: %w", err)
+		}
+		if err := s.record(writeCtx, actor, "finding.created", engagementID, f.ID,
+			map[string]string{"severity": string(f.Severity), "kind": string(f.Kind)}); err != nil {
+			return err
+		}
+		if project {
+			return s.shadow.ProjectCreatedFinding(writeCtx, tenantID, f, actor)
+		}
+		return nil
+	})
+	return f, err
+}
+
+func (s *Service) withCreationBoundary(ctx context.Context, engagementID shared.ID, write func(context.Context, shared.ID, bool) error) error {
+	if s.shadowTx == nil || s.shadow == nil || s.shadowOn == nil {
+		return write(ctx, "", false)
+	}
+	engagement, err := s.engagements.GetByID(ctx, engagementID)
 	if err != nil {
-		return finding.Finding{}, err
+		return err
 	}
-	if err := s.repo.Upsert(ctx, []finding.Finding{f}); err != nil {
-		return finding.Finding{}, fmt.Errorf("persist finding: %w", err)
+	tenantID := shared.TenantOrDefault(engagement.TenantID)
+	if !s.shadowOn(tenantID.String()) {
+		return write(ctx, tenantID, false)
 	}
-	if err := s.record(ctx, actor, "finding.created", engagementID, f.ID,
-		map[string]string{"severity": string(f.Severity), "kind": string(f.Kind)}); err != nil {
-		return finding.Finding{}, err
-	}
-	return f, nil
+	return s.shadowTx.Run(ctx, tenantID, func(txCtx context.Context) error {
+		return write(txCtx, tenantID, true)
+	})
 }
 
 // UpdateStatus validates and applies a triage status change with optimistic

--- a/internal/usecase/findings/service_test.go
+++ b/internal/usecase/findings/service_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
@@ -112,8 +113,71 @@ func (g *fakeIDs) NewID() shared.ID {
 	return shared.ID("id-" + strconv.Itoa(g.n))
 }
 
+type lifecycleEngagementResolver struct{ tenantID shared.ID }
+
+func (resolver lifecycleEngagementResolver) GetByID(context.Context, shared.ID) (*engagement.Engagement, error) {
+	return &engagement.Engagement{TenantID: resolver.tenantID}, nil
+}
+
+type lifecycleProjector struct {
+	calls int
+	err   error
+}
+
+func (projector *lifecycleProjector) ProjectCreatedFinding(context.Context, shared.ID, finding.Finding, string) error {
+	projector.calls++
+	return projector.err
+}
+
+type rollbackFindingTransaction struct{ repository *fakeRepo }
+
+func (transaction rollbackFindingTransaction) Run(ctx context.Context, _ shared.ID, write func(context.Context) error) error {
+	upserted := append([]finding.Finding(nil), transaction.repository.upserted...)
+	listed := append([]finding.Finding(nil), transaction.repository.list...)
+	if err := write(ctx); err != nil {
+		transaction.repository.upserted = upserted
+		transaction.repository.list = listed
+		return err
+	}
+	return nil
+}
+
 func newSvc(repo ports.FindingRepository, comments ports.CommentRepository, audit ports.AuditLogger) *Service {
 	return NewService(repo, comments, &fakeRetests{}, audit, fixedClock{t: testNow}, &fakeIDs{})
+}
+
+func TestFindingLifecycleShadowHonorsAllowlistAndRollsBackProjectionFailure(t *testing.T) {
+	t.Run("disabled tenant skips projection", func(t *testing.T) {
+		repository := &fakeRepo{}
+		projector := &lifecycleProjector{}
+		service := newSvc(repository, &fakeComments{}, &fakeAudit{})
+		service.SetEngagementTenantResolver(lifecycleEngagementResolver{tenantID: "tenant"})
+		if err := service.SetLifecycleShadow(rollbackFindingTransaction{repository: repository}, projector, func(string) bool { return false }); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := service.Create(context.Background(), "actor", "assessment", finding.ManualInput{Title: "manual", Severity: shared.SeverityHigh}); err != nil {
+			t.Fatal(err)
+		}
+		if projector.calls != 0 || len(repository.upserted) != 1 {
+			t.Fatalf("projection calls=%d persisted=%d", projector.calls, len(repository.upserted))
+		}
+	})
+
+	t.Run("projection failure rolls back finding", func(t *testing.T) {
+		repository := &fakeRepo{}
+		projector := &lifecycleProjector{err: errors.New("projection unavailable")}
+		service := newSvc(repository, &fakeComments{}, &fakeAudit{})
+		service.SetEngagementTenantResolver(lifecycleEngagementResolver{tenantID: "tenant"})
+		if err := service.SetLifecycleShadow(rollbackFindingTransaction{repository: repository}, projector, func(string) bool { return true }); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := service.Create(context.Background(), "actor", "assessment", finding.ManualInput{Title: "manual", Severity: shared.SeverityHigh}); err == nil {
+			t.Fatal("projection failure was ignored")
+		}
+		if projector.calls != 1 || len(repository.upserted) != 0 || len(repository.list) != 0 {
+			t.Fatalf("projection calls=%d persisted=%d listed=%d", projector.calls, len(repository.upserted), len(repository.list))
+		}
+	})
 }
 
 func TestRecordRetest(t *testing.T) {

--- a/internal/usecase/sca/assessment_evidence_test.go
+++ b/internal/usecase/sca/assessment_evidence_test.go
@@ -1,0 +1,193 @@
+package sca
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	cmpdom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	linedom "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	comparisonuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcomparison"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type nativeEvidenceAudit struct{ err error }
+
+func (a *nativeEvidenceAudit) Record(context.Context, ports.AuditEntry) error { return a.err }
+
+func TestNativeAssessmentEvidenceUsesFrozenRunNotMutableFindings(t *testing.T) {
+	ctx := shared.WithTenant(context.Background(), "native-tenant")
+	now := time.Date(2026, 9, 7, 12, 0, 0, 0, time.UTC)
+	clock := fakeClock{t: now.Add(time.Minute)}
+	tx := memory.NewTenantTransactionRunner()
+	engagements := memory.NewEngagementRepository()
+	assessment, _ := engdom.New("assessment", "native-tenant", "Native scan", "", now)
+	if err := engagements.Create(ctx, assessment); err != nil {
+		t.Fatal(err)
+	}
+	cycles := memory.NewAssessmentCycleRepository()
+	audit := &nativeEvidenceAudit{}
+	cycleService, err := cycleuc.NewService(cycles, engagements, nil, nil, tx, idgen.RandomID{}, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cycle, _, err := cycleService.CreateInitialCycle(ctx, cycleuc.CreateInitialCycleInput{TenantID: assessment.TenantID, RootAssessmentID: assessment.ID, Name: "Native cycle", BoundaryKind: cycledom.BoundaryStandalone, Actor: "tester"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	runs := memory.NewScanRunStore()
+	service := &Service{engagements: engagements, runs: runs, runProvenance: runs, scanRunTransactions: tx, clock: clock, audit: audit}
+	v := vulnerability.Vulnerability{ID: "CVE-2026-1234", Component: "example", Version: "1.0.0", Ecosystem: "npm", PackagePURL: "pkg:npm/example@1.0.0", Path: []string{"pkg:npm/root@1.0.0", "pkg:npm/example@1.0.0"}, Severity: shared.SeverityHigh}
+	item := finding.Finding{ID: "finding", EngagementID: assessment.ID, Kind: finding.KindSCA, Severity: shared.SeverityHigh, DedupKey: vulnDedupKey(v), Title: "secret text must not enter retained evidence", Audit: shared.Audit{CreatedAt: now}}
+	result := &ScanResult{Target: "https://github.com/example/repo", SourceCommit: strings.Repeat("a", 40), ScanMode: ScanModeVulnerabilities, Findings: []finding.Finding{item}, Vulnerabilities: []vulnerability.Vulnerability{v}, ReproDigest: strings.Repeat("b", 64), Completeness: ports.Completeness{Confident: true}, Manifest: ports.ScanManifest{ToolVersions: map[string]string{"scanner": "1.0"}}}
+	runID, err := service.persistAssessmentScanRun(ctx, assessment.ID, "native-run", now, ports.AcquireRequest{Value: result.Target}, result, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	evidence, err := runs.GetScanRunEvidence(ctx, assessment.TenantID, runID.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(evidence.Payload), item.Title) {
+		t.Fatal("raw finding text leaked into comparison evidence")
+	}
+	var retained lineageuc.NativeEvidence
+	if err := json.Unmarshal(evidence.Payload, &retained); err != nil {
+		t.Fatal(err)
+	}
+	if len(retained.Records) != 1 {
+		t.Fatalf("retained %d observations", len(retained.Records))
+	}
+	fingerprint, err := linedom.CanonicalizeFingerprintV1(retained.Records[0].FingerprintInput)
+	if err != nil || fingerprint.Fingerprint == "" {
+		t.Fatalf("retained fingerprint invalid: %v", err)
+	}
+	findings := memory.NewFindingRepository()
+	item.Severity = shared.SeverityLow
+	if err := findings.Upsert(ctx, []finding.Finding{item}); err != nil {
+		t.Fatal(err)
+	}
+	snapshots := memory.NewAssessmentSnapshotRepository()
+	lineageStore := memory.NewFindingLineageRepository()
+	lineage, err := lineageuc.NewService(lineageStore, tx, audit, clock, idgen.RandomID{}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	projector, err := lineageuc.NewShadowProjector(lineage, cycles, snapshots, findings, func(string) bool { return true })
+	if err != nil {
+		t.Fatal(err)
+	}
+	projector.SetNativeEvidence(runs, runs)
+	finalizer, err := snapshotuc.NewService(snapshots, cycles, engagements, runs, tx, idgen.RandomID{}, clock, audit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	finalizer.SetFinalizationObserver(projector)
+	snapshot, _, err := finalizer.Finalize(ctx, snapshotuc.FinalizeInput{TenantID: assessment.TenantID, CycleID: cycle.ID, AssessmentID: assessment.ID, SelectedRunIDs: []string{runID.String()}, RequestKey: "snapshot", Actor: "tester"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	observations, err := lineageStore.ListObservationsBySnapshot(ctx, assessment.TenantID, cycle.ID, snapshot.ID)
+	if err != nil || len(observations) != 1 || observations[0].Severity != shared.SeverityHigh {
+		t.Fatalf("snapshot used mutable current rows: %+v err=%v", observations, err)
+	}
+	if observations[0].EvidenceDigest != evidence.ContentHash {
+		t.Fatal("observation not bound to sealed evidence")
+	}
+	if _, err := runs.GetScanRunEvidence(ctx, "other-tenant", runID.String()); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("cross tenant read=%v", err)
+	}
+
+	verification, err := comparisonuc.NewRetestVerificationReader(lineageStore, snapshots, memory.NewRetestRepository())
+	if err != nil {
+		t.Fatal(err)
+	}
+	comparison, err := comparisonuc.NewService(memory.NewAssessmentComparisonRepository(), snapshots, cycles, lineageStore, tx, audit, clock, idgen.RandomID{}, verification, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedVersion := int64(1)
+	for index, scenario := range []struct {
+		name      string
+		empty     bool
+		confident bool
+		want      cmpdom.Presence
+	}{
+		{"upgraded-version", false, true, cmpdom.PresenceDetected},
+		{"partial-empty", true, false, cmpdom.PresenceNotEvaluated},
+		{"complete-empty", true, true, cmpdom.PresenceNotDetected},
+	} {
+		t.Run(scenario.name, func(t *testing.T) {
+			nextClock := fakeClock{t: now.Add(time.Duration(index+3) * time.Minute)}
+			service.clock = nextClock
+			next := *result
+			next.Completeness = ports.Completeness{Confident: scenario.confident}
+			if scenario.empty {
+				next.Findings = nil
+				next.Vulnerabilities = nil
+			} else {
+				upgraded := v
+				upgraded.Version, upgraded.PackagePURL = "2.0.0", "pkg:npm/example@2.0.0"
+				upgraded.Path = []string{"pkg:npm/root@2.0.0", "pkg:npm/example@2.0.0"}
+				found := item
+				found.ID, found.DedupKey = "upgraded-finding", vulnDedupKey(upgraded)
+				next.Findings, next.Vulnerabilities = []finding.Finding{found}, []vulnerability.Vulnerability{upgraded}
+			}
+			nextID, err := service.persistAssessmentScanRun(ctx, assessment.ID, shared.ID(scenario.name), nextClock.t.Add(-time.Second), ports.AcquireRequest{Value: result.Target}, &next, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			finalizer, err := snapshotuc.NewService(snapshots, cycles, engagements, runs, tx, idgen.RandomID{}, nextClock, audit)
+			if err != nil {
+				t.Fatal(err)
+			}
+			finalizer.SetFinalizationObserver(projector)
+			current, _, err := finalizer.Finalize(ctx, snapshotuc.FinalizeInput{TenantID: assessment.TenantID, CycleID: cycle.ID, AssessmentID: assessment.ID, SelectedRunIDs: []string{nextID.String()}, RequestKey: scenario.name, ExpectedDefaultVersion: expectedVersion, Actor: "tester"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			expectedVersion++
+			captured, err := lineageStore.ListObservationsBySnapshot(ctx, assessment.TenantID, cycle.ID, current.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if scenario.empty && len(captured) != 0 {
+				t.Fatal("empty run copied previous evidence")
+			}
+			if !scenario.empty && (len(captured) != 1 || captured[0].IdentityID != observations[0].IdentityID || captured[0].ComponentVersion != "2.0.0") {
+				t.Fatalf("version upgrade forked identity: %+v", captured)
+			}
+			queued, _, decision, err := comparison.Queue(ctx, comparisonuc.QueueInput{TenantID: assessment.TenantID, BaselineSnapshotID: snapshot.ID, CurrentSnapshotID: current.ID, Mode: cmpdom.ModeLifecycle, FingerprintVersion: 1, RiskModelVersion: 1, Actor: "tester"})
+			if err != nil || !decision.Allowed {
+				t.Fatalf("queue decision=%+v err=%v", decision, err)
+			}
+			generated, err := comparison.Generate(ctx, comparisonuc.WorkInput{TenantID: assessment.TenantID, ComparisonID: queued.ID, Actor: "worker"})
+			if err != nil || len(generated.Items) != 1 || generated.Items[0].Presence != scenario.want {
+				t.Fatalf("presence=%+v err=%v", generated.Items, err)
+			}
+		})
+	}
+	audit.err = errors.New("audit unavailable")
+	if _, err := service.persistAssessmentScanRun(ctx, assessment.ID, "failed-run", now, ports.AcquireRequest{Value: result.Target}, result, ""); err == nil {
+		t.Fatal("audit failure ignored")
+	}
+	if _, err := runs.GetScanRun(ctx, assessment.TenantID, "failed-run"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("run survived transaction failure: %v", err)
+	}
+	if _, err := runs.GetScanRunEvidence(ctx, assessment.TenantID, "failed-run"); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("evidence survived transaction failure: %v", err)
+	}
+}

--- a/internal/usecase/sca/assessment_iac_scan_test.go
+++ b/internal/usecase/sca/assessment_iac_scan_test.go
@@ -1,0 +1,355 @@
+package sca
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	cmpdom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcomparison"
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	snapshotdom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	linedom "github.com/KKloudTarus/synapse-ce/internal/domain/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/tools/misconfig"
+	"github.com/KKloudTarus/synapse-ce/internal/platform/idgen"
+	comparisonuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcomparison"
+	cycleuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentcycle"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentlifecycle"
+	snapshotuc "github.com/KKloudTarus/synapse-ce/internal/usecase/assessmentsnapshot"
+	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// The fixtures are inert parser input, never deployed or executed. In particular,
+// the real IaC scanner uses New() without opting into Helm or any host command.
+func assessmentIaCWorkspace(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	files := map[string]string{
+		"Dockerfile":               "FROM alpine:latest\nUSER root\n",
+		"compose.yaml":             "services:\n  web:\n    image: nginx:latest\n    privileged: true\n",
+		".github/workflows/ci.yml": "name: ci\non: pull_request\npermissions: write-all\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n",
+		"azuredeploy.json": `{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [{"type":"Microsoft.Storage/storageAccounts","apiVersion":"2023-01-01","name":"fixturestore","location":"eastus","properties":{"allowBlobPublicAccess":true,"supportsHttpsTrafficOnly":false}}]
+}`,
+		"main.tf":             "resource \"aws_s3_bucket\" \"fixture\" {\n  acl = \"public-read\"\n}\n",
+		"cloudformation.yaml": "AWSTemplateFormatVersion: '2010-09-09'\nResources:\n  FixtureBucket:\n    Type: AWS::S3::Bucket\n    Properties:\n      AccessControl: PublicRead\n",
+		"pod.yaml":            "apiVersion: v1\nkind: Pod\nmetadata:\n  name: fixture\nspec:\n  containers:\n    - name: app\n      image: nginx:latest\n      securityContext:\n        privileged: true\n",
+	}
+	for name, content := range files {
+		path := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return root
+}
+
+type assessmentIaCAcquirer struct {
+	*fakeAcquirer
+	commit string
+}
+
+func (acquirer *assessmentIaCAcquirer) Acquire(ctx context.Context, request ports.AcquireRequest) (*ports.Workspace, error) {
+	workspace, err := acquirer.fakeAcquirer.Acquire(ctx, request)
+	if err == nil {
+		workspace.Commit = acquirer.commit
+	}
+	return workspace, err
+}
+
+func TestAssessmentIaCMixedScanPersistsAllFamiliesAndNeverInfersFixed(t *testing.T) {
+	for _, mode := range []string{"synchronous", "durable-job"} {
+		t.Run(mode, func(t *testing.T) {
+			ctx := shared.WithTenant(context.Background(), "iac-scan-tenant")
+			clock := &fakeClock{t: time.Date(2026, 9, 8, 12, 0, 0, 0, time.UTC)}
+			ids := idgen.RandomID{}
+			audit := &fakeAudit{}
+			transactions := memory.NewTenantTransactionRunner()
+			engagements := memory.NewEngagementRepository()
+			assessment, err := engdom.New("iac-assessment", "iac-scan-tenant", "Mixed IaC scan", "", clock.t)
+			if err != nil {
+				t.Fatal(err)
+			}
+			request := ports.AcquireRequest{Kind: ports.TargetGit, Value: "https://example.com/fixture/repository.git"}
+			assessment.Scope.InScope = []engdom.Target{{Kind: engdom.TargetRepo, Value: request.Value}}
+			if err := assessment.Transition(engdom.StatusActive, clock.t); err != nil {
+				t.Fatal(err)
+			}
+			if err := engagements.Create(ctx, assessment); err != nil {
+				t.Fatal(err)
+			}
+			cycles := memory.NewAssessmentCycleRepository()
+			cycleService, err := cycleuc.NewService(cycles, engagements, nil, nil, transactions, ids, clock, audit)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cycle, _, err := cycleService.CreateInitialCycle(ctx, cycleuc.CreateInitialCycleInput{TenantID: assessment.TenantID, RootAssessmentID: assessment.ID, Name: "Mixed IaC cycle", BoundaryKind: cycledom.BoundaryStandalone, Actor: "tester"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			findings := memory.NewFindingRepository()
+			runs := memory.NewScanRunStore()
+			results := memory.NewScanResultStore()
+			jobs := memory.NewScanJobStore()
+			evidenceService, err := evidenceuc.NewService(&fakeEvidence{}, nil, audit, clock, ids)
+			if err != nil {
+				t.Fatal(err)
+			}
+			acquirer := &assessmentIaCAcquirer{fakeAcquirer: &fakeAcquirer{dir: assessmentIaCWorkspace(t)}, commit: strings.Repeat("a", 40)}
+			scanner := misconfig.New()
+			rawIaC, err := scanner.ScanConfigs(ctx, acquirer.dir)
+			if err != nil || len(rawIaC) == 0 {
+				t.Fatalf("fixture scan: findings=%d err=%v", len(rawIaC), err)
+			}
+			scaFinding := vulnerability.RawFinding{Source: "static", AdvisoryID: "CVE-2026-1234", Component: "fixture-package", Version: "1.0.0", Ecosystem: "npm", PackagePURL: "pkg:npm/fixture-package@1.0.0", Severity: shared.SeverityHigh}
+			service := NewService(engagements, findings, memory.NewScanRepository(), results, jobs, runs, evidenceService, ids, ports.Provenance{}, clock, audit, shared.SeverityInfo, 0, acquirer, &fakeDetector{}, staticSBOM{doc: &sbom.SBOM{Components: []sbom.Component{{Name: scaFinding.Component, Version: scaFinding.Version, PURL: scaFinding.PackagePURL}}}}, []ports.DetectionSource{staticVuln{scaFinding}}, nil, fakeLic{}, nil)
+			service.SetMisconfigScanner(scanner)
+			service.SetScanRunProvenance(runs, transactions)
+			snapshots := memory.NewAssessmentSnapshotRepository()
+			lineageStore := memory.NewFindingLineageRepository()
+			lineage, err := lineageuc.NewService(lineageStore, transactions, audit, clock, ids, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			projector, err := lineageuc.NewShadowProjector(lineage, cycles, snapshots, findings, func(string) bool { return true })
+			if err != nil {
+				t.Fatal(err)
+			}
+			projector.SetNativeEvidence(runs, runs)
+			finalizer, err := snapshotuc.NewService(snapshots, cycles, engagements, runs, transactions, ids, clock, audit)
+			if err != nil {
+				t.Fatal(err)
+			}
+			finalizer.SetFinalizationObserver(projector)
+			verification, err := comparisonuc.NewRetestVerificationReader(lineageStore, snapshots, memory.NewRetestRepository())
+			if err != nil {
+				t.Fatal(err)
+			}
+			comparisons := memory.NewAssessmentComparisonRepository()
+			comparison, err := comparisonuc.NewService(comparisons, snapshots, cycles, lineageStore, transactions, audit, clock, ids, verification, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			coordinator, err := assessmentlifecycle.NewShadowCoordinator(cycles, snapshots, finalizer, comparison, func(string) bool { return true })
+			if err != nil {
+				t.Fatal(err)
+			}
+			service.SetScanRunObserver(coordinator)
+			queue := memory.NewJobQueue(ids, clock.Now)
+			if mode == "durable-job" {
+				service.SetQueue(queue)
+			}
+			runScan := func() *ScanResult {
+				t.Helper()
+				if mode == "synchronous" {
+					result, err := service.Scan(ctx, "tester", assessment.ID, request)
+					if err != nil {
+						t.Fatalf("mixed native Scan failed: %v", err)
+					}
+					return result
+				}
+				job, err := service.StartScan(ctx, "tester", assessment.ID, request)
+				if err != nil {
+					t.Fatal(err)
+				}
+				queued, err := queue.Claim(ctx, time.Minute, ScanJobKind)
+				if err != nil || queued == nil {
+					t.Fatalf("claim scan job: %+v err=%v", queued, err)
+				}
+				if err := service.RunScanJob(ctx, queued.Payload); err != nil {
+					t.Fatal(err)
+				}
+				terminal, err := jobs.GetJob(ctx, job.ID)
+				if err != nil || terminal.Status != ports.ScanSucceeded || terminal.Progress != 100 || terminal.Error != "" {
+					t.Fatalf("mixed native job must succeed, not merely reach 100%%: %+v err=%v", terminal, err)
+				}
+				if err := queue.Complete(ctx, queued.ID, queued.Fence); err != nil {
+					t.Fatal(err)
+				}
+				data, err := results.LatestResult(ctx, assessment.ID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				var result ScanResult
+				if err := json.Unmarshal(data, &result); err != nil {
+					t.Fatal(err)
+				}
+				return &result
+			}
+
+			result := runScan()
+			wantCount := len(rawIaC) + 1 // The unrelated SCA vulnerability must also survive.
+			if len(result.Findings) != wantCount || len(result.Vulnerabilities) != 1 {
+				t.Fatalf("pipeline lost derived findings: findings=%d want=%d vulnerabilities=%d", len(result.Findings), wantCount, len(result.Vulnerabilities))
+			}
+			storedFindings, err := findings.ListByEngagement(ctx, assessment.ID)
+			if err != nil || len(storedFindings) != wantCount {
+				t.Fatalf("persisted findings=%d want=%d err=%v", len(storedFindings), wantCount, err)
+			}
+			cached, err := results.LatestResult(ctx, assessment.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var cachedResult ScanResult
+			if err := json.Unmarshal(cached, &cachedResult); err != nil || len(cachedResult.Findings) != wantCount {
+				t.Fatalf("persisted scan result lost findings: count=%d err=%v", len(cachedResult.Findings), err)
+			}
+			baseline, _, err := snapshots.GetDefault(ctx, assessment.TenantID, assessment.ID)
+			if err != nil {
+				t.Fatalf("scan did not finalize its native snapshot: %v", err)
+			}
+			var runID string
+			for _, dimension := range baseline.Dimensions {
+				if dimension.Producer == "iac" {
+					if dimension.State != snapshotdom.CoveragePartial {
+						t.Fatalf("IaC positive findings incorrectly imply exhaustive coverage: %+v", dimension)
+					}
+					runID = dimension.RunID
+				}
+			}
+			if runID == "" {
+				t.Fatal("snapshot lost the IaC lane")
+			}
+			retainedRun, err := runs.GetScanRun(ctx, assessment.TenantID, runID)
+			if err != nil || retainedRun.Provenance != scanrun.ProvenanceNative || !retainedRun.IsSealed() {
+				t.Fatalf("native run is not sealed: %+v err=%v", retainedRun, err)
+			}
+			evidence, err := runs.GetScanRunEvidence(ctx, assessment.TenantID, runID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var native lineageuc.NativeEvidence
+			if err := json.Unmarshal(evidence.Payload, &native); err != nil || len(native.Records) != wantCount {
+				t.Fatalf("retained native records=%d want=%d err=%v", len(native.Records), wantCount, err)
+			}
+			families := []string{"dockerfile", "compose", "github_actions", "arm", "terraform", "cloudformation", "kubernetes"}
+			seenFamilies := make(map[string]bool)
+			for _, record := range native.Records {
+				if record.ProducerKind != "iac" {
+					continue
+				}
+				if !record.ProvisionalIdentity || record.ReviewReason != linedom.ReasonInsufficientAnchor {
+					t.Fatalf("unanchored IaC observation must remain provisional for review: %+v", record)
+				}
+				for _, family := range families {
+					if reflect.DeepEqual(record.FingerprintInput.IdentityFields["config_kind"], linedom.Text(family)) {
+						seenFamilies[family] = true
+					}
+				}
+			}
+			for _, family := range families {
+				if !seenFamilies[family] {
+					t.Errorf("real scanner family %q is missing from immutable native evidence", family)
+				}
+			}
+			observations, err := lineageStore.ListObservationsBySnapshot(ctx, assessment.TenantID, cycle.ID, baseline.ID)
+			if err != nil || len(observations) != wantCount {
+				t.Fatalf("snapshot observations=%d want=%d err=%v", len(observations), wantCount, err)
+			}
+			candidates, err := lineageStore.ListOpenCandidatesBySnapshot(ctx, assessment.TenantID, cycle.ID, baseline.ID)
+			if err != nil || len(candidates) < len(rawIaC) {
+				t.Fatalf("unanchored IaC findings lost their review candidates: count=%d want >=%d err=%v", len(candidates), len(rawIaC), err)
+			}
+
+			// Repeated positive scans must retain review in each Snapshot, even when
+			// the source Finding ID and provisional fingerprint match exactly.
+			for repeat := 0; repeat < 2; repeat++ {
+				clock.t = clock.t.Add(time.Minute)
+				runScan()
+				next, _, err := snapshots.GetDefault(ctx, assessment.TenantID, assessment.ID)
+				if err != nil || next.ID == baseline.ID {
+					t.Fatalf("repeat scan did not advance its snapshot: err=%v", err)
+				}
+				candidates, err := lineageStore.ListOpenCandidatesBySnapshot(ctx, assessment.TenantID, cycle.ID, next.ID)
+				if err != nil || len(candidates) < len(rawIaC) {
+					t.Fatalf("repeat scan lost provisional review: count=%d want >=%d err=%v", len(candidates), len(rawIaC), err)
+				}
+				queued, _, _, err := comparison.Queue(ctx, comparisonuc.QueueInput{
+					TenantID: assessment.TenantID, BaselineSnapshotID: baseline.ID, CurrentSnapshotID: next.ID,
+					Mode: cmpdom.ModeLifecycle, FingerprintVersion: 1, RiskModelVersion: comparisonuc.RiskModelVersionV1, Actor: "tester",
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				generated, err := comparison.Generate(ctx, comparisonuc.WorkInput{TenantID: assessment.TenantID, ComparisonID: queued.ID, Actor: "worker"})
+				if err != nil {
+					t.Fatal(err)
+				}
+				iacItems := 0
+				for _, item := range generated.Items {
+					if item.ProducerKind != "iac" {
+						continue
+					}
+					iacItems++
+					if item.Presence != cmpdom.PresenceNeedsReview || item.ComparableBaseline || item.FixedBasis != "" {
+						t.Errorf("repeated provisional finding became definitive: %+v", item)
+					}
+				}
+				if iacItems != len(rawIaC) {
+					t.Fatalf("repeat comparison lost IaC observations: count=%d want=%d", iacItems, len(rawIaC))
+				}
+				baseline = next
+			}
+
+			// Removing config files establishes no exhaustive IaC coverage. The full
+			// comparison pipeline must never classify that absence as remediation.
+			clock.t = clock.t.Add(time.Minute)
+			acquirer.dir, acquirer.commit = t.TempDir(), strings.Repeat("b", 40)
+			current := runScan()
+			for _, item := range current.Findings {
+				if item.Kind == finding.KindMisconfig {
+					t.Fatalf("empty scan unexpectedly retained a removed IaC finding: %s", item.ID)
+				}
+			}
+			finalSnapshot, _, err := snapshots.GetDefault(ctx, assessment.TenantID, assessment.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			queued, created, _, err := comparison.Queue(ctx, comparisonuc.QueueInput{
+				TenantID: assessment.TenantID, BaselineSnapshotID: baseline.ID, CurrentSnapshotID: finalSnapshot.ID,
+				Mode: cmpdom.ModeLifecycle, FingerprintVersion: 1, RiskModelVersion: comparisonuc.RiskModelVersionV1, Actor: "tester",
+			})
+			if err != nil || created {
+				t.Fatalf("empty scan did not auto-queue its comparison: created=%t err=%v", created, err)
+			}
+			generated, err := comparison.Generate(ctx, comparisonuc.WorkInput{TenantID: assessment.TenantID, ComparisonID: queued.ID, Actor: "worker"})
+			if err != nil {
+				t.Fatal(err)
+			}
+			iacItems := 0
+			for _, item := range generated.Items {
+				if item.ProducerKind != "iac" {
+					continue
+				}
+				iacItems++
+				if item.Presence != cmpdom.PresenceNeedsReview && item.Presence != cmpdom.PresenceNotEvaluated {
+					t.Errorf("IaC absence falsely resolved: presence=%s fixed_basis=%s", item.Presence, item.FixedBasis)
+				}
+				if item.FixedBasis != "" || item.ComparableBaseline {
+					t.Errorf("partial IaC evidence counted as Fixed: %+v", item)
+				}
+			}
+			if iacItems != len(rawIaC) {
+				t.Fatalf("comparison lost IaC observations: count=%d want=%d", iacItems, len(rawIaC))
+			}
+		})
+	}
+}

--- a/internal/usecase/sca/assessment_lifecycle.go
+++ b/internal/usecase/sca/assessment_lifecycle.go
@@ -1,0 +1,486 @@
+package sca
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/finding"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	lineageuc "github.com/KKloudTarus/synapse-ce/internal/usecase/findinglineage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// ScanRunObserver receives a successfully persisted immutable scan-run boundary.
+// Implementations may create Snapshot, lineage, and comparison shadow artifacts.
+type ScanRunObserver interface {
+	AssessmentScanRunSealed(context.Context, shared.ID, shared.ID, shared.ID) error
+}
+
+func (s *Service) SetScanRunObserver(observer ScanRunObserver) { s.scanRunObserver = observer }
+
+func (s *Service) SetAssessmentCycleMembership(cycles ports.AssessmentCycleRepository, snapshots ports.AssessmentSnapshotDefaultReader) {
+	s.assessmentCycles, s.assessmentSnapshots = cycles, snapshots
+}
+
+// SetScanRunProvenance enables native manifests without broadening the legacy
+// ScanRunStore port used by integrations and existing scan-history callers.
+func (s *Service) SetScanRunProvenance(store ports.ScanRunProvenanceStore, tx ports.TenantTransactionRunner) {
+	s.runProvenance, s.scanRunTransactions = store, tx
+}
+
+func (s *Service) persistAssessmentScanRun(ctx context.Context, engagementID, preferredRunID shared.ID, startedAt time.Time, request ports.AcquireRequest, result *ScanResult, sourceDigest string) (shared.ID, error) {
+	if s.runs == nil || result == nil {
+		return "", nil
+	}
+	item, err := s.engagements.GetByID(ctx, engagementID)
+	if err != nil {
+		return "", fmt.Errorf("load scan-run engagement: %w", err)
+	}
+	tenantID := shared.TenantOrDefault(item.TenantID)
+	if bound, ok := shared.TenantFrom(ctx); ok && shared.TenantOrDefault(bound) != tenantID {
+		return "", fmt.Errorf("%w: scan-run tenant context mismatch", shared.ErrValidation)
+	}
+	runID := preferredRunID
+	if runID.IsZero() {
+		runID = shared.ID(s.newRunID())
+	}
+	if s.runProvenance == nil {
+		return runID, s.runs.Save(shared.WithTenant(ctx, tenantID), ports.ScanRun{
+			ID: runID.String(), EngagementID: engagementID.String(), CreatedAt: startedAt.UTC(),
+			Manifest: result.Manifest, FindingKeys: assessmentFindingKeys(result.Findings),
+		})
+	}
+	manifest, err := json.Marshal(result.Manifest)
+	if err != nil {
+		return "", fmt.Errorf("marshal scan-run manifest: %w", err)
+	}
+	building := scanrun.ScanRun{
+		TenantID: tenantID, EngagementID: engagementID, ID: runID.String(), Provenance: scanrun.ProvenanceNative,
+		TerminalStatus: scanrun.StatusBuilding, ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion,
+		CreatedAt: startedAt.UTC(), UpdatedAt: startedAt.UTC(), LegacyManifest: manifest, LegacyFindingKeys: assessmentFindingKeys(result.Findings),
+	}
+
+	evidenceStore, ok := s.runProvenance.(ports.ScanRunEvidenceStore)
+	if !ok || s.scanRunTransactions == nil {
+		return "", fmt.Errorf("%w: native scan evidence persistence is unavailable", shared.ErrValidation)
+	}
+	finishedAt := s.clock.Now().UTC()
+	lane, terminalStatus, err := assessmentSCALane(item, runID.String(), startedAt.UTC(), finishedAt, request, result, sourceDigest)
+	if err != nil {
+		return "", err
+	}
+	if err := s.bindUploadedAssessmentSource(ctx, item, request, &lane); err != nil {
+		return "", err
+	}
+	evidence, err := buildAssessmentEvidence(result, lane.Target.TargetIdentityCanonical)
+	if err != nil {
+		return "", err
+	}
+	payload, err := json.Marshal(evidence)
+	if err != nil {
+		return "", err
+	}
+	digest := sha256.Sum256(payload)
+	evidenceHash := hex.EncodeToString(digest[:])
+	lane.ResultSHA256 = evidenceHash
+	lane.Producer = "sca"
+	lane.AuthoritativeFindingKinds = []string{"vulnerability"}
+	if result.ScanMode == ScanModeLicenses {
+		lane.Producer = "license"
+		lane.AuthoritativeFindingKinds = []string{"license"}
+		lane.TerminalStatus = scanrun.StatusPartial
+	}
+	lane.LaneKey = lane.Producer
+	lanesByKey := map[string]scanrun.Lane{lane.Producer: lane}
+	for _, record := range evidence.Records {
+		if _, exists := lanesByKey[record.ProducerKind]; exists {
+			continue
+		}
+		other := lane
+		other.LaneKey, other.Producer = record.ProducerKind, record.ProducerKind
+		other.AuthoritativeFindingKinds = []string{record.FindingKind}
+		// Positive observations establish presence, not exhaustive source coverage.
+		other.TerminalStatus = scanrun.StatusPartial
+		lanesByKey[other.LaneKey] = other
+	}
+	keys := make([]string, 0, len(lanesByKey))
+	for key := range lanesByKey {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	lanes := make([]scanrun.Lane, 0, len(keys))
+	for _, key := range keys {
+		current := lanesByKey[key]
+		current.SealedAt = &finishedAt
+		current.ManifestHash, err = scanrun.ComputeManifestHash(current)
+		if err != nil {
+			return "", err
+		}
+		if current.TerminalStatus != scanrun.StatusSucceeded {
+			terminalStatus = scanrun.StatusPartial
+		}
+		lanes = append(lanes, current)
+	}
+	manifestHash, err := scanrun.ComputeRunManifestHash(lanes)
+	if err != nil {
+		return "", err
+	}
+	err = s.scanRunTransactions.Run(ctx, tenantID, func(txCtx context.Context) error {
+		if err := s.runProvenance.SaveScanRun(txCtx, building); err != nil {
+			return err
+		}
+		if err := evidenceStore.SaveScanRunEvidence(txCtx, ports.ScanRunEvidence{TenantID: tenantID, RunID: runID.String(), ContentHash: evidenceHash, Payload: payload}); err != nil {
+			return err
+		}
+		if err := s.runProvenance.SealScanRun(txCtx, ports.SealScanRunCommand{TenantID: tenantID, RunID: runID.String(), TerminalStatus: terminalStatus, Lanes: lanes, ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion, ManifestHash: manifestHash, SealedAt: finishedAt}); err != nil {
+			return err
+		}
+		if s.audit != nil {
+			return s.audit.Record(txCtx, ports.AuditEntry{Actor: "system:scan-provenance", Action: "assessment_scan_run.sealed", Target: runID.String(), At: finishedAt, Metadata: map[string]string{"tenant_id": tenantID.String(), "assessment_id": engagementID.String(), "manifest_hash": manifestHash, "evidence_hash": evidenceHash}})
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("persist immutable native scan evidence: %w", err)
+	}
+
+	return runID, nil
+}
+
+// An uploaded revision changes bytes, not the logical application under test.
+// Use the Cycle's immutable root source as its namespace anchor, while keeping
+// the evaluated content digest on each run. Only explicit same-Cycle uploads are
+// eligible; arbitrary local paths or unrelated repositories never share this key.
+func (s *Service) bindUploadedAssessmentSource(ctx context.Context, item *engagement.Engagement, request ports.AcquireRequest, lane *scanrun.Lane) error {
+	if s.assessmentCycles == nil || s.assessmentSnapshots == nil || request.Kind != ports.TargetUpload || sourcepackage.DigestFromTarget(request.Value) == "" {
+		return nil
+	}
+	tenantID := shared.TenantOrDefault(item.TenantID)
+	cycle, err := s.assessmentCycles.GetCycleByAssessment(ctx, tenantID, item.ID)
+	if errors.Is(err, shared.ErrNotFound) {
+		return nil // Legacy/unmigrated uploads retain revision-isolated identity.
+	}
+	if err != nil {
+		return err
+	}
+	baseline, _, err := s.assessmentSnapshots.GetDefault(ctx, tenantID, cycle.RootAssessmentID)
+	if errors.Is(err, shared.ErrNotFound) {
+		return nil
+	} // The initial run establishes the namespace.
+	if err != nil {
+		return err
+	}
+	if baseline.CycleID != cycle.ID || baseline.Provenance != assessmentsnapshot.ProvenanceNative {
+		return nil
+	}
+	var rootTarget string
+	for _, dimension := range baseline.Dimensions {
+		for _, scope := range dimension.IncludedScope {
+			candidate := strings.TrimPrefix(scope, string(engagement.TargetRepo)+":")
+			if sourcepackage.DigestFromTarget(candidate) == "" {
+				continue
+			}
+			if rootTarget != "" && rootTarget != candidate {
+				return nil
+			}
+			rootTarget = candidate
+		}
+	}
+	if rootTarget == "" {
+		return nil
+	}
+	var target *assessmentsnapshot.Target
+	for _, dimension := range baseline.Dimensions {
+		matchesSource := false
+		for _, scope := range dimension.IncludedScope {
+			matchesSource = matchesSource || scope == string(engagement.TargetRepo)+":"+rootTarget
+		}
+		if !matchesSource || dimension.Target.Kind != scanrun.TargetRepository {
+			continue
+		}
+		if target != nil && (target.Canonical != dimension.Target.Canonical || target.SchemaVersion != dimension.Target.SchemaVersion) {
+			return nil
+		}
+		value := dimension.Target
+		target = &value
+	}
+	if target == nil {
+		return nil
+	}
+	lane.Target.TargetIdentityCanonical, lane.Target.TargetIdentitySchemaVersion = target.Canonical, target.SchemaVersion
+	for index, scope := range lane.IncludedScope {
+		if scope == string(engagement.TargetRepo)+":"+request.Value {
+			lane.IncludedScope[index] = string(engagement.TargetRepo) + ":" + rootTarget
+		}
+	}
+	sort.Strings(lane.IncludedScope)
+	return lane.Validate()
+}
+
+func assessmentSCALane(item *engagement.Engagement, runID string, startedAt, finishedAt time.Time, request ports.AcquireRequest, result *ScanResult, sourceDigest string) (scanrun.Lane, scanrun.TerminalStatus, error) {
+	target, immutable, err := assessmentScanTarget(request, result, sourceDigest)
+	if err != nil {
+		return scanrun.Lane{}, "", err
+	}
+	status := scanrun.StatusSucceeded
+	if result.VulnsBelowThreshold > 0 || result.UnfixedSuppressed > 0 {
+		status = scanrun.StatusPartial
+	}
+	if !immutable || !result.Completeness.Confident || len(result.SourceWarnings) > 0 || strings.TrimSpace(result.ReproDigest) == "" {
+		status = scanrun.StatusPartial
+	}
+	for _, event := range result.DebugEvents {
+		if event.Status == ports.ScanDebugFailed || event.Status == ports.ScanDebugRunning {
+			status = scanrun.StatusPartial
+			break
+		}
+	}
+	lane := scanrun.Lane{
+		TenantID: shared.TenantOrDefault(item.TenantID), EngagementID: item.ID, ScanRunID: runID, LaneKey: "sca", Producer: "synapse-sca", TerminalStatus: status,
+		Target: target, AuthoritativeFindingKinds: assessmentFindingKinds(result), IncludedScope: assessmentScope(item.Scope.InScope), ExcludedScope: assessmentScope(item.Scope.OutOfScope),
+		StartedAt: startedAt, FinishedAt: &finishedAt, ResultRef: "scan-result/" + runID, ResultSHA256: result.ReproDigest,
+		ManifestSchemaVersion: scanrun.CurrentManifestSchemaVersion, Versions: assessmentScanVersions(result.Manifest), Stages: assessmentScanStages(result.DebugEvents, startedAt, finishedAt),
+	}
+	return lane, status, lane.Validate()
+}
+
+func assessmentScanTarget(request ports.AcquireRequest, result *ScanResult, sourceDigest string) (scanrun.TargetIdentity, bool, error) {
+	if result.Image != nil && strings.TrimSpace(result.Image.Digest) != "" {
+		reference := strings.TrimSpace(result.Image.Reference)
+		digest := strings.TrimSpace(result.Image.Digest)
+		if !strings.HasPrefix(strings.ToLower(digest), "sha256:") {
+			digest = "sha256:" + digest
+		}
+		if at := strings.Index(reference, "@"); at >= 0 {
+			reference = reference[:at]
+		}
+		if reference != "" {
+			if target, err := scanrun.CanonicalizeOCITarget(reference + "@" + digest); err == nil {
+				return target, true, nil
+			}
+		}
+		return scanrun.TargetIdentity{TargetKind: scanrun.TargetOCI, TargetIdentitySchemaVersion: 1, TargetIdentityCanonical: "managed-oci@" + strings.ToLower(digest), EvaluatedRevision: strings.ToLower(digest)}, true, nil
+	}
+
+	revision := strings.ToLower(strings.TrimSpace(result.SourceCommit))
+	immutable := revision != ""
+	if revision == "" {
+		revision = strings.TrimPrefix(strings.ToLower(strings.TrimSpace(sourceDigest)), "sha256:")
+		if revision == "" && request.Kind == ports.TargetUpload {
+			// Source-upload acquisition verifies these bytes against the retained
+			// digest before scanning. A hash of a locator is not a content revision.
+			revision = sourcepackage.DigestFromTarget(request.Value)
+		}
+		immutable = revision != ""
+	}
+	if len(revision) != 40 && len(revision) != 64 {
+		sum := sha256.Sum256([]byte(strings.TrimSpace(request.Value)))
+		revision = hex.EncodeToString(sum[:])
+		immutable = false
+	}
+	raw := strings.TrimSpace(result.Target)
+	if raw == "" {
+		raw = strings.TrimSpace(request.Value)
+	}
+	if target, err := scanrun.CanonicalizeRepositoryTarget(raw, revision); err == nil {
+		return target, immutable, nil
+	}
+	target := scanrun.TargetIdentity{
+		TargetKind: scanrun.TargetRepository, TargetIdentitySchemaVersion: 1,
+		TargetIdentityCanonical: "managed-repository://sha256/" + revision, EvaluatedRevision: revision,
+	}
+	return target, immutable, target.Validate()
+}
+
+func assessmentFindingKinds(result *ScanResult) []string {
+	set := map[string]struct{}{}
+	if result.ScanMode == ScanModeLicenses {
+		set["license"] = struct{}{}
+	} else {
+		set[string(finding.KindSCA)] = struct{}{}
+	}
+	for _, item := range result.Findings {
+		kind := item.Kind
+		if kind == "" {
+			kind = finding.KindSCA
+		}
+		set[string(kind)] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for kind := range set {
+		out = append(out, kind)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func assessmentFindingKeys(findings []finding.Finding) []string {
+	keys := make([]string, 0, len(findings))
+	for _, item := range findings {
+		keys = append(keys, item.DedupKey)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func assessmentScope(targets []engagement.Target) []string {
+	out := make([]string, 0, len(targets))
+	for _, target := range targets {
+		out = append(out, string(target.Kind)+":"+strings.TrimSpace(target.Value))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func assessmentScanVersions(manifest ports.ScanManifest) []scanrun.LaneVersion {
+	versions := make([]scanrun.LaneVersion, 0, len(manifest.ToolVersions)+4)
+	seen := map[string]struct{}{}
+	appendVersion := func(kind scanrun.VersionKind, name, version string) {
+		name, version = strings.TrimSpace(name), strings.TrimSpace(version)
+		if name == "" || version == "" {
+			return
+		}
+		key := string(kind) + "\x00" + name
+		if _, exists := seen[key]; exists {
+			return
+		}
+		seen[key] = struct{}{}
+		versions = append(versions, scanrun.LaneVersion{VersionKind: kind, Name: name, Version: version})
+	}
+	for name, version := range manifest.ToolVersions {
+		kind := scanrun.VersionTool
+		lower := strings.ToLower(name)
+		if lower == "epss-date" || lower == "kev-catalog" {
+			// Risk enrichment is retained in the hashed run manifest/Observation,
+			// but does not change vulnerability detection coverage. In particular,
+			// an empty scan need not request EPSS scores for nonexistent findings.
+			continue
+		}
+		if strings.Contains(lower, "db") || strings.Contains(lower, "catalog") {
+			kind = scanrun.VersionAdvisoryDB
+		}
+		appendVersion(kind, name, version)
+	}
+	appendVersion(scanrun.VersionAdvisoryDB, "grype-db", manifest.GrypeDBVersion)
+	appendVersion(scanrun.VersionAdvisoryDB, "vulnerability-feed", manifest.VulnDBSnapshot)
+	appendVersion(scanrun.VersionCorrelation, "finding-correlation", strconv.Itoa(manifest.CorrelationVersion))
+	appendVersion(scanrun.VersionSchema, "scan-run-manifest", strconv.Itoa(scanrun.CurrentManifestSchemaVersion))
+	return versions
+}
+
+func assessmentScanStages(events []ports.ScanDebugEvent, fallbackStarted, fallbackFinished time.Time) []scanrun.LaneStage {
+	if len(events) == 0 {
+		return []scanrun.LaneStage{{StageKey: "pipeline", Status: scanrun.StageSucceeded, StartedAt: fallbackStarted, FinishedAt: &fallbackFinished}}
+	}
+	counts := map[string]int{}
+	stages := make([]scanrun.LaneStage, 0, len(events))
+	for _, event := range events {
+		key := strings.TrimSpace(event.Step)
+		if key == "" {
+			key = strings.TrimSpace(event.Stage)
+		}
+		if key == "" {
+			continue
+		}
+		counts[key]++
+		if counts[key] > 1 {
+			key += "-" + strconv.Itoa(counts[key])
+		}
+		status, reason := scanrun.StageSucceeded, ""
+		if event.Status == ports.ScanDebugFailed {
+			status, reason = scanrun.StageFailed, "producer_failed"
+		} else if event.Status == ports.ScanDebugRunning {
+			status, reason = scanrun.StageSkipped, "not_terminal"
+		}
+		started := event.StartedAt.UTC()
+		if started.IsZero() {
+			started = fallbackStarted
+		}
+		finished := event.FinishedAt
+		if finished == nil || finished.IsZero() {
+			value := fallbackFinished
+			finished = &value
+		}
+		stages = append(stages, scanrun.LaneStage{StageKey: key, Status: status, ReasonCode: reason, StartedAt: started, FinishedAt: finished})
+	}
+	if len(stages) == 0 {
+		return []scanrun.LaneStage{{StageKey: "pipeline", Status: scanrun.StageSucceeded, StartedAt: fallbackStarted, FinishedAt: &fallbackFinished}}
+	}
+	return stages
+}
+
+func (s *Service) notifyAssessmentScanRun(ctx context.Context, engagementID, runID shared.ID) error {
+	if s.scanRunObserver == nil || runID.IsZero() {
+		return nil
+	}
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok || tenantID.IsZero() {
+		item, err := s.engagements.GetByID(ctx, engagementID)
+		if err != nil {
+			return fmt.Errorf("load scan-run engagement for lifecycle projection: %w", err)
+		}
+		tenantID = shared.TenantOrDefault(item.TenantID)
+	}
+	if err := s.scanRunObserver.AssessmentScanRunSealed(ctx, tenantID, engagementID, runID); err != nil {
+		return fmt.Errorf("project native scan run to assessment lifecycle: %w", err)
+	}
+	return nil
+}
+
+func buildAssessmentEvidence(result *ScanResult, target string) (lineageuc.NativeEvidence, error) {
+	evidence := lineageuc.NativeEvidence{Version: lineageuc.NativeEvidenceVersion, Records: make([]lineageuc.CorrelateInput, 0, len(result.Findings))}
+	if len(result.Findings) > lineageuc.MaxNativeObservations {
+		return evidence, fmt.Errorf("%w: native scan exceeds observation limit", shared.ErrValidation)
+	}
+	vulnerabilities := make(map[string]int, len(result.Vulnerabilities))
+	for index, v := range result.Vulnerabilities {
+		vulnerabilities[vulnDedupKey(v)] = index
+	}
+	for _, item := range result.Findings {
+		switch item.Kind {
+		case "", finding.KindSCA, finding.KindSAST, finding.KindQuality, finding.KindReliability, finding.KindSecret, finding.KindMisconfig:
+		default:
+			continue
+		}
+		var record lineageuc.CorrelateInput
+		var err error
+		if index, ok := vulnerabilities[item.DedupKey]; ok && (item.Kind == finding.KindSCA || item.Kind == "") {
+			record, err = lineageuc.BuildNativeEvidenceRecord(item, target, &result.Vulnerabilities[index])
+		} else {
+			record, err = lineageuc.BuildNativeEvidenceRecord(item, target, nil)
+		}
+		if err != nil {
+			return evidence, fmt.Errorf("prepare redacted native observation: %w", err)
+		}
+		evidence.Records = append(evidence.Records, record)
+	}
+	sort.Slice(evidence.Records, func(i, j int) bool {
+		left, right := evidence.Records[i], evidence.Records[j]
+		if left.ProducerKind != right.ProducerKind {
+			return left.ProducerKind < right.ProducerKind
+		}
+		return left.Observation.SourceFindingID < right.Observation.SourceFindingID
+	})
+	return evidence, nil
+}
+
+func (s *Service) copyAssessmentScanResult(result *ScanResult) *ScanResult {
+	copy := *result
+	copy.Findings = append([]finding.Finding(nil), result.Findings...)
+	copy.VulnsBelowThreshold = countBelowThreshold(copy.Vulnerabilities, s.minSeverity)
+	copy.UnfixedSuppressed = countUnfixedSuppressed(copy.Vulnerabilities, s.minSeverity, s.ignoreUnfixed)
+	copy.ReproDigest = ReproDigest(&copy)
+	return &copy
+}

--- a/internal/usecase/sca/assessment_uploaded_source_test.go
+++ b/internal/usecase/sca/assessment_uploaded_source_test.go
@@ -1,0 +1,111 @@
+package sca
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	cycledom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentcycle"
+	snapshotdom "github.com/KKloudTarus/synapse-ce/internal/domain/assessmentsnapshot"
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type uploadedCycleReader struct {
+	ports.AssessmentCycleRepository
+}
+
+func (uploadedCycleReader) GetCycleByAssessment(_ context.Context, tenantID, assessmentID shared.ID) (*cycledom.AssessmentCycle, error) {
+	if tenantID != "tenant" || assessmentID != "retest" {
+		return nil, shared.ErrNotFound
+	}
+	return &cycledom.AssessmentCycle{ID: "cycle", TenantID: tenantID, RootAssessmentID: "root"}, nil
+}
+
+type uploadedSnapshotReader struct {
+	snapshot *snapshotdom.Snapshot
+	err      error
+}
+
+func (r uploadedSnapshotReader) GetDefault(_ context.Context, tenantID, assessmentID shared.ID) (*snapshotdom.Snapshot, ports.AssessmentSnapshotDefault, error) {
+	if tenantID != "tenant" || assessmentID != "root" {
+		return nil, ports.AssessmentSnapshotDefault{}, shared.ErrNotFound
+	}
+	return r.snapshot, ports.AssessmentSnapshotDefault{}, r.err
+}
+
+func TestUploadedRetestNamespaceUsesImmutableRootSnapshotNotNewRevision(t *testing.T) {
+	now := time.Date(2026, 9, 8, 0, 0, 0, 0, time.UTC)
+	rootTarget := sourcepackage.TargetPrefix + strings.Repeat("a", 64)
+	newTarget := sourcepackage.TargetPrefix + strings.Repeat("b", 64)
+	item, err := engdom.New("retest", "tenant", "Revision", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item.Scope.InScope = []engdom.Target{{Kind: engdom.TargetRepo, Value: newTarget}}
+	request := ports.AcquireRequest{Kind: ports.TargetUpload, Value: newTarget}
+	result := &ScanResult{Target: newTarget, ReproDigest: strings.Repeat("c", 64), Completeness: ports.Completeness{Confident: true}, Manifest: ports.ScanManifest{ToolVersions: map[string]string{"scanner": "1.0"}}}
+	lane, _, err := assessmentSCALane(item, "run", now, now.Add(time.Second), request, result, strings.Repeat("d", 64))
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := lane
+	baseline := &snapshotdom.Snapshot{CycleID: "cycle", Provenance: snapshotdom.ProvenanceNative, Dimensions: []snapshotdom.Dimension{{Target: snapshotdom.Target{Kind: scanrun.TargetRepository, SchemaVersion: 1, Canonical: "managed-repository://sha256/" + strings.Repeat("e", 64)}, IncludedScope: []string{"repo:" + rootTarget}}}}
+	service := &Service{assessmentCycles: uploadedCycleReader{}, assessmentSnapshots: uploadedSnapshotReader{snapshot: baseline}}
+	if err := service.bindUploadedAssessmentSource(context.Background(), item, request, &lane); err != nil {
+		t.Fatal(err)
+	}
+	if lane.Target.TargetIdentityCanonical != baseline.Dimensions[0].Target.Canonical || lane.Target.EvaluatedRevision != original.Target.EvaluatedRevision || lane.Target.EvaluatedRevision != strings.Repeat("d", 64) || lane.IncludedScope[0] != "repo:"+rootTarget {
+		t.Fatalf("revision/identity binding=%+v", lane)
+	}
+	// A repository that was not an uploaded source cannot gain this namespace.
+	unrelated := original
+	unrelated.IncludedScope = []string{"repo:" + newTarget}
+	baseline.Dimensions[0].IncludedScope = []string{"repo:https://example.com/unrelated.git"}
+	if err := service.bindUploadedAssessmentSource(context.Background(), item, request, &unrelated); err != nil || unrelated.Target.TargetIdentityCanonical != original.Target.TargetIdentityCanonical {
+		t.Fatalf("unrelated target remapped: %+v err=%v", unrelated.Target, err)
+	}
+	service.assessmentSnapshots = uploadedSnapshotReader{err: errors.New("unavailable")}
+	if err := service.bindUploadedAssessmentSource(context.Background(), item, request, &lane); err == nil {
+		t.Fatal("source lookup failure ignored")
+	}
+}
+
+func TestUploadedScanUsesVerifiedContentDigestForCompleteCoverage(t *testing.T) {
+	now := time.Date(2026, 9, 8, 0, 0, 0, 0, time.UTC)
+	item, err := engdom.New("initial", "tenant", "Native upload", "", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	digest := strings.Repeat("a", 64)
+	request := ports.AcquireRequest{Kind: ports.TargetUpload, Value: sourcepackage.TargetPrefix + digest}
+	result := &ScanResult{Target: request.Value, ReproDigest: strings.Repeat("b", 64), Completeness: ports.Completeness{Confident: true}, Manifest: ports.ScanManifest{ToolVersions: map[string]string{"scanner": "1"}}}
+	lane, status, err := assessmentSCALane(item, "run", now, now.Add(time.Second), request, result, "")
+	if err != nil || status != scanrun.StatusSucceeded || lane.Target.EvaluatedRevision != digest {
+		t.Fatalf("native upload falsely partial: %+v status=%s err=%v", lane, status, err)
+	}
+	request.Kind = ports.TargetLocal
+	_, status, err = assessmentSCALane(item, "untrusted-local", now, now.Add(time.Second), request, result, "")
+	if err != nil || status != scanrun.StatusPartial {
+		t.Fatalf("unverified locator trusted: status=%s err=%v", status, err)
+	}
+}
+
+func TestAssessmentCoverageVersionsExcludeRiskOnlyEnrichment(t *testing.T) {
+	versions := assessmentScanVersions(ports.ScanManifest{ToolVersions: map[string]string{
+		"grype": "1", "epss-date": "2026-09-08", "kev-catalog": "2026.09.08",
+	}, GrypeDBVersion: "db-v1"})
+	if len(versions) != 4 { // Grype, detection DB, correlation, manifest schema.
+		t.Fatalf("unexpected coverage versions: %+v", versions)
+	}
+	for _, version := range versions {
+		if version.Name == "epss-date" || version.Name == "kev-catalog" || version.Name == "vulnerability-feed" {
+			t.Fatalf("risk-only/unused feed changes coverage: %+v", version)
+		}
+	}
+}

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -125,11 +125,16 @@ type Service struct {
 	projectAnalysisRecorder interface {
 		RecordProjectAnalysis(context.Context, shared.ID, string, time.Time, *ScanResult) error
 	}
-	sourceArtifacts  ports.ProjectSourceArtifactStore
-	comparisonSource ports.ProjectComparisonSource
-	log              *slog.Logger
-	gateDecoder      ports.GateDecoder
-	slaAssessor      ports.FindingSLAAssessor // optional; nil while SYNAPSE_SLA_ENABLED=false
+	sourceArtifacts     ports.ProjectSourceArtifactStore
+	comparisonSource    ports.ProjectComparisonSource
+	log                 *slog.Logger
+	gateDecoder         ports.GateDecoder
+	slaAssessor         ports.FindingSLAAssessor // optional; nil while SYNAPSE_SLA_ENABLED=false
+	scanRunObserver     ScanRunObserver          // optional; tenant-gated assessment lifecycle shadow writer
+	runProvenance       ports.ScanRunProvenanceStore
+	scanRunTransactions ports.TenantTransactionRunner
+	assessmentCycles    ports.AssessmentCycleRepository
+	assessmentSnapshots ports.AssessmentSnapshotDefaultReader
 }
 
 // SetSeverityEnricher configures optional severity backfill (NVD CVSS) for vulnerabilities the
@@ -156,13 +161,7 @@ func (s *Service) UploadedSourceMetadata(ctx context.Context, tenantID, engageme
 }
 
 func (s *Service) StartUploadedSourceScanWithOptions(ctx context.Context, actor string, tenantID, engagementID shared.ID, opts ScanOptions) (ports.ScanJob, error) {
-	item, err := s.UploadedSourceMetadata(ctx, tenantID, engagementID)
-	if err != nil {
-		return ports.ScanJob{}, err
-	}
-	return s.StartScanWithOptions(ctx, actor, engagementID, ports.AcquireRequest{
-		Kind: ports.TargetUpload, Value: item.Target(), Locator: item.Locator,
-	}, opts)
+	return s.StartUploadedSourceVersionScanWithOptions(ctx, actor, tenantID, engagementID, "", opts)
 }
 
 // SetScannedImageRecorder wires the scanned-image digest index (#446). When set, a completed image
@@ -1592,6 +1591,10 @@ func (s *Service) ScanWithOptions(ctx context.Context, actor string, engagementI
 		return nil, err
 	}
 	req = normalizeLocalTarget(req)
+	req, err = s.pinUploadedSource(ctx, engagementID, req)
+	if err != nil {
+		return nil, err
+	}
 	if s.timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, s.timeout)
@@ -1638,6 +1641,10 @@ func (s *Service) StartScanWithOptions(ctx context.Context, actor string, engage
 	}
 	req = normalizeLocalTarget(req)
 	var imported importedsbom.Record
+	req, err = s.pinUploadedSource(ctx, engagementID, req)
+	if err != nil {
+		return ports.ScanJob{}, err
+	}
 	var importedDoc *sbom.SBOM
 	var useImported bool
 	if imported, importedDoc, useImported, err = s.loadImportedSBOMForRequest(ctx, engagementID, req, opts); err != nil {
@@ -1661,14 +1668,15 @@ func (s *Service) StartScanWithOptions(ctx context.Context, actor string, engage
 		_ = importedDoc // loaded now to fail fast; worker reloads the active artifact when executing.
 	}
 	job := ports.ScanJob{
-		ID:           s.ids.NewID().String(),
-		EngagementID: engagementID.String(),
-		Target:       target,
-		Kind:         kind,
-		Status:       ports.ScanRunning,
-		Stage:        "queued",
-		StartedAt:    now,
-		DebugEvents:  []ports.ScanDebugEvent{},
+		SourcePackage: publicSourcePackage(req.SourcePackage),
+		ID:            s.ids.NewID().String(),
+		EngagementID:  engagementID.String(),
+		Target:        target,
+		Kind:          kind,
+		Status:        ports.ScanRunning,
+		Stage:         "queued",
+		StartedAt:     now,
+		DebugEvents:   []ports.ScanDebugEvent{},
 	}
 	if s.jobs != nil {
 		if err := s.jobs.CreateRunning(ctx, job); err != nil {
@@ -1882,10 +1890,25 @@ func (s *Service) SweepStaleScans(ctx context.Context, staleFor time.Duration) (
 			release()
 			continue
 		}
+		jobCtx := ctx
+		if source := job.SourcePackage; source != nil {
+			if source.TenantID.IsZero() || source.EngagementID.String() != job.EngagementID || job.Kind != ports.TargetUpload || job.Target != source.Target() {
+				release()
+				return n, fmt.Errorf("%w: stranded scan source ownership is invalid", shared.ErrValidation)
+			}
+			// The daemon sweeps across tenants. Derive each write's tenant from
+			// the frozen source binding, then verify its engagement owner before
+			// using tenant-scoped persistence; do not weaken the store's checks.
+			jobCtx = shared.WithTenant(ctx, source.TenantID)
+			if _, err := s.engagements.GetByIDInTenant(jobCtx, source.TenantID, source.EngagementID); err != nil {
+				release()
+				return n, fmt.Errorf("verify stranded scan source owner: %w", err)
+			}
+		}
 		fin := s.clock.Now()
 		job.FinishedAt, job.Progress = &fin, 100
 		job.Status, job.Stage, job.Error = ports.ScanFailed, "swept", "scan stranded running past staleFor with no live owner – reclaimed by sweeper"
-		if err := s.jobs.Save(ctx, job); err != nil {
+		if err := s.jobs.Save(jobCtx, job); err != nil {
 			release()
 			return n, fmt.Errorf("save swept scan job %s: %w", job.ID, err)
 		}
@@ -1933,12 +1956,20 @@ func (s *Service) gateAndAudit(ctx context.Context, actor string, engagementID s
 	if req.Kind == ports.TargetImage {
 		targetKind = engagement.TargetImage
 	}
+	metadata := map[string]string{"kind": kindOrLocal(req.Kind), "engagement": engagementID.String(), "mode": opts.Mode}
+	if req.SourcePackage != nil {
+		metadata["source_version_id"] = req.SourcePackage.VersionID.String()
+		metadata["source_sha256"] = req.SourcePackage.SHA256
+		if !req.SourcePackage.ReusedFromVersionID.IsZero() {
+			metadata["reused_from_version_id"] = req.SourcePackage.ReusedFromVersionID.String()
+		}
+	}
 	return s.guard.Authorize(ctx, execution.Request{
 		Actor:        actor,
 		EngagementID: engagementID,
 		Action:       "sca.scan",
 		Target:       engagement.Target{Kind: targetKind, Value: req.Value},
-		Metadata:     map[string]string{"kind": kindOrLocal(req.Kind), "engagement": engagementID.String(), "mode": opts.Mode},
+		Metadata:     metadata,
 	})
 }
 
@@ -2282,6 +2313,9 @@ func (s *Service) runImportedSBOMPipeline(ctx context.Context, actor string, eng
 			_, _ = s.correlation.Record(ctx, engagementID, report)
 		}
 	}
+	// The UI cache may combine different scan modes. Native comparison evidence
+	// must contain only the detections from this execution, captured beforehand.
+	assessmentResult := s.copyAssessmentScanResult(result)
 	if s.results != nil {
 		if previousData, loadErr := s.results.LatestResult(ctx, engagementID); loadErr == nil {
 			var previous ScanResult
@@ -2300,14 +2334,9 @@ func (s *Service) runImportedSBOMPipeline(ctx context.Context, actor string, eng
 	if err != nil {
 		return nil, err
 	}
-	if s.runs != nil {
-		keys := make([]string, 0, len(result.Findings))
-		for _, f := range result.Findings {
-			keys = append(keys, f.DedupKey)
-		}
-		if err := s.runs.Save(ctx, ports.ScanRun{ID: s.newRunID(), EngagementID: engagementID.String(), CreatedAt: now, Manifest: manifest, FindingKeys: keys}); err != nil {
-			return nil, fmt.Errorf("persist scan run: %w", err)
-		}
+	assessmentRunID, err := s.persistAssessmentScanRun(ctx, engagementID, evidenceID, now, ports.AcquireRequest{Kind: ports.TargetUpload, Value: record.TargetRef}, assessmentResult, record.SHA256)
+	if err != nil {
+		return nil, err
 	}
 	if s.scans != nil {
 		skipped, err := s.scans.SaveScan(ctx, engagementID, doc, vulns, snap)
@@ -2343,6 +2372,9 @@ func (s *Service) runImportedSBOMPipeline(ctx context.Context, actor string, eng
 		if data, mErr := json.Marshal(result); mErr == nil {
 			_ = s.results.SaveResult(ctx, engagementID, data)
 		}
+	}
+	if err := s.notifyAssessmentScanRun(ctx, engagementID, assessmentRunID); err != nil {
+		return nil, err
 	}
 	return result, nil
 }
@@ -2476,6 +2508,11 @@ func importedCompleteness(doc *sbom.SBOM) ports.Completeness {
 }
 
 func (s *Service) runPipeline(ctx context.Context, actor string, engagementID shared.ID, now time.Time, req ports.AcquireRequest, opts ScanOptions, report func(stage string, pct int, events []ports.ScanDebugEvent), evidenceID shared.ID) (*ScanResult, error) {
+	var err error
+	req, err = s.pinUploadedSource(ctx, engagementID, req)
+	if err != nil {
+		return nil, err
+	}
 	stage, pct := stageAcquire, 5
 	trace := newScanDebugTrace(func(events []ports.ScanDebugEvent) { report(stage, pct, events) })
 	report(stage, pct, trace.snapshot())
@@ -2980,6 +3017,7 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	sourceWarnings = append(sourceWarnings, dbFreshnessWarnings(toolVersions, now, s.dbMaxAgeDays)...) // stale-DB freshness policy
 	sourceWarnings = append(sourceWarnings, detectionSourceWarnings...)                                // sources skipped by the non-strict degrade policy
 	manifest := buildManifest(toolVersions, snap.VulnDBSnapshot, grypeDB, doc)
+	manifest.SourcePackage = publicSourcePackage(req.SourcePackage)
 
 	// Maven, once its full tree is resolved (mvn dependency:list), is no longer an under-reporting
 	// unresolved ecosystem – drop it from the completeness signal so the scan reads as complete.
@@ -3260,6 +3298,7 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 		}
 	}
 
+	assessmentResult := s.copyAssessmentScanResult(result)
 	if s.results != nil {
 		if previousData, loadErr := s.results.LatestResult(ctx, engagementID); loadErr == nil {
 			var previous ScanResult
@@ -3283,20 +3322,9 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	if err != nil {
 		return nil, err
 	}
-	if s.runs != nil {
-		keys := make([]string, 0, len(result.Findings))
-		for _, f := range result.Findings {
-			keys = append(keys, f.DedupKey)
-		}
-		if err := s.runs.Save(ctx, ports.ScanRun{
-			ID:           s.newRunID(),
-			EngagementID: engagementID.String(),
-			CreatedAt:    now,
-			Manifest:     manifest,
-			FindingKeys:  keys,
-		}); err != nil {
-			return nil, fmt.Errorf("persist scan run: %w", err)
-		}
+	assessmentRunID, err := s.persistAssessmentScanRun(ctx, engagementID, evidenceID, now, req, assessmentResult, "")
+	if err != nil {
+		return nil, err
 	}
 
 	// The scan snapshot and the findings are written in SEPARATE transactions. A
@@ -3358,6 +3386,9 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	// Record the image's manifest digest so the fleet cluster agent can correlate a running digest
 	// with this scan (#446). This is the pipeline that populates result.Image (image scans).
 	s.recordScannedImage(ctx, engagementID, result)
+	if err := s.notifyAssessmentScanRun(ctx, engagementID, assessmentRunID); err != nil {
+		return nil, err
+	}
 	return result, nil
 }
 
@@ -3455,10 +3486,12 @@ func mergeCachedScanResult(current *ScanResult, previous ScanResult, opts ScanOp
 	preserved := false
 	preservedVulnerabilities := false
 	if !opts.scansVulnerabilities() {
+		source := current.Manifest.SourcePackage
 		current.Vulnerabilities = previous.Vulnerabilities
 		current.VulnDBSnapshot = previous.VulnDBSnapshot
 		current.ToolVersions = previous.ToolVersions
 		current.Manifest = previous.Manifest
+		current.Manifest.SourcePackage = source
 		current.RiskMatches = previous.RiskMatches
 		current.Findings = mergeFindingsByKind(previous.Findings, current.Findings, true)
 		current.AnalysisCoverage = cloneAnalysisCoverage(previous.AnalysisCoverage)
@@ -4312,7 +4345,7 @@ type ScanDrift struct {
 
 // CompareRuns computes the drift between two runs and explains it from the
 // manifest deltas (chain-of-custody: "why does this differ from last month?").
-func (s *Service) CompareRuns(ctx context.Context, runA, runB string) (ScanDrift, error) {
+func (s *Service) CompareRuns(ctx context.Context, engagementID shared.ID, runA, runB string) (ScanDrift, error) {
 	if s.runs == nil {
 		return ScanDrift{}, fmt.Errorf("scan runs: %w", shared.ErrNotFound)
 	}
@@ -4323,6 +4356,9 @@ func (s *Service) CompareRuns(ctx context.Context, runA, runB string) (ScanDrift
 	b, err := s.runs.Get(ctx, runB)
 	if err != nil {
 		return ScanDrift{}, err
+	}
+	if a.EngagementID != engagementID.String() || b.EngagementID != engagementID.String() {
+		return ScanDrift{}, fmt.Errorf("scan runs: %w", shared.ErrNotFound)
 	}
 	return diffRuns(a, b), nil
 }

--- a/internal/usecase/sca/service_test.go
+++ b/internal/usecase/sca/service_test.go
@@ -1309,7 +1309,6 @@ func (s *sequenceIDs) NewID() shared.ID {
 	s.next++
 	return shared.ID(fmt.Sprintf("scan-sequence-%d", s.next))
 }
-
 func newAsyncSvc(repo ports.EngagementRepository, clk ports.Clock, acq ports.Acquirer, audit ports.AuditLogger, det ports.LanguageDetector, jobs ports.ScanJobStore, ids ports.IDGenerator) *Service {
 	return NewService(repo, nil, nil, nil, jobs, nil, nil, ids, ports.Provenance{}, clk, audit, shared.SeverityHigh, 0, acq, det, fakeSBOM{}, []ports.DetectionSource{fakeVuln{}}, nil, fakeLic{}, nil)
 }

--- a/internal/usecase/sca/uploaded_source.go
+++ b/internal/usecase/sca/uploaded_source.go
@@ -1,0 +1,82 @@
+package sca
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// publicSourcePackage freezes metadata without retaining a private locator or
+// mutable pointer. The acquisition request carries its locator separately.
+func publicSourcePackage(item *sourcepackage.Package) *sourcepackage.Package {
+	if item == nil {
+		return nil
+	}
+	copy := *item
+	copy.Locator, copy.ObjectKey = "", ""
+	return &copy
+}
+
+func (s *Service) StartUploadedSourceVersionScanWithOptions(ctx context.Context, actor string, tenantID, engagementID, versionID shared.ID, opts ScanOptions) (ports.ScanJob, error) {
+	item, err := s.UploadedSourceMetadata(ctx, tenantID, engagementID)
+	if err != nil {
+		return ports.ScanJob{}, err
+	}
+	if !versionID.IsZero() && item.VersionID != versionID {
+		return ports.ScanJob{}, fmt.Errorf("%w: uploaded source version does not match this assessment", shared.ErrConflict)
+	}
+	return s.StartScanWithOptions(ctx, actor, engagementID, ports.AcquireRequest{
+		Kind: ports.TargetUpload, Value: item.Target(), Locator: item.Locator, SourcePackage: publicSourcePackage(&item),
+	}, opts)
+}
+
+// Current is selected at admission. Queued uploads resolve their exact owned
+// version and verify frozen metadata; legacy jobs require the same content digest.
+func (s *Service) pinUploadedSource(ctx context.Context, engagementID shared.ID, req ports.AcquireRequest) (ports.AcquireRequest, error) {
+	if req.Kind != ports.TargetUpload {
+		if req.SourcePackage != nil {
+			return req, fmt.Errorf("%w: uploaded source metadata requires an upload target", shared.ErrValidation)
+		}
+		return req, nil
+	}
+	tenantID, ok := shared.TenantFrom(ctx)
+	if !ok || s.uploadedSources == nil {
+		return req, fmt.Errorf("%w: tenant-bound uploaded source storage is required", shared.ErrValidation)
+	}
+	if _, err := s.engagements.GetByIDInTenant(ctx, tenantID, engagementID); err != nil {
+		return req, err
+	}
+	var item sourcepackage.Package
+	var err error
+	if req.SourcePackage != nil && !req.SourcePackage.VersionID.IsZero() {
+		reader, ok := s.uploadedSources.(ports.EngagementSourceVersionReader)
+		if !ok {
+			return req, fmt.Errorf("%w: uploaded source version lookup is unavailable", shared.ErrValidation)
+		}
+		item, err = reader.GetByVersion(ctx, tenantID, engagementID, req.SourcePackage.VersionID)
+	} else {
+		item, err = s.uploadedSources.Get(ctx, tenantID, engagementID)
+	}
+	if err != nil {
+		return req, err
+	}
+	if err := item.Validate(); err != nil {
+		return req, err
+	}
+	if item.TenantID != tenantID || item.EngagementID != engagementID || item.Locator == "" || req.Value != item.Target() {
+		return req, fmt.Errorf("%w: uploaded source ownership or content identity does not match", shared.ErrValidation)
+	}
+	if req.SourcePackage != nil {
+		expected, _ := json.Marshal(publicSourcePackage(req.SourcePackage))
+		actual, _ := json.Marshal(publicSourcePackage(&item))
+		if string(expected) != string(actual) || req.Locator != item.Locator {
+			return req, fmt.Errorf("%w: queued uploaded source metadata changed", shared.ErrConflict)
+		}
+	}
+	req.Locator, req.SourcePackage = item.Locator, publicSourcePackage(&item)
+	return req, nil
+}

--- a/internal/usecase/sca/uploaded_source_sweeper_test.go
+++ b/internal/usecase/sca/uploaded_source_sweeper_test.go
@@ -1,0 +1,87 @@
+package sca
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type tenantCheckedSourceJobs struct{ *memory.ScanJobStore }
+
+func (store tenantCheckedSourceJobs) Save(ctx context.Context, job ports.ScanJob) error {
+	if job.SourcePackage != nil {
+		tenant, ok := shared.TenantFrom(ctx)
+		if !ok || tenant != job.SourcePackage.TenantID {
+			return shared.ErrValidation
+		}
+	}
+	return store.ScanJobStore.Save(ctx, job)
+}
+
+func TestUploadedSourceSweeperBindsEachOwnedTenant(t *testing.T) {
+	ctx := context.Background() // API/worker sweepers are global daemons.
+	engagements := memory.NewEngagementRepository()
+	jobs := tenantCheckedSourceJobs{memory.NewScanJobStore()}
+	for _, tenant := range []shared.ID{"tenant-a", "tenant-b"} {
+		assessment, err := engdom.New(shared.ID("assessment-"+tenant.String()), tenant, "Uploaded source", "", time.Unix(1000, 0).UTC())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := engagements.Create(ctx, assessment); err != nil {
+			t.Fatal(err)
+		}
+		item := sourcepackage.Package{TenantID: tenant, EngagementID: assessment.ID, VersionID: "owned-version", SHA256: "owned-content"}
+		job := ports.ScanJob{ID: "job-" + tenant.String(), EngagementID: assessment.ID.String(), Kind: ports.TargetUpload, Target: item.Target(),
+			Status: ports.ScanRunning, StartedAt: time.Unix(1000, 0).UTC(), SourcePackage: &item}
+		if err := jobs.CreateRunning(ctx, job); err != nil {
+			t.Fatal(err)
+		}
+	}
+	svc := newAsyncSvc(engagements, fakeClock{t: time.Unix(10000, 0).UTC()}, &fakeAcquirer{}, &fakeAudit{}, &fakeDetector{}, jobs, fakeIDs{})
+	svc.SetRunLock(memory.NewRunLock())
+	n, err := svc.SweepStaleScans(ctx, 5*time.Minute)
+	if err != nil || n != 2 {
+		t.Fatalf("global sweeper failed to finalize tenant-bound uploads: count=%d err=%v", n, err)
+	}
+	for _, tenant := range []shared.ID{"tenant-a", "tenant-b"} {
+		got, err := jobs.GetJob(ctx, "job-"+tenant.String())
+		if err != nil || got.Status != ports.ScanFailed || got.SourcePackage == nil || got.SourcePackage.TenantID != tenant {
+			t.Fatalf("sweeper lost source/terminal state for %s: %+v %v", tenant, got, err)
+		}
+	}
+}
+
+func TestUploadedSourceSweeperRejectsForgedOwner(t *testing.T) {
+	ctx := context.Background()
+	engagements := memory.NewEngagementRepository()
+	assessment, err := engdom.New("assessment", "owner-tenant", "Source", "", time.Unix(1000, 0).UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := engagements.Create(ctx, assessment); err != nil {
+		t.Fatal(err)
+	}
+	jobs := tenantCheckedSourceJobs{memory.NewScanJobStore()}
+	item := sourcepackage.Package{TenantID: "foreign-tenant", EngagementID: assessment.ID, SHA256: "content"}
+	job := ports.ScanJob{ID: "forged-job", EngagementID: assessment.ID.String(), Kind: ports.TargetUpload, Target: item.Target(),
+		Status: ports.ScanRunning, StartedAt: time.Unix(1000, 0).UTC(), SourcePackage: &item}
+	if err := jobs.CreateRunning(ctx, job); err != nil {
+		t.Fatal(err)
+	}
+	svc := newAsyncSvc(engagements, fakeClock{t: time.Unix(10000, 0).UTC()}, &fakeAcquirer{}, &fakeAudit{}, &fakeDetector{}, jobs, fakeIDs{})
+	svc.SetRunLock(memory.NewRunLock())
+	if n, err := svc.SweepStaleScans(ctx, 5*time.Minute); n != 0 || !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("sweeper trusted unverified source tenant: count=%d err=%v", n, err)
+	}
+	got, err := jobs.GetJob(ctx, job.ID)
+	if err != nil || got.Status != ports.ScanRunning {
+		t.Fatalf("forged source job was mutated: %+v %v", got, err)
+	}
+}

--- a/internal/usecase/sca/uploaded_source_test.go
+++ b/internal/usecase/sca/uploaded_source_test.go
@@ -1,0 +1,284 @@
+package sca
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	engdom "github.com/KKloudTarus/synapse-ce/internal/domain/engagement"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/scanrun"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sourcepackage"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/acquire"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/blob"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/persistence/memory"
+	"github.com/KKloudTarus/synapse-ce/internal/infrastructure/sourceupload"
+	evidenceuc "github.com/KKloudTarus/synapse-ce/internal/usecase/evidence"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+type uploadedMarkerDetector struct {
+	markers []string
+	paths   []string
+}
+
+func (d *uploadedMarkerDetector) Detect(_ context.Context, root string) ([]ports.DetectedLanguage, error) {
+	data, err := os.ReadFile(filepath.Join(root, "marker.txt"))
+	if err != nil {
+		return nil, err
+	}
+	d.markers, d.paths = append(d.markers, string(data)), append(d.paths, root)
+	return []ports.DetectedLanguage{{Name: "Go", Percent: 100}}, nil
+}
+
+type uploadedScanFixture struct {
+	ctx         context.Context
+	tenant      shared.ID
+	clock       *fakeClock
+	service     *Service
+	engagements *memory.EngagementRepository
+	objects     *blob.Memory
+	sources     *sourceupload.Store
+	jobs        *memory.ScanJobStore
+	runs        *memory.ScanRunStore
+	queue       *memory.JobQueue
+	detector    *uploadedMarkerDetector
+}
+
+func newUploadedScanFixture(t *testing.T) *uploadedScanFixture {
+	t.Helper()
+	tenant := shared.ID("uploaded-scan-tenant")
+	fixture := &uploadedScanFixture{ctx: shared.WithTenant(context.Background(), tenant), tenant: tenant, clock: &fakeClock{t: time.Date(2026, 9, 8, 11, 0, 0, 0, time.UTC)}, engagements: memory.NewEngagementRepository(), objects: blob.NewMemory(), jobs: memory.NewScanJobStore(), runs: memory.NewScanRunStore(), detector: &uploadedMarkerDetector{}}
+	fixture.sources = sourceupload.NewStoreWithRepository(fixture.objects, memory.NewEngagementSourceRepository(), 0)
+	ids, audit := &sequenceIDs{}, &fakeAudit{}
+	evidence, err := evidenceuc.NewService(&fakeEvidence{}, nil, audit, fixture.clock, ids)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.service = NewService(fixture.engagements, memory.NewFindingRepository(), memory.NewScanRepository(), memory.NewScanResultStore(), fixture.jobs, fixture.runs, evidence, ids, ports.Provenance{}, fixture.clock, audit, shared.SeverityInfo, 0, sourceupload.NewAcquirer(acquire.New(), fixture.sources), fixture.detector, fakeSBOM{}, []ports.DetectionSource{fakeVuln{}}, nil, fakeLic{}, nil)
+	fixture.service.SetUploadedSourceStore(fixture.sources)
+	fixture.service.SetScanRunProvenance(fixture.runs, memory.NewTenantTransactionRunner())
+	fixture.queue = memory.NewJobQueue(ids, fixture.clock.Now)
+	fixture.service.SetQueue(fixture.queue)
+	return fixture
+}
+
+func uploadedZip(t *testing.T, marker string) []byte {
+	t.Helper()
+	var content bytes.Buffer
+	archive := zip.NewWriter(&content)
+	entry, err := archive.Create("marker.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := entry.Write([]byte(marker)); err != nil {
+		t.Fatal(err)
+	}
+	if err := archive.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return content.Bytes()
+}
+
+func (f *uploadedScanFixture) createAssessment(t *testing.T, id shared.ID, target string) {
+	t.Helper()
+	item, err := engdom.New(id, f.tenant, id.String(), "", f.clock.t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	item.Scope.InScope = []engdom.Target{{Kind: engdom.TargetRepo, Value: target}}
+	if err := item.Transition(engdom.StatusActive, f.clock.t); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.engagements.Create(f.ctx, item); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (f *uploadedScanFixture) upload(t *testing.T, id shared.ID, marker string) sourcepackage.Package {
+	t.Helper()
+	data := uploadedZip(t, marker)
+	hash := sha256.Sum256(data)
+	digest := hex.EncodeToString(hash[:])
+	f.createAssessment(t, id, sourcepackage.TargetPrefix+digest)
+	item, err := f.sources.Save(f.ctx, f.tenant, id, "source.zip", "alice", f.clock.t, int64(len(data)), digest, bytes.NewReader(data))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return item
+}
+
+func (f *uploadedScanFixture) start(t *testing.T, item sourcepackage.Package) ports.ScanJob {
+	t.Helper()
+	job, err := f.service.StartUploadedSourceVersionScanWithOptions(f.ctx, "tester", f.tenant, item.EngagementID, item.VersionID, ScanOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return job
+}
+
+func (f *uploadedScanFixture) runNext(t *testing.T, mutate func(*scaJobPayload)) {
+	t.Helper()
+	queued, err := f.queue.Claim(f.ctx, time.Minute, ScanJobKind)
+	if err != nil || queued == nil {
+		t.Fatalf("claim uploaded scan = %+v %v", queued, err)
+	}
+	payload := queued.Payload
+	if mutate != nil {
+		var parsed scaJobPayload
+		if err := json.Unmarshal(payload, &parsed); err != nil {
+			t.Fatal(err)
+		}
+		mutate(&parsed)
+		payload, err = json.Marshal(parsed)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := f.service.RunScanJob(f.ctx, payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.queue.Complete(f.ctx, queued.ID, queued.Fence); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestUploadedSourceQueuedScansFreezeInitialReuseAndNewUpload(t *testing.T) {
+	f := newUploadedScanFixture(t)
+	initial := f.upload(t, "initial", "source A")
+	initialJob := f.start(t, initial)
+	// Before the worker runs, subsequent assessments select both a new upload
+	// and the original package. Neither can redirect the already admitted job.
+	newUpload := f.upload(t, "retest-new-upload", "source B")
+	f.createAssessment(t, "retest-reuse", initial.Target())
+	reused, err := f.sources.Reuse(f.ctx, f.tenant, initial.EngagementID, "retest-reuse", initial.VersionID, "bob", f.clock.t.Add(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if initialJob.SourcePackage == nil || initialJob.SourcePackage.Locator != "" || initialJob.SourcePackage.ObjectKey != "" {
+		t.Fatalf("queued public metadata exposes storage: %+v", initialJob.SourcePackage)
+	}
+	initialJob.SourcePackage.Filename = "caller-mutated.zip"
+	f.runNext(t, nil)
+	for _, item := range []sourcepackage.Package{newUpload, reused} {
+		f.start(t, item)
+		f.runNext(t, nil)
+	}
+	if strings.Join(f.detector.markers, ",") != "source A,source B,source A" {
+		t.Fatalf("wrong acquired source bytes: %v", f.detector.markers)
+	}
+	for _, path := range f.detector.paths {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("scan workspace not cleaned: %s %v", path, err)
+		}
+	}
+	for _, item := range []sourcepackage.Package{initial, newUpload, reused} {
+		job, err := f.jobs.LatestForEngagement(f.ctx, item.EngagementID)
+		if err != nil || job.Status != ports.ScanSucceeded || job.Error != "" || job.SourcePackage == nil || *job.SourcePackage != *publicSourcePackage(&item) {
+			t.Fatalf("terminal job source = %+v %v", job, err)
+		}
+		run, err := f.runs.GetScanRun(f.ctx, f.tenant, job.ID)
+		if err != nil || run.Provenance != scanrun.ProvenanceNative || !run.IsSealed() || len(run.Lanes) == 0 {
+			t.Fatalf("native uploaded run = %+v %v", run, err)
+		}
+		for _, lane := range run.Lanes {
+			if lane.Target.EvaluatedRevision != item.SHA256 {
+				t.Fatalf("native target revision does not identify acquired bytes: %+v", lane.Target)
+			}
+		}
+		retained, err := f.runs.Get(f.ctx, job.ID)
+		if err != nil || retained.Manifest.SourcePackage == nil || *retained.Manifest.SourcePackage != *publicSourcePackage(&item) {
+			t.Fatalf("frozen run source = %+v %v", retained.Manifest.SourcePackage, err)
+		}
+		// Returned pointers are read copies, not mutable references into history.
+		retained.Manifest.SourcePackage.CreatedBy = "forged"
+		job.SourcePackage.CreatedBy = "forged"
+		freshRun, _ := f.runs.Get(f.ctx, job.ID)
+		freshJob, _ := f.jobs.GetJob(f.ctx, job.ID)
+		if freshRun.Manifest.SourcePackage.CreatedBy != "alice" || freshJob.SourcePackage.CreatedBy != "alice" {
+			t.Fatal("returned metadata pointer mutated stored provenance")
+		}
+	}
+	if reused.VersionID == initial.VersionID || reused.ReusedFromVersionID != initial.VersionID || reused.AssociatedBy != "bob" {
+		t.Fatal("child scan did not retain its distinct reuse association")
+	}
+}
+
+func TestUploadedSourceAdmissionRejectsStaleVersionAndForeignOwnership(t *testing.T) {
+	f := newUploadedScanFixture(t)
+	initial := f.upload(t, "initial", "source A")
+	other := f.upload(t, "other", "source B")
+	if _, err := f.service.StartUploadedSourceVersionScanWithOptions(f.ctx, "tester", f.tenant, initial.EngagementID, other.VersionID, ScanOptions{}); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("stale selected version = %v", err)
+	}
+	if _, err := f.service.StartUploadedSourceVersionScanWithOptions(shared.WithTenant(f.ctx, "other-tenant"), "tester", "other-tenant", initial.EngagementID, initial.VersionID, ScanOptions{}); !errors.Is(err, shared.ErrNotFound) {
+		t.Fatalf("foreign source admission = %v", err)
+	}
+	req := ports.AcquireRequest{Kind: ports.TargetUpload, Value: initial.Target(), Locator: initial.Locator, SourcePackage: publicSourcePackage(&initial)}
+	req.SourcePackage.EngagementID = other.EngagementID
+	if _, err := f.service.StartScan(f.ctx, "tester", initial.EngagementID, req); !errors.Is(err, shared.ErrConflict) {
+		t.Fatalf("mismatched source owner = %v", err)
+	}
+	if queued, err := f.queue.Claim(f.ctx, time.Minute, ScanJobKind); err != nil || queued != nil {
+		t.Fatalf("invalid source selection enqueued a scan: %+v %v", queued, err)
+	}
+}
+
+func TestUploadedSourceFailedQueuedAcquisitionRetainsAdmittedMetadata(t *testing.T) {
+	for _, scenario := range []string{"tampered-bytes", "missing-bytes", "invalid-zip", "tampered-metadata", "mismatched-owner", "mismatched-locator"} {
+		t.Run(scenario, func(t *testing.T) {
+			f := newUploadedScanFixture(t)
+			item := f.upload(t, "initial", "source A")
+			if scenario == "invalid-zip" {
+				// Valid digest/storage metadata must not make an invalid archive executable.
+				data := []byte("not a ZIP archive")
+				hash := sha256.Sum256(data)
+				digest := hex.EncodeToString(hash[:])
+				f.createAssessment(t, "invalid", sourcepackage.TargetPrefix+digest)
+				var err error
+				item, err = f.sources.Save(f.ctx, f.tenant, "invalid", "source.zip", "alice", f.clock.t, int64(len(data)), digest, bytes.NewReader(data))
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+			job := f.start(t, item)
+			var mutate func(*scaJobPayload)
+			switch scenario {
+			case "tampered-bytes":
+				if err := f.objects.Put(f.ctx, item.ObjectKey, bytes.Repeat([]byte("x"), int(item.Size))); err != nil {
+					t.Fatal(err)
+				}
+			case "missing-bytes":
+				if err := f.objects.DeleteObject(f.ctx, item.ObjectKey); err != nil {
+					t.Fatal(err)
+				}
+			case "tampered-metadata":
+				mutate = func(payload *scaJobPayload) { payload.Req.SourcePackage.CreatedBy = "forged" }
+			case "mismatched-owner":
+				mutate = func(payload *scaJobPayload) { payload.Req.SourcePackage.EngagementID = "unrelated" }
+			case "mismatched-locator":
+				mutate = func(payload *scaJobPayload) { payload.Req.Locator += "-changed" }
+			}
+			f.runNext(t, mutate)
+			terminal, err := f.jobs.GetJob(f.ctx, job.ID)
+			if err != nil || terminal.Status != ports.ScanFailed || terminal.Error == "" || terminal.SourcePackage == nil || *terminal.SourcePackage != *publicSourcePackage(&item) {
+				t.Fatalf("failed job lost original source: %+v %v", terminal, err)
+			}
+			if len(f.detector.markers) != 0 {
+				t.Fatal("untrusted/mismatched source reached a scanner")
+			}
+			if runs, err := f.runs.List(f.ctx, item.EngagementID); err != nil || len(runs) != 0 {
+				t.Fatalf("failed acquisition emitted successful history: %+v %v", runs, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Expose the lifecycle contract over HTTP and connect scan/worker evidence publication, finding writes and rollout gates. Retain current main response/scanner behavior and extend the existing ScanRun history reader without duplicate definitions.

Phase 8/10. Base: `codex/868-phase-08-closure-relationships`. Keep #868 as tracking/reference only; do not merge it.

## Review follow-up: migration 0145 collision

Addressed the new review on #884 and the dependent holds on #885–#893. Main `9a7bae2d` includes #921's `0145_advisory_alias_index.sql`; the entire unmerged assessment block moves from 0145–0159 to **0146–0160**. #884 adds only 0146; #885 adds 0147–0160. All 15 assessment SQL bodies and their relative order are preserved. Existing main migrations (including 0145), core ScanRun and governed response/correlation code remain unchanged.

Updated migration test filenames and embedded-file references, Goose UpTo/DownTo targets, upgrade fixtures from main version 0145, diagnostics, and operational documentation. The complete payload is preserved through an explicit old/new filename map; runtime assessment code is unchanged by renumbering. Each PR still contains one capability commit against its immediate predecessor.

## Validation

Local validation after this update: all 10 phases passed scoped tests and repository-wide Go builds; the final stack passed repository-wide Go tests and vet. Isolated PostgreSQL 17 tests passed for duplicate migration inventory, authoritative main migrations, assessment upgrade/rollback paths, tenant isolation, immutable evidence and source bindings. Frontend typecheck, 116 test files / 694 tests, production build and lint passed (0 errors, 10 existing warnings); Helm lint/render assertions passed. CI is disabled, so these are explicitly local results. Final GitHub heads, bases and incremental file diffs are checked against the tested commits.

## Stack merge order

#884 → #885 → #886 → #887 → #888 → #889 → #890 → #891 → #892 → #893

Merge #884 first, then proceed in order. Prefer merge commits to retain ancestry; after each predecessor merges, retarget the next PR to `main` and inspect its remaining diff. Branch names remain stable. See the [preservation and migration audit](https://github.com/KKloudTarus/synapse-ce/blob/codex/868-phase-11-operations-docs/docs/architecture/assessment-stack-868-audit.md).
