### PR TITLE
feat(ui): [9/10] expose lifecycle comparison and retest workflows

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { Menu01 } from '@untitledui/icons'
-import { lazy, Suspense, useState } from 'react'
+import { lazy, Suspense, useState, type ReactNode } from 'react'
 import { Navigate, Outlet, Route, Routes, useLocation } from 'react-router-dom'
 import { AuthProvider, useAuth } from './auth/AuthContext'
 import { ErrorBoundary } from './components/layout/ErrorBoundary'
@@ -12,6 +12,8 @@ import { NotFound } from './pages/NotFound'
 // --- Lazy-loaded page components ---
 const Dashboard = lazy(() => import('./pages/Dashboard/DashboardPage').then(m => ({ default: m.DashboardPage })))
 const Engagements = lazy(() => import('./pages/Engagements/EngagementsPage').then(m => ({ default: m.EngagementsPage })))
+const AssessmentCycles = lazy(() => import('./pages/AssessmentCycles/AssessmentCyclesPage').then(m => ({ default: m.AssessmentCyclesPage })))
+const AssessmentCycleDetail = lazy(() => import('./pages/AssessmentCycles/AssessmentCycleDetailPage').then(m => ({ default: m.AssessmentCycleDetailPage })))
 const NewEngagement = lazy(() => import('./pages/Engagements/NewEngagementPage').then(m => ({ default: m.NewEngagementPage })))
 const EngagementDetail = lazy(() => import('./pages/EngagementDetail').then(m => ({ default: m.EngagementDetail })))
 const Assets = lazy(() => import('./pages/Assets/Assets').then(m => ({ default: m.Assets })))
@@ -44,6 +46,8 @@ const Integrations = lazy(() => import('./pages/Settings/Integrations').then(m =
 const Connectors = lazy(() => import('./pages/Settings/Connectors').then(m => ({ default: m.Connectors })))
 const TelemetryPrivacy = lazy(() => import('./pages/Settings/TelemetryPrivacy').then(m => ({ default: m.TelemetryPrivacy })))
 const ResponseOps = lazy(() => import('./pages/BlueTeam/ResponseOps').then(m => ({ default: m.ResponseOps })))
+
+const AssessmentRelationships = lazy(() => import('./pages/Settings/AssessmentRelationships').then(m => ({ default: m.AssessmentRelationships })))
 const AITriageReviews = lazy(() => import('./pages/AITriage/AITriageReviews').then(m => ({ default: m.AITriageReviews })))
 const AITriageObservability = lazy(() => import('./pages/AITriage/AITriageObservability').then(m => ({ default: m.AITriageObservability })))
 const VulnerabilityIntelligence = lazy(() => import('./pages/VulnerabilityIntelligence').then(m => ({ default: m.VulnerabilityIntelligence })))
@@ -80,6 +84,8 @@ function Gate() {
         <Route index element={<Navigate to="/dashboard" replace />} />
         <Route path="dashboard" element={<Dashboard />} />
         <Route path="engagements" element={<Engagements />} />
+        <Route path="assessment-cycles" element={<AssessmentLifecycleRoute><AssessmentCycles /></AssessmentLifecycleRoute>} />
+        <Route path="assessment-cycles/:cycleId" element={<AssessmentLifecycleRoute><AssessmentCycleDetail /></AssessmentLifecycleRoute>} />
         <Route path="engagements/new" element={<NewEngagement />} />
         <Route path="engagements/:id" element={<EngagementDetail />} />
         <Route path="engagements/:id/:tabSlug" element={<EngagementDetail />} />
@@ -123,6 +129,8 @@ function Gate() {
           <Route path="integrations" element={<Integrations />} />
           <Route path="connectors" element={<Connectors />} />
           <Route path="privacy" element={<TelemetryPrivacy />} />
+
+          <Route path="relationships" element={<AssessmentRelationships />} />
           <Route path="config" element={<SettingsConfig />} />
           <Route path="sla" element={<SLAPolicy />} />
           <Route path="offensive-policy" element={<OffensivePolicy />} />
@@ -138,6 +146,12 @@ function Gate() {
       </Route>
     </Routes>
   )
+}
+
+function AssessmentLifecycleRoute({ children }: { children: ReactNode }) {
+  const { currentUser } = useAuth()
+  if (currentUser?.features?.assessmentLifecycleUIDefault !== true) return <Navigate to="/engagements" replace />
+  return children
 }
 
 function Shell() {

--- a/web/src/auth/AuthContext.tsx
+++ b/web/src/auth/AuthContext.tsx
@@ -8,7 +8,7 @@ import {
   type ReactNode,
 } from 'react'
 import { api, ApiError, discoverSession, logoutSession, setCSRFToken, setToken as setApiToken, setUnauthorizedHandler } from '../lib/api'
-import type { AupStatus } from '../lib/types'
+import type { AupStatus, CurrentUser } from '../lib/types'
 
 // The development/automation bearer token is kept in sessionStorage so it dies with the
 // browser tab instead of persisting across restarts for later XSS to read.
@@ -18,6 +18,7 @@ type Phase = 'connecting' | 'unauthenticated' | 'need-aup' | 'ready'
 interface AuthState {
   phase: Phase
   aup: AupStatus | null
+  currentUser: CurrentUser | null
   error: string | null
   connecting: boolean
   oidcAvailable: boolean
@@ -43,6 +44,7 @@ export function useOptionalAuth(): AuthState | null {
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [phase, setPhase] = useState<Phase>('connecting')
   const [aup, setAup] = useState<AupStatus | null>(null)
+  const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [connecting, setConnecting] = useState(false)
   const [oidcAvailable, setOidcAvailable] = useState(true)
@@ -54,11 +56,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setCSRFToken('')
     setAuthMethod(null)
     setAup(null)
+    setCurrentUser(null)
   }, [])
 
   const refreshAup = useCallback(async () => {
     const status = await api.aup()
     setAup(status)
+    const me = status.accepted && typeof api.me === 'function' ? await api.me().catch(() => null) : null
+    setCurrentUser(me)
     setPhase(status.accepted ? 'ready' : 'need-aup')
   }, [])
 
@@ -198,8 +203,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [clearAuthentication, refreshAup])
 
   const value = useMemo(
-    () => ({ phase, aup, error, connecting, oidcAvailable, connect, acceptAup, logout }),
-    [phase, aup, error, connecting, oidcAvailable, connect, acceptAup, logout],
+    () => ({ phase, aup, currentUser, error, connecting, oidcAvailable, connect, acceptAup, logout }),
+    [phase, aup, currentUser, error, connecting, oidcAvailable, connect, acceptAup, logout],
   )
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>

--- a/web/src/components/layout/Sidebar.tsx
+++ b/web/src/components/layout/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   ChevronRight,
   Cube01,
   Dataflow03,
+  GitBranch01,
   Key01,
   LogOut01,
   Plus,
@@ -59,6 +60,7 @@ const NAV_GROUPS: Array<{
       label: 'Security operations',
       items: [
         { icon: Target04, label: 'Engagements', to: '/engagements' },
+        { icon: GitBranch01, label: 'Assessment Cycles', to: '/assessment-cycles' },
         { icon: ShieldTick, label: 'Review Queue', to: '/ai-triage/reviews', capability: 'ai_triage' },
       ],
     },
@@ -155,6 +157,7 @@ function renderDisabledItem({
 
 function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; onNavigate?: () => void }) {
   const auth = useOptionalAuth()
+  const lifecycleUIEnabled = auth?.currentUser?.features?.assessmentLifecycleUIDefault === true
   const [signingOut, setSigningOut] = useState(false)
   async function onSignOut() {
     if (!auth) return
@@ -180,7 +183,7 @@ function SidebarNav({ collapsed = false, onNavigate }: { collapsed?: boolean; on
   }
 
   function renderItems(items: NavItem[]) {
-    return items.map(({ icon: Icon, label, to, end, children, capability }) => {
+    return items.filter((item) => item.to !== '/assessment-cycles' || lifecycleUIEnabled).map(({ icon: Icon, label, to, end, children, capability }) => {
       const offline = disabledCapability(capabilities, capability)
       if (offline) return renderDisabledItem({ icon: Icon, label, to, capability: offline, collapsed })
       const hasChildren = Boolean(children && children.length > 0)

--- a/web/src/components/synapse/RetestSourceChoice.tsx
+++ b/web/src/components/synapse/RetestSourceChoice.tsx
@@ -1,0 +1,96 @@
+import { File02, RefreshCw01, Upload01, XClose } from '@untitledui/icons'
+import { useId, useRef, useState } from 'react'
+import { Spinner, cn } from '../ui'
+import type { useRetestSource } from '../../hooks/useRetestSource'
+import { SourcePackageSummary } from './SourcePackageSummary'
+
+function formatSize(bytes: number) {
+  if (bytes < 1024 * 1024) return `${Math.max(1, Math.ceil(bytes / 1024))} KiB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MiB`
+}
+
+export function RetestSourceChoice({ selection, disabled = false, onChange }: { selection: ReturnType<typeof useRetestSource>; disabled?: boolean; onChange?: () => void }) {
+  const id = useId()
+  const fileInput = useRef<HTMLInputElement>(null)
+  const [dragging, setDragging] = useState(false)
+  const chooseFile = (file?: File) => {
+    onChange?.()
+    selection.chooseFile(file)
+  }
+
+  if (selection.loading) return <Spinner label="Loading previous source…" />
+  if (selection.error) return <div role="alert" className="rounded-xl border border-error/30 bg-error/5 p-4 text-sm text-error-primary">
+    <p className="font-medium">Could not load the previous source</p>
+    <p className="mt-1 text-xs">{selection.error}</p>
+    <button type="button" disabled={disabled} onClick={() => { onChange?.(); selection.refetch() }} className="mt-3 inline-flex min-h-9 items-center gap-2 rounded-lg px-2 text-sm font-semibold underline underline-offset-4 disabled:opacity-50">
+      <RefreshCw01 className="size-4" aria-hidden="true" />Retry source lookup
+    </button>
+  </div>
+  if (!selection.hasUploadedSource) return null
+
+  const usePrevious = selection.strategy === 'reuse_current'
+  const selectStrategy = (strategy: 'reuse_current' | 'upload_new') => {
+    onChange?.()
+    selection.changeStrategy(strategy)
+  }
+  return <fieldset disabled={disabled} className="min-w-0 space-y-4">
+    <div>
+      <legend className="text-base font-semibold text-primary">Source</legend>
+      <p className="mt-1 text-sm text-tertiary">Choose what this verification cycle should assess.</p>
+    </div>
+
+    <div role="radiogroup" aria-label="Re-test source" className="grid gap-3 sm:grid-cols-2">
+      <label className={cn('cursor-pointer rounded-xl border p-4 transition-colors focus-within:ring-2 focus-within:ring-brand/60', usePrevious ? 'border-brand/50 bg-brand-primary/10' : 'border-secondary bg-primary hover:border-brand/40')}>
+        <input type="radio" disabled={!selection.source} name={`${id}-source`} checked={usePrevious} onChange={() => selectStrategy('reuse_current')} className="sr-only" />
+        <span className="flex items-start gap-3">
+          <span aria-hidden="true" className={cn('mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border', usePrevious ? 'border-brand-solid bg-brand-solid ring-2 ring-brand-primary' : 'border-secondary')}><span className={cn('size-1.5 rounded-full bg-white', !usePrevious && 'hidden')} /></span>
+          <span className="min-w-0">
+            <span className="block text-sm font-semibold text-primary">Use current source</span>
+            <span className="mt-1 block text-xs leading-relaxed text-tertiary">Continue using the current source retained by the previous assessment.</span>
+          </span>
+        </span>
+      </label>
+      <label className={cn('cursor-pointer rounded-xl border p-4 transition-colors focus-within:ring-2 focus-within:ring-brand/60', !usePrevious ? 'border-brand/50 bg-brand-primary/10' : 'border-secondary bg-primary hover:border-brand/40')}>
+        <input type="radio" name={`${id}-source`} checked={!usePrevious} onChange={() => selectStrategy('upload_new')} className="sr-only" />
+        <span className="flex items-start gap-3">
+          <span aria-hidden="true" className={cn('mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-full border', !usePrevious ? 'border-brand-solid bg-brand-solid ring-2 ring-brand-primary' : 'border-secondary')}><span className={cn('size-1.5 rounded-full bg-white', usePrevious && 'hidden')} /></span>
+          <span className="min-w-0">
+            <span className="block text-sm font-semibold text-primary">Upload new source</span>
+            <span className="mt-1 block text-xs leading-relaxed text-tertiary">Use a remediated archive for this Re-test.</span>
+          </span>
+        </span>
+      </label>
+    </div>
+
+    {!selection.source ? <p role="status" className="rounded-xl border border-warning/30 bg-warning/10 p-3 text-xs leading-relaxed text-warning">The previous source archive is unavailable. Upload an archive for this Re-test; previous scan history remains unchanged.</p> : null}
+
+    {usePrevious && selection.source ? <div className="rounded-xl border border-secondary bg-secondary/30 p-4">
+      <p className="mb-3 text-xs font-semibold uppercase tracking-wide text-tertiary">Previous source</p>
+      <SourcePackageSummary source={selection.source} compact />
+    </div> : null}
+
+    {!usePrevious ? <div className="space-y-3 rounded-xl border border-secondary bg-secondary/20 p-4">
+      <input ref={fileInput} key={selection.assessmentId} id={`${id}-source-file`} disabled={disabled} aria-label="Re-test source archive" type="file" accept=".zip,.tar,.tar.gz,.tgz" className="sr-only" onChange={(event) => chooseFile(event.target.files?.[0])} />
+      {selection.file ? <div className="flex min-w-0 items-start gap-3 rounded-lg bg-primary p-3">
+        <File02 className="mt-0.5 size-5 shrink-0 text-brand-secondary" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold text-primary" title={selection.file.name}>{selection.file.name}</p>
+          <p className="mt-1 text-xs text-tertiary">{formatSize(selection.file.size)} · Ready to upload when the Re-test is created</p>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <button type="button" disabled={disabled} onClick={() => fileInput.current?.click()} className="min-h-9 rounded-lg px-2 text-xs font-semibold text-brand-secondary hover:bg-brand-primary/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:opacity-50">Replace</button>
+          <button type="button" disabled={disabled} onClick={() => chooseFile()} className="flex size-9 items-center justify-center rounded-lg text-tertiary hover:bg-secondary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:opacity-50" aria-label="Remove source archive"><XClose className="size-4" aria-hidden="true" /></button>
+        </div>
+      </div> : <button type="button" disabled={disabled} onClick={() => fileInput.current?.click()} onDragEnter={(event) => { event.preventDefault(); setDragging(true) }} onDragOver={(event) => event.preventDefault()} onDragLeave={() => setDragging(false)} onDrop={(event) => { event.preventDefault(); setDragging(false); chooseFile(event.dataTransfer.files[0]) }} className={cn('flex min-h-28 w-full flex-col items-center justify-center rounded-lg border border-dashed px-4 text-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:cursor-not-allowed disabled:opacity-50', dragging ? 'border-brand bg-brand-primary/10 text-primary' : 'border-secondary bg-primary text-tertiary hover:border-brand/50')}>
+        <Upload01 className="size-5" aria-hidden="true" />
+        <span className="mt-2 text-sm font-semibold text-primary">Drop an archive here or choose a file</span>
+        <span className="mt-1 text-xs">ZIP, TAR, TAR.GZ, or TGZ · up to 512 MiB</span>
+      </button>}
+      {selection.file ? <label className="flex cursor-default items-start gap-2 rounded-lg bg-primary/70 px-3 py-2.5 text-xs text-secondary">
+        <input type="checkbox" checked readOnly aria-label="Force update source" className="mt-0.5 size-4 shrink-0 rounded accent-brand-solid" />
+        <span><span className="font-semibold text-primary">Force update source</span><span className="mt-0.5 block leading-relaxed">This archive will be used for this Re-test. The previous assessment’s archive remains unchanged.</span></span>
+      </label> : null}
+    </div> : null}
+    <p className="text-xs text-tertiary">The source is immutable for this Assessment. Creating the draft does not start a scan.</p>
+  </fieldset>
+}

--- a/web/src/components/synapse/SourcePackageSummary.tsx
+++ b/web/src/components/synapse/SourcePackageSummary.tsx
@@ -1,0 +1,20 @@
+import type { UploadedSourcePackage } from '../../lib/types'
+
+function formatTime(value?: string | null) {
+  if (!value) return 'Unknown time'
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? 'Unknown time' : date.toLocaleString()
+}
+
+export function SourcePackageSummary({ source, compact = false }: { source: UploadedSourcePackage; compact?: boolean }) {
+  return <div className="min-w-0 space-y-1 text-xs text-tertiary">
+    <p className="break-words font-medium text-primary">{source.filename || 'Source archive'}</p>
+    <p>{source.size.toLocaleString()} bytes{source.reusedFromVersionId ? ' · Reused source' : ''}</p>
+    <p className="break-all font-mono" aria-label={`Source SHA-256 ${source.sha256}`}>SHA-256: {source.sha256 || 'Unavailable'}</p>
+    {!compact ? <>
+      {source.versionId ? <p className="break-all font-mono">Version: {source.versionId}</p> : null}
+      <p className="break-words">Uploaded by {source.uploadedBy || 'Unknown actor'} · {formatTime(source.uploadedAt)}</p>
+      {source.associatedAt ? <p className="break-words">Associated by {source.associatedBy || 'Unknown actor'} · {formatTime(source.associatedAt)}</p> : null}
+    </> : null}
+  </div>
+}

--- a/web/src/hooks/useRequestIdempotency.ts
+++ b/web/src/hooks/useRequestIdempotency.ts
@@ -1,0 +1,15 @@
+import { useRef } from 'react'
+import { newIdempotencyKey } from '../lib/api/client'
+
+// Retries of one logical command reuse its key. An edited payload or a newly
+// selected File is a different command, not a retry of the retained request.
+export function useRequestIdempotency() {
+  const attempt = useRef<{ payload: string; file?: File; key: string } | null>(null)
+  return (input: unknown, file?: File) => {
+    const payload = JSON.stringify(input)
+    if (!attempt.current || attempt.current.payload !== payload || attempt.current.file !== file) {
+      attempt.current = { payload, file, key: newIdempotencyKey() }
+    }
+    return attempt.current.key
+  }
+}

--- a/web/src/hooks/useRetestSource.test.tsx
+++ b/web/src/hooks/useRetestSource.test.tsx
@@ -1,0 +1,134 @@
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api, ApiError } from '../lib/api'
+import type { UploadedSourcePackage } from '../lib/types'
+import { RetestSourceChoice } from '../components/synapse/RetestSourceChoice'
+import { MAX_SOURCE_BYTES, sourceArchiveError, useRetestSource } from './useRetestSource'
+
+vi.mock('../lib/api', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../lib/api')>(),
+  api: { uploadedSource: vi.fn(), getEngagement: vi.fn() },
+}))
+
+const source: UploadedSourcePackage = {
+  versionId: 'version-a', filename: 'source-a.zip', size: 2048, sha256: 'a'.repeat(64), target: '', uploadedBy: 'operator', uploadedAt: '2026-09-08T00:00:00Z',
+}
+
+describe('uploaded predecessor source selection', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(api.getEngagement).mockResolvedValue({ inScope: [{ kind: 'repo', value: 'https://example.test/repo' }] } as never)
+  })
+
+  it('clears a selected file when the predecessor changes, including switching back', async () => {
+    vi.mocked(api.uploadedSource).mockImplementation(async (id) => ({ ...source, versionId: `version-${id}` }))
+    const { result, rerender } = renderHook(({ id }) => useRetestSource(id), { initialProps: { id: 'a' } })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    const file = new File(['revision'], 'new.zip')
+    act(() => result.current.chooseFile(file))
+    expect(result.current.input).toMatchObject({ sourceStrategy: 'upload_new', source: file })
+    rerender({ id: 'b' })
+    expect(result.current.file).toBeUndefined()
+    expect(result.current.input).toEqual({})
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.input).toMatchObject({ sourceStrategy: 'reuse_current', sourceVersionId: 'version-b' })
+    rerender({ id: 'a' })
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.input).toMatchObject({ sourceStrategy: 'reuse_current', sourceVersionId: 'version-a', source: undefined })
+  })
+
+  it('does not reuse stale metadata when an older predecessor lookup resolves later', async () => {
+    let resolveFirst!: (value: UploadedSourcePackage) => void
+    vi.mocked(api.uploadedSource).mockImplementation((id) => id === 'a'
+      ? new Promise((resolve) => { resolveFirst = resolve })
+      : Promise.resolve({ ...source, versionId: 'version-b' }))
+    const { result, rerender } = renderHook(({ id }) => useRetestSource(id), { initialProps: { id: 'a' } })
+    expect(result.current.loading).toBe(true)
+    expect(result.current.validationError('copy')).toMatch(/Wait/)
+    rerender({ id: 'b' })
+    await waitFor(() => expect(result.current.input.sourceVersionId).toBe('version-b'))
+    await act(async () => { resolveFirst(source) })
+    expect(result.current.input.sourceVersionId).toBe('version-b')
+  })
+
+  it.each([
+    ['git', { kind: 'repo', value: 'https://example.test/repository.git' }],
+    ['local', { kind: 'repo', value: '/authorized/source/repository' }],
+    ['image', { kind: 'image', value: 'registry.example.test/application:v1' }],
+  ])('keeps %s predecessor requests unchanged when no uploaded package exists', async (_kind, target) => {
+    vi.mocked(api.uploadedSource).mockRejectedValue(new ApiError(404, 'Not found'))
+    vi.mocked(api.getEngagement).mockResolvedValue({ inScope: [target] } as never)
+    const { result } = renderHook(() => useRetestSource('source-less'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.input).toEqual({})
+    expect(result.current.validationError('empty')).toBe('')
+    render(<RetestSourceChoice selection={result.current} />)
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument()
+  })
+
+  it('keeps permission failures distinct from an absent source and constrains empty scope', async () => {
+    vi.mocked(api.uploadedSource).mockRejectedValueOnce(new ApiError(403, 'Not authorized')).mockResolvedValueOnce(source)
+    const { result } = renderHook(() => useRetestSource('a'))
+    await waitFor(() => expect(result.current.error).toBe('Not authorized'))
+    expect(result.current.validationError('copy')).toMatch(/Retry/)
+    act(() => result.current.refetch())
+    await waitFor(() => expect(result.current.source).toEqual(source))
+    expect(result.current.validationError('empty')).toMatch(/must copy/)
+    expect(result.current.validationError('copy')).toBe('')
+  })
+
+  it('allows a new child archive when a legacy uploaded predecessor has lost its package metadata', async () => {
+    vi.mocked(api.uploadedSource).mockRejectedValue(new ApiError(404, 'No package'))
+    vi.mocked(api.getEngagement).mockResolvedValue({ inScope: [{ kind: 'repo', value: `uploaded-source/sha256/${'a'.repeat(64)}` }] } as never)
+    const { result } = renderHook(() => useRetestSource('legacy-upload'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.source).toBeNull()
+    expect(result.current.strategy).toBe('upload_new')
+    expect(result.current.validationError('copy')).toBe('Choose a source archive to upload.')
+    expect(api.getEngagement).toHaveBeenCalledWith('legacy-upload')
+    const file = new File(['recovered revision'], 'replacement.zip')
+    act(() => result.current.chooseFile(file))
+    expect(result.current.input).toEqual({ sourceStrategy: 'upload_new', sourceVersionId: undefined, source: file })
+    expect(result.current.validationError('empty')).toMatch(/must copy/)
+    render(<RetestSourceChoice selection={result.current} />)
+    expect(screen.getByRole('radio', { name: /Use current source/ })).toBeDisabled()
+    expect(screen.getByRole('radio', { name: /Upload new source/ })).toBeChecked()
+    expect(screen.getByRole('status')).toHaveTextContent('previous source archive is unavailable')
+    expect(screen.queryByText('source-a.zip')).not.toBeInTheDocument()
+  })
+
+  it('does not classify a failed fallback scope lookup as a source-less predecessor', async () => {
+    vi.mocked(api.uploadedSource).mockRejectedValue(new ApiError(404, 'No package'))
+    vi.mocked(api.getEngagement).mockRejectedValue(new ApiError(503, 'Scope lookup unavailable'))
+    const { result } = renderHook(() => useRetestSource('a'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.error).toBe('Scope lookup unavailable')
+    expect(result.current.validationError('copy')).toMatch(/Retry/)
+    expect(result.current.input).toEqual({})
+  })
+
+  it('renders an untrusted archive filename as text and disables all choices during submission', async () => {
+    vi.mocked(api.uploadedSource).mockResolvedValue({ ...source, filename: '<img src=x onerror=alert(1)>.zip' })
+    function Choice() { return <RetestSourceChoice selection={useRetestSource('a')} disabled /> }
+    const view = render(<Choice />)
+    expect(await screen.findByText('<img src=x onerror=alert(1)>.zip')).toBeVisible()
+    expect(view.container.querySelector('img')).toBeNull()
+    expect(screen.getByRole('radio', { name: /Use current source/ })).toBeDisabled()
+    expect(screen.getByRole('radio', { name: /Upload new source/ })).toBeDisabled()
+    await userEvent.click(screen.getByRole('radio', { name: /Upload new source/ }))
+    expect(screen.queryByLabelText('Re-test source archive')).not.toBeInTheDocument()
+  })
+
+  it('validates archive type and non-empty size without accepting an oversized upload', () => {
+    for (const name of ['source.zip', 'source.tar', 'source.tar.gz', 'source.tgz', 'SOURCE.ZIP']) {
+      expect(sourceArchiveError(new File(['archive'], name))).toBe('')
+    }
+    expect(sourceArchiveError()).not.toBe('')
+    expect(sourceArchiveError(new File([], 'empty.zip'))).not.toBe('')
+    expect(sourceArchiveError(new File(['bytes'], 'source.zip.exe'))).not.toBe('')
+    const oversized = new File(['small fixture'], 'large.zip')
+    Object.defineProperty(oversized, 'size', { value: MAX_SOURCE_BYTES + 1 })
+    expect(sourceArchiveError(oversized)).not.toBe('')
+  })
+})

--- a/web/src/hooks/useRetestSource.ts
+++ b/web/src/hooks/useRetestSource.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react'
+import { api, ApiError } from '../lib/api'
+import type { CreateAssessmentRetestInput, UploadedSourcePackage } from '../lib/types'
+
+export const MAX_SOURCE_BYTES = 512 * 1024 * 1024
+export function sourceArchiveError(file?: File): string {
+  if (!file) return 'Choose a source archive to upload.'
+  return /\.(zip|tar|tar\.gz|tgz)$/i.test(file.name) && file.size > 0 && file.size <= MAX_SOURCE_BYTES
+    ? '' : 'Choose a non-empty ZIP or TAR source archive up to 512 MiB.'
+}
+
+type SourceStrategy = 'reuse_current' | 'upload_new'
+type Lookup = { assessmentId: string; loading: boolean; source: UploadedSourcePackage | null; uploaded: boolean; error: string }
+type Selection = { assessmentId: string; strategy: SourceStrategy; file?: File }
+
+export function useRetestSource(assessmentId: string) {
+  const [lookup, setLookup] = useState<Lookup>({ assessmentId: '', loading: false, source: null, uploaded: false, error: '' })
+  const [selection, setSelection] = useState<Selection>({ assessmentId: '', strategy: 'reuse_current' })
+  const [retry, setRetry] = useState(0)
+  useEffect(() => { setSelection({ assessmentId, strategy: 'reuse_current' }) }, [assessmentId])
+  useEffect(() => {
+    if (!assessmentId) return
+    let live = true
+    setLookup({ assessmentId, loading: true, source: null, uploaded: false, error: '' })
+    api.uploadedSource(assessmentId).then((source) => {
+      if (live) setLookup({ assessmentId, loading: false, source, uploaded: Boolean(source), error: '' })
+    }).catch(async (cause) => {
+      if (!live) return
+      if (cause instanceof ApiError && cause.status === 404) {
+        try {
+          // A legacy upload may have lost its archive metadata. Its frozen
+          // scope still distinguishes it from a genuine linked/git/image source.
+          const engagement = await api.getEngagement(assessmentId)
+          const uploaded = engagement.inScope.some((target) => target.kind === 'repo' && /^uploaded-source\/sha256\/[0-9a-f]{64}$/.test(target.value.trim()))
+          if (live) setLookup({ assessmentId, loading: false, source: null, uploaded, error: '' })
+          return
+        } catch (failure) { cause = failure }
+      }
+      if (live) setLookup({ assessmentId, loading: false, source: null, uploaded: false,
+        error: cause instanceof Error ? cause.message : 'Could not load the predecessor source.',
+      })
+    })
+    return () => { live = false }
+  }, [assessmentId, retry])
+
+  // Never expose the previous predecessor's archive during the render before
+  // the next lookup starts or when an earlier request resolves out of order.
+  const current = lookup.assessmentId === assessmentId ? lookup : null
+  const chosen = selection.assessmentId === assessmentId ? selection : { assessmentId, strategy: 'reuse_current' as const, file: undefined }
+  const loading = Boolean(assessmentId) && (!current || current.loading)
+  const source = current?.source ?? null
+  const hasUploadedSource = Boolean(source) || current?.uploaded === true
+  const strategy: SourceStrategy = hasUploadedSource && !source ? 'upload_new' : chosen.strategy
+  const error = current?.error ?? ''
+  const changeStrategy = (strategy: SourceStrategy) => setSelection({ assessmentId, strategy })
+  const chooseFile = (file?: File) => setSelection({ assessmentId, strategy: 'upload_new', file })
+  const validationError = (scopeStrategy: 'copy' | 'empty') => {
+    if (loading) return 'Wait for the predecessor source to load.'
+    if (error) return 'Retry loading the predecessor source before creating a Re-test.'
+    if (!hasUploadedSource) return ''
+    if (scopeStrategy !== 'copy') return 'An uploaded-source Re-test must copy the frozen scope.'
+    return strategy === 'upload_new' ? sourceArchiveError(chosen.file) : ''
+  }
+  const input: Pick<CreateAssessmentRetestInput, 'source' | 'sourceStrategy' | 'sourceVersionId'> = hasUploadedSource ? {
+    sourceStrategy: strategy,
+    sourceVersionId: strategy === 'reuse_current' ? source?.versionId : undefined,
+    source: strategy === 'upload_new' ? chosen.file : undefined,
+  } : {}
+  return { assessmentId, source, hasUploadedSource, loading, error, strategy, file: chosen.file, input, validationError, changeStrategy, chooseFile, refetch: () => setRetry((value) => value + 1) }
+}

--- a/web/src/lib/api.contract.test.ts
+++ b/web/src/lib/api.contract.test.ts
@@ -47,6 +47,7 @@ function engagementWire() {
     authorized_to: '2026-09-12T00:00:00Z',
     timezone: 'Asia/Ho_Chi_Minh',
     live_recon_enabled: true,
+    requires_explicit_execution_authorization: true,
     created_at: '2026-09-05T02:56:56.617935338Z',
     updated_at: '2026-09-05T02:57:29.686174473Z',
   }
@@ -101,9 +102,11 @@ describe('engagement wire contract', () => {
         blackouts: [{ from: '2026-09-06T00:00:00Z', to: '2026-09-07T00:00:00Z' }],
       },
       liveReconEnabled: true,
+      requiresExplicitExecutionAuthorization: true,
       offensiveRoe: { customerContact: '', emergencyContact: '', riskCeiling: '', exclusionsChecked: false },
       createdAt: '2026-09-05T02:56:56.617935338Z',
       businessAssetId: 'ba-77',
+      assessmentProjectId: '',
       findingsCount: undefined,
       lastScanDate: undefined,
     })

--- a/web/src/lib/api.engagements.test.ts
+++ b/web/src/lib/api.engagements.test.ts
@@ -26,12 +26,13 @@ describe('Engagements API', () => {
       inScope: [],
       outOfScope: [],
       timezone: 'Asia/Ho_Chi_Minh',
-    }, source)
+    }, source, 'stable-upload-request')
 
     const init = fetchSpy.mock.calls[0][1] as RequestInit
     expect(fetchSpy.mock.calls[0][0]).toBe('/api/v1/engagements')
     expect(init.body).toBeInstanceOf(FormData)
     expect(init.headers).not.toHaveProperty('content-type')
+		expect(init.headers).toHaveProperty('Idempotency-Key', 'stable-upload-request')
     const form = init.body as FormData
     expect(form.get('source')).toBe(source)
     expect(JSON.parse(String(form.get('metadata')))).toMatchObject({
@@ -50,13 +51,33 @@ describe('Engagements API', () => {
         filename: 'source.zip', size: 42, sha256: 'a'.repeat(64),
         target: `uploaded-source/sha256/${'a'.repeat(64)}`,
         uploaded_by: 'operator', uploaded_at: '2026-08-28T00:00:00Z',
+        version_id: 'version-2', reused_from_version_id: 'version-1', associated_by: 'reviewer', associated_at: '2026-09-08T00:00:00Z',
       }),
     } as Response)
 
     await expect(api.uploadedSource('eng upload')).resolves.toMatchObject({
       filename: 'source.zip', size: 42, uploadedBy: 'operator', uploadedAt: '2026-08-28T00:00:00Z',
+      versionId: 'version-2', reusedFromVersionId: 'version-1', associatedBy: 'reviewer', associatedAt: '2026-09-08T00:00:00Z',
     })
     expect(fetchSpy.mock.calls[0][0]).toBe('/api/v1/engagements/eng%20upload/source')
+  })
+
+  it('maps immutable source metadata from each scan run and leaves legacy absence undefined', async () => {
+    fetchSpy.mockResolvedValueOnce({ ok: true, status: 200, json: async () => [
+      { id: 'run-1', engagement_id: 'eng-upload', target_kind: 'upload', target: 'uploaded-source/sha256/aaa', source_package: {
+        version_id: 'source-1', filename: 'initial.zip', size: 123, sha256: 'a'.repeat(64), uploaded_by: 'alice', uploaded_at: '2026-09-01T00:00:00Z',
+      } },
+      { id: 'run-2', engagement_id: 'eng-upload', target_kind: 'upload', source_package: {
+        version_id: 'source-2', filename: 'updated.zip', size: 456, sha256: 'b'.repeat(64), uploaded_by: 'bob', uploaded_at: '2026-09-08T00:00:00Z',
+      } },
+      { id: 'legacy-run', engagement_id: 'eng-upload', provenance: 'legacy' },
+    ] } as Response)
+    const runs = await api.scanRuns('eng-upload')
+    expect(runs[0]).toMatchObject({ targetKind: 'upload', sourcePackage: { versionId: 'source-1', filename: 'initial.zip', sha256: 'a'.repeat(64), uploadedBy: 'alice' } })
+    expect(runs[1]).toMatchObject({ sourcePackage: { versionId: 'source-2', filename: 'updated.zip', sha256: 'b'.repeat(64), uploadedBy: 'bob' } })
+    expect(runs[2]?.sourcePackage).toBeUndefined()
+    expect(fetchSpy.mock.calls[0][0]).toBe('/api/v1/engagements/eng-upload/scan-runs')
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 
   it('runEmulation posts the target and maps the tag-less run summary defensively', async () => {

--- a/web/src/lib/api/assessment-comparisons.test.ts
+++ b/web/src/lib/api/assessment-comparisons.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { assessmentComparisonsApi } from './assessment-comparisons'
+
+describe('assessmentComparisonsApi', () => {
+  it('maps comparison pages and sends review concurrency headers', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        id: 'comparison-1', cycle_id: 'cycle-1', baseline_snapshot_id: 'snapshot-1', current_snapshot_id: 'snapshot-2', mode: 'lifecycle',
+        input_hash: 'a'.repeat(64), algorithm_version: 1, fingerprint_version: 1, risk_model_version: 1, coverage_policy_version: 1,
+        status: 'needs_review', version: 3, attempts: 1, summary: { fixed_rate: { numerator: 1, denominator: 2 } },
+        created_at: '2026-09-01T07:00:00Z', updated_at: '2026-09-01T07:01:00Z',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        comparison_id: 'comparison-1', baseline_snapshot_id: 'snapshot-1', current_snapshot_id: 'snapshot-2',
+        baseline_count: 40, current_count: 36, fixed_rate: { numerator: 5, denominator: 40 },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        items: [{
+          id: 'item-1', position: 0, identity_id: 'identity-1', presence: 'needs_review', change_flags: ['severity_increased'],
+          baseline_actionable: true, current_actionable: true, comparable_baseline: true, baseline_risk_milli: 1000, current_risk_milli: 2000,
+          review_candidate_ids: ['candidate-1'],
+          review_candidates: [{ id: 'candidate-1', source_observation_ids: ['observation-1'] }],
+        }], next_cursor: 'next-1',
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({
+        override_event_id: 'override-1', superseded_comparison_id: 'comparison-1', replacement_comparison_id: 'comparison-2', replacement_status: 'queued',
+      }), { status: 202, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const comparison = await assessmentComparisonsApi.assessmentComparison('comparison/1')
+    const summary = await assessmentComparisonsApi.assessmentComparisonSummary('comparison/1', 'vulnerability')
+    const page = await assessmentComparisonsApi.assessmentComparisonItems('comparison/1', { limit: 25, presence: 'needs_review', scope: 'vulnerability' })
+    const review = await assessmentComparisonsApi.reviewAssessmentComparisonItem({
+      comparisonId: comparison.id, itemId: page.items[0].id, comparisonVersion: comparison.version, action: 'confirm',
+      candidateId: page.items[0].reviewCandidateIds[0], sourceObservationId: 'observation-1', reason: 'confirmed match', idempotencyKey: 'review-1',
+    })
+
+    expect(comparison.summary.fixedRate).toEqual({ numerator: 1, denominator: 2, naReason: '' })
+    expect(summary).toEqual(expect.objectContaining({ baselineCount: 40, currentCount: 36 }))
+    expect(page.items[0].changeFlags).toEqual(['severity_increased'])
+    expect(page.items[0].reviewCandidates).toEqual([{ id: 'candidate-1', sourceObservationIds: ['observation-1'] }])
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/v1/assessment-comparisons/comparison%2F1/summary?scope=vulnerability', expect.anything())
+    expect(fetchMock).toHaveBeenNthCalledWith(3, '/api/v1/assessment-comparisons/comparison%2F1/items?limit=25&presence=needs_review&scope=vulnerability', expect.anything())
+    expect(fetchMock).toHaveBeenNthCalledWith(4, '/api/v1/assessment-comparisons/comparison-1/items/item-1/confirm', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ 'Idempotency-Key': 'review-1', 'If-Match': '"3"' }),
+    }))
+    expect(review.replacementComparisonId).toBe('comparison-2')
+  })
+})

--- a/web/src/lib/api/assessment-comparisons.ts
+++ b/web/src/lib/api/assessment-comparisons.ts
@@ -1,0 +1,211 @@
+import type {
+  AssessmentComparison,
+  AssessmentComparisonChangeFlag,
+  AssessmentComparisonItem,
+  AssessmentComparisonItemPage,
+  AssessmentComparisonMode,
+  AssessmentComparisonScope,
+  AssessmentComparisonSummary,
+  AssessmentComparisonReviewResult,
+  AssessmentComparisonStatus,
+} from '../types'
+import { newIdempotencyKey, req } from './client'
+
+const id = encodeURIComponent
+
+function mapRatio(value: any) {
+  return {
+    numerator: Number(value?.numerator ?? 0),
+    denominator: Number(value?.denominator ?? 0),
+    naReason: value?.na_reason ?? '',
+  }
+}
+
+function mapSeverityCounts(value: any) {
+  return {
+    critical: Number(value?.critical ?? 0), high: Number(value?.high ?? 0), medium: Number(value?.medium ?? 0),
+    low: Number(value?.low ?? 0), info: Number(value?.info ?? 0), unknown: Number(value?.unknown ?? 0),
+  }
+}
+
+function mapObservation(value: any) {
+  if (!value?.observed_at) return null
+  return {
+    severity: value.severity ?? 'unknown', componentVersion: value.component_version ?? '', location: value.location ?? '',
+    reachability: value.reachability ?? '', evidenceDigest: value.evidence_digest ?? '', observedAt: value.observed_at,
+    scanner: {
+      scanRunId: value.scanner?.scan_run_id ?? '', laneKey: value.scanner?.lane_key ?? '', toolName: value.scanner?.tool_name ?? '',
+      toolVersion: value.scanner?.tool_version ?? '', ruleId: value.scanner?.rule_id ?? '',
+    },
+  }
+}
+
+export function mapAssessmentComparisonSummary(value: any) {
+  return {
+    comparisonId: value?.comparison_id ?? '',
+    baselineSnapshotId: value?.baseline_snapshot_id ?? '',
+    currentSnapshotId: value?.current_snapshot_id ?? '',
+    riskModelVersion: Number(value?.risk_model_version ?? 0),
+    fixedRate: mapRatio(value?.fixed_rate),
+    countReduction: mapRatio(value?.count_reduction),
+    riskReduction: mapRatio(value?.risk_reduction),
+    fixedCount: Number(value?.fixed_count ?? 0),
+    baselineCount: Number(value?.baseline_count ?? 0),
+    currentCount: Number(value?.current_count ?? 0),
+    baselineRisk: Number(value?.baseline_risk ?? 0),
+    currentRisk: Number(value?.current_risk ?? 0),
+    newCount: Number(value?.new_count ?? 0),
+    reopenedCount: Number(value?.reopened_count ?? 0),
+    stillDetectedCount: Number(value?.still_detected_count ?? 0),
+    notEvaluatedCount: Number(value?.not_evaluated_count ?? 0),
+    reviewCount: Number(value?.review_count ?? 0),
+    newRisk: Number(value?.new_risk ?? 0),
+    reopenedRisk: Number(value?.reopened_risk ?? 0),
+    baselineSeverity: mapSeverityCounts(value?.baseline_severity),
+    currentSeverity: mapSeverityCounts(value?.current_severity),
+  }
+}
+
+export function mapAssessmentComparison(value: any): AssessmentComparison {
+  return {
+    id: value?.id ?? '',
+    cycleId: value?.cycle_id ?? '',
+    baselineSnapshotId: value?.baseline_snapshot_id ?? '',
+    currentSnapshotId: value?.current_snapshot_id ?? '',
+    mode: value?.mode ?? 'lifecycle',
+    inputHash: value?.input_hash ?? '',
+    algorithmVersion: Number(value?.algorithm_version ?? 0),
+    fingerprintVersion: Number(value?.fingerprint_version ?? 0),
+    riskModelVersion: Number(value?.risk_model_version ?? 0),
+    coveragePolicyVersion: Number(value?.coverage_policy_version ?? 0),
+    status: value?.status ?? 'queued',
+    version: Number(value?.version ?? 0),
+    attempts: Number(value?.attempts ?? 0),
+    failureCode: value?.failure_code ?? '',
+    contentHash: value?.content_hash ?? '',
+    summary: mapAssessmentComparisonSummary(value?.summary),
+    createdAt: value?.created_at ?? '',
+    updatedAt: value?.updated_at ?? '',
+    completedAt: value?.completed_at ?? null,
+    supersededAt: value?.superseded_at ?? null,
+    supersededBy: value?.superseded_by ?? '',
+  }
+}
+
+function mapItem(value: any): AssessmentComparisonItem {
+  return {
+    id: value?.id ?? '',
+    position: Number(value?.position ?? 0),
+    identityId: value?.identity_id ?? '',
+    producerKind: value?.producer_kind ?? '',
+    findingKind: value?.finding_kind ?? '',
+    targetCanonical: value?.target_canonical ?? '',
+    baselineObservationId: value?.baseline_observation_id ?? '',
+    currentObservationId: value?.current_observation_id ?? '',
+    baselineObservation: mapObservation(value?.baseline_observation),
+    currentObservation: mapObservation(value?.current_observation),
+    presence: value?.presence || undefined,
+    neutralPresence: value?.neutral_presence || undefined,
+    changeFlags: value?.change_flags ?? [],
+    coverageDecision: value?.coverage_decision ?? '',
+    matchMethods: value?.match_methods ?? [],
+    verificationId: value?.verification_id ?? '',
+    verificationState: value?.verification_state ?? '',
+    fixedBasis: value?.fixed_basis ?? '',
+    baselineActionable: Boolean(value?.baseline_actionable),
+    currentActionable: Boolean(value?.current_actionable),
+    comparableBaseline: Boolean(value?.comparable_baseline),
+    baselineRiskMilli: Number(value?.baseline_risk_milli ?? 0),
+    currentRiskMilli: Number(value?.current_risk_milli ?? 0),
+    reviewCandidateIds: value?.review_candidate_ids ?? [],
+    reviewCandidates: (value?.review_candidates ?? []).map((candidate: any) => ({
+      id: candidate?.id ?? '',
+      sourceObservationIds: candidate?.source_observation_ids ?? [],
+    })),
+  }
+}
+
+export const assessmentComparisonsApi = {
+  createAssessmentComparison: async (input: {
+    baselineSnapshotId: string
+    currentSnapshotId: string
+    mode: AssessmentComparisonMode
+    idempotencyKey?: string
+  }): Promise<{ comparison: AssessmentComparison; created: boolean }> => {
+    const value = await req('/assessment-comparisons', {
+      method: 'POST',
+      headers: { 'Idempotency-Key': input.idempotencyKey ?? newIdempotencyKey() },
+      body: JSON.stringify({
+        baseline_snapshot_id: input.baselineSnapshotId,
+        current_snapshot_id: input.currentSnapshotId,
+        mode: input.mode,
+      }),
+    })
+    return { comparison: mapAssessmentComparison(value?.comparison), created: Boolean(value?.created) }
+  },
+
+  assessmentComparison: async (comparisonId: string): Promise<AssessmentComparison> =>
+    mapAssessmentComparison(await req(`/assessment-comparisons/${id(comparisonId)}`)),
+
+  assessmentComparisonSummary: async (comparisonId: string, scope: AssessmentComparisonScope): Promise<AssessmentComparisonSummary> =>
+    mapAssessmentComparisonSummary(await req(`/assessment-comparisons/${id(comparisonId)}/summary?scope=${id(scope)}`)),
+
+  assessmentComparisonItems: async (comparisonId: string, input: {
+    cursor?: string
+    limit?: number
+    presence?: string
+    changeFlag?: AssessmentComparisonChangeFlag
+    severity?: string
+    producer?: string
+    findingKind?: string
+    disposition?: string
+    reviewState?: string
+    scope?: AssessmentComparisonScope
+  } = {}): Promise<AssessmentComparisonItemPage> => {
+    const query = new URLSearchParams()
+    if (input.cursor) query.set('cursor', input.cursor)
+    if (input.limit) query.set('limit', String(input.limit))
+    if (input.presence) query.set('presence', input.presence)
+    if (input.changeFlag) query.set('change_flag', input.changeFlag)
+    if (input.severity) query.set('severity', input.severity)
+    if (input.producer) query.set('producer', input.producer)
+    if (input.findingKind) query.set('finding_kind', input.findingKind)
+    if (input.disposition) query.set('disposition', input.disposition)
+    if (input.reviewState) query.set('review_state', input.reviewState)
+    if (input.scope) query.set('scope', input.scope)
+    const value = await req(`/assessment-comparisons/${id(comparisonId)}/items${query.size ? `?${query}` : ''}`)
+    return { items: (value?.items ?? []).map(mapItem), nextCursor: value?.next_cursor ?? '' }
+  },
+
+  reviewAssessmentComparisonItem: async (input: {
+    comparisonId: string
+    itemId: string
+    comparisonVersion: number
+    action: 'confirm' | 'unlink'
+    candidateId: string
+    sourceObservationId: string
+    targetObservationId?: string
+    reason: string
+    idempotencyKey?: string
+  }): Promise<AssessmentComparisonReviewResult> => {
+    const value = await req(`/assessment-comparisons/${id(input.comparisonId)}/items/${id(input.itemId)}/${input.action}`, {
+      method: 'POST',
+      headers: {
+        'Idempotency-Key': input.idempotencyKey ?? newIdempotencyKey(),
+        'If-Match': `"${input.comparisonVersion}"`,
+      },
+      body: JSON.stringify({
+        candidate_id: input.candidateId,
+        source_observation_id: input.sourceObservationId,
+        target_observation_id: input.targetObservationId || undefined,
+        reason: input.reason,
+      }),
+    })
+    return {
+      overrideEventId: value?.override_event_id ?? '',
+      supersededComparisonId: value?.superseded_comparison_id ?? '',
+      replacementComparisonId: value?.replacement_comparison_id ?? '',
+      replacementStatus: (value?.replacement_status ?? 'queued') as AssessmentComparisonStatus,
+    }
+  },
+}

--- a/web/src/lib/api/assessment-cycles.test.ts
+++ b/web/src/lib/api/assessment-cycles.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { assessmentCyclesApi } from './assessment-cycles'
+
+const manifest = {
+  id: 'manifest-1', cycle_id: 'cycle-1', manifest_version: 1, lifecycle: 'active', cycle_version: 5,
+  root_assessment_id: 'assessment-root', final_assessment_id: 'assessment-final', initial_snapshot_id: 'snapshot-root',
+  final_snapshot_id: 'snapshot-final', comparison_id: 'comparison-1', initial_snapshot_hash: 'a'.repeat(64),
+  final_snapshot_hash: 'b'.repeat(64), comparison_hash: 'c'.repeat(64), canonical_input_hash: 'd'.repeat(64), content_hash: 'e'.repeat(64),
+  policy_version: 'closure-policy-v1', algorithm_version: 'comparison-v1', fingerprint_version: 'fingerprint-v1', risk_version: 'risk-v1',
+  renderer_contract_version: 'assessment-cycle-report-v1', coverage_decisions: { initial: [], final: [] }, scope_profile_changes: [],
+  override_blocker_ids: [], non_final_branches: [], path: [{ path_position: 0, assessment_id: 'assessment-root', assessment_type: 'initial', retest_number: 0, relationship_version: 1, snapshot_id: 'snapshot-root' }],
+  references: [], reason: 'release accepted', as_of_at: '2026-09-01T07:00:00Z', created_at: '2026-09-01T07:00:00Z', created_by: 'reviewer',
+  sealed_at: '2026-09-01T07:00:00Z', sealed_by: 'reviewer',
+}
+
+describe('assessmentCyclesApi closure workflow', () => {
+  it('creates a default Re-test draft without a name, dates, or execution authorization', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+      engagement: { id: 'retest', name: 'Payments Re-test', status: 'draft', requires_explicit_execution_authorization: true },
+      cycle: cycle('open', 2), member: { assessment_id: 'retest', assessment_status: 'draft' },
+    }, 201))
+    vi.stubGlobal('fetch', fetchMock)
+    const result = await assessmentCyclesApi.createRetest('root', { predecessorAssessmentId: 'root', idempotencyKey: 'draft-key' })
+    const request = fetchMock.mock.calls[0]?.[1]
+    expect(JSON.parse(request.body)).toEqual({
+      name: '', planned_date: '', predecessor_assessment_id: 'root', scope_strategy: 'copy', profile_strategy: 'none',
+      authorized_from: '', authorized_to: '', timezone: '',
+    })
+    expect(new Headers(request.headers).get('Idempotency-Key')).toBe('draft-key')
+    expect(result.engagement).toMatchObject({ name: 'Payments Re-test', status: 'draft', requiresExplicitExecutionAuthorization: true })
+  })
+
+  it('uploads an explicit Re-test revision with bounded metadata and the same retry key', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({engagement: {id: 'retest'}, cycle: cycle('open', 2), member: {assessment_id: 'retest'}}, 201))
+    vi.stubGlobal('fetch', fetchMock)
+    const source = new File(['revision'], 'source.zip', {type: 'application/zip'})
+    await assessmentCyclesApi.createRetest('root', {name: 'Revision', source, sourceStrategy: 'upload_new', idempotencyKey: 'upload-key'})
+    const request = fetchMock.mock.calls[0]?.[1]
+    expect(request.body).toBeInstanceOf(FormData)
+    expect(request.body.get('source')).toBe(source)
+    expect(JSON.parse(request.body.get('metadata'))).toMatchObject({name: 'Revision', scope_strategy: 'copy', source_strategy: 'upload_new'})
+    expect(new Headers(request.headers).get('Idempotency-Key')).toBe('upload-key')
+    expect(new Headers(request.headers).has('Content-Type')).toBe(false)
+  })
+
+  it('reuses a pinned predecessor source using JSON and maps the retained selection receipt', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+      engagement: { id: 'retest' }, cycle: cycle('open', 2), member: { assessment_id: 'retest' },
+      source_selection: { strategy: 'reuse_current', version_id: 'child-version', filename: 'current.zip', size: 4096, sha256: 'a'.repeat(64), reused_from_version_id: 'parent-version', source_assessment_id: 'root' },
+    }, 201))
+    vi.stubGlobal('fetch', fetchMock)
+    const result = await assessmentCyclesApi.createRetest('root', { sourceStrategy: 'reuse_current', sourceVersionId: 'parent-version', idempotencyKey: 'reuse-key' })
+    const request = fetchMock.mock.calls[0]?.[1]
+    expect(typeof request.body).toBe('string')
+    expect(JSON.parse(request.body)).toMatchObject({ source_strategy: 'reuse_current', source_version_id: 'parent-version', scope_strategy: 'copy' })
+    expect(JSON.parse(request.body)).not.toHaveProperty('source')
+    expect(new Headers(request.headers).get('Idempotency-Key')).toBe('reuse-key')
+    expect(result.sourceSelection).toEqual({ strategy: 'reuse_current', versionId: 'child-version', filename: 'current.zip', size: 4096, sha256: 'a'.repeat(64), reusedFromVersionId: 'parent-version', sourceAssessmentId: 'root' })
+  })
+
+  it('persists a date-only Re-test plan separately from execution authorization', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({
+      engagement: { id: 'retest' }, cycle: cycle('open', 2),
+      member: { assessment_id: 'retest', assessment_status: 'draft', planned_date: '2026-09-21' },
+    }, 201))
+    vi.stubGlobal('fetch', fetchMock)
+    const result = await assessmentCyclesApi.createRetest('root', { plannedDate: '2026-09-21', idempotencyKey: 'plan-key' })
+    const body = JSON.parse(fetchMock.mock.calls[0]?.[1]?.body)
+    expect(body).toMatchObject({ planned_date: '2026-09-21', authorized_from: '', authorized_to: '' })
+    expect(result.member).toMatchObject({ plannedDate: '2026-09-21', assessmentStatus: 'draft' })
+  })
+
+  it('maps previews and sends retained concurrency headers for close and reopen', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({
+        cycle_id: 'cycle-1', cycle_version: 4, manifest_version: 1, final_assessment_id: 'assessment-final',
+        path: manifest.path, policy: { policy_version: 'closure-policy-v1', blockers: [], warnings: [], coverage_decisions: { initial: [], final: [] }, commit_allowed: true },
+        references: [], scope_profile_changes: [], renderer_contract_version: 'assessment-cycle-report-v1', expires_at: '2026-09-01T07:05:00Z', preview_token: 'signed-close',
+      }))
+      .mockResolvedValueOnce(jsonResponse({ cycle: cycle('completed', 5, 'manifest-1'), manifest, report_job_id: 'job-1' }, 201))
+      .mockResolvedValueOnce(jsonResponse({ cycle_id: 'cycle-1', cycle_version: 5, manifest, impact: 'Manifest remains immutable.', expires_at: '2026-09-01T07:05:00Z', preview_token: 'signed-reopen' }))
+      .mockResolvedValueOnce(jsonResponse({ cycle: cycle('open', 6), superseded_manifest: { ...manifest, lifecycle: 'superseded', superseded_at: '2026-09-01T07:02:00Z' } }))
+      .mockResolvedValueOnce(jsonResponse({ items: [manifest] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const input = { reason: 'release accepted', overrideBlockerIds: [], overrideReason: '' }
+    const preview = await assessmentCyclesApi.previewAssessmentClosure('cycle/1', input)
+    const committed = await assessmentCyclesApi.commitAssessmentClosure('cycle/1', preview.cycleVersion, input, preview.previewToken, 'close-key')
+    const reopenPreview = await assessmentCyclesApi.previewAssessmentReopen('cycle/1')
+    const reopened = await assessmentCyclesApi.commitAssessmentReopen('cycle/1', reopenPreview.cycleVersion, reopenPreview.previewToken, 'more testing', 'reopen-key')
+    const manifests = await assessmentCyclesApi.listAssessmentClosureManifests('cycle/1')
+
+    expect(preview.policy.commitAllowed).toBe(true)
+    expect(committed.manifest.finalSnapshotId).toBe('snapshot-final')
+    expect(committed.cycle.activeClosureManifestId).toBe('manifest-1')
+    expect(reopened.supersededManifest.lifecycle).toBe('superseded')
+    expect(manifests[0]?.rendererContractVersion).toBe('assessment-cycle-report-v1')
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/v1/assessment-cycles/cycle%2F1/closure-commits', expect.objectContaining({
+      method: 'POST', headers: expect.objectContaining({ 'If-Match': '"4"', 'Idempotency-Key': 'close-key' }),
+      body: JSON.stringify({ reason: 'release accepted', override_blocker_ids: [], override_reason: '', preview_token: 'signed-close' }),
+    }))
+    expect(fetchMock).toHaveBeenNthCalledWith(4, '/api/v1/assessment-cycles/cycle%2F1/reopen-commits', expect.objectContaining({
+      method: 'POST', headers: expect.objectContaining({ 'If-Match': '"5"', 'Idempotency-Key': 'reopen-key' }),
+    }))
+  })
+})
+
+function cycle(status: 'open' | 'completed', version: number, activeClosureManifestId = '') {
+  return {
+    id: 'cycle-1', name: 'Payments', boundary_kind: 'standalone', status, root_assessment_id: 'assessment-root',
+    selected_head_assessment_id: 'assessment-final', active_closure_manifest_id: activeClosureManifestId,
+    active_closure_cycle_version: activeClosureManifestId ? version : 0, next_retest_number: 2, version,
+    created_at: '2026-09-01T06:00:00Z', updated_at: '2026-09-01T07:00:00Z', created_by: 'owner', updated_by: 'reviewer',
+  }
+}
+
+function jsonResponse(value: unknown, status = 200) {
+  return new Response(JSON.stringify(value), { status, headers: { 'Content-Type': 'application/json' } })
+}

--- a/web/src/lib/api/assessment-cycles.ts
+++ b/web/src/lib/api/assessment-cycles.ts
@@ -1,0 +1,343 @@
+import type {
+  AssessmentCycle,
+  AssessmentCycleDetail,
+  AssessmentCycleMember,
+  AssessmentCycleMemberPage,
+  AssessmentCycleListFilters,
+  AssessmentCyclePage,
+  AssessmentClosureBranchState,
+  AssessmentClosureCommitResult,
+  AssessmentClosureCoverageDecisions,
+  AssessmentClosureManifest,
+  AssessmentClosurePathMember,
+  AssessmentClosurePolicyResult,
+  AssessmentClosurePreview,
+  AssessmentClosurePreviewInput,
+  AssessmentClosureReference,
+  AssessmentClosureScopeProfileChange,
+  AssessmentLifecycle,
+  AssessmentReopenCommitResult,
+  AssessmentReopenPreview,
+  AssessmentRelationshipChangeRequest,
+  AssessmentRelationshipCommitResult,
+  AssessmentRelationshipPreview,
+  CreateAssessmentRetestInput,
+  CreateAssessmentRetestResponse,
+} from '../types'
+import { blobDownload, newIdempotencyKey, req } from './client'
+import { mapEngagement } from './engagements'
+import { mapAssessmentComparisonSummary } from './assessment-comparisons'
+
+const id = encodeURIComponent
+
+function mapMember(value: any): AssessmentCycleMember {
+  return {
+    assessmentId: value.assessment_id ?? '',
+    assessmentStatus: value.assessment_status,
+    plannedDate: value.planned_date ?? '',
+    assessmentType: value.assessment_type ?? 'initial',
+    predecessorAssessmentId: value.predecessor_assessment_id ?? '',
+    retestNumber: value.retest_number ?? 0,
+    relationshipVersion: value.relationship_version ?? 0,
+    createdAt: value.created_at ?? '',
+    createdBy: value.created_by ?? '',
+    archivedAt: value.archived_at ?? null,
+  }
+}
+
+function mapCycle(value: any): AssessmentCycle {
+  return {
+    id: value.id ?? '',
+    name: value.name ?? '',
+    boundaryKind: value.boundary_kind ?? 'standalone',
+    businessAssetId: value.business_asset_id ?? '',
+    projectId: value.project_id ?? '',
+    status: value.status ?? 'open',
+    rootAssessmentId: value.root_assessment_id ?? '',
+    selectedHeadAssessmentId: value.selected_head_assessment_id ?? '',
+    activeClosureManifestId: value.active_closure_manifest_id ?? '',
+    activeClosureCycleVersion: Number(value.active_closure_cycle_version ?? 0),
+    nextRetestNumber: value.next_retest_number ?? 1,
+    version: value.version ?? 0,
+    createdAt: value.created_at ?? '',
+    updatedAt: value.updated_at ?? '',
+    createdBy: value.created_by ?? '',
+    updatedBy: value.updated_by ?? '',
+  }
+}
+
+function mapClosurePathMember(value: any): AssessmentClosurePathMember {
+  return {
+    pathPosition: Number(value.path_position ?? 0), assessmentId: value.assessment_id ?? '', assessmentType: value.assessment_type ?? 'initial',
+    retestNumber: Number(value.retest_number ?? 0), relationshipVersion: Number(value.relationship_version ?? 0), snapshotId: value.snapshot_id ?? '',
+  }
+}
+
+function mapClosureReference(value: any): AssessmentClosureReference {
+  return {
+    kind: value.kind ?? '', id: value.id ?? '', version: Number(value.version ?? 0), contentHash: value.content_hash ?? '',
+    expiresAt: value.expires_at ?? null, metadata: value.metadata ?? null,
+  }
+}
+
+function mapClosureBranch(value: any): AssessmentClosureBranchState {
+  return { assessmentId: value.assessment_id ?? '', relationshipVersion: Number(value.relationship_version ?? 0), archived: Boolean(value.archived) }
+}
+
+function mapClosureScopeChange(value: any): AssessmentClosureScopeProfileChange {
+  return { assessmentId: value.assessment_id ?? '', kind: value.kind ?? '', summary: value.summary ?? '' }
+}
+
+function mapClosureCoverage(value: any): AssessmentClosureCoverageDecisions {
+  const mapDecision = (decision: any) => ({
+    snapshotId: decision.snapshot_id ?? '', dimensionId: decision.dimension_id ?? '', state: decision.state ?? 'unknown',
+    reasonCode: decision.reason_code ?? '', waived: Boolean(decision.waived),
+  })
+  return { initial: (value?.initial ?? []).map(mapDecision), final: (value?.final ?? []).map(mapDecision) }
+}
+
+function mapClosurePolicy(value: any): AssessmentClosurePolicyResult {
+  return {
+    policyVersion: value?.policy_version ?? '',
+    blockers: (value?.blockers ?? []).map((blocker: any) => ({
+      id: blocker.id ?? '', code: blocker.code ?? '', message: blocker.message ?? '', overrideable: Boolean(blocker.overrideable), overridden: Boolean(blocker.overridden),
+    })),
+    warnings: (value?.warnings ?? []).map((warning: any) => ({ code: warning.code ?? '', message: warning.message ?? '' })),
+    coverageDecisions: mapClosureCoverage(value?.coverage_decisions), commitAllowed: Boolean(value?.commit_allowed),
+  }
+}
+
+function mapClosureManifest(value: any): AssessmentClosureManifest {
+  return {
+    id: value.id ?? '', cycleId: value.cycle_id ?? '', manifestVersion: Number(value.manifest_version ?? 0), lifecycle: value.lifecycle ?? 'building',
+    cycleVersion: Number(value.cycle_version ?? 0), rootAssessmentId: value.root_assessment_id ?? '', finalAssessmentId: value.final_assessment_id ?? '',
+    initialSnapshotId: value.initial_snapshot_id ?? '', finalSnapshotId: value.final_snapshot_id ?? '', comparisonId: value.comparison_id ?? '',
+    initialSnapshotHash: value.initial_snapshot_hash ?? '', finalSnapshotHash: value.final_snapshot_hash ?? '', comparisonHash: value.comparison_hash ?? '',
+    canonicalInputHash: value.canonical_input_hash ?? '', contentHash: value.content_hash ?? '', policyVersion: value.policy_version ?? '',
+    algorithmVersion: value.algorithm_version ?? '', fingerprintVersion: value.fingerprint_version ?? '', riskVersion: value.risk_version ?? '',
+    rendererContractVersion: value.renderer_contract_version ?? '', coverageDecisions: mapClosureCoverage(value.coverage_decisions),
+    scopeProfileChanges: (value.scope_profile_changes ?? []).map(mapClosureScopeChange), overrideBlockerIds: value.override_blocker_ids ?? [],
+    nonFinalBranches: (value.non_final_branches ?? []).map(mapClosureBranch), path: (value.path ?? []).map(mapClosurePathMember),
+    references: (value.references ?? []).map(mapClosureReference), reason: value.reason ?? '', overrideReason: value.override_reason ?? '',
+    asOfAt: value.as_of_at ?? '', createdAt: value.created_at ?? '', createdBy: value.created_by ?? '', sealedAt: value.sealed_at ?? null,
+    sealedBy: value.sealed_by ?? '', supersededAt: value.superseded_at ?? null,
+  }
+}
+
+function closureBody(input: AssessmentClosurePreviewInput) {
+  return { reason: input.reason, override_blocker_ids: input.overrideBlockerIds, override_reason: input.overrideReason }
+}
+
+function mapDetail(value: any): AssessmentCycleDetail {
+  return {
+    cycle: mapCycle(value.cycle ?? {}),
+    members: (value.members ?? []).map(mapMember),
+    branchHeads: (value.branch_heads ?? []).map(mapMember),
+  }
+}
+
+function changeBody(input: AssessmentRelationshipChangeRequest) {
+  return {
+    command: input.command,
+    assessment_id: input.assessmentId ?? '',
+    new_predecessor_assessment_id: input.newPredecessorAssessmentId ?? '',
+    selected_head_assessment_id: input.selectedHeadAssessmentId ?? '',
+  }
+}
+
+function mapRelationshipPreview(value: any): AssessmentRelationshipPreview {
+  return {
+    cycleId: value.cycle_id ?? '', command: value.command ?? 'reparent_within_cycle', assessmentId: value.assessment_id ?? '',
+    oldPredecessorAssessmentId: value.old_predecessor_assessment_id ?? '', newPredecessorAssessmentId: value.new_predecessor_assessment_id ?? '',
+    oldSelectedHeadAssessmentId: value.old_selected_head_assessment_id ?? '', newSelectedHeadAssessmentId: value.new_selected_head_assessment_id ?? '',
+    descendantAssessmentIds: value.descendant_assessment_ids ?? [],
+    impact: {
+      memberIds: value.impact?.member_ids ?? [], snapshotIds: value.impact?.snapshot_ids ?? [], identityIds: value.impact?.identity_ids ?? [],
+      comparisonIds: value.impact?.comparison_ids ?? [], projectionIds: value.impact?.projection_ids ?? [],
+    },
+    locks: value.locks ?? [], reasonRequired: Boolean(value.reason_required), commitAllowed: Boolean(value.commit_allowed),
+    cycleVersion: Number(value.cycle_version ?? 0), expiresAt: value.expires_at ?? '', previewToken: value.preview_token ?? '',
+  }
+}
+
+export const assessmentCyclesApi = {
+  createRetest: async (assessmentId: string, input: CreateAssessmentRetestInput = {}): Promise<CreateAssessmentRetestResponse> => {
+    const metadata = JSON.stringify({
+        name: input.name ?? '',
+        planned_date: input.plannedDate ?? '',
+        predecessor_assessment_id: input.predecessorAssessmentId ?? '',
+        scope_strategy: input.scopeStrategy ?? 'copy',
+        profile_strategy: input.profileStrategy ?? 'none',
+        source_strategy: input.sourceStrategy,
+        source_version_id: input.sourceVersionId,
+        authorized_from: input.authorizedFrom ?? '',
+        authorized_to: input.authorizedTo ?? '',
+        timezone: input.timezone ?? '',
+        roe: input.roe
+          ? { allowed_tool_classes: input.roe.allowedToolClasses, blackouts: input.roe.blackouts }
+          : undefined,
+      })
+    let body: BodyInit = metadata
+    if (input.source) {
+      const form = new FormData()
+      form.append('metadata', metadata)
+      form.append('source', input.source)
+      body = form
+    }
+    const value = await req(`/engagements/${id(assessmentId)}/retests`, {
+      method: 'POST',
+      headers: { 'Idempotency-Key': input.idempotencyKey ?? newIdempotencyKey() },
+      body,
+    })
+    return {
+      engagement: mapEngagement(value.engagement ?? {}),
+      cycle: mapCycle(value.cycle ?? {}),
+      member: mapMember(value.member ?? {}),
+      inheritanceDiff: {
+        scope: value.inheritance_diff?.scope ?? 'copy',
+        authorization: value.inheritance_diff?.authorization ?? 'explicit_only',
+        roe: value.inheritance_diff?.roe ?? 'explicit_only',
+        scannerProfile: value.inheritance_diff?.scanner_profile ?? 'none',
+      },
+      warnings: value.warnings ?? [],
+      sourceSelection: value.source_selection ? {
+        strategy: value.source_selection.strategy,
+        versionId: value.source_selection.version_id ?? '',
+        filename: value.source_selection.filename ?? '',
+        size: value.source_selection.size ?? 0,
+        sha256: value.source_selection.sha256 ?? '',
+        reusedFromVersionId: value.source_selection.reused_from_version_id || undefined,
+        sourceAssessmentId: value.source_selection.source_assessment_id || undefined,
+      } : undefined,
+    }
+  },
+
+  assessmentLifecycle: async (assessmentId: string): Promise<AssessmentLifecycle> => {
+    const value = await req(`/engagements/${id(assessmentId)}/lifecycle`)
+    return { assessmentId: value.assessment_id ?? '', ...mapDetail(value) }
+  },
+
+  assessmentCycle: async (cycleId: string): Promise<AssessmentCycleDetail> =>
+    mapDetail(await req(`/assessment-cycles/${id(cycleId)}`)),
+
+  listAssessmentCycles: async (input: AssessmentCycleListFilters = {}): Promise<AssessmentCyclePage> => {
+    const query = new URLSearchParams()
+    if (input.status) query.set('status', input.status)
+    if (input.boundaryKind) query.set('boundary_kind', input.boundaryKind)
+    if (input.assessmentStatus) query.set('assessment_status', input.assessmentStatus)
+    if (input.selectedHeadAssessmentId) query.set('selected_head_assessment_id', input.selectedHeadAssessmentId)
+    if (input.assessmentType) query.set('assessment_type', input.assessmentType)
+    if (input.producer) query.set('producer', input.producer)
+    if (input.findingKind) query.set('finding_kind', input.findingKind)
+    if (input.reviewState) query.set('review_state', input.reviewState)
+    if (input.changePresence) query.set('change_presence', input.changePresence)
+    if (input.changeSeverity) query.set('change_severity', input.changeSeverity)
+    if (input.scanStaleness) query.set('scan_staleness', input.scanStaleness)
+    if (input.search) query.set('q', input.search)
+    if (input.cursor) query.set('cursor', input.cursor)
+    if (input.limit) query.set('limit', String(input.limit))
+    const value = await req(`/assessment-cycles${query.size ? `?${query}` : ''}`)
+    return {
+      items: (value.items ?? []).map((item: any) => ({
+        ...mapCycle(item),
+        memberCount: item.member_count ?? 0,
+        activeBranchCount: item.active_branch_count ?? 0,
+        latestAssessmentId: item.latest_assessment_id ?? '',
+        latestRetestNumber: item.latest_retest_number ?? 0,
+        members: (item.members ?? []).map(mapMember),
+        membersNextCursor: item.members_next_cursor ?? '',
+        rootSnapshotId: item.root_snapshot_id ?? '',
+        currentSnapshotId: item.current_snapshot_id ?? '',
+        comparisonId: item.comparison_id ?? '',
+        comparisonStatus: item.comparison_status ?? '',
+        comparisonSummary: item.comparison_summary ? mapAssessmentComparisonSummary(item.comparison_summary) : null,
+        activeClosureManifestId: item.active_closure_manifest_id ?? '',
+        selectedHeadLastScanAt: item.selected_head_last_scan_at ?? null,
+        scanStaleness: item.scan_staleness ?? 'missing',
+      })),
+      nextCursor: value.next_cursor ?? '',
+      migrationPending: (value.migration_pending ?? []).map((item: any) => ({
+        assessmentId: item.assessment_id ?? '', name: item.name ?? '', status: item.status ?? '',
+        boundaryKind: item.boundary_kind ?? 'standalone', businessAssetId: item.business_asset_id ?? '', updatedAt: item.updated_at ?? '',
+      })),
+      migrationPendingTotal: Number(value.migration_pending_total ?? 0),
+    }
+  },
+
+  listAssessmentCycleMembers: async (cycleId: string, cursor = '', limit = 25): Promise<AssessmentCycleMemberPage> => {
+    const query = new URLSearchParams({ limit: String(limit) })
+    if (cursor) query.set('cursor', cursor)
+    const value = await req(`/assessment-cycles/${id(cycleId)}/members?${query}`)
+    return { items: (value.items ?? []).map(mapMember), nextCursor: value.next_cursor ?? '' }
+  },
+
+  archiveAssessmentCycle: async (cycleId: string, version: number): Promise<AssessmentCycleDetail> =>
+    mapDetail(await req(`/assessment-cycles/${id(cycleId)}/archive`, {
+      method: 'POST',
+      headers: { 'Idempotency-Key': newIdempotencyKey(), 'If-Match': String(version) },
+      body: '{}',
+    })),
+
+  reopenAssessmentCycle: async (cycleId: string, version: number, reason: string, idempotencyKey = newIdempotencyKey()): Promise<AssessmentCycleDetail> =>
+    mapDetail(await req(`/assessment-cycles/${id(cycleId)}/reopen`, {
+      method: 'POST',
+      headers: { 'Idempotency-Key': idempotencyKey, 'If-Match': String(version) },
+      body: JSON.stringify({ reason }),
+    })),
+
+
+  previewAssessmentRelationshipChange: async (cycleId: string, input: AssessmentRelationshipChangeRequest): Promise<AssessmentRelationshipPreview> =>
+    mapRelationshipPreview(await req(`/assessment-cycles/${id(cycleId)}/relationship-previews`, { method: 'POST', body: JSON.stringify(changeBody(input)) })),
+
+  commitAssessmentRelationshipChange: async (cycleId: string, version: number, input: AssessmentRelationshipChangeRequest, previewToken: string, reason: string, idempotencyKey: string): Promise<AssessmentRelationshipCommitResult> => {
+    const value = await req(`/assessment-cycles/${id(cycleId)}/relationship-commits`, {
+      method: 'POST', headers: { 'If-Match': `"${version}"`, 'Idempotency-Key': idempotencyKey },
+      body: JSON.stringify({ ...changeBody(input), preview_token: previewToken, reason }),
+    })
+    return { cycle: mapCycle(value.cycle ?? {}), replacedComparisonIds: value.replaced_comparison_ids ?? [], replacementComparisonIds: value.replacement_comparison_ids ?? [] }
+  },
+
+  previewAssessmentClosure: async (cycleId: string, input: AssessmentClosurePreviewInput): Promise<AssessmentClosurePreview> => {
+    const value = await req(`/assessment-cycles/${id(cycleId)}/closure-previews`, { method: 'POST', body: JSON.stringify(closureBody(input)) })
+    return {
+      cycleId: value.cycle_id ?? '', cycleVersion: Number(value.cycle_version ?? 0), manifestVersion: Number(value.manifest_version ?? 0),
+      finalAssessmentId: value.final_assessment_id ?? '', path: (value.path ?? []).map(mapClosurePathMember), nonFinalBranches: (value.non_final_branches ?? []).map(mapClosureBranch),
+      initialSnapshotId: value.initial_snapshot_id ?? '', finalSnapshotId: value.final_snapshot_id ?? '', comparisonId: value.comparison_id ?? '',
+      policy: mapClosurePolicy(value.policy), references: (value.references ?? []).map(mapClosureReference),
+      scopeProfileChanges: (value.scope_profile_changes ?? []).map(mapClosureScopeChange), rendererContractVersion: value.renderer_contract_version ?? '',
+      expiresAt: value.expires_at ?? '', previewToken: value.preview_token ?? '',
+    }
+  },
+
+  commitAssessmentClosure: async (cycleId: string, version: number, input: AssessmentClosurePreviewInput, previewToken: string, idempotencyKey: string): Promise<AssessmentClosureCommitResult> => {
+    const value = await req(`/assessment-cycles/${id(cycleId)}/closure-commits`, {
+      method: 'POST', headers: { 'If-Match': `"${version}"`, 'Idempotency-Key': idempotencyKey },
+      body: JSON.stringify({ ...closureBody(input), preview_token: previewToken }),
+    })
+    return { cycle: mapCycle(value.cycle ?? {}), manifest: mapClosureManifest(value.manifest ?? {}), reportJobId: value.report_job_id ?? '' }
+  },
+
+  previewAssessmentReopen: async (cycleId: string): Promise<AssessmentReopenPreview> => {
+    const value = await req(`/assessment-cycles/${id(cycleId)}/reopen-previews`, { method: 'POST', body: '{}' })
+    return {
+      cycleId: value.cycle_id ?? '', cycleVersion: Number(value.cycle_version ?? 0), manifest: mapClosureManifest(value.manifest ?? {}),
+      impact: value.impact ?? '', expiresAt: value.expires_at ?? '', previewToken: value.preview_token ?? '',
+    }
+  },
+
+  commitAssessmentReopen: async (cycleId: string, version: number, previewToken: string, reason: string, idempotencyKey: string): Promise<AssessmentReopenCommitResult> => {
+    const value = await req(`/assessment-cycles/${id(cycleId)}/reopen-commits`, {
+      method: 'POST', headers: { 'If-Match': `"${version}"`, 'Idempotency-Key': idempotencyKey },
+      body: JSON.stringify({ preview_token: previewToken, reason }),
+    })
+    return { cycle: mapCycle(value.cycle ?? {}), supersededManifest: mapClosureManifest(value.superseded_manifest ?? {}) }
+  },
+
+  listAssessmentClosureManifests: async (cycleId: string): Promise<AssessmentClosureManifest[]> => {
+    const value = await req(`/assessment-cycles/${id(cycleId)}/closure-manifests`)
+    return (value.items ?? []).map(mapClosureManifest)
+  },
+
+  downloadAssessmentClosureReport: (cycleId: string, manifestId: string): Promise<void> =>
+    blobDownload(`/api/v1/assessment-cycles/${id(cycleId)}/closure-manifests/${id(manifestId)}/report`, `assessment-cycle-${cycleId}-closure-${manifestId}.json`),
+}

--- a/web/src/lib/api/assessment-relationships.ts
+++ b/web/src/lib/api/assessment-relationships.ts
@@ -1,0 +1,94 @@
+import type {
+  AssessmentRelationshipCandidate,
+  AssessmentRelationshipDecisionAction,
+  AssessmentRelationshipSignal,
+  AssessmentRelationshipStatus,
+} from '../types'
+import { req } from './client'
+
+function mapSignal(value: any): AssessmentRelationshipSignal {
+  return {
+    kind: value.kind,
+    evidenceHash: value.evidence_hash ?? '',
+    matchCount: Number(value.match_count ?? 0),
+    scoreMilli: Number(value.score_milli ?? 0),
+    schemaVersion: Number(value.schema_version ?? 0),
+  }
+}
+
+function mapCandidate(value: any): AssessmentRelationshipCandidate {
+  return {
+    id: value.id,
+    predecessorCycleId: value.predecessor_cycle_id,
+    predecessorAssessmentId: value.predecessor_assessment_id,
+    predecessorRelationshipVersion: Number(value.predecessor_relationship_version),
+    predecessorSnapshotId: value.predecessor_snapshot_id,
+    successorCycleId: value.successor_cycle_id,
+    successorAssessmentId: value.successor_assessment_id,
+    successorRelationshipVersion: Number(value.successor_relationship_version),
+    successorSnapshotId: value.successor_snapshot_id,
+    boundaryKeyHash: value.boundary_key_hash,
+    signals: Array.isArray(value.signals) ? value.signals.map(mapSignal) : [],
+    inputHash: value.input_hash,
+    confidence: value.confidence,
+    status: value.status,
+    version: Number(value.version),
+    expiresAt: value.expires_at,
+    createdBy: value.created_by,
+    createdAt: value.created_at,
+    decision: value.decision ? {
+      id: value.decision.id,
+      action: value.decision.action,
+      actor: value.decision.actor,
+      reason: value.decision.reason,
+      version: Number(value.decision.version),
+      createdAt: value.decision.created_at,
+    } : undefined,
+    repairPlan: value.repair_plan ? {
+      id: value.repair_plan.id,
+      inputHash: value.repair_plan.input_hash,
+      planHash: value.repair_plan.plan_hash,
+      body: value.repair_plan.body ?? {},
+      createdBy: value.repair_plan.created_by,
+      createdAt: value.repair_plan.created_at,
+    } : undefined,
+  }
+}
+
+export const assessmentRelationshipsApi = {
+  listAssessmentRelationshipCandidates: async (status: AssessmentRelationshipStatus | 'all' = 'open'): Promise<AssessmentRelationshipCandidate[]> => {
+    const value = await req(`/assessment-relationship-candidates?status=${encodeURIComponent(status)}`)
+    return Array.isArray(value?.items) ? value.items.map(mapCandidate) : []
+  },
+
+  generateAssessmentRelationshipCandidate: async (input: {
+    predecessorCycleId: string
+    successorCycleId: string
+    importedReferenceHash?: string
+    expiresInDays?: number
+  }): Promise<AssessmentRelationshipCandidate> => mapCandidate(await req('/assessment-relationship-candidates/generate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      predecessor_cycle_id: input.predecessorCycleId,
+      successor_cycle_id: input.successorCycleId,
+      imported_reference_hash: input.importedReferenceHash || undefined,
+      expires_in_days: input.expiresInDays || undefined,
+    }),
+  })),
+
+  decideAssessmentRelationshipCandidate: async (
+    candidate: AssessmentRelationshipCandidate,
+    action: AssessmentRelationshipDecisionAction,
+    reason: string,
+    idempotencyKey = globalThis.crypto.randomUUID(),
+  ): Promise<AssessmentRelationshipCandidate> => mapCandidate(await req(`/assessment-relationship-candidates/${encodeURIComponent(candidate.id)}/decisions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'If-Match': `"${candidate.version}"`,
+      'Idempotency-Key': idempotencyKey,
+    },
+    body: JSON.stringify({ action, reason }),
+  })),
+}

--- a/web/src/lib/api/assessment-snapshots.test.ts
+++ b/web/src/lib/api/assessment-snapshots.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from 'vitest'
+import { assessmentSnapshotsApi } from './assessment-snapshots'
+
+describe('assessmentSnapshotsApi', () => {
+  it('sends concurrency headers and maps immutable snapshot fields', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({
+      snapshot: {
+        id: 'snapshot-1', cycle_id: 'cycle-1', assessment_id: 'assessment-1', snapshot_number: 1,
+        lifecycle: 'finalized', provenance: 'native', boundary: { boundary_kind: 'standalone' },
+        run_references: [{ run_id: 'run-1', manifest_hash: 'a'.repeat(64), lane_refs: [{ lane_key: 'sca', manifest_hash: 'b'.repeat(64) }] }],
+        dimensions: [{
+          run_id: 'run-1', lane_key: 'sca', lane_manifest_hash: 'b'.repeat(64), producer: 'sca', finding_kind: 'vulnerability',
+          target: { kind: 'repository', schema_version: 1, canonical: 'https://example.com/repo', evaluated_revision: 'abc' },
+          state: 'complete', reason_code: 'trusted_terminal_lane', included_scope: ['src/**'], excluded_scope: [],
+          versions: [{ kind: 'scanner', name: 'sca', version: '1' }],
+        }],
+        schema_version: 1, content_hash: 'c'.repeat(64), created_at: '2026-09-01T07:00:00Z', created_by: 'operator',
+        finalized_at: '2026-09-01T07:00:00Z', finalized_by: 'operator',
+      },
+      default_version: 1,
+    }), { status: 201, headers: { 'Content-Type': 'application/json' } }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await assessmentSnapshotsApi.finalizeAssessmentSnapshot('assessment/1', {
+      selectedRuns: [{ runId: 'run-1', laneKeys: ['sca'] }], expectedDefaultVersion: 0, idempotencyKey: 'snapshot-request-1',
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/v1/engagements/assessment%2F1/snapshots/finalize', expect.objectContaining({
+      method: 'POST',
+      headers: expect.objectContaining({ 'Idempotency-Key': 'snapshot-request-1', 'If-Match': '0' }),
+      body: JSON.stringify({ selected_runs: [{ run_id: 'run-1', lane_keys: ['sca'] }] }),
+    }))
+    expect(result.defaultVersion).toBe(1)
+    expect(result.snapshot.runReferences[0].laneReferences[0].laneKey).toBe('sca')
+    expect(result.snapshot.dimensions[0].target.schemaVersion).toBe(1)
+    expect(result.snapshot.supersededAt).toBeNull()
+  })
+})

--- a/web/src/lib/api/assessment-snapshots.ts
+++ b/web/src/lib/api/assessment-snapshots.ts
@@ -1,0 +1,103 @@
+import type {
+  AssessmentSnapshot,
+  AssessmentSnapshotDimension,
+  AssessmentSnapshotListResponse,
+  AssessmentSnapshotRunReference,
+  AssessmentSnapshotVersion,
+  FinalizeAssessmentSnapshotInput,
+  FinalizeAssessmentSnapshotResponse,
+} from '../types'
+import { newIdempotencyKey, req } from './client'
+
+const id = encodeURIComponent
+
+function mapVersion(value: any): AssessmentSnapshotVersion {
+  return { kind: value.kind ?? 'tool', name: value.name ?? '', version: value.version ?? '', digest: value.digest ?? '' }
+}
+
+function mapRunReference(value: any): AssessmentSnapshotRunReference {
+  return {
+    runId: value.run_id ?? '',
+    manifestHash: value.manifest_hash ?? '',
+    laneReferences: (value.lane_refs ?? []).map((lane: any) => ({
+      laneKey: lane.lane_key ?? '', manifestHash: lane.manifest_hash ?? '',
+    })),
+  }
+}
+
+function mapDimension(value: any): AssessmentSnapshotDimension {
+  return {
+    runId: value.run_id ?? '',
+    laneKey: value.lane_key ?? '',
+    laneManifestHash: value.lane_manifest_hash ?? '',
+    producer: value.producer ?? '',
+    findingKind: value.finding_kind ?? '',
+    target: {
+      kind: value.target?.kind ?? 'repository',
+      schemaVersion: Number(value.target?.schema_version ?? 0),
+      canonical: value.target?.canonical ?? '',
+      evaluatedRevision: value.target?.evaluated_revision ?? '',
+    },
+    state: value.state ?? 'unknown',
+    reasonCode: value.reason_code ?? '',
+    includedScope: value.included_scope ?? [],
+    excludedScope: value.excluded_scope ?? [],
+    versions: (value.versions ?? []).map(mapVersion),
+  }
+}
+
+export function mapAssessmentSnapshot(value: any): AssessmentSnapshot {
+  return {
+    id: value.id ?? '',
+    cycleId: value.cycle_id ?? '',
+    assessmentId: value.assessment_id ?? '',
+    snapshotNumber: Number(value.snapshot_number ?? 0),
+    lifecycle: value.lifecycle ?? 'finalized',
+    provenance: value.provenance ?? 'native',
+    boundary: {
+      boundaryKind: value.boundary?.boundary_kind ?? 'standalone',
+      businessAssetId: value.boundary?.business_asset_id ?? '',
+      projectId: value.boundary?.project_id ?? '',
+    },
+    runReferences: (value.run_references ?? []).map(mapRunReference),
+    dimensions: (value.dimensions ?? []).map(mapDimension),
+    schemaVersion: Number(value.schema_version ?? 0),
+    contentHash: value.content_hash ?? '',
+    createdAt: value.created_at ?? '',
+    createdBy: value.created_by ?? '',
+    finalizedAt: value.finalized_at ?? '',
+    finalizedBy: value.finalized_by ?? '',
+    supersededAt: value.superseded_at ?? null,
+    supersededBy: value.superseded_by ?? '',
+  }
+}
+
+export const assessmentSnapshotsApi = {
+  finalizeAssessmentSnapshot: async (assessmentId: string, input: FinalizeAssessmentSnapshotInput): Promise<FinalizeAssessmentSnapshotResponse> => {
+    const value = await req(`/engagements/${id(assessmentId)}/snapshots/finalize`, {
+      method: 'POST',
+      headers: {
+        'Idempotency-Key': input.idempotencyKey ?? newIdempotencyKey(),
+        'If-Match': String(input.expectedDefaultVersion),
+      },
+      body: JSON.stringify({
+        selected_runs: input.selectedRuns.map((selection) => ({ run_id: selection.runId, lane_keys: selection.laneKeys })),
+      }),
+    })
+    return { snapshot: mapAssessmentSnapshot(value.snapshot ?? {}), defaultVersion: Number(value.default_version ?? 0) }
+  },
+
+  assessmentSnapshots: async (assessmentId: string, cursor = ''): Promise<AssessmentSnapshotListResponse> => {
+    const query = cursor ? `?cursor=${encodeURIComponent(cursor)}` : ''
+    const value = await req(`/engagements/${id(assessmentId)}/snapshots${query}`)
+    return {
+      items: (value.items ?? []).map(mapAssessmentSnapshot),
+      nextCursor: value.next_cursor ?? '',
+      defaultSnapshotId: value.default_snapshot_id ?? '',
+      defaultVersion: Number(value.default_version ?? 0),
+    }
+  },
+
+  assessmentSnapshot: async (snapshotId: string): Promise<AssessmentSnapshot> =>
+    mapAssessmentSnapshot(await req(`/assessment-snapshots/${id(snapshotId)}`)),
+}

--- a/web/src/lib/api/auth.ts
+++ b/web/src/lib/api/auth.ts
@@ -7,7 +7,16 @@ export const authApi = {
   acceptAup: (version: string): Promise<unknown> =>
     req('/aup/accept', { method: 'POST', body: JSON.stringify({ version }) }),
 
-  me: async (): Promise<CurrentUser> => req('/me'),
+  me: async (): Promise<CurrentUser> => {
+    const value = await req('/me')
+    return {
+      id: value.id ?? '', name: value.name ?? '', role: value.role ?? '',
+      features: value.features ? {
+        assessmentLifecycleRead: Boolean(value.features.assessment_lifecycle_read),
+        assessmentLifecycleUIDefault: Boolean(value.features.assessment_lifecycle_ui_default),
+      } : undefined,
+    }
+  },
 }
 
 export const teamApi = {

--- a/web/src/lib/api/client.ts
+++ b/web/src/lib/api/client.ts
@@ -37,6 +37,13 @@ export function getOnUnauthorized(): (() => void) | null {
   return onUnauthorized
 }
 
+export function newIdempotencyKey(): string {
+  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID()
+  const bytes = new Uint8Array(16)
+  globalThis.crypto.getRandomValues(bytes)
+  return Array.from(bytes, (value) => value.toString(16).padStart(2, '0')).join('')
+}
+
 export type BFFSession = { authenticated: boolean; csrfToken: string }
 
 function apiRequestInit(init: RequestInit = {}, json = true): RequestInit {

--- a/web/src/lib/api/engagements.ts
+++ b/web/src/lib/api/engagements.ts
@@ -17,6 +17,7 @@ function createRequest(input: CreateEngagementInput) {
     authorized_to: input.authorizedTo ?? '',
     timezone: input.timezone ?? '',
     asset_id: input.assetId ?? '',
+    assessment_project_id: input.assessmentProjectId ?? '',
   }
 }
 
@@ -47,6 +48,8 @@ function mapEngagement(r: EngagementWire): Engagement {
     },
     createdAt: r.created_at ?? null,
     businessAssetId: r.business_asset_id ?? '',
+    assessmentProjectId: r.assessment_project_id ?? '',
+    requiresExplicitExecutionAuthorization: r.requires_explicit_execution_authorization ?? false,
     // Optional list-view enrichment; stays undefined when the API omits it.
     findingsCount: r.findings_count
       ? {
@@ -64,6 +67,21 @@ function mapEngagement(r: EngagementWire): Engagement {
 
 export { mapEngagement }
 
+export function mapUploadedSource(source: any): UploadedSourcePackage {
+  return {
+    versionId: source.version_id || undefined,
+    reusedFromVersionId: source.reused_from_version_id || undefined,
+    associatedBy: source.associated_by || undefined,
+    associatedAt: source.associated_at ?? null,
+    filename: source.filename ?? '',
+    size: source.size ?? 0,
+    sha256: source.sha256 ?? '',
+    target: source.target ?? '',
+    uploadedBy: source.uploaded_by ?? '',
+    uploadedAt: source.uploaded_at ?? null,
+  }
+}
+
 // A per-engagement tool credential. The secret value is write-only: it is sealed in the vault on set
 // and never returned, so this metadata carries only the name and timestamps.
 export interface EngagementCredential {
@@ -76,20 +94,22 @@ export const engagementsApi = {
   listEngagements: async (): Promise<Engagement[]> =>
     ((await req('/engagements')) ?? []).map(mapEngagement),
 
-  createEngagement: async (input: CreateEngagementInput): Promise<Engagement> =>
+  createEngagement: async (input: CreateEngagementInput, idempotencyKey: string): Promise<Engagement> =>
     mapEngagement(
       await req('/engagements', {
         method: 'POST',
+        headers: { 'Idempotency-Key': idempotencyKey },
         body: JSON.stringify(createRequest(input)),
       }),
     ),
 
-  createEngagementFromSource: async (input: CreateEngagementInput, source: File): Promise<Engagement> => {
+  createEngagementFromSource: async (input: CreateEngagementInput, source: File, idempotencyKey: string): Promise<Engagement> => {
     const form = new FormData()
     form.append('metadata', JSON.stringify(createRequest(input)))
     form.append('source', source)
     return mapEngagement(await req('/engagements', {
       method: 'POST',
+      headers: { 'Idempotency-Key': idempotencyKey },
       body: form,
     }))
   },
@@ -99,14 +119,7 @@ export const engagementsApi = {
 
   uploadedSource: async (id: string): Promise<UploadedSourcePackage> => {
     const source = await req(`/engagements/${encodeURIComponent(id)}/source`)
-    return {
-      filename: source.filename ?? '',
-      size: source.size ?? 0,
-      sha256: source.sha256 ?? '',
-      target: source.target ?? '',
-      uploadedBy: source.uploaded_by ?? '',
-      uploadedAt: source.uploaded_at ?? null,
-    }
+    return mapUploadedSource(source)
   },
 
   updateScope: async (id: string, inScope: ScopeTarget[], outOfScope: ScopeTarget[]): Promise<Engagement> =>

--- a/web/src/lib/api/index.ts
+++ b/web/src/lib/api/index.ts
@@ -49,6 +49,10 @@ import { alertingApi } from './alerting'
 import { privacyApi } from './privacy'
 import { writeupApi } from './writeup'
 import { cspmApi } from './cspm'
+import { assessmentCyclesApi } from './assessment-cycles'
+import { assessmentSnapshotsApi } from './assessment-snapshots'
+import { assessmentRelationshipsApi } from './assessment-relationships'
+import { assessmentComparisonsApi } from './assessment-comparisons'
 
 // projectMeasures was a standalone export in the old api.ts
 export const projectMeasures = codeQualityApi.projectMeasures
@@ -92,6 +96,10 @@ export const api = {
   ...privacyApi,
   ...writeupApi,
   ...cspmApi,
+  ...assessmentCyclesApi,
+  ...assessmentSnapshotsApi,
+  ...assessmentRelationshipsApi,
+  ...assessmentComparisonsApi,
 }
 export {
   type CoverageWindow,

--- a/web/src/lib/api/scan.ts
+++ b/web/src/lib/api/scan.ts
@@ -1,3 +1,4 @@
+import { mapUploadedSource } from './engagements'
 import type {
   AITriage,
   CodeQualityReport,
@@ -309,6 +310,9 @@ function mapScanRun(r: any): ScanRun {
     manifestHash: r?.manifest_hash ?? '',
     laneCount: r?.lane_count ?? 0,
     completeCoverage: r?.complete_coverage === true,
+    sourcePackage: r?.source_package ? mapUploadedSource(r.source_package) : undefined,
+    targetKind: r?.target_kind || undefined,
+    target: r?.target || undefined,
   }
 }
 

--- a/web/src/lib/api/wire.ts
+++ b/web/src/lib/api/wire.ts
@@ -34,6 +34,8 @@ export interface ScopeWire {
 
 /** `engagementView`. `business_asset_id`, `project_id` and `timezone` are `omitempty`. */
 export interface EngagementWire {
+	assessment_project_id?: string
+  requires_explicit_execution_authorization?: boolean
   id: string
   tenant_id: string
   project_id?: string
@@ -92,6 +94,8 @@ export const ENGAGEMENT_WIRE_KEYS = [
   'id',
   'tenant_id',
   'project_id',
+  'assessment_project_id',
+  'requires_explicit_execution_authorization',
   'business_asset_id',
   'name',
   'client',

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -52,6 +52,7 @@ export interface OffensiveRoe {
 }
 
 export interface Engagement {
+	assessmentProjectId?: string
   id: string
   name: string
   client: string
@@ -65,6 +66,7 @@ export interface Engagement {
   /** Offensive rules of engagement the governance policy requires before emulation / exploitation.
    *  Always populated by mapEngagement from the API; optional here so lightweight fixtures may omit it. */
   offensiveRoe?: OffensiveRoe
+  requiresExplicitExecutionAuthorization?: boolean
   createdAt: string | null
   businessAssetId: string
   /** List-view enrichment. Absent unless the API includes it; the Engagements
@@ -85,6 +87,7 @@ export interface EngagementFindingsCount {
 }
 
 export interface CreateEngagementInput {
+	assessmentProjectId?: string
   name: string
   client: string
   inScope: ScopeTarget[]
@@ -96,12 +99,619 @@ export interface CreateEngagementInput {
 }
 
 export interface UploadedSourcePackage {
+  versionId?: string
+  reusedFromVersionId?: string
+  associatedBy?: string
+  associatedAt?: string | null
   filename: string
   size: number
   sha256: string
   target: string
   uploadedBy: string
   uploadedAt: string | null
+}
+
+export type AssessmentCycleBoundaryKind = 'standalone' | 'asset' | 'project' | 'asset_project'
+export type AssessmentCycleStatus = 'open' | 'completed' | 'archived'
+export type AssessmentStatus = 'draft' | 'active' | 'completed' | 'archived'
+export type AssessmentCycleReviewState = 'needs_review' | 'verified' | 'clear'
+export type AssessmentCycleChangePresence = 'new' | 'reopened'
+export type AssessmentCycleScanStaleness = 'fresh' | 'stale' | 'missing'
+
+export interface AssessmentCycleListFilters {
+  status?: AssessmentCycleStatus
+  boundaryKind?: AssessmentCycleBoundaryKind
+  assessmentStatus?: AssessmentStatus
+  selectedHeadAssessmentId?: string
+  assessmentType?: AssessmentCycleMember['assessmentType']
+  producer?: string
+  findingKind?: string
+  reviewState?: AssessmentCycleReviewState
+  changePresence?: AssessmentCycleChangePresence
+  changeSeverity?: Extract<Severity, 'critical' | 'high'>
+  scanStaleness?: AssessmentCycleScanStaleness
+  search?: string
+  cursor?: string
+  limit?: number
+}
+
+export interface AssessmentCycleMember {
+  plannedDate?: string
+	assessmentStatus?: Engagement['status']
+  assessmentId: string
+  assessmentType: 'initial' | 'retest'
+  predecessorAssessmentId: string
+  retestNumber: number
+  relationshipVersion: number
+  createdAt: string
+  createdBy: string
+  archivedAt: string | null
+}
+
+export interface AssessmentCycle {
+  id: string
+  name: string
+  boundaryKind: AssessmentCycleBoundaryKind
+  businessAssetId: string
+  projectId: string
+  status: AssessmentCycleStatus
+  rootAssessmentId: string
+  selectedHeadAssessmentId: string
+  activeClosureManifestId?: string
+  activeClosureCycleVersion?: number
+  nextRetestNumber: number
+  version: number
+  createdAt: string
+  updatedAt: string
+  createdBy: string
+  updatedBy: string
+}
+
+export interface AssessmentCycleDetail {
+  cycle: AssessmentCycle
+  members: AssessmentCycleMember[]
+  branchHeads: AssessmentCycleMember[]
+}
+
+export interface AssessmentLifecycle extends AssessmentCycleDetail {
+  assessmentId: string
+}
+
+export type AssessmentRelationshipChangeCommand = 'reparent_within_cycle' | 'select_head'
+
+export interface AssessmentRelationshipChangeRequest {
+  command: AssessmentRelationshipChangeCommand
+  assessmentId?: string
+  newPredecessorAssessmentId?: string
+  selectedHeadAssessmentId?: string
+}
+
+export interface AssessmentRelationshipImpact {
+  memberIds: string[]
+  snapshotIds: string[]
+  identityIds: string[]
+  comparisonIds: string[]
+  projectionIds: string[]
+}
+
+export interface AssessmentRelationshipPreview {
+  cycleId: string
+  command: AssessmentRelationshipChangeCommand
+  assessmentId: string
+  oldPredecessorAssessmentId: string
+  newPredecessorAssessmentId: string
+  oldSelectedHeadAssessmentId: string
+  newSelectedHeadAssessmentId: string
+  descendantAssessmentIds: string[]
+  impact: AssessmentRelationshipImpact
+  locks: string[]
+  reasonRequired: boolean
+  commitAllowed: boolean
+  cycleVersion: number
+  expiresAt: string
+  previewToken: string
+}
+
+export interface AssessmentRelationshipCommitResult {
+  cycle: AssessmentCycle
+  replacedComparisonIds: string[]
+  replacementComparisonIds: string[]
+}
+
+export type AssessmentClosureLifecycle = 'building' | 'active' | 'superseded'
+
+export interface AssessmentClosureBlocker {
+  id: string
+  code: string
+  message: string
+  overrideable: boolean
+  overridden: boolean
+}
+
+export interface AssessmentClosureWarning {
+  code: string
+  message: string
+}
+
+export interface AssessmentClosureCoverageDecision {
+  snapshotId: string
+  dimensionId: string
+  state: AssessmentSnapshotCoverageState
+  reasonCode: string
+  waived: boolean
+}
+
+export interface AssessmentClosureCoverageDecisions {
+  initial: AssessmentClosureCoverageDecision[]
+  final: AssessmentClosureCoverageDecision[]
+}
+
+export interface AssessmentClosurePathMember {
+  pathPosition: number
+  assessmentId: string
+  assessmentType: AssessmentCycleMember['assessmentType']
+  retestNumber: number
+  relationshipVersion: number
+  snapshotId: string
+}
+
+export interface AssessmentClosureReference {
+  kind: string
+  id: string
+  version: number
+  contentHash: string
+  expiresAt: string | null
+  metadata: unknown
+}
+
+export interface AssessmentClosureBranchState {
+  assessmentId: string
+  relationshipVersion: number
+  archived: boolean
+}
+
+export interface AssessmentClosureScopeProfileChange {
+  assessmentId: string
+  kind: string
+  summary: string
+}
+
+export interface AssessmentClosurePolicyResult {
+  policyVersion: string
+  blockers: AssessmentClosureBlocker[]
+  warnings: AssessmentClosureWarning[]
+  coverageDecisions: AssessmentClosureCoverageDecisions
+  commitAllowed: boolean
+}
+
+export interface AssessmentClosurePreviewInput {
+  reason: string
+  overrideBlockerIds: string[]
+  overrideReason: string
+}
+
+export interface AssessmentClosurePreview {
+  cycleId: string
+  cycleVersion: number
+  manifestVersion: number
+  finalAssessmentId: string
+  path: AssessmentClosurePathMember[]
+  nonFinalBranches: AssessmentClosureBranchState[]
+  initialSnapshotId: string
+  finalSnapshotId: string
+  comparisonId: string
+  policy: AssessmentClosurePolicyResult
+  references: AssessmentClosureReference[]
+  scopeProfileChanges: AssessmentClosureScopeProfileChange[]
+  rendererContractVersion: string
+  expiresAt: string
+  previewToken: string
+}
+
+export interface AssessmentClosureManifest {
+  id: string
+  cycleId: string
+  manifestVersion: number
+  lifecycle: AssessmentClosureLifecycle
+  cycleVersion: number
+  rootAssessmentId: string
+  finalAssessmentId: string
+  initialSnapshotId: string
+  finalSnapshotId: string
+  comparisonId: string
+  initialSnapshotHash: string
+  finalSnapshotHash: string
+  comparisonHash: string
+  canonicalInputHash: string
+  contentHash: string
+  policyVersion: string
+  algorithmVersion: string
+  fingerprintVersion: string
+  riskVersion: string
+  rendererContractVersion: string
+  coverageDecisions: AssessmentClosureCoverageDecisions
+  scopeProfileChanges: AssessmentClosureScopeProfileChange[]
+  overrideBlockerIds: string[]
+  nonFinalBranches: AssessmentClosureBranchState[]
+  path: AssessmentClosurePathMember[]
+  references: AssessmentClosureReference[]
+  reason: string
+  overrideReason: string
+  asOfAt: string
+  createdAt: string
+  createdBy: string
+  sealedAt: string | null
+  sealedBy: string
+  supersededAt: string | null
+}
+
+export interface AssessmentClosureCommitResult {
+  cycle: AssessmentCycle
+  manifest: AssessmentClosureManifest
+  reportJobId: string
+}
+
+export interface AssessmentReopenPreview {
+  cycleId: string
+  cycleVersion: number
+  manifest: AssessmentClosureManifest
+  impact: string
+  expiresAt: string
+  previewToken: string
+}
+
+export interface AssessmentReopenCommitResult {
+  cycle: AssessmentCycle
+  supersededManifest: AssessmentClosureManifest
+}
+
+export interface AssessmentCycleSummary extends AssessmentCycle {
+  memberCount: number
+  activeBranchCount: number
+  latestAssessmentId: string
+  latestRetestNumber: number
+  members: AssessmentCycleMember[]
+  membersNextCursor: string
+  rootSnapshotId: string
+  currentSnapshotId: string
+  comparisonId: string
+  comparisonStatus: AssessmentComparisonStatus | ''
+  comparisonSummary: AssessmentComparisonSummary | null
+  activeClosureManifestId: string
+  selectedHeadLastScanAt: string | null
+  scanStaleness: AssessmentCycleScanStaleness
+}
+
+export interface AssessmentCyclePage {
+  items: AssessmentCycleSummary[]
+  nextCursor: string
+  migrationPending: AssessmentCycleMigrationPending[]
+  migrationPendingTotal: number
+}
+
+export interface AssessmentCycleMemberPage {
+  items: AssessmentCycleMember[]
+  nextCursor: string
+}
+
+export interface AssessmentCycleMigrationPending {
+  assessmentId: string
+  name: string
+  status: string
+  boundaryKind: AssessmentCycleBoundaryKind
+  businessAssetId: string
+  updatedAt: string
+}
+
+export type AssessmentRelationshipStatus = 'open' | 'confirmed' | 'rejected' | 'dismissed' | 'expired'
+export type AssessmentRelationshipConfidence = 'medium' | 'high'
+export type AssessmentRelationshipDecisionAction = 'confirm' | 'reject' | 'dismiss'
+export type AssessmentRelationshipSignalKind =
+  | 'exact_frozen_boundary'
+  | 'explicit_imported_reference'
+  | 'trusted_manifest_compatible'
+  | 'deterministic_finding_overlap'
+
+export interface AssessmentRelationshipSignal {
+  kind: AssessmentRelationshipSignalKind
+  evidenceHash: string
+  matchCount: number
+  scoreMilli: number
+  schemaVersion: number
+}
+
+export interface AssessmentRelationshipDecision {
+  id: string
+  action: AssessmentRelationshipDecisionAction
+  actor: string
+  reason: string
+  version: number
+  createdAt: string
+}
+
+export interface AssessmentRelationshipRepairPlan {
+  id: string
+  inputHash: string
+  planHash: string
+  body: Record<string, unknown>
+  createdBy: string
+  createdAt: string
+}
+
+export interface AssessmentRelationshipCandidate {
+  id: string
+  predecessorCycleId: string
+  predecessorAssessmentId: string
+  predecessorRelationshipVersion: number
+  predecessorSnapshotId: string
+  successorCycleId: string
+  successorAssessmentId: string
+  successorRelationshipVersion: number
+  successorSnapshotId: string
+  boundaryKeyHash: string
+  signals: AssessmentRelationshipSignal[]
+  inputHash: string
+  confidence: AssessmentRelationshipConfidence
+  status: AssessmentRelationshipStatus
+  version: number
+  expiresAt: string
+  createdBy: string
+  createdAt: string
+  decision?: AssessmentRelationshipDecision
+  repairPlan?: AssessmentRelationshipRepairPlan
+}
+
+export interface CreateAssessmentRetestInput {
+  source?: File
+  sourceStrategy?: 'reuse_current' | 'upload_new'
+  sourceVersionId?: string
+  plannedDate?: string
+  name?: string
+  predecessorAssessmentId?: string
+  scopeStrategy?: 'copy' | 'empty'
+  profileStrategy?: 'none'
+  authorizedFrom?: string
+  authorizedTo?: string
+  timezone?: string
+  roe?: RoE
+  idempotencyKey?: string
+}
+
+export interface CreateAssessmentRetestResponse {
+  engagement: Engagement
+  cycle: AssessmentCycle
+  member: AssessmentCycleMember
+  inheritanceDiff: { scope: 'copy' | 'empty'; authorization: 'explicit_only'; roe: 'explicit_only'; scannerProfile: 'none' }
+  warnings: Array<'authorization_not_inherited' | 'roe_not_inherited' | 'scanner_profile_not_inherited'>
+  sourceSelection?: {
+    strategy: 'reuse_current' | 'upload_new'
+    versionId: string
+    filename: string
+    size: number
+    sha256: string
+    reusedFromVersionId?: string
+    sourceAssessmentId?: string
+  }
+}
+
+export type AssessmentSnapshotLifecycle = 'finalized' | 'superseded'
+export type AssessmentSnapshotProvenance = 'native' | 'legacy'
+export type AssessmentSnapshotCoverageState = 'complete' | 'partial' | 'unknown'
+export type AssessmentSnapshotTargetKind = 'repository' | 'oci' | 'host' | 'url' | 'cloud_resource'
+export type AssessmentSnapshotVersionKind = 'tool' | 'scanner' | 'profile' | 'rule_pack' | 'advisory_database' | 'correlation' | 'schema'
+
+export interface AssessmentSnapshotBoundary {
+  boundaryKind: AssessmentCycleBoundaryKind
+  businessAssetId: string
+  projectId: string
+}
+
+export interface AssessmentSnapshotLaneReference {
+  laneKey: string
+  manifestHash: string
+}
+
+export interface AssessmentSnapshotRunReference {
+  runId: string
+  manifestHash: string
+  laneReferences: AssessmentSnapshotLaneReference[]
+}
+
+export interface AssessmentSnapshotTarget {
+  kind: AssessmentSnapshotTargetKind
+  schemaVersion: number
+  canonical: string
+  evaluatedRevision: string
+}
+
+export interface AssessmentSnapshotVersion {
+  kind: AssessmentSnapshotVersionKind
+  name: string
+  version: string
+  digest: string
+}
+
+export interface AssessmentSnapshotDimension {
+  runId: string
+  laneKey: string
+  laneManifestHash: string
+  producer: string
+  findingKind: string
+  target: AssessmentSnapshotTarget
+  state: AssessmentSnapshotCoverageState
+  reasonCode: string
+  includedScope: string[]
+  excludedScope: string[]
+  versions: AssessmentSnapshotVersion[]
+}
+
+export interface AssessmentSnapshot {
+  id: string
+  cycleId: string
+  assessmentId: string
+  snapshotNumber: number
+  lifecycle: AssessmentSnapshotLifecycle
+  provenance: AssessmentSnapshotProvenance
+  boundary: AssessmentSnapshotBoundary
+  runReferences: AssessmentSnapshotRunReference[]
+  dimensions: AssessmentSnapshotDimension[]
+  schemaVersion: number
+  contentHash: string
+  createdAt: string
+  createdBy: string
+  finalizedAt: string
+  finalizedBy: string
+  supersededAt: string | null
+  supersededBy: string
+}
+
+export interface AssessmentSnapshotRunSelection {
+  runId: string
+  laneKeys?: string[]
+}
+
+export interface FinalizeAssessmentSnapshotInput {
+  selectedRuns: AssessmentSnapshotRunSelection[]
+  expectedDefaultVersion: number
+  idempotencyKey?: string
+}
+
+export interface FinalizeAssessmentSnapshotResponse {
+  snapshot: AssessmentSnapshot
+  defaultVersion: number
+}
+
+export interface AssessmentSnapshotListResponse {
+  items: AssessmentSnapshot[]
+  nextCursor: string
+  defaultSnapshotId: string
+  defaultVersion: number
+}
+
+export type AssessmentComparisonMode = 'lifecycle' | 'neutral_diff'
+export type AssessmentComparisonScope = 'vulnerability' | 'security' | 'all'
+export type AssessmentComparisonStatus = 'queued' | 'generating' | 'complete' | 'needs_review' | 'failed' | 'superseded'
+export type AssessmentComparisonPresence = 'new' | 'still_detected' | 'not_detected_under_comparable_coverage' | 'not_evaluated' | 'reopened' | 'needs_review'
+export type AssessmentComparisonNeutralPresence = 'only_in_a' | 'both' | 'only_in_b' | 'needs_review'
+export type AssessmentComparisonChangeFlag = 'severity_increased' | 'severity_decreased' | 'component_version_changed' | 'location_changed' | 'reachability_changed' | 'evidence_changed' | 'scanner_changed' | 'rule_profile_changed' | 'advisory_changed'
+export type AssessmentComparisonCoverage = 'comparable' | 'partially_comparable' | 'not_comparable'
+
+export interface AssessmentComparisonSeverityCounts {
+  critical: number
+  high: number
+  medium: number
+  low: number
+  info: number
+  unknown: number
+}
+
+export interface AssessmentComparisonRatio {
+  numerator: number
+  denominator: number
+  naReason: string
+}
+
+export interface AssessmentComparisonSummary {
+  comparisonId: string
+  baselineSnapshotId: string
+  currentSnapshotId: string
+  riskModelVersion: number
+  fixedRate: AssessmentComparisonRatio
+  countReduction: AssessmentComparisonRatio
+  riskReduction: AssessmentComparisonRatio
+  fixedCount: number
+  baselineCount: number
+  currentCount: number
+  baselineRisk: number
+  currentRisk: number
+  newCount: number
+  reopenedCount: number
+  stillDetectedCount: number
+  notEvaluatedCount: number
+  reviewCount: number
+  newRisk: number
+  reopenedRisk: number
+  baselineSeverity: AssessmentComparisonSeverityCounts
+  currentSeverity: AssessmentComparisonSeverityCounts
+}
+
+export interface AssessmentComparisonObservation {
+  severity: Severity
+  componentVersion: string
+  location: string
+  reachability: string
+  evidenceDigest: string
+  scanner: { scanRunId: string; laneKey: string; toolName: string; toolVersion: string; ruleId: string }
+  observedAt: string
+}
+
+export interface AssessmentComparison {
+  id: string
+  cycleId: string
+  baselineSnapshotId: string
+  currentSnapshotId: string
+  mode: AssessmentComparisonMode
+  inputHash: string
+  algorithmVersion: number
+  fingerprintVersion: number
+  riskModelVersion: number
+  coveragePolicyVersion: number
+  status: AssessmentComparisonStatus
+  version: number
+  attempts: number
+  failureCode: string
+  contentHash: string
+  summary: AssessmentComparisonSummary
+  createdAt: string
+  updatedAt: string
+  completedAt: string | null
+  supersededAt: string | null
+  supersededBy: string
+}
+
+export interface AssessmentComparisonItem {
+  id: string
+  position: number
+  identityId: string
+  producerKind: string
+  findingKind: string
+  targetCanonical: string
+  baselineObservationId: string
+  currentObservationId: string
+  baselineObservation: AssessmentComparisonObservation | null
+  currentObservation: AssessmentComparisonObservation | null
+  presence?: AssessmentComparisonPresence
+  neutralPresence?: AssessmentComparisonNeutralPresence
+  changeFlags: AssessmentComparisonChangeFlag[]
+  coverageDecision: AssessmentComparisonCoverage | ''
+  matchMethods: string[]
+  verificationId: string
+  verificationState: string
+  fixedBasis: '' | 'comparable_absence' | 'explicit_verification'
+  baselineActionable: boolean
+  currentActionable: boolean
+  comparableBaseline: boolean
+  baselineRiskMilli: number
+  currentRiskMilli: number
+  reviewCandidateIds: string[]
+  reviewCandidates: AssessmentComparisonReviewCandidate[]
+}
+
+export interface AssessmentComparisonReviewCandidate {
+  id: string
+  sourceObservationIds: string[]
+}
+
+export interface AssessmentComparisonItemPage {
+  items: AssessmentComparisonItem[]
+  nextCursor: string
+}
+
+export interface AssessmentComparisonReviewResult {
+  overrideEventId: string
+  supersededComparisonId: string
+  replacementComparisonId: string
+  replacementStatus: AssessmentComparisonStatus
 }
 
 export type BusinessAssetType = 'product' | 'application' | 'system' | 'business_service'
@@ -434,6 +1044,9 @@ export interface ScanRun {
   manifestHash: string
   laneCount: number
   completeCoverage: boolean
+  sourcePackage?: UploadedSourcePackage
+  targetKind?: string
+  target?: string
 }
 
 // The difference between two scan runs: which finding keys appeared or disappeared,
@@ -732,6 +1345,10 @@ export interface CurrentUser {
   id: string
   name: string
   role: string
+  features?: {
+    assessmentLifecycleRead: boolean
+    assessmentLifecycleUIDefault: boolean
+  }
 }
 
 // Audit: one append-only, attributable audit record.

--- a/web/src/pages/AssessmentCycles/AssessmentCycleDetailPage.test.tsx
+++ b/web/src/pages/AssessmentCycles/AssessmentCycleDetailPage.test.tsx
@@ -1,0 +1,133 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api, ApiError } from '../../lib/api'
+import type { AssessmentClosureManifest, AssessmentClosurePreview, AssessmentCycleDetail } from '../../lib/types'
+import { AssessmentCycleDetailPage } from './AssessmentCycleDetailPage'
+
+vi.mock('../../lib/api', async () => {
+  const actual = await vi.importActual<typeof import('../../lib/api')>('../../lib/api')
+  return {
+    ...actual,
+    api: {
+      assessmentCycle: vi.fn(), listAssessmentClosureManifests: vi.fn(), me: vi.fn(), downloadAssessmentClosureReport: vi.fn(),
+      previewAssessmentClosure: vi.fn(), commitAssessmentClosure: vi.fn(), previewAssessmentReopen: vi.fn(), commitAssessmentReopen: vi.fn(),
+    },
+  }
+})
+
+const detail: AssessmentCycleDetail = {
+  cycle: {
+    id: 'cycle-1', name: 'Payments Cycle', boundaryKind: 'standalone', businessAssetId: '', projectId: '', status: 'completed',
+    rootAssessmentId: 'assessment-root', selectedHeadAssessmentId: 'assessment-final', activeClosureManifestId: 'manifest-active', activeClosureCycleVersion: 5,
+    nextRetestNumber: 2, version: 5, createdAt: '2026-08-30T07:00:00Z', updatedAt: '2026-09-01T07:00:00Z', createdBy: 'owner', updatedBy: 'reviewer',
+  },
+  members: [], branchHeads: [],
+}
+
+const activeManifest: AssessmentClosureManifest = manifest('manifest-active', 'active', 2)
+const supersededManifest: AssessmentClosureManifest = { ...manifest('manifest-old', 'superseded', 1), supersededAt: '2026-08-31T07:00:00Z' }
+
+describe('AssessmentCycleDetailPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(api.assessmentCycle).mockResolvedValue(detail)
+    vi.mocked(api.listAssessmentClosureManifests).mockResolvedValue([activeManifest, supersededManifest])
+    vi.mocked(api.me).mockResolvedValue({ id: 'reviewer', name: 'Reviewer', role: 'reviewer' })
+    vi.mocked(api.downloadAssessmentClosureReport).mockResolvedValue()
+  })
+
+  it('renders final path, superseded history, and report metadata', async () => {
+    renderPage()
+
+    expect(await screen.findByRole('heading', { name: 'Payments Cycle' })).toBeInTheDocument()
+    expect(screen.getByRole('list', { name: 'Frozen root-to-final path' })).toBeInTheDocument()
+    expect(screen.getAllByText('Closure v2')).toHaveLength(2)
+    expect(screen.getByText(/prior closure remain available/)).toBeInTheDocument()
+    fireEvent.click(screen.getAllByRole('button', { name: 'Download report' })[0]!)
+    await waitFor(() => expect(api.downloadAssessmentClosureReport).toHaveBeenCalledWith('cycle-1', 'manifest-active'))
+  })
+
+  it('never renders hard blockers or unknown coverage as success', async () => {
+    vi.mocked(api.assessmentCycle).mockResolvedValue({ ...detail, cycle: { ...detail.cycle, status: 'open', version: 4, activeClosureManifestId: '', activeClosureCycleVersion: 0 } })
+    vi.mocked(api.listAssessmentClosureManifests).mockResolvedValue([])
+    vi.mocked(api.previewAssessmentClosure).mockResolvedValue(preview({
+      commitAllowed: false,
+      blockers: [{ id: 'coverage:unknown', code: 'coverage_incomplete', message: 'Coverage is incomplete.', overrideable: false, overridden: false }],
+      coverageDecisions: { initial: [], final: [{ snapshotId: 'snapshot-final', dimensionId: 'sca:vulnerability', state: 'unknown', reasonCode: 'legacy_provenance', waived: false }] },
+    }))
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Review closure' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Preview server policy' }))
+    expect(await screen.findByText('Hard blocker')).toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('Coverage is not complete')
+    expect(screen.getByRole('button', { name: 'Close from authoritative preview' })).toBeDisabled()
+    expect(screen.queryByText('No policy blocker is active.')).not.toBeInTheDocument()
+  })
+
+  it('shows refresh-review flow and preserves reason after a two-operator conflict', async () => {
+    vi.mocked(api.assessmentCycle).mockResolvedValue({ ...detail, cycle: { ...detail.cycle, status: 'open', version: 4, activeClosureManifestId: '', activeClosureCycleVersion: 0 } })
+    vi.mocked(api.listAssessmentClosureManifests).mockResolvedValue([])
+    vi.mocked(api.previewAssessmentClosure).mockResolvedValue(preview())
+    vi.mocked(api.commitAssessmentClosure).mockRejectedValue(new ApiError(409, 'cycle_version_conflict'))
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Review closure' }))
+    fireEvent.change(screen.getByRole('textbox', { name: 'Closure reason' }), { target: { value: 'Release accepted' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Preview server policy' }))
+    await screen.findByText('No policy blocker is active.')
+    fireEvent.click(screen.getByRole('button', { name: 'Close from authoritative preview' }))
+
+    expect(await screen.findByText(/Another operator changed, closed, reopened, or consumed this preview/)).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: 'Closure reason' })).toHaveValue('Release accepted')
+    expect(screen.getByRole('button', { name: 'Close from authoritative preview' })).toBeDisabled()
+    expect(api.commitAssessmentClosure).toHaveBeenCalledWith('cycle-1', 4, expect.objectContaining({ reason: 'Release accepted' }), 'signed-close', expect.any(String))
+  })
+
+  it('preserves the reopen reason and requires a new preview after a conflict', async () => {
+    vi.mocked(api.previewAssessmentReopen).mockResolvedValue({
+      cycleId: 'cycle-1', cycleVersion: 5, manifest: activeManifest,
+      impact: 'The Cycle returns to open while the manifest remains immutable.',
+      expiresAt: '2026-09-01T07:05:00Z', previewToken: 'signed-reopen',
+    })
+    vi.mocked(api.commitAssessmentReopen).mockRejectedValue(new ApiError(409, 'cycle_version_conflict'))
+    renderPage()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Review reopen' }))
+    await screen.findByText(/Cycle returns to open/)
+    fireEvent.change(screen.getByRole('textbox', { name: 'Reopen reason' }), { target: { value: 'Additional evidence arrived' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Reopen from authoritative preview' }))
+
+    expect(await screen.findByText(/Another operator changed or reopened this Cycle/)).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: 'Reopen reason' })).toHaveValue('Additional evidence arrived')
+    expect(screen.getByRole('button', { name: 'Reopen from authoritative preview' })).toBeDisabled()
+    expect(api.commitAssessmentReopen).toHaveBeenCalledWith('cycle-1', 5, 'signed-reopen', 'Additional evidence arrived', expect.any(String))
+  })
+})
+
+function renderPage() {
+  return render(<MemoryRouter initialEntries={['/assessment-cycles/cycle-1']}><Routes><Route path="/assessment-cycles/:cycleId" element={<AssessmentCycleDetailPage />} /></Routes></MemoryRouter>)
+}
+
+function preview(policy: Partial<AssessmentClosurePreview['policy']> = {}): AssessmentClosurePreview {
+  return {
+    cycleId: 'cycle-1', cycleVersion: 4, manifestVersion: 2, finalAssessmentId: 'assessment-final',
+    path: activeManifest.path, nonFinalBranches: [], initialSnapshotId: 'snapshot-root', finalSnapshotId: 'snapshot-final', comparisonId: 'comparison-1',
+    policy: { policyVersion: 'closure-policy-v1', blockers: [], warnings: [], coverageDecisions: { initial: [], final: [] }, commitAllowed: true, ...policy },
+    references: [], scopeProfileChanges: [], rendererContractVersion: 'assessment-cycle-report-v1', expiresAt: '2026-09-01T07:05:00Z', previewToken: 'signed-close',
+  }
+}
+function manifest(id: string, lifecycle: AssessmentClosureManifest['lifecycle'], manifestVersion: number): AssessmentClosureManifest {
+  return {
+    id, cycleId: 'cycle-1', manifestVersion, lifecycle, cycleVersion: manifestVersion + 3, rootAssessmentId: 'assessment-root', finalAssessmentId: 'assessment-final',
+    initialSnapshotId: 'snapshot-root', finalSnapshotId: 'snapshot-final', comparisonId: 'comparison-1', initialSnapshotHash: 'a'.repeat(64), finalSnapshotHash: 'b'.repeat(64),
+    comparisonHash: 'c'.repeat(64), canonicalInputHash: 'd'.repeat(64), contentHash: 'e'.repeat(64), policyVersion: 'closure-policy-v1', algorithmVersion: 'comparison-v1',
+    fingerprintVersion: 'fingerprint-v1', riskVersion: 'risk-v1', rendererContractVersion: 'assessment-cycle-report-v1', coverageDecisions: { initial: [], final: [] },
+    scopeProfileChanges: [], overrideBlockerIds: [], nonFinalBranches: [], path: [
+      { pathPosition: 0, assessmentId: 'assessment-root', assessmentType: 'initial', retestNumber: 0, relationshipVersion: 1, snapshotId: 'snapshot-root' },
+      { pathPosition: 1, assessmentId: 'assessment-final', assessmentType: 'retest', retestNumber: 1, relationshipVersion: 1, snapshotId: 'snapshot-final' },
+    ], references: [], reason: 'release accepted', overrideReason: '', asOfAt: '2026-09-01T07:00:00Z', createdAt: '2026-09-01T07:00:00Z', createdBy: 'reviewer',
+    sealedAt: '2026-09-01T07:00:00Z', sealedBy: 'reviewer', supersededAt: null,
+  }
+}

--- a/web/src/pages/AssessmentCycles/AssessmentCycleDetailPage.tsx
+++ b/web/src/pages/AssessmentCycles/AssessmentCycleDetailPage.tsx
@@ -1,0 +1,240 @@
+import { AlertTriangle, ArrowLeft, CheckCircle, Download01, Lock01, RefreshCw01, XClose } from '@untitledui/icons'
+import { useEffect, useState } from 'react'
+import { Link, useParams } from 'react-router-dom'
+import { Dialog, Modal, ModalOverlay } from '../../components/application/modals/modal'
+import { Button, Card, EmptyState, ErrorState, Field, Pill, Spinner } from '../../components/ui'
+import { useParallelFetch } from '../../hooks'
+import { api, ApiError } from '../../lib/api'
+import { newIdempotencyKey } from '../../lib/api/client'
+import type {
+  AssessmentClosureBlocker,
+  AssessmentClosureManifest,
+  AssessmentClosurePreview,
+  AssessmentClosurePreviewInput,
+  AssessmentCycleDetail,
+  AssessmentReopenPreview,
+} from '../../lib/types'
+
+type CycleDetailData = [AssessmentCycleDetail, AssessmentClosureManifest[], { role: string }]
+
+export function AssessmentCycleDetailPage() {
+  const { cycleId = '' } = useParams()
+  const result = useParallelFetch<CycleDetailData>(() => Promise.all([
+    api.assessmentCycle(cycleId), api.listAssessmentClosureManifests(cycleId), api.me(),
+  ]), { enabled: Boolean(cycleId), deps: [cycleId] })
+  const [dialog, setDialog] = useState<'close' | 'reopen' | null>(null)
+  const [downloadError, setDownloadError] = useState('')
+  const [downloading, setDownloading] = useState('')
+
+  if (result.loading && !result.data) return <Spinner label="Loading Assessment Cycle…" />
+  if (result.error) return <ErrorState message={result.error} />
+  if (!result.data) return <EmptyState icon={Lock01} title="Assessment Cycle not found" />
+
+  const [detail, manifests, me] = result.data
+  const cycle = detail.cycle
+  const activeManifest = manifests.find((manifest) => manifest.lifecycle === 'active') ?? null
+  const superseded = manifests.filter((manifest) => manifest.lifecycle === 'superseded')
+  const canReview = me.role === 'admin' || me.role === 'reviewer'
+
+  async function download(manifest: AssessmentClosureManifest) {
+    setDownloading(manifest.id)
+    setDownloadError('')
+    try {
+      await api.downloadAssessmentClosureReport(cycle.id, manifest.id)
+    } catch (cause) {
+      setDownloadError(cause instanceof Error ? cause.message : 'Report download failed.')
+    } finally {
+      setDownloading('')
+    }
+  }
+
+  return <div className="mx-auto max-w-[1400px] animate-fade-in space-y-6">
+    <header className="flex flex-wrap items-start justify-between gap-4">
+      <div>
+        <Link to="/assessment-cycles" className="inline-flex items-center gap-2 text-sm font-semibold text-brand-secondary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"><ArrowLeft className="size-4" />Assessment Cycles</Link>
+        <div className="mt-3 flex flex-wrap items-center gap-2"><h1 className="text-2xl font-bold tracking-tight text-primary">{cycle.name}</h1><Pill>{cycle.status} Cycle</Pill>{activeManifest ? <Pill className="text-success">Closure v{activeManifest.manifestVersion}</Pill> : null}</div>
+        <p className="mt-1 font-mono text-xs text-tertiary">{cycle.id}</p>
+        <p className="mt-2 text-sm text-tertiary">Final Assessment <strong className="text-primary">{activeManifest?.finalAssessmentId || cycle.selectedHeadAssessmentId}</strong> · Cycle version {cycle.version}</p>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <Button variant="secondary" onClick={result.refetch}><RefreshCw01 className="size-4" />Refresh</Button>
+        {canReview && cycle.status === 'open' ? <Button onClick={() => setDialog('close')}><Lock01 className="size-4" />Review closure</Button> : null}
+        {canReview && cycle.status === 'completed' && activeManifest ? <Button variant="secondary-color" onClick={() => setDialog('reopen')}><RefreshCw01 className="size-4" />Review reopen</Button> : null}
+      </div>
+    </header>
+
+    {!canReview ? <p className="rounded-lg border border-secondary bg-primary px-4 py-3 text-sm text-tertiary">Review permission is required to close or reopen a Cycle.</p> : null}
+
+    <Card title="Final state">
+      <dl className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Detail label="Root Assessment" value={activeManifest?.rootAssessmentId || cycle.rootAssessmentId} />
+        <Detail label="Selected / final Assessment" value={activeManifest?.finalAssessmentId || cycle.selectedHeadAssessmentId} />
+        <Detail label="Final Snapshot" value={activeManifest?.finalSnapshotId || 'Not closed'} />
+        <Detail label="Final Comparison" value={activeManifest?.comparisonId || 'Not closed'} />
+      </dl>
+      {activeManifest ? <PathList manifest={activeManifest} /> : <p className="mt-5 text-sm text-tertiary">The Cycle remains open. Closure uses a server-authoritative preview and immutable root-to-final references.</p>}
+    </Card>
+
+    <Card title="Closure history" actions={<Pill>{manifests.length} manifests</Pill>}>
+      {downloadError ? <ErrorState className="mb-4" message={downloadError} /> : null}
+      {manifests.length ? <ul className="space-y-3">{manifests.map((manifest) => <li key={manifest.id} className="rounded-lg border border-secondary p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3"><div><div className="flex flex-wrap items-center gap-2"><strong className="text-sm text-primary">Closure v{manifest.manifestVersion}</strong><Pill className={manifest.lifecycle === 'active' ? 'text-success' : 'text-warning'}>{manifest.lifecycle}</Pill></div><p className="mt-1 font-mono text-xs text-tertiary">{manifest.id}</p></div><Button variant="secondary" loading={downloading === manifest.id} onClick={() => download(manifest)}><Download01 className="size-4" />Download report</Button></div>
+        <dl className="mt-4 grid gap-3 text-xs sm:grid-cols-2 lg:grid-cols-4"><Detail label="Manifest hash" value={shortHash(manifest.contentHash)} mono /><Detail label="Renderer" value={manifest.rendererContractVersion} /><Detail label="Generated" value={formatDateTime(manifest.sealedAt)} /><Detail label="Final Assessment" value={manifest.finalAssessmentId} /></dl>
+        {manifest.lifecycle === 'superseded' ? <p className="mt-3 rounded-md bg-warning/10 px-3 py-2 text-xs text-warning">Superseded {formatDateTime(manifest.supersededAt)}. The manifest and downloaded report remain immutable.</p> : null}
+      </li>)}</ul> : <EmptyState icon={Lock01} title="No closure manifests" hint="A sealed manifest appears after a successful closure commit." />}
+      {superseded.length ? <p className="mt-4 text-xs text-tertiary">{superseded.length} prior closure{(superseded.length === 1) ? '' : 's'} remain available for audit and report download.</p> : null}
+    </Card>
+
+    {dialog === 'close' ? <ClosureDialog cycleId={cycle.id} onClose={() => setDialog(null)} onCommitted={() => { setDialog(null); result.refetch() }} /> : null}
+    {dialog === 'reopen' && activeManifest ? <ReopenDialog cycleId={cycle.id} manifest={activeManifest} onClose={() => setDialog(null)} onCommitted={() => { setDialog(null); result.refetch() }} /> : null}
+  </div>
+}
+
+function ClosureDialog({ cycleId, onClose, onCommitted }: { cycleId: string; onClose: () => void; onCommitted: () => void }) {
+  const [input, setInput] = useState<AssessmentClosurePreviewInput>({ reason: '', overrideBlockerIds: [], overrideReason: '' })
+  const [preview, setPreview] = useState<AssessmentClosurePreview | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [conflict, setConflict] = useState(false)
+  const [idempotencyKey, setIdempotencyKey] = useState(() => newIdempotencyKey())
+
+  function change(next: Partial<AssessmentClosurePreviewInput>) {
+    setInput((current) => ({ ...current, ...next }))
+    setPreview(null)
+    setConflict(false)
+    setError('')
+  }
+
+  async function loadPreview() {
+    setLoading(true)
+    setError('')
+    setConflict(false)
+    try {
+      const value = await api.previewAssessmentClosure(cycleId, input)
+      setPreview(value)
+      setIdempotencyKey(newIdempotencyKey())
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Closure preview failed.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function commit() {
+    if (!preview?.previewToken) return
+    setLoading(true)
+    setError('')
+    try {
+      await api.commitAssessmentClosure(cycleId, preview.cycleVersion, input, preview.previewToken, idempotencyKey)
+      onCommitted()
+    } catch (cause) {
+      if (cause instanceof ApiError && cause.status === 409) {
+        setConflict(true)
+        setPreview(null)
+        setIdempotencyKey(newIdempotencyKey())
+      } else {
+        setError(cause instanceof Error ? cause.message : 'Closure commit failed.')
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const unknownCoverage = preview ? [...preview.policy.coverageDecisions.initial, ...preview.policy.coverageDecisions.final].filter((decision) => decision.state !== 'complete' && !decision.waived) : []
+  const canCommit = Boolean(preview?.policy.commitAllowed && preview.previewToken && input.reason.trim())
+  return <WorkflowModal title="Review Cycle closure" onClose={onClose} loading={loading}>
+    <Field label="Closure reason" hint="Required and stored in the immutable manifest."><textarea aria-label="Closure reason" maxLength={4096} value={input.reason} disabled={loading} onChange={(event) => change({ reason: event.target.value })} className={textareaClass} /></Field>
+    {preview ? <div className="space-y-4" aria-live="polite">
+      <div className="rounded-lg border border-secondary bg-secondary/30 p-4 text-sm"><p><strong>Selected final:</strong> {preview.finalAssessmentId}</p><p><strong>Immutable pair:</strong> {preview.initialSnapshotId || 'missing'} → {preview.finalSnapshotId || 'missing'}</p><p><strong>Comparison:</strong> {preview.comparisonId || 'missing'} · renderer {preview.rendererContractVersion}</p><p className="mt-2 font-mono text-xs text-tertiary">Preview Cycle v{preview.cycleVersion} · expires {formatDateTime(preview.expiresAt)}</p></div>
+      <PathList preview={preview} />
+      <PolicyPanel preview={preview} unknownCoverage={unknownCoverage} input={input} onChange={change} disabled={loading} />
+      <ReferencePanel preview={preview} />
+    </div> : <p className="text-sm text-tertiary">Preview the server policy after every reason or override change. No client-side state can authorize closure.</p>}
+    {conflict ? <ErrorState message="Another operator changed, closed, reopened, or consumed this preview. Refresh the Cycle, review a new preview, and submit again." /> : null}
+    {error ? <ErrorState message={error} /> : null}
+    <div className="flex flex-wrap justify-end gap-2"><Button variant="secondary" disabled={loading} onClick={loadPreview}>Preview server policy</Button><Button loading={loading} disabled={!canCommit} onClick={commit}>Close from authoritative preview</Button></div>
+  </WorkflowModal>
+}
+
+function ReopenDialog({ cycleId, manifest, onClose, onCommitted }: { cycleId: string; manifest: AssessmentClosureManifest; onClose: () => void; onCommitted: () => void }) {
+  const [preview, setPreview] = useState<AssessmentReopenPreview | null>(null)
+  const [reason, setReason] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [conflict, setConflict] = useState(false)
+  const [idempotencyKey, setIdempotencyKey] = useState(() => newIdempotencyKey())
+
+  useEffect(() => {
+    let active = true
+    api.previewAssessmentReopen(cycleId).then((value) => { if (active) { setPreview(value); setIdempotencyKey(newIdempotencyKey()) } }).catch((cause) => { if (active) setError(cause instanceof Error ? cause.message : 'Reopen preview failed.') }).finally(() => { if (active) setLoading(false) })
+    return () => { active = false }
+  }, [cycleId])
+
+  async function commit() {
+    if (!preview?.previewToken || !reason.trim()) return
+    setLoading(true)
+    setError('')
+    try {
+      await api.commitAssessmentReopen(cycleId, preview.cycleVersion, preview.previewToken, reason.trim(), idempotencyKey)
+      onCommitted()
+    } catch (cause) {
+      if (cause instanceof ApiError && cause.status === 409) {
+        setConflict(true)
+        setPreview(null)
+        setIdempotencyKey(newIdempotencyKey())
+      } else {
+        setError(cause instanceof Error ? cause.message : 'Reopen commit failed.')
+      }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return <WorkflowModal title="Review Cycle reopen" onClose={onClose} loading={loading}>
+    <div className="rounded-lg border border-warning/30 bg-warning/10 p-4 text-sm text-warning"><p className="font-semibold">Closure v{manifest.manifestVersion} remains immutable.</p><p className="mt-1">Manifest {shortHash(manifest.contentHash)} and its report stay downloadable; the Cycle returns to open for additional work.</p></div>
+    {preview ? <div className="rounded-lg border border-secondary p-4 text-sm"><p>{preview.impact}</p><p className="mt-2 font-mono text-xs text-tertiary">Preview Cycle v{preview.cycleVersion} · expires {formatDateTime(preview.expiresAt)}</p></div> : null}
+    <Field label="Reopen reason" hint="Required for the audit record."><textarea aria-label="Reopen reason" maxLength={4096} value={reason} disabled={loading} onChange={(event) => setReason(event.target.value)} className={textareaClass} /></Field>
+    {conflict ? <ErrorState message="Another operator changed or reopened this Cycle. Refresh and review the current immutable manifest before retrying." /> : null}
+    {error ? <ErrorState message={error} /> : null}
+    <div className="flex justify-end"><Button loading={loading} disabled={!preview?.previewToken || !reason.trim()} onClick={commit}>Reopen from authoritative preview</Button></div>
+  </WorkflowModal>
+}
+
+function WorkflowModal({ title, onClose, loading, children }: { title: string; onClose: () => void; loading: boolean; children: React.ReactNode }) {
+  return <ModalOverlay isOpen isDismissable={!loading} onOpenChange={(open) => { if (!open && !loading) onClose() }}><Modal className="w-full max-w-3xl"><Dialog aria-label={title}>
+    <div className="flex items-start justify-between gap-3 border-b border-secondary px-6 py-4"><div><h2 className="text-lg font-semibold text-primary">{title}</h2><p className="mt-1 text-sm text-tertiary">Signed previews expire and are single-use.</p></div><button type="button" aria-label="Close dialog" disabled={loading} onClick={onClose} className="rounded-lg p-2 text-tertiary hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand disabled:opacity-50"><XClose className="size-5" /></button></div>
+    <div className="space-y-5 p-6">{children}</div>
+  </Dialog></Modal></ModalOverlay>
+}
+
+function PolicyPanel({ preview, unknownCoverage, input, onChange, disabled }: { preview: AssessmentClosurePreview; unknownCoverage: AssessmentClosurePreview['policy']['coverageDecisions']['initial']; input: AssessmentClosurePreviewInput; onChange: (next: Partial<AssessmentClosurePreviewInput>) => void; disabled: boolean }) {
+  const blockers = preview.policy.blockers
+  return <section aria-labelledby="closure-policy-title" className="space-y-3"><div className="flex flex-wrap items-center gap-2"><h3 id="closure-policy-title" className="text-sm font-semibold text-primary">Closure policy</h3><Pill className={preview.policy.commitAllowed ? 'text-success' : 'text-critical'}>{preview.policy.commitAllowed ? 'Commit allowed' : 'Blocked'}</Pill></div>
+    {blockers.length ? <ul className="space-y-2">{blockers.map((blocker) => <BlockerRow key={blocker.id} blocker={blocker} selected={input.overrideBlockerIds.includes(blocker.id)} disabled={disabled} onToggle={() => onChange({ overrideBlockerIds: toggle(input.overrideBlockerIds, blocker.id) })} />)}</ul> : <p className="flex items-center gap-2 text-sm text-success"><CheckCircle className="size-4" />No policy blocker is active.</p>}
+    {unknownCoverage.length ? <div role="alert" className="rounded-lg border border-critical/30 bg-critical/10 p-3 text-sm text-critical"><strong>Coverage is not complete.</strong> {unknownCoverage.length} unwaived dimensions remain partial or unknown; this never renders as success.</div> : null}
+    {preview.policy.warnings.length ? <ul className="space-y-1 text-sm text-warning">{preview.policy.warnings.map((warning) => <li key={warning.code}><AlertTriangle className="mr-2 inline size-4" />{warning.message}</li>)}</ul> : null}
+    {input.overrideBlockerIds.length ? <Field label="Override reason" hint="Required only for policy-approved override IDs."><textarea aria-label="Override reason" maxLength={4096} value={input.overrideReason} disabled={disabled} onChange={(event) => onChange({ overrideReason: event.target.value })} className={textareaClass} /></Field> : null}
+  </section>
+}
+
+function BlockerRow({ blocker, selected, disabled, onToggle }: { blocker: AssessmentClosureBlocker; selected: boolean; disabled: boolean; onToggle: () => void }) {
+  return <li className="rounded-lg border border-critical/25 bg-critical/5 p-3 text-sm"><div className="flex items-start gap-3"><AlertTriangle className="mt-0.5 size-4 shrink-0 text-critical" /><div className="min-w-0 flex-1"><p className="font-semibold text-primary">{blocker.message}</p><p className="mt-1 font-mono text-xs text-tertiary">{blocker.code} · {blocker.id}</p></div>{blocker.overrideable ? <label className="flex items-center gap-2 text-xs font-semibold text-tertiary"><input type="checkbox" checked={selected} disabled={disabled} onChange={onToggle} />Override</label> : <Pill className="text-critical">Hard blocker</Pill>}</div></li>
+}
+
+function ReferencePanel({ preview }: { preview: AssessmentClosurePreview }) {
+  return <section aria-labelledby="closure-references-title"><h3 id="closure-references-title" className="text-sm font-semibold text-primary">Effective references and changes</h3><p className="mt-1 text-xs text-tertiary">{preview.references.length} verification / accepted-risk / waiver references · {preview.scopeProfileChanges.length} scope or profile changes · {preview.nonFinalBranches.length} non-final branches</p>{preview.references.length ? <ul className="mt-2 grid gap-2 sm:grid-cols-2">{preview.references.map((reference) => <li key={`${reference.kind}:${reference.id}`} className="rounded-md border border-secondary px-3 py-2 text-xs"><strong className="text-primary">{reference.kind}</strong><span className="ml-2 font-mono text-tertiary">{reference.id}</span>{reference.expiresAt ? <span className="mt-1 block text-warning">Expires {formatDateTime(reference.expiresAt)}</span> : null}</li>)}</ul> : null}</section>
+}
+
+function PathList({ manifest, preview }: { manifest?: AssessmentClosureManifest; preview?: AssessmentClosurePreview }) {
+  const path = manifest?.path ?? preview?.path ?? []
+  return <div className="mt-5"><h3 className="text-sm font-semibold text-primary">Frozen root-to-final path</h3><ol className="mt-2 flex flex-wrap gap-2" aria-label="Frozen root-to-final path">{path.map((member) => <li key={`${member.pathPosition}:${member.assessmentId}`} className="rounded-lg border border-secondary bg-secondary/30 px-3 py-2 text-xs"><span className="font-semibold text-primary">{member.assessmentType === 'initial' ? 'Initial' : `Re-test #${member.retestNumber}`}</span><span className="ml-2 font-mono text-tertiary">{member.assessmentId}</span>{member.snapshotId ? <span className="mt-1 block font-mono text-quaternary">{member.snapshotId}</span> : null}</li>)}</ol></div>
+}
+
+function Detail({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+  return <div><dt className="text-[11px] font-semibold uppercase tracking-wide text-quaternary">{label}</dt><dd className={`mt-1 break-all text-sm text-primary ${mono ? 'font-mono text-xs' : 'font-semibold'}`}>{value}</dd></div>
+}
+
+function toggle(values: string[], value: string) { return values.includes(value) ? values.filter((item) => item !== value) : [...values, value].sort() }
+function shortHash(value: string) { return value ? `${value.slice(0, 12)}…${value.slice(-8)}` : 'N/A' }
+function formatDateTime(value: string | null) { return value ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value)) : 'Pending' }
+const textareaClass = 'input-inset min-h-24 w-full resize-y rounded-lg border border-secondary bg-secondary px-3.5 py-2.5 text-sm text-primary outline-none placeholder:text-quaternary focus:border-brand focus:ring-2 focus:ring-brand/40 disabled:opacity-50'

--- a/web/src/pages/AssessmentCycles/AssessmentCyclesPage.test.tsx
+++ b/web/src/pages/AssessmentCycles/AssessmentCyclesPage.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import type { AssessmentCycleSummary } from '../../lib/types'
+import { AssessmentCyclesPage } from './AssessmentCyclesPage'
+
+vi.mock('../../lib/api', () => ({ api: { listAssessmentCycles: vi.fn(), listAssessmentCycleMembers: vi.fn() } }))
+
+const cycle: AssessmentCycleSummary = {
+  id: 'cycle-1', name: 'Payments Cycle', boundaryKind: 'asset', businessAssetId: 'asset-1', projectId: '', status: 'open',
+  rootAssessmentId: 'assessment-root', selectedHeadAssessmentId: 'assessment-head', nextRetestNumber: 3, version: 4,
+  createdAt: '2026-08-01T00:00:00Z', updatedAt: '2026-08-03T00:00:00Z', createdBy: 'alice', updatedBy: 'alice',
+  memberCount: 3, activeBranchCount: 2, latestAssessmentId: 'assessment-head', latestRetestNumber: 2,
+  members: [
+    { assessmentId: 'assessment-root', assessmentType: 'initial', predecessorAssessmentId: '', retestNumber: 0, relationshipVersion: 1, createdAt: '2026-08-01T00:00:00Z', createdBy: 'alice', archivedAt: null },
+    { assessmentId: 'assessment-head', assessmentType: 'retest', predecessorAssessmentId: 'assessment-root', retestNumber: 1, relationshipVersion: 1, createdAt: '2026-08-02T00:00:00Z', createdBy: 'alice', archivedAt: null },
+  ],
+  membersNextCursor: 'member-cursor', rootSnapshotId: '', currentSnapshotId: '', comparisonId: '', comparisonStatus: '', comparisonSummary: null, activeClosureManifestId: '',
+  selectedHeadLastScanAt: null, scanStaleness: 'missing',
+}
+
+describe('AssessmentCyclesPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(api.listAssessmentCycles).mockResolvedValue({
+      items: [cycle], nextCursor: '', migrationPendingTotal: 1,
+      migrationPending: [{ assessmentId: 'legacy-1', name: 'Legacy Assessment', status: 'completed', boundaryKind: 'standalone', businessAssetId: '', updatedAt: '2026-08-04T00:00:00Z' }],
+    })
+    vi.mocked(api.listAssessmentCycleMembers).mockResolvedValue({
+      items: [{ assessmentId: 'assessment-archived', assessmentType: 'retest', predecessorAssessmentId: 'assessment-root', retestNumber: 2, relationshipVersion: 1, createdAt: '2026-08-03T00:00:00Z', createdBy: 'alice', archivedAt: '2026-08-04T00:00:00Z' }],
+      nextCursor: '',
+    })
+  })
+
+  it('renders N/A metrics, expands members, and continues the member cursor', async () => {
+    render(<MemoryRouter initialEntries={['/assessment-cycles?expanded=cycle-1']}><AssessmentCyclesPage /></MemoryRouter>)
+
+    expect(await screen.findByText('Payments Cycle')).toBeInTheDocument()
+    expect(screen.getAllByText('N/A').length).toBeGreaterThan(0)
+    expect(screen.getByText('Initial')).toBeInTheDocument()
+    expect(screen.getByText('Selected head')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Load more members' }))
+    await waitFor(() => expect(api.listAssessmentCycleMembers).toHaveBeenCalledWith('cycle-1', 'member-cursor', 25))
+    expect(await screen.findByText('Archived')).toBeInTheDocument()
+  })
+
+  it('renders migration-pending assessments without fabricating a Cycle', async () => {
+    render(<MemoryRouter initialEntries={['/assessment-cycles']}><AssessmentCyclesPage /></MemoryRouter>)
+
+    expect(await screen.findByText('Migration pending · 1')).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Legacy Assessment/ })).toHaveAttribute('href', '/engagements/legacy-1')
+    expect(screen.getByText('Migration pending')).toBeInTheDocument()
+  })
+
+  it('persists bounded filters in the URL-backed API query and clears them', async () => {
+    render(<MemoryRouter initialEntries={['/assessment-cycles?assessment_status=active&assessment_type=retest&selected_head=assessment-head&producer=semgrep&kind=sast&review=needs_review&presence=new&severity=critical&scan=stale&q=payments']}><AssessmentCyclesPage /></MemoryRouter>)
+
+    await waitFor(() => expect(api.listAssessmentCycles).toHaveBeenCalledWith(expect.objectContaining({
+      assessmentStatus: 'active', assessmentType: 'retest', selectedHeadAssessmentId: 'assessment-head', producer: 'semgrep', findingKind: 'sast',
+      reviewState: 'needs_review', changePresence: 'new', changeSeverity: 'critical', scanStaleness: 'stale', search: 'payments',
+    })))
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }))
+    await waitFor(() => expect(api.listAssessmentCycles).toHaveBeenLastCalledWith(expect.objectContaining({
+      assessmentStatus: undefined, assessmentType: undefined, selectedHeadAssessmentId: undefined, producer: undefined, findingKind: undefined,
+      reviewState: undefined, changePresence: undefined, changeSeverity: undefined, scanStaleness: undefined, search: undefined,
+    })))
+  })
+})

--- a/web/src/pages/AssessmentCycles/AssessmentCyclesPage.tsx
+++ b/web/src/pages/AssessmentCycles/AssessmentCyclesPage.tsx
@@ -1,0 +1,119 @@
+import { ChevronDown, GitBranch01, RefreshCw01, SearchLg } from '@untitledui/icons'
+import { useState } from 'react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { Button, Card, EmptyState, ErrorState, Input, Pill, Select, Spinner, cn } from '../../components/ui'
+import { useFetch } from '../../hooks'
+import { api } from '../../lib/api'
+import type {
+  AssessmentCycleBoundaryKind,
+  AssessmentCycleChangePresence,
+  AssessmentCycleMember,
+  AssessmentCycleReviewState,
+  AssessmentCycleScanStaleness,
+  AssessmentCycleStatus,
+  AssessmentCycleSummary,
+  AssessmentStatus,
+  Severity,
+} from '../../lib/types'
+
+export function AssessmentCyclesPage() {
+  const [params, setParams] = useSearchParams()
+  const status = (params.get('status') ?? '') as AssessmentCycleStatus | ''
+  const boundaryKind = (params.get('boundary') ?? '') as AssessmentCycleBoundaryKind | ''
+  const assessmentStatus = (params.get('assessment_status') ?? '') as AssessmentStatus | ''
+  const assessmentType = (params.get('assessment_type') ?? '') as AssessmentCycleMember['assessmentType'] | ''
+  const reviewState = (params.get('review') ?? '') as AssessmentCycleReviewState | ''
+  const changePresence = (params.get('presence') ?? '') as AssessmentCycleChangePresence | ''
+  const changeSeverity = (params.get('severity') ?? '') as Extract<Severity, 'critical' | 'high'> | ''
+  const scanStaleness = (params.get('scan') ?? '') as AssessmentCycleScanStaleness | ''
+  const selectedHeadAssessmentId = params.get('selected_head') ?? ''
+  const producer = params.get('producer') ?? ''
+  const findingKind = params.get('kind') ?? ''
+  const cursor = params.get('cursor') ?? ''
+  const search = params.get('q') ?? ''
+  const expanded = new Set((params.get('expanded') ?? '').split(',').filter(Boolean))
+  const filterValues = [status, boundaryKind, assessmentStatus, assessmentType, reviewState, changePresence, changeSeverity, scanStaleness, selectedHeadAssessmentId, producer, findingKind, search]
+  const cyclesFetch = useFetch(() => api.listAssessmentCycles({
+    status: status || undefined,
+    boundaryKind: boundaryKind || undefined,
+    assessmentStatus: assessmentStatus || undefined,
+    selectedHeadAssessmentId: selectedHeadAssessmentId || undefined,
+    assessmentType: assessmentType || undefined,
+    producer: producer || undefined,
+    findingKind: findingKind || undefined,
+    reviewState: reviewState || undefined,
+    changePresence: changePresence || undefined,
+    changeSeverity: changeSeverity || undefined,
+    scanStaleness: scanStaleness || undefined,
+    search: search || undefined,
+    cursor,
+    limit: 50,
+  }), { deps: [...filterValues, cursor] })
+  const [extraMembers, setExtraMembers] = useState<Record<string, AssessmentCycleMember[]>>({})
+  const [memberCursors, setMemberCursors] = useState<Record<string, string>>({})
+  const [memberLoading, setMemberLoading] = useState('')
+  const [memberErrors, setMemberErrors] = useState<Record<string, string>>({})
+
+  function update(next: Record<string, string>, replace = true) {
+    const values = new URLSearchParams(params)
+    for (const [key, value] of Object.entries(next)) value ? values.set(key, value) : values.delete(key)
+    setParams(values, { replace })
+  }
+
+  function toggle(cycleId: string) {
+    const next = new Set(expanded)
+    next.has(cycleId) ? next.delete(cycleId) : next.add(cycleId)
+    update({ expanded: [...next].sort().join(',') })
+  }
+
+  async function loadMore(cycle: AssessmentCycleSummary) {
+    const nextCursor = memberCursors[cycle.id] ?? cycle.membersNextCursor
+    if (!nextCursor) return
+    setMemberLoading(cycle.id)
+    setMemberErrors((current) => ({ ...current, [cycle.id]: '' }))
+    try {
+      const page = await api.listAssessmentCycleMembers(cycle.id, nextCursor, 25)
+      setExtraMembers((current) => ({ ...current, [cycle.id]: [...(current[cycle.id] ?? []), ...page.items] }))
+      setMemberCursors((current) => ({ ...current, [cycle.id]: page.nextCursor }))
+    } catch (cause) {
+      setMemberErrors((current) => ({ ...current, [cycle.id]: cause instanceof Error ? cause.message : 'Member page failed.' }))
+    } finally {
+      setMemberLoading('')
+    }
+  }
+
+  const items = cyclesFetch.data?.items ?? []
+  return <div className="mx-auto max-w-[1600px] animate-fade-in space-y-6">
+    <header className="flex flex-wrap items-end justify-between gap-4"><div><p className="text-xs font-semibold uppercase tracking-wider text-brand-secondary">Assessment lifecycle</p><h1 className="mt-1 text-2xl font-bold tracking-tight text-primary">Assessment Cycles</h1><p className="mt-1 text-sm text-tertiary">Root-to-selected/final projections only. Display latest never changes semantic precedence.</p></div><Button variant="secondary" onClick={cyclesFetch.refetch}><RefreshCw01 className="size-4" aria-hidden="true" />Refresh</Button></header>
+    <Card bodyClass="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      <div className="relative sm:col-span-2"><SearchLg className="pointer-events-none absolute left-3 top-3 size-4 text-quaternary" aria-hidden="true" /><Input aria-label="Search Assessment Cycles" value={search} onChange={(event) => update({ q: event.target.value, cursor: '' })} className="pl-9" placeholder="Search Cycle, root, or selected head" /></div>
+      <Select ariaLabel="Cycle status" value={status} onValueChange={(value) => update({ status: value, cursor: '' })} placeholder="All Cycle statuses" options={[{ value: 'open', label: 'Open' }, { value: 'completed', label: 'Completed' }, { value: 'archived', label: 'Archived' }]} className="w-full" />
+      <Select ariaLabel="Boundary kind" value={boundaryKind} onValueChange={(value) => update({ boundary: value, cursor: '' })} placeholder="All boundaries" options={[{ value: 'standalone', label: 'Standalone' }, { value: 'asset', label: 'Asset' }, { value: 'project', label: 'Project' }, { value: 'asset_project', label: 'Asset + Project' }]} className="w-full" />
+      <Select ariaLabel="Selected-head Assessment status" value={assessmentStatus} onValueChange={(value) => update({ assessment_status: value, cursor: '' })} placeholder="All Assessment statuses" options={[{ value: 'draft', label: 'Draft' }, { value: 'active', label: 'Active' }, { value: 'completed', label: 'Completed' }, { value: 'archived', label: 'Archived' }]} className="w-full" />
+      <Select ariaLabel="Assessment member type" value={assessmentType} onValueChange={(value) => update({ assessment_type: value, cursor: '' })} placeholder="Initial or Re-test" options={[{ value: 'initial', label: 'Initial' }, { value: 'retest', label: 'Re-test' }]} className="w-full" />
+      <Input aria-label="Selected head Assessment ID" value={selectedHeadAssessmentId} onChange={(event) => update({ selected_head: event.target.value, cursor: '' })} placeholder="Selected head ID" />
+      <Select ariaLabel="Selected-head scan staleness" value={scanStaleness} onValueChange={(value) => update({ scan: value, cursor: '' })} placeholder="Any scan freshness" options={[{ value: 'fresh', label: 'Fresh ≤ 24h' }, { value: 'stale', label: 'Stale > 24h' }, { value: 'missing', label: 'No trustworthy scan' }]} className="w-full" />
+      <Input aria-label="Comparison producer" value={producer} onChange={(event) => update({ producer: event.target.value, cursor: '' })} placeholder="Producer" />
+      <Input aria-label="Comparison finding kind" value={findingKind} onChange={(event) => update({ kind: event.target.value, cursor: '' })} placeholder="Finding kind" />
+      <Select ariaLabel="Comparison review state" value={reviewState} onValueChange={(value) => update({ review: value, cursor: '' })} placeholder="Any review state" options={[{ value: 'needs_review', label: 'Needs review' }, { value: 'verified', label: 'Verified' }, { value: 'clear', label: 'Clear' }]} className="w-full" />
+      <Select ariaLabel="Comparison change presence" value={changePresence} onValueChange={(value) => update({ presence: value, cursor: '' })} placeholder="New or reopened" options={[{ value: 'new', label: 'New' }, { value: 'reopened', label: 'Reopened' }]} className="w-full" />
+      <Select ariaLabel="Comparison change severity" value={changeSeverity} onValueChange={(value) => update({ severity: value, cursor: '' })} placeholder="Critical or High" options={[{ value: 'critical', label: 'Critical' }, { value: 'high', label: 'High' }]} className="w-full" />
+      {filterValues.some(Boolean) ? <Button variant="secondary" onClick={() => setParams(new URLSearchParams(), { replace: true })}>Clear filters</Button> : null}
+    </Card>
+    {cyclesFetch.loading && !cyclesFetch.data ? <Spinner label="Loading Assessment Cycles…" /> : null}
+    {cyclesFetch.error ? <ErrorState message={cyclesFetch.error} /> : null}
+    {!cyclesFetch.loading && !cyclesFetch.error && items.length === 0 && !(cyclesFetch.data?.migrationPendingTotal) ? <EmptyState icon={GitBranch01} title="No Assessment Cycles" hint="No Cycle or migration-pending Assessment matches these filters." /> : null}
+    <div className="space-y-3">{items.map((cycle) => <CycleRow key={cycle.id} cycle={cycle} expanded={expanded.has(cycle.id)} extraMembers={extraMembers[cycle.id] ?? []} nextMemberCursor={memberCursors[cycle.id] ?? cycle.membersNextCursor} loading={memberLoading === cycle.id} error={memberErrors[cycle.id] ?? ''} onToggle={() => toggle(cycle.id)} onLoadMore={() => loadMore(cycle)} />)}</div>
+    {cyclesFetch.data?.nextCursor ? <div className="flex justify-end"><Button variant="secondary" onClick={() => update({ cursor: cyclesFetch.data?.nextCursor ?? '' }, false)}>Next Cycle page</Button></div> : null}
+    {cyclesFetch.data?.migrationPendingTotal ? <Card title={`Migration pending · ${cyclesFetch.data.migrationPendingTotal}`}>{cyclesFetch.data.migrationPending.length ? <div className="space-y-2">{cyclesFetch.data.migrationPending.map((assessment) => <Link key={assessment.assessmentId} to={`/engagements/${encodeURIComponent(assessment.assessmentId)}`} className="flex flex-wrap items-center gap-2 rounded-lg border border-warning/30 bg-warning/5 px-4 py-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"><span className="font-semibold text-primary">{assessment.name}</span><span className="font-mono text-xs text-tertiary">{assessment.assessmentId}</span><Pill className="text-warning">Migration pending</Pill><Pill>{assessment.status} Assessment</Pill><span className="ml-auto text-xs text-tertiary">{formatDate(assessment.updatedAt)}</span></Link>)}</div> : <p className="text-sm text-tertiary">Pending legacy Assessments exist but are excluded by Cycle-only filters. Clear filters to inspect them.</p>}</Card> : null}
+  </div>
+}
+
+function CycleRow({ cycle, expanded, extraMembers, nextMemberCursor, loading, error, onToggle, onLoadMore }: { cycle: AssessmentCycleSummary; expanded: boolean; extraMembers: AssessmentCycleMember[]; nextMemberCursor: string; loading: boolean; error: string; onToggle: () => void; onLoadMore: () => void }) {
+  const members = [...cycle.members, ...extraMembers]
+  return <Card bodyClass="p-0"><button type="button" aria-expanded={expanded} aria-controls={`cycle-${cycle.id}`} onClick={onToggle} className="grid w-full gap-3 px-5 py-4 text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand md:grid-cols-[minmax(240px,1.4fr)_repeat(4,minmax(110px,.6fr))_auto] md:items-center"><span><span className="flex flex-wrap items-center gap-2"><strong className="text-sm text-primary">{cycle.name}</strong><Pill>{cycle.status} Cycle</Pill>{cycle.activeClosureManifestId ? <Pill className="text-success">Final manifest</Pill> : null}</span><span className="mt-1 block font-mono text-xs text-tertiary">{cycle.id}</span></span><Stat label="Members / branches" value={`${cycle.memberCount} / ${cycle.activeBranchCount}`} /><Stat label="Fixed rate" value={ratio(cycle.comparisonSummary?.fixedRate)} /><Stat label="New / reopened" value={cycle.comparisonSummary ? `${cycle.comparisonSummary.newCount} / ${cycle.comparisonSummary.reopenedCount}` : 'N/A'} /><Stat label="Selected-head scan" value={cycle.scanStaleness} /><ChevronDown className={cn('size-4 text-tertiary transition-transform', expanded && 'rotate-180')} aria-hidden="true" /></button>{expanded ? <div id={`cycle-${cycle.id}`} className="border-t border-secondary px-5 py-4"><div className="mb-3 grid gap-2 text-xs text-tertiary sm:grid-cols-2 lg:grid-cols-5"><span><strong>Root snapshot:</strong> {cycle.rootSnapshotId || 'N/A'}</span><span><strong>Current/final snapshot:</strong> {cycle.currentSnapshotId || 'N/A'}</span><span><strong>Comparison:</strong> {cycle.comparisonId || 'N/A'}</span><span><strong>Display latest:</strong> {cycle.latestAssessmentId || 'N/A'}</span><span><strong>Last trusted scan:</strong> {cycle.selectedHeadLastScanAt ? formatDate(cycle.selectedHeadLastScanAt) : 'N/A'}</span></div><Link to={`/assessment-cycles/${encodeURIComponent(cycle.id)}`} className="mb-3 inline-flex rounded-lg text-sm font-semibold text-brand-secondary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand">Open Cycle details and closure history</Link><ul aria-label={`${cycle.name} members`} className="space-y-2">{members.map((member) => <li key={member.assessmentId}><Link to={`/engagements/${encodeURIComponent(member.assessmentId)}`} className="flex flex-wrap items-center gap-2 rounded-lg border border-secondary px-3 py-2 text-sm hover:border-brand focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"><span className="font-semibold text-primary">{member.assessmentType === 'retest' ? `Re-test #${member.retestNumber}` : 'Initial'}</span><span className="font-mono text-xs text-tertiary">{member.assessmentId}</span>{member.assessmentId === cycle.selectedHeadAssessmentId ? <Pill className="text-brand-secondary">Selected head</Pill> : null}{member.assessmentId === cycle.latestAssessmentId ? <Pill className="text-brand-secondary">Display latest</Pill> : null}{member.archivedAt ? <Pill className="text-warning">Archived</Pill> : null}<span className="ml-auto text-xs text-tertiary">{formatDate(member.createdAt)}</span></Link></li>)}</ul>{error ? <ErrorState className="mt-3" message={error} /> : null}{nextMemberCursor ? <Button className="mt-3" variant="secondary" loading={loading} onClick={onLoadMore}>Load more members</Button> : null}</div> : null}</Card>
+}
+
+function Stat({ label, value }: { label: string; value: string }) { return <span><span className="block text-[11px] font-semibold uppercase tracking-wide text-quaternary">{label}</span><span className="mt-1 block text-sm font-semibold capitalize text-primary">{value}</span></span> }
+function ratio(value?: { numerator: number; denominator: number; naReason: string }) { return !value || value.denominator <= 0 ? 'N/A' : `${Math.round(value.numerator * 100 / value.denominator)}%` }
+function formatDate(value: string) { return value ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(value)) : 'Unknown' }

--- a/web/src/pages/Dashboard/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard/Dashboard.test.tsx
@@ -37,10 +37,10 @@ const assets: BusinessAsset[] = [
 
 const engagements: Engagement[] = [
   {
-    id: 'eng-active', name: 'Payment API Review', client: 'Internal', status: 'active', inScope: [{ kind: 'repo', value: 'payments' }], outOfScope: [], authorizedFrom: null, authorizedTo: null, roe: { allowedToolClasses: [], blackouts: [] }, liveReconEnabled: false, createdAt: '2026-08-01T00:00:00Z', businessAssetId: 'asset-critical',
+    id: 'eng-active', name: 'Payment API Review', client: 'Internal', status: 'active', inScope: [{ kind: 'repo', value: 'payments' }], outOfScope: [], authorizedFrom: null, authorizedTo: null, roe: { allowedToolClasses: [], blackouts: [] }, liveReconEnabled: false, requiresExplicitExecutionAuthorization: false, createdAt: '2026-08-01T00:00:00Z', businessAssetId: 'asset-critical',
   },
   {
-    id: 'eng-unassigned', name: 'New Service Review', client: 'Internal', status: 'draft', inScope: [{ kind: 'service', value: 'new-service' }], outOfScope: [], authorizedFrom: null, authorizedTo: null, roe: { allowedToolClasses: [], blackouts: [] }, liveReconEnabled: false, createdAt: '2026-08-02T00:00:00Z', businessAssetId: '',
+    id: 'eng-unassigned', name: 'New Service Review', client: 'Internal', status: 'draft', inScope: [{ kind: 'service', value: 'new-service' }], outOfScope: [], authorizedFrom: null, authorizedTo: null, roe: { allowedToolClasses: [], blackouts: [] }, liveReconEnabled: false, requiresExplicitExecutionAuthorization: false, createdAt: '2026-08-02T00:00:00Z', businessAssetId: '',
   },
 ]
 

--- a/web/src/pages/EngagementDetail/AssessmentComparisonTab.test.tsx
+++ b/web/src/pages/EngagementDetail/AssessmentComparisonTab.test.tsx
@@ -1,0 +1,147 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api } from '../../lib/api'
+import type { AssessmentSnapshot } from '../../lib/types'
+import { AssessmentComparisonTab } from './AssessmentComparisonTab'
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    assessmentLifecycle: vi.fn(), assessmentSnapshots: vi.fn(), createAssessmentComparison: vi.fn(),
+    assessmentComparison: vi.fn(), assessmentComparisonSummary: vi.fn(), assessmentComparisonItems: vi.fn(), reviewAssessmentComparisonItem: vi.fn(),
+  },
+  ApiError: class ApiError extends Error { constructor(public status: number, message: string) { super(message) } },
+}))
+
+const snapshot = (id: string, number: number) => ({
+  id, cycleId: 'cycle-1', assessmentId: 'assessment-1', snapshotNumber: number, lifecycle: 'finalized' as const, provenance: 'native' as const,
+  boundary: { boundaryKind: 'standalone' as const, businessAssetId: '', projectId: '' }, runReferences: [], schemaVersion: 1,
+  contentHash: 'a'.repeat(64), createdAt: '2026-08-31T00:00:00Z', createdBy: 'operator', finalizedAt: '2026-08-31T00:00:00Z', finalizedBy: 'operator', supersededAt: null, supersededBy: '',
+  dimensions: [{ runId: `run-${number}`, laneKey: 'sca', laneManifestHash: 'b'.repeat(64), producer: 'sca', findingKind: 'vulnerability', target: { kind: 'repository' as const, schemaVersion: 1, canonical: 'repo:example', evaluatedRevision: '' }, state: 'complete' as const, reasonCode: 'complete', includedScope: ['src/**'], excludedScope: [], versions: [] }],
+})
+
+const comparison = {
+  id: 'comparison-1', cycleId: 'cycle-1', baselineSnapshotId: 'snapshot-1', currentSnapshotId: 'snapshot-2', mode: 'lifecycle' as const,
+  inputHash: 'c'.repeat(64), algorithmVersion: 1, fingerprintVersion: 1, riskModelVersion: 1, coveragePolicyVersion: 1,
+  status: 'needs_review' as const, version: 3, attempts: 1, failureCode: '', contentHash: 'd'.repeat(64),
+  summary: {
+    comparisonId: 'comparison-1', baselineSnapshotId: 'snapshot-1', currentSnapshotId: 'snapshot-2', riskModelVersion: 1,
+    fixedRate: { numerator: 0, denominator: 0, naReason: 'no_comparable_actionable_baseline' }, countReduction: { numerator: 0, denominator: 0, naReason: 'no_actionable_baseline' }, riskReduction: { numerator: 0, denominator: 0, naReason: 'non_positive_baseline_risk' },
+    fixedCount: 0, baselineCount: 0, currentCount: 1, baselineRisk: 0, currentRisk: 5000, newCount: 1, reopenedCount: 0, stillDetectedCount: 0, notEvaluatedCount: 0, reviewCount: 1, newRisk: 5000, reopenedRisk: 0,
+    baselineSeverity: { critical: 0, high: 0, medium: 0, low: 0, info: 0, unknown: 0 }, currentSeverity: { critical: 0, high: 1, medium: 0, low: 0, info: 0, unknown: 0 },
+  },
+  createdAt: '2026-08-31T00:00:00Z', updatedAt: '2026-08-31T00:00:00Z', completedAt: '2026-08-31T00:00:00Z', supersededAt: null, supersededBy: '',
+}
+
+const configuredUrl = '/engagements/assessment-1/comparison?comparison_mode=lifecycle&comparison_base_assessment=assessment-1&comparison_baseline=snapshot-1&comparison_current=snapshot-2'
+const comparedUrl = `${configuredUrl}&comparison_id=comparison-1`
+
+function renderComparison(url = configuredUrl) {
+  return render(<MemoryRouter initialEntries={[url]}><Routes><Route path="/engagements/:id/comparison" element={<AssessmentComparisonTab assessmentId="assessment-1" />} /></Routes></MemoryRouter>)
+}
+
+describe('AssessmentComparisonTab', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(api.assessmentLifecycle).mockResolvedValue({ assessmentId: 'assessment-1', cycle: { id: 'cycle-1', name: 'Cycle', boundaryKind: 'standalone', businessAssetId: '', projectId: '', status: 'open', rootAssessmentId: 'assessment-1', selectedHeadAssessmentId: 'assessment-1', nextRetestNumber: 1, version: 1, createdAt: '', updatedAt: '', createdBy: '', updatedBy: '' }, members: [{ assessmentId: 'assessment-1', assessmentType: 'initial', predecessorAssessmentId: '', retestNumber: 0, relationshipVersion: 1, createdAt: '', createdBy: '', archivedAt: null }], branchHeads: [] })
+    vi.mocked(api.assessmentSnapshots).mockResolvedValue({ items: [snapshot('snapshot-1', 1), snapshot('snapshot-2', 2)], defaultSnapshotId: 'snapshot-2', defaultVersion: 2, nextCursor: '' })
+    vi.mocked(api.createAssessmentComparison).mockResolvedValue({ comparison, created: true })
+    vi.mocked(api.assessmentComparison).mockResolvedValue(comparison)
+    vi.mocked(api.assessmentComparisonSummary).mockResolvedValue(comparison.summary)
+    vi.mocked(api.assessmentComparisonItems).mockResolvedValue({ items: [{ id: 'item-1', position: 0, identityId: 'identity-1', producerKind: 'sca', findingKind: 'vulnerability', targetCanonical: 'repo:example', baselineObservationId: '', currentObservationId: 'observation-1', baselineObservation: null, currentObservation: { severity: 'high', componentVersion: '1.0.0', location: 'go.mod', reachability: 'reachable', evidenceDigest: 'e'.repeat(64), scanner: { scanRunId: 'run-2', laneKey: 'sca', toolName: 'scanner', toolVersion: '1', ruleId: 'rule' }, observedAt: '2026-08-31T00:00:00Z' }, presence: 'needs_review', changeFlags: [], coverageDecision: 'not_comparable', matchMethods: ['matcher'], verificationId: '', verificationState: '', fixedBasis: '', baselineActionable: false, currentActionable: true, comparableBaseline: false, baselineRiskMilli: 0, currentRiskMilli: 5000, reviewCandidateIds: ['candidate-1'], reviewCandidates: [{ id: 'candidate-1', sourceObservationIds: ['source-observation-1'] }] }], nextCursor: 'next' })
+  })
+
+  it('configures the pair, renders N/A ratios, and opens immutable item detail', async () => {
+    renderComparison()
+    expect(await screen.findByRole('dialog', { name: 'Configure comparison' })).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Comparison mode' })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Run comparison' }))
+    await waitFor(() => expect(api.createAssessmentComparison).toHaveBeenCalledWith({ baselineSnapshotId: 'snapshot-1', currentSnapshotId: 'snapshot-2', mode: 'lifecycle' }))
+    await waitFor(() => expect(api.assessmentComparisonSummary).toHaveBeenCalledWith('comparison-1', 'vulnerability'))
+    expect(screen.queryByRole('dialog', { name: 'Configure comparison' })).not.toBeInTheDocument()
+    expect(screen.getByText('Comparison confidence: High')).toBeInTheDocument()
+    expect((await screen.findAllByText('N/A')).length).toBe(3)
+    expect(screen.getByRole('combobox', { name: 'Disposition filter' })).toBeInTheDocument()
+    expect((await screen.findAllByRole('button', { name: /Needs review/i })).length).toBeGreaterThan(1)
+    fireEvent.click(screen.getAllByRole('button', { name: /Needs review/i }).at(-1)!)
+    expect(await screen.findByRole('heading', { name: 'Immutable item detail' })).toBeInTheDocument()
+    expect(screen.getByText('none → identity-1 → observation-1')).toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Review source observation' })).toBeInTheDocument()
+    expect(screen.getByText(/completed item is never mutated/i)).toBeInTheDocument()
+  })
+
+  it.each([
+    ['scope', 'partial'], ['advisory_database', 'partial'], ['tool', 'partial'],
+    ['profile', 'unknown'], ['rule_pack', 'unknown'], ['target_schema', 'unknown'],
+  ] as const)('does not overstate coverage after %s changes', async (kind, expected) => {
+    const baseline: AssessmentSnapshot = snapshot('snapshot-1', 1)
+    const current: AssessmentSnapshot = snapshot('snapshot-2', 2)
+    if (kind === 'scope') current.dimensions[0].includedScope = ['different/**']
+    else if (kind === 'target_schema') current.dimensions[0].target.schemaVersion = 2
+    else current.dimensions[0].versions = [{ kind, name: 'changed', version: '2', digest: '' }]
+    vi.mocked(api.assessmentSnapshots).mockResolvedValue({ items: [baseline, current], defaultSnapshotId: current.id, defaultVersion: 2, nextCursor: '' })
+    renderComparison(comparedUrl)
+    const message = expected === 'partial' ? /0 comparable · 1 partial · 0 not comparable or unknown/i : /0 comparable · 0 partial · 1 not comparable or unknown/i
+    expect(await screen.findByText(message)).toBeInTheDocument()
+  })
+
+  it('keeps summary and explorer on the same selected scope', async () => {
+    renderComparison(comparedUrl)
+    expect(await screen.findByRole('tab', { name: 'Vulnerabilities' })).toHaveAttribute('aria-selected', 'true')
+    fireEvent.click(screen.getByRole('tab', { name: 'Security findings' }))
+    await waitFor(() => expect(api.assessmentComparisonSummary).toHaveBeenCalledWith('comparison-1', 'security'))
+    await waitFor(() => expect(api.assessmentComparisonItems).toHaveBeenCalledWith('comparison-1', expect.objectContaining({ scope: 'security' })))
+  })
+
+  it('surfaces critical exposure with the shared severity treatment', async () => {
+    vi.mocked(api.assessmentComparisonSummary).mockResolvedValue({
+      ...comparison.summary,
+      baselineCount: 1,
+      currentCount: 2,
+      baselineSeverity: { ...comparison.summary.baselineSeverity, critical: 0, high: 1 },
+      currentSeverity: { ...comparison.summary.currentSeverity, critical: 1, high: 1 },
+    })
+    renderComparison(comparedUrl)
+
+    const criticalCard = await screen.findByLabelText('Critical: 0 before, 1 after, +1 net change')
+    expect(criticalCard).toHaveClass('border-critical/30', 'bg-critical/5')
+    expect(within(criticalCard).getByText('Critical')).toBeInTheDocument()
+    expect(screen.getByLabelText('Critical after: 1')).toBeInTheDocument()
+    fireEvent.click(criticalCard)
+    await waitFor(() => expect(api.assessmentComparisonItems).toHaveBeenCalledWith('comparison-1', expect.objectContaining({ severity: 'critical' })))
+  })
+
+  it('opens the compact configuration step from an existing result', async () => {
+    renderComparison(comparedUrl)
+    expect(await screen.findByText('Compared findings')).toBeInTheDocument()
+    expect(screen.queryByRole('dialog', { name: 'Configure comparison' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Change comparison' }))
+    expect(await screen.findByRole('dialog', { name: 'Configure comparison' })).toBeInTheDocument()
+  })
+
+  it('supports findings-style search, sorting, expansion, and cursor pagination', async () => {
+    renderComparison(comparedUrl)
+    expect(await screen.findByText('Compared findings')).toBeInTheDocument()
+    expect(await screen.findByRole('button', { name: 'Toggle comparison details for identity-1' })).toBeInTheDocument()
+
+    const severityHeader = screen.getByRole('columnheader', { name: 'Severity' })
+    expect(severityHeader).toHaveAttribute('aria-sort', 'descending')
+    fireEvent.click(within(severityHeader).getByRole('button'))
+    await waitFor(() => expect(screen.getByRole('columnheader', { name: 'Severity' })).toHaveAttribute('aria-sort', 'ascending'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Toggle comparison details for identity-1' }))
+    expect(await screen.findByText('Finding state transition')).toBeInTheDocument()
+    expect(screen.getAllByText('After').length).toBeGreaterThan(0)
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search compared findings' }), { target: { value: 'does-not-exist' } })
+    expect(await screen.findByText('No compared findings match')).toBeInTheDocument()
+    expect(screen.getByText(/No item on this page matches/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Clear comparison search' }))
+    expect(await screen.findByRole('button', { name: 'Toggle comparison details for identity-1' })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next comparison page' }))
+    await waitFor(() => expect(api.assessmentComparisonItems).toHaveBeenCalledWith('comparison-1', expect.objectContaining({ cursor: 'next' })))
+    fireEvent.click(screen.getByRole('button', { name: 'Previous comparison page' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Previous comparison page' })).toBeDisabled())
+  })
+})

--- a/web/src/pages/EngagementDetail/AssessmentComparisonTab.tsx
+++ b/web/src/pages/EngagementDetail/AssessmentComparisonTab.tsx
@@ -1,0 +1,651 @@
+import { AlertCircle, ArrowDown, ArrowNarrowRight, ArrowUp, CheckCircle, ChevronLeft, ChevronRight, FilterLines, GitBranch01, InfoCircle, RefreshCw01, SearchLg, ShieldTick, Sliders04, SwitchVertical01, XClose } from '@untitledui/icons'
+import { Fragment, useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { Dialog, Modal, ModalOverlay } from '../../components/application/modals/modal'
+import { SlideoutMenu } from '../../components/application/slideout-menus/slideout-menu'
+import { Metric, MetricStrip } from '../../components/synapse/Metric'
+import { SeverityBadge } from '../../components/synapse/SeverityBadge'
+import { Button, Card, EmptyState, ErrorState, Field, Input, Pill, Select, Spinner, cn } from '../../components/ui'
+import { useFetch } from '../../hooks'
+import { api, ApiError } from '../../lib/api'
+import { sevRank } from '../../lib/severity'
+import type { AssessmentComparison, AssessmentComparisonChangeFlag, AssessmentComparisonItem, AssessmentComparisonMode, AssessmentComparisonRatio, AssessmentComparisonScope, AssessmentComparisonSummary, AssessmentLifecycle, AssessmentSnapshot, AssessmentSnapshotListResponse, Severity } from '../../lib/types'
+import { DEFAULT_PAGE_SIZE, PAGE_SIZE_OPTIONS, type SortDirection } from './components/FindingsTable'
+
+const ALL = 'all'
+const PRESENCE = ['all', 'new', 'still_detected', 'not_detected_under_comparable_coverage', 'not_evaluated', 'reopened', 'needs_review'].map(option)
+const NEUTRAL_PRESENCE = ['all', 'only_in_a', 'both', 'only_in_b', 'needs_review'].map(option)
+const SEVERITY = ['all', 'critical', 'high', 'medium', 'low', 'info', 'unknown'].map(option)
+const REVIEW = ['all', 'needs_review', 'verified', 'clear'].map(option)
+const DISPOSITION = ['all', 'current_actionable', 'baseline_only', 'non_actionable'].map(option)
+const CHANGES = ['all', 'severity_increased', 'severity_decreased', 'component_version_changed', 'location_changed', 'reachability_changed', 'evidence_changed', 'scanner_changed', 'rule_profile_changed', 'advisory_changed'].map(option)
+const SCOPES: Array<{ value: AssessmentComparisonScope; label: string; description: string }> = [
+  { value: 'vulnerability', label: 'Vulnerabilities', description: 'Unique SCA vulnerability identities' },
+  { value: 'security', label: 'Security findings', description: 'Vulnerabilities, SAST, secrets, and misconfigurations' },
+  { value: 'all', label: 'All findings', description: 'Includes quality and reliability findings' },
+]
+const TERMINAL_STATUSES = ['complete', 'needs_review', 'superseded']
+type ComparisonSortKey = 'lifecycle' | 'severity' | 'identity' | 'change' | 'coverage'
+
+const COMPARISON_SORT_KEYS: ComparisonSortKey[] = ['lifecycle', 'severity', 'identity', 'change', 'coverage']
+
+function selectedOption(value: string | null, options: Array<{ value: string }>, fallback = ALL) {
+  return value && options.some((option) => option.value === value) ? value : fallback
+}
+
+function isComparisonSortKey(value: string | null): value is ComparisonSortKey {
+  return value !== null && COMPARISON_SORT_KEYS.includes(value as ComparisonSortKey)
+}
+
+export function AssessmentComparisonTab({ assessmentId }: { assessmentId: string }) {
+  const [params, setParams] = useSearchParams()
+  const mode = (params.get('comparison_mode') === 'neutral_diff' ? 'neutral_diff' : 'lifecycle') as AssessmentComparisonMode
+  const baselineAssessmentParam = params.get('comparison_base_assessment') ?? ''
+  const baselineSnapshotId = params.get('comparison_baseline') ?? ''
+  const currentSnapshotId = params.get('comparison_current') ?? ''
+  const comparisonId = params.get('comparison_id') ?? ''
+  const requestedScope = params.get('comparison_scope')
+  const scope = (SCOPES.some((item) => item.value === requestedScope) ? requestedScope : 'vulnerability') as AssessmentComparisonScope
+  const cursor = params.get('comparison_cursor') ?? ''
+  const presenceOptions = mode === 'neutral_diff' ? NEUTRAL_PRESENCE : PRESENCE
+  const presence = selectedOption(params.get('comparison_presence'), presenceOptions)
+  const severity = selectedOption(params.get('comparison_severity'), SEVERITY)
+  const changeFlag = selectedOption(params.get('comparison_change'), CHANGES)
+  const reviewState = selectedOption(params.get('comparison_review'), REVIEW)
+  const disposition = selectedOption(params.get('comparison_disposition'), DISPOSITION)
+  const producer = params.get('comparison_producer') ?? ''
+  const findingKind = params.get('comparison_kind') ?? ''
+  const searchQuery = params.get('comparison_q') ?? ''
+  const sortParam = params.get('comparison_sort')
+  const sortKey: ComparisonSortKey = isComparisonSortKey(sortParam) ? sortParam : 'severity'
+  const sortDirection: SortDirection = params.get('comparison_dir') === 'asc' ? 'asc' : 'desc'
+  const sizeParam = Number(params.get('comparison_size'))
+  const pageSize = (PAGE_SIZE_OPTIONS as readonly number[]).includes(sizeParam) ? sizeParam : DEFAULT_PAGE_SIZE
+  const [creating, setCreating] = useState(false)
+  const [createError, setCreateError] = useState('')
+  const [selectedItem, setSelectedItem] = useState<AssessmentComparisonItem | null>(null)
+  const [configOpen, setConfigOpen] = useState(!comparisonId)
+  const [expandedItemId, setExpandedItemId] = useState('')
+  const [cursorHistory, setCursorHistory] = useState<string[]>([])
+
+  const context = useFetch(() => Promise.all([api.assessmentLifecycle(assessmentId), api.assessmentSnapshots(assessmentId)]), { deps: [assessmentId] })
+  const lifecycle = context.data?.[0] ?? null
+  const currentSnapshots = context.data?.[1] ?? null
+  const assessmentIds = useMemo(() => comparisonAssessmentIds(lifecycle, assessmentId, mode), [assessmentId, lifecycle, mode])
+  const baselineAssessmentId = assessmentIds.includes(baselineAssessmentParam) ? baselineAssessmentParam : (assessmentIds[0] ?? '')
+  const baselineFetch = useFetch(() => api.assessmentSnapshots(baselineAssessmentId), { enabled: Boolean(baselineAssessmentId), deps: [baselineAssessmentId] })
+  const baselineSnapshots = baselineAssessmentId === assessmentId ? currentSnapshots : baselineFetch.data
+
+  useEffect(() => {
+    if (!currentSnapshots || !baselineSnapshots || !baselineAssessmentId) return
+    const current = currentSnapshots.items.some((item) => item.id === currentSnapshotId) ? currentSnapshotId : currentSnapshots.defaultSnapshotId || currentSnapshots.items.at(-1)?.id || ''
+    const validBaseline = baselineSnapshots.items.some((item) => item.id === baselineSnapshotId) && baselineSnapshotId !== current
+    const baseline = validBaseline ? baselineSnapshotId : chooseBaselineSnapshot(baselineSnapshots, baselineAssessmentId === assessmentId, current)
+    if (baselineAssessmentParam === baselineAssessmentId && baselineSnapshotId === baseline && currentSnapshotId === current) return
+    setParams((next) => {
+      next.set('comparison_mode', mode)
+      next.set('comparison_base_assessment', baselineAssessmentId)
+      setOrDelete(next, 'comparison_baseline', baseline)
+      setOrDelete(next, 'comparison_current', current)
+      next.delete('comparison_id'); next.delete('comparison_cursor')
+      return next
+    }, { replace: true })
+  }, [assessmentId, baselineAssessmentId, baselineAssessmentParam, baselineSnapshotId, baselineSnapshots, currentSnapshotId, currentSnapshots, mode, setParams])
+
+  const comparisonFetch = useFetch(() => api.assessmentComparison(comparisonId), { enabled: Boolean(comparisonId), deps: [comparisonId] })
+  const comparison = comparisonFetch.data
+  const terminal = TERMINAL_STATUSES.includes(comparison?.status ?? '')
+  useEffect(() => {
+    if (!comparison || !['queued', 'generating'].includes(comparison.status)) return
+    const timer = window.setInterval(comparisonFetch.refetch, 2000)
+    return () => window.clearInterval(timer)
+  }, [comparison, comparisonFetch.refetch])
+
+  const summaryFetch = useFetch(async () => ({ scope, summary: await api.assessmentComparisonSummary(comparisonId, scope) }), {
+    enabled: Boolean(comparisonId) && terminal,
+    deps: [comparisonId, scope, terminal],
+  })
+
+  const itemFetch = useFetch(async () => ({ scope, page: await api.assessmentComparisonItems(comparisonId, {
+    cursor: cursor || undefined, limit: pageSize, scope,
+    presence: presence === ALL ? undefined : presence,
+    severity: severity === ALL ? undefined : severity,
+    changeFlag: changeFlag === ALL ? undefined : changeFlag as AssessmentComparisonChangeFlag,
+    reviewState: reviewState === ALL ? undefined : reviewState,
+    disposition: disposition === ALL ? undefined : disposition,
+    producer: producer || undefined, findingKind: findingKind || undefined,
+  }) }), {
+    enabled: Boolean(comparisonId) && terminal,
+    deps: [changeFlag, comparisonId, cursor, disposition, findingKind, pageSize, presence, producer, reviewState, scope, severity, terminal],
+  })
+
+  const baselineSnapshot = baselineSnapshots?.items.find((item) => item.id === baselineSnapshotId) ?? null
+  const currentSnapshot = currentSnapshots?.items.find((item) => item.id === currentSnapshotId) ?? null
+  const scopedSummary = summaryFetch.data?.scope === scope ? summaryFetch.data.summary : null
+  const scopedItemPage = itemFetch.data?.scope === scope ? itemFetch.data.page : null
+  const visibleItems = useMemo(() => sortComparisonItems(filterComparisonItems(scopedItemPage?.items ?? [], searchQuery), sortKey, sortDirection), [scopedItemPage?.items, searchQuery, sortDirection, sortKey])
+
+  function setParam(key: string, value: string, clearComparison = false) {
+    setCursorHistory([])
+    setParams((next) => {
+      setOrDelete(next, key, key === 'comparison_scope' ? value : value === ALL ? '' : value)
+      next.delete('comparison_cursor')
+      if (clearComparison) next.delete('comparison_id')
+      return next
+    }, { replace: true })
+  }
+
+  async function createComparison() {
+    if (!baselineSnapshotId || !currentSnapshotId || baselineSnapshotId === currentSnapshotId) return setCreateError('Baseline and current must be different immutable snapshots.')
+    setCreating(true); setCreateError('')
+    try {
+      const result = await api.createAssessmentComparison({ baselineSnapshotId, currentSnapshotId, mode })
+      const returned = result.comparison
+      if (returned.mode !== mode || returned.baselineSnapshotId !== baselineSnapshotId || returned.currentSnapshotId !== currentSnapshotId) throw new Error('The server returned a different pair or mode; comparison was rejected locally.')
+      setParams((next) => { next.set('comparison_id', returned.id); next.delete('comparison_cursor'); return next })
+      setConfigOpen(false)
+    } catch (error) { setCreateError(error instanceof Error ? error.message : 'Comparison request failed.') }
+    finally { setCreating(false) }
+  }
+
+  if (context.loading && !context.data) return <Spinner label="Loading assessment comparison context…" />
+  if (context.error) return <ErrorState message={context.error} />
+  if (!lifecycle || !currentSnapshots?.items.length) return <EmptyState icon={GitBranch01} title="No immutable snapshots to compare" hint="Finalize at least one assessment snapshot before creating a comparison." />
+
+  const scopeDetails = SCOPES.find((item) => item.value === scope) ?? SCOPES[0]
+  const hasAdvancedFilters = Boolean(producer || findingKind || reviewState !== ALL || disposition !== ALL)
+  const hasFilters = Boolean(searchQuery || presence !== ALL || severity !== ALL || changeFlag !== ALL || hasAdvancedFilters)
+
+  function clearFilters() {
+    setCursorHistory([])
+    setExpandedItemId('')
+    setParams((next) => {
+      for (const key of ['comparison_q', 'comparison_presence', 'comparison_severity', 'comparison_change', 'comparison_review', 'comparison_disposition', 'comparison_producer', 'comparison_kind', 'comparison_cursor']) next.delete(key)
+      return next
+    }, { replace: true })
+  }
+
+  function onSort(key: ComparisonSortKey) {
+    const direction: SortDirection = sortKey === key ? (sortDirection === 'asc' ? 'desc' : 'asc') : key === 'severity' ? 'desc' : 'asc'
+    setCursorHistory([])
+    setParams((next) => {
+      next.set('comparison_sort', key)
+      next.set('comparison_dir', direction)
+      next.delete('comparison_cursor')
+      return next
+    }, { replace: true })
+  }
+
+  function nextPage() {
+    if (!scopedItemPage?.nextCursor) return
+    setCursorHistory((history) => [...history, cursor])
+    setParams((next) => { next.set('comparison_cursor', scopedItemPage.nextCursor); return next }, { replace: true })
+    setExpandedItemId('')
+  }
+
+  function previousPage() {
+    if (!cursorHistory.length) return
+    const previousCursor = cursorHistory.at(-1) ?? ''
+    setCursorHistory((history) => history.slice(0, -1))
+    setParams((next) => { setOrDelete(next, 'comparison_cursor', previousCursor); return next }, { replace: true })
+    setExpandedItemId('')
+  }
+
+  return <div className="space-y-5">
+    {!comparisonId ? <EmptyState icon={GitBranch01} title="Configure a comparison" hint="Choose two immutable snapshots and the finding scope you want to inspect." action={<Button onClick={() => setConfigOpen(true)}><Sliders04 className="size-4" />Configure comparison</Button>} /> : <ComparisonPairBar mode={mode} baseline={baselineSnapshot} current={currentSnapshot} baselineLabel={baselineAssessmentId ? memberLabel(lifecycle, baselineAssessmentId, false) : 'Baseline'} currentLabel={memberLabel(lifecycle, assessmentId, false)} onConfigure={() => setConfigOpen(true)} />}
+    {comparisonId ? <CoverageBanner baseline={baselineSnapshot} current={currentSnapshot} /> : null}
+    {comparisonId && comparisonFetch.loading && !comparison ? <Spinner label="Loading immutable comparison…" /> : null}
+    {comparisonFetch.error ? <ErrorState message={comparisonFetch.error} /> : null}
+    {comparison ? <ComparisonState comparison={comparison} onRefresh={comparisonFetch.refetch} /> : null}
+    {comparison && terminal ? <>
+      <Card title="Comparison overview" bodyClass="space-y-6">
+        <ScopeTabs scope={scope} onChange={(value) => setParam('comparison_scope', value)} />
+        <p className="-mt-3 text-sm text-tertiary">{scopeDetails.description}. Switch scope to keep vulnerability outcomes separate from code quality noise.</p>
+        {summaryFetch.loading && !scopedSummary ? <Spinner label={`Calculating ${scopeDetails.label.toLowerCase()}…`} /> : null}
+        {summaryFetch.error ? <ErrorState message={summaryFetch.error} /> : null}
+        {scopedSummary ? <Summary comparison={comparison} summary={scopedSummary} scope={scope} coverage={coverageCounts(baselineSnapshot, currentSnapshot)} onPresenceChange={(value) => setParam('comparison_presence', value)} onSeverityChange={(value) => setParam('comparison_severity', value)} /> : null}
+      </Card>
+      <Card bodyClass="p-3" className="shadow-xs">
+        <ComparisonFilterBar searchQuery={searchQuery} presence={presence} severity={severity} changeFlag={changeFlag} presenceOptions={presenceOptions} hasFilters={hasFilters} onSetParam={setParam} onClear={clearFilters} />
+        <details className="group mt-3 rounded-lg border border-secondary bg-secondary/20" open={hasAdvancedFilters}>
+          <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs font-semibold text-secondary hover:text-primary"><FilterLines className="size-3.5" />Advanced filters</summary>
+          <div className="grid gap-3 border-t border-secondary p-3 md:grid-cols-2 xl:grid-cols-4">
+            <Field label="Review state"><Select size="sm" ariaLabel="Review state filter" value={reviewState} onValueChange={(value) => setParam('comparison_review', value)} options={REVIEW} className="w-full" /></Field>
+            <Field label="Disposition"><Select size="sm" ariaLabel="Disposition filter" value={disposition} onValueChange={(value) => setParam('comparison_disposition', value)} options={DISPOSITION} className="w-full" /></Field>
+            <Field label="Producer"><Input aria-label="Producer filter" placeholder="e.g. trivy" value={producer} onChange={(event) => setParam('comparison_producer', event.target.value)} className="h-8 py-1.5 text-xs" /></Field>
+            <Field label="Finding kind"><Input aria-label="Finding kind filter" placeholder="e.g. vulnerability" value={findingKind} onChange={(event) => setParam('comparison_kind', event.target.value)} className="h-8 py-1.5 text-xs" /></Field>
+          </div>
+        </details>
+      </Card>
+      <Card title={<span className="flex items-center gap-2"><SearchLg className="size-4 text-quaternary" />Compared findings</span>} actions={<Pill>{scopeDetails.label}</Pill>} bodyClass="p-0" className="overflow-hidden shadow-xs">
+        <ItemTable loading={itemFetch.loading} error={itemFetch.error} items={visibleItems} unfilteredCount={scopedItemPage?.items.length ?? 0} searchQuery={searchQuery} sortKey={sortKey} sortDirection={sortDirection} onSort={onSort} expandedItemId={expandedItemId} onToggle={(id) => setExpandedItemId((current) => current === id ? '' : id)} onSelect={setSelectedItem} />
+        <ComparisonPagination page={cursorHistory.length + 1} pageSize={pageSize} count={visibleItems.length} canPrevious={cursorHistory.length > 0} canNext={Boolean(scopedItemPage?.nextCursor)} onPrevious={previousPage} onNext={nextPage} onPageSizeChange={(value) => setParam('comparison_size', String(value))} />
+      </Card>
+    </> : null}
+    {configOpen ? <ComparisonConfigModal lifecycle={lifecycle} assessmentId={assessmentId} mode={mode} baselineAssessmentId={baselineAssessmentId} assessmentIds={assessmentIds} baselineSnapshotId={baselineSnapshotId} currentSnapshotId={currentSnapshotId} baselineSnapshots={baselineSnapshots} currentSnapshots={currentSnapshots} scope={scope} creating={creating} error={createError} onSetParam={setParam} onCompare={createComparison} onClose={() => setConfigOpen(false)} /> : null}
+    {selectedItem ? <ReviewDrawer comparison={comparison} item={selectedItem} onClose={() => setSelectedItem(null)} onReplacement={(id) => { setSelectedItem(null); setParams((next) => { next.set('comparison_id', id); next.delete('comparison_cursor'); return next }) }} /> : null}
+  </div>
+}
+
+function ComparisonState({ comparison, onRefresh }: { comparison: AssessmentComparison; onRefresh: () => void }) {
+  const terminal = TERMINAL_STATUSES.includes(comparison.status)
+  const failed = comparison.status === 'failed'
+  if (terminal) return <div role="status" className="flex flex-wrap items-center justify-between gap-3 text-xs text-tertiary"><span>Comparison ready · projection v{comparison.version} · {comparison.id.slice(0, 8)}</span>{comparison.status === 'needs_review' ? <Pill className="bg-warning/10 text-warning-primary">Review required</Pill> : null}</div>
+  return <div role="status" className={cn('flex flex-wrap items-center justify-between gap-4 rounded-xl border px-5 py-4', failed ? 'border-critical/30 bg-critical/5' : 'border-brand/30 bg-brand/5')}>
+    <div className="flex items-start gap-3">
+      {failed ? <AlertCircle className="mt-0.5 size-5 text-critical" /> : <RefreshCw01 className="mt-0.5 size-5 animate-spin text-brand-secondary" />}
+      <div><p className="font-semibold text-primary">{failed ? 'Comparison could not be generated' : 'Calculating changes between snapshots'}</p><p className="mt-1 text-sm text-tertiary">{failed ? `Failure code: ${comparison.failureCode || 'unknown'}. Retry after checking the comparison worker.` : 'Synapse is matching identities and validating scan coverage. This page refreshes automatically.'}</p></div>
+    </div>
+    <Button variant="secondary" onClick={onRefresh}><RefreshCw01 className="size-4" />Refresh</Button>
+  </div>
+}
+
+function ComparisonPairBar({ mode, baseline, current, baselineLabel, currentLabel, onConfigure }: { mode: AssessmentComparisonMode; baseline: AssessmentSnapshot | null; current: AssessmentSnapshot | null; baselineLabel: string; currentLabel: string; onConfigure: () => void }) {
+  return <Card bodyClass="p-3" className="shadow-xs">
+    <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-brand-primary/10 text-brand-secondary"><GitBranch01 className="size-4" aria-hidden="true" /></div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2"><p className="text-xs font-semibold uppercase tracking-wide text-tertiary">Active comparison</p><Pill className="bg-brand-primary/10 text-brand-secondary">{mode === 'lifecycle' ? 'Scan → re-scan' : 'Neutral diff'}</Pill></div>
+          <div className="mt-1 flex min-w-0 flex-wrap items-center gap-2 text-sm">
+            <span className="truncate font-semibold text-primary">{baselineLabel}</span><SnapshotInline snapshot={baseline} />
+            <ArrowNarrowRight className="size-4 shrink-0 text-quaternary" aria-hidden="true" />
+            <span className="truncate font-semibold text-primary">{currentLabel}</span><SnapshotInline snapshot={current} />
+          </div>
+        </div>
+      </div>
+      <Button variant="secondary" className="h-9 shrink-0 text-xs" onClick={onConfigure}><Sliders04 className="size-4" />Change comparison</Button>
+    </div>
+  </Card>
+}
+
+function SnapshotInline({ snapshot }: { snapshot: AssessmentSnapshot | null }) {
+  if (!snapshot) return <span className="text-xs text-tertiary">No snapshot</span>
+  return <span className="whitespace-nowrap font-mono text-xs text-tertiary">Snapshot {snapshot.snapshotNumber} · {snapshot.id.slice(0, 8)}</span>
+}
+
+function ComparisonConfigModal({ lifecycle, assessmentId, mode, baselineAssessmentId, assessmentIds, baselineSnapshotId, currentSnapshotId, baselineSnapshots, currentSnapshots, scope, creating, error, onSetParam, onCompare, onClose }: { lifecycle: AssessmentLifecycle; assessmentId: string; mode: AssessmentComparisonMode; baselineAssessmentId: string; assessmentIds: string[]; baselineSnapshotId: string; currentSnapshotId: string; baselineSnapshots: AssessmentSnapshotListResponse | null | undefined; currentSnapshots: AssessmentSnapshotListResponse; scope: AssessmentComparisonScope; creating: boolean; error: string; onSetParam: (key: string, value: string, clearComparison?: boolean) => void; onCompare: () => void; onClose: () => void }) {
+  const ready = Boolean(baselineAssessmentId && baselineSnapshotId && currentSnapshotId && baselineSnapshots)
+  const invalidPair = !baselineSnapshotId || !currentSnapshotId || baselineSnapshotId === currentSnapshotId
+  const baseline = baselineSnapshots?.items.find((item) => item.id === baselineSnapshotId) ?? null
+  const current = currentSnapshots.items.find((item) => item.id === currentSnapshotId) ?? null
+  return <ModalOverlay isOpen isDismissable={!creating} onOpenChange={(open) => { if (!open && !creating) onClose() }}>
+    <Modal className="w-full max-w-3xl overflow-hidden rounded-2xl border border-secondary bg-primary shadow-2xl">
+      <Dialog aria-label="Configure comparison" className="flex max-h-[85vh] flex-col overflow-hidden">
+        <header className="flex shrink-0 items-start justify-between border-b border-secondary px-6 py-5">
+          <div><div className="flex items-center gap-2"><div className="flex size-9 items-center justify-center rounded-lg bg-brand-primary/10 text-brand-secondary"><Sliders04 className="size-4" aria-hidden="true" /></div><div><h2 className="text-lg font-semibold text-primary">Configure comparison</h2><p className="mt-0.5 text-sm text-tertiary">Choose what Synapse should compare. The underlying comparison rules remain unchanged.</p></div></div></div>
+          <button type="button" onClick={onClose} disabled={creating} aria-label="Close comparison configuration" className="flex size-9 shrink-0 items-center justify-center rounded-lg text-tertiary hover:bg-secondary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60 disabled:opacity-50"><XClose className="size-4" aria-hidden="true" /></button>
+        </header>
+        <div className="min-h-0 flex-1 space-y-5 overflow-y-auto px-6 py-5">
+          {!ready ? <div className="flex min-h-64 items-center justify-center"><Spinner label="Preparing comparison options…" /></div> : <>
+          <section className="grid gap-4 rounded-xl border border-secondary bg-secondary/20 p-4 md:grid-cols-2" aria-label="Comparison behavior">
+            <Field label="Comparison mode" hint="Lifecycle mode classifies fixed, new and re-opened findings."><Select disabled={creating} ariaLabel="Comparison mode" value={mode} onValueChange={(value) => onSetParam('comparison_mode', value, true)} options={[{ value: 'lifecycle', label: 'Scan → re-scan lifecycle' }, { value: 'neutral_diff', label: 'Neutral snapshot diff' }]} className="w-full" /></Field>
+            <Field label="Result scope" hint="This changes presentation scope, not the immutable snapshots."><Select disabled={creating} ariaLabel="Comparison result scope" value={scope} onValueChange={(value) => onSetParam('comparison_scope', value)} options={SCOPES} className="w-full" /></Field>
+          </section>
+          <section aria-labelledby="comparison-pair-heading">
+            <div className="mb-3"><h3 id="comparison-pair-heading" className="text-sm font-semibold text-primary">Select comparison pair</h3><p className="mt-1 text-xs text-tertiary">For a re-test, the closest previous finalized snapshot is selected by default.</p></div>
+            <div className="grid gap-4 md:grid-cols-3">
+              <Field label="Baseline assessment"><Select disabled={creating} ariaLabel="Baseline assessment" value={baselineAssessmentId} onValueChange={(value) => onSetParam('comparison_base_assessment', value, true)} options={assessmentIds.map((id) => ({ value: id, label: memberLabel(lifecycle, id) }))} className="w-full" /></Field>
+              <Field label="Before snapshot"><Select disabled={creating} ariaLabel="Baseline snapshot" value={baselineSnapshotId} onValueChange={(value) => onSetParam('comparison_baseline', value, true)} options={(baselineSnapshots?.items ?? []).map(snapshotOption)} className="w-full" /></Field>
+              <Field label="After snapshot"><Select disabled={creating} ariaLabel="Current snapshot" value={currentSnapshotId} onValueChange={(value) => onSetParam('comparison_current', value, true)} options={currentSnapshots.items.map(snapshotOption)} className="w-full" /></Field>
+            </div>
+          </section>
+          <div className="grid items-stretch gap-3 md:grid-cols-[1fr_auto_1fr]">
+            <SnapshotCard eyebrow="Before" snapshot={baseline} assessmentLabel={baselineAssessmentId ? memberLabel(lifecycle, baselineAssessmentId, false) : 'Select a baseline'} />
+            <div className="flex items-center justify-center text-quaternary"><ArrowNarrowRight className="size-5 rotate-90 md:rotate-0" aria-hidden="true" /></div>
+            <SnapshotCard eyebrow="After" snapshot={current} assessmentLabel={memberLabel(lifecycle, assessmentId, false)} current />
+          </div>
+          {error ? <ErrorState message={error} /> : null}
+          </>}
+        </div>
+        <footer className="flex shrink-0 flex-wrap items-center justify-between gap-3 border-t border-secondary bg-primary px-6 py-4">
+          <p className="text-xs text-tertiary">Metrics use immutable finding identities from this pair.</p>
+          <div className="flex gap-3"><Button variant="ghost" disabled={creating} onClick={onClose}>Cancel</Button><Button loading={creating} disabled={!ready || invalidPair} onClick={onCompare}>Run comparison</Button></div>
+        </footer>
+      </Dialog>
+    </Modal>
+  </ModalOverlay>
+}
+
+function ComparisonFilterBar({ searchQuery, presence, severity, changeFlag, presenceOptions, hasFilters, onSetParam, onClear }: { searchQuery: string; presence: string; severity: string; changeFlag: string; presenceOptions: Array<{ value: string; label: string }>; hasFilters: boolean; onSetParam: (key: string, value: string) => void; onClear: () => void }) {
+  return <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+    <div className="flex flex-1 flex-wrap items-center gap-2.5">
+      <div className="relative min-w-[16rem] flex-1 sm:max-w-sm">
+        <SearchLg className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-tertiary" aria-hidden="true" />
+        <input type="text" value={searchQuery} onChange={(event) => onSetParam('comparison_q', event.target.value)} placeholder="Search current page: identity, target, tool, rule…" aria-label="Search compared findings" className="h-9 w-full rounded-lg border border-secondary bg-primary pl-9 pr-8 text-xs text-primary placeholder:text-quaternary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-solid" />
+        {searchQuery ? <button type="button" onClick={() => onSetParam('comparison_q', '')} aria-label="Clear comparison search" className="absolute right-2.5 top-1/2 -translate-y-1/2 text-quaternary hover:text-primary"><XClose className="size-3.5" /></button> : null}
+      </div>
+      <Select size="sm" ariaLabel="Presence filter" value={presence} onValueChange={(value) => onSetParam('comparison_presence', value)} options={presenceOptions} className="min-w-[10rem]" />
+      <Select size="sm" ariaLabel="Severity filter" value={severity} onValueChange={(value) => onSetParam('comparison_severity', value)} options={SEVERITY} className="min-w-[9rem]" />
+      <Select size="sm" ariaLabel="Changed field filter" value={changeFlag} onValueChange={(value) => onSetParam('comparison_change', value)} options={CHANGES} className="min-w-[11rem]" />
+    </div>
+    {hasFilters ? <Button variant="ghost" className="h-9 self-end px-3 text-xs lg:self-auto" onClick={onClear}><XClose className="size-3.5" />Clear filters</Button> : null}
+  </div>
+}
+
+function CoverageBanner({ baseline, current }: { baseline: AssessmentSnapshot | null; current: AssessmentSnapshot | null }) {
+  const counts = coverageCounts(baseline, current)
+  const unsafe = !baseline || !current || baseline.provenance === 'legacy' || current.provenance === 'legacy' || counts.notComparable > 0
+  const confidence = unsafe ? 'Low' : counts.partial ? 'Partial' : 'High'
+  return <div className={cn('rounded-xl border px-4 py-4', unsafe ? 'border-warning/30 bg-warning/10' : counts.partial ? 'border-brand/30 bg-brand/5' : 'border-success/30 bg-success/10')}><div className="flex items-start gap-3">{unsafe ? <AlertCircle className="mt-0.5 size-5 shrink-0 text-warning" /> : counts.partial ? <InfoCircle className="mt-0.5 size-5 shrink-0 text-brand-secondary" /> : <CheckCircle className="mt-0.5 size-5 shrink-0 text-success" />}<div><p className="font-semibold text-primary">Comparison confidence: {confidence}</p><p className="mt-1 text-sm text-secondary">{unsafe ? 'Some scan lanes are not comparable. A missing finding is not automatically considered fixed.' : counts.partial ? 'Some scan lanes changed scope or tooling. Interpret reductions with the coverage details in mind.' : 'The selected snapshots have comparable scan coverage.'}</p><p className="mt-1 text-xs text-tertiary">{counts.comparable} comparable · {counts.partial} partial · {counts.notComparable} not comparable or unknown</p></div></div></div>
+}
+
+function Summary({ comparison, summary, scope, coverage, onPresenceChange, onSeverityChange }: { comparison: AssessmentComparison; summary: AssessmentComparisonSummary; scope: AssessmentComparisonScope; coverage: ReturnType<typeof coverageCounts>; onPresenceChange: (presence: string) => void; onSeverityChange: (severity: Severity) => void }) {
+  const delta = summary.currentCount - summary.baselineCount
+  const changeRate = summary.baselineCount > 0 ? (delta / summary.baselineCount) * 100 : null
+  const comparable = coverage.notComparable === 0 && coverage.partial === 0
+  const neutral = comparison.mode === 'neutral_diff'
+  const conclusion = summary.baselineCount === summary.currentCount
+    ? `No net change: ${summary.currentCount.toLocaleString()} ${scopeNoun(scope)} in both snapshots.`
+    : `${Math.abs(delta).toLocaleString()} ${scopeNoun(scope)} ${delta < 0 ? 'fewer' : 'more'} after the re-scan (${formatSignedPercent(changeRate)}).`
+  return <div className="space-y-6">
+    <MetricStrip ariaLabel="Before and after comparison metrics">
+      <Metric label="Before" value={summary.baselineCount} hint="Actionable finding identities in the baseline snapshot." />
+      <Metric label="After" value={summary.currentCount} hint="Actionable finding identities in the current snapshot." />
+      <Metric label="Net change" value={formatSignedNumber(delta)} tone={delta < 0 ? 'accent' : delta > 0 ? 'critical' : 'muted'} hint="After minus before. A negative value means fewer findings." />
+      <Metric label="Change rate" value={formatSignedPercent(changeRate)} tone={delta < 0 ? 'accent' : delta > 0 ? 'critical' : 'muted'} hint="Net change divided by the before count." />
+      <Metric label="Critical after" value={summary.currentSeverity.critical} tone="critical" hint="Critical actionable findings in the current snapshot." />
+      <Metric label="High after" value={summary.currentSeverity.high} tone="high" hint="High-severity actionable findings in the current snapshot." />
+    </MetricStrip>
+
+    <div className={cn('flex items-start gap-3 rounded-lg border px-4 py-3', !comparable ? 'border-warning/30 bg-warning/10' : delta <= 0 ? 'border-success/30 bg-success/10' : 'border-critical/30 bg-critical/5')}>
+      {!comparable ? <AlertCircle className="mt-0.5 size-5 shrink-0 text-warning" /> : delta <= 0 ? <ShieldTick className="mt-0.5 size-5 shrink-0 text-success" /> : <AlertCircle className="mt-0.5 size-5 shrink-0 text-critical" />}
+      <div><p className="font-semibold text-primary">{conclusion}</p><p className="mt-1 text-sm text-secondary">{!comparable ? 'Coverage is incomplete, so this is a count comparison—not proof that every missing finding was remediated.' : neutral ? 'This is a neutral snapshot diff; lifecycle claims such as fixed or re-opened do not apply.' : `${summary.fixedCount.toLocaleString()} findings are classified as fixed under comparable coverage; ${summary.newCount + summary.reopenedCount} are new or re-opened.`}</p></div>
+    </div>
+
+    <TrendHighlights summary={summary} neutral={neutral} />
+
+    {!neutral ? <section aria-labelledby="lifecycle-heading">
+      <div className="mb-3 flex items-center justify-between gap-3"><h3 id="lifecycle-heading" className="text-sm font-semibold text-primary">Lifecycle outcome</h3><span className="text-xs text-tertiary">Select a metric to inspect its findings</span></div>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+        <LifecycleMetric label="Fixed" value={summary.fixedCount} tone="success" onClick={() => onPresenceChange('not_detected_under_comparable_coverage')} />
+        <LifecycleMetric label="New" value={summary.newCount} tone="critical" onClick={() => onPresenceChange('new')} />
+        <LifecycleMetric label="Re-opened" value={summary.reopenedCount} tone="warning" onClick={() => onPresenceChange('reopened')} />
+        <LifecycleMetric label="Still detected" value={summary.stillDetectedCount} onClick={() => onPresenceChange('still_detected')} />
+        <LifecycleMetric label="Not evaluated" value={summary.notEvaluatedCount} tone="muted" onClick={() => onPresenceChange('not_evaluated')} />
+        <LifecycleMetric label="Needs review" value={summary.reviewCount} tone="warning" onClick={() => onPresenceChange('needs_review')} />
+      </div>
+    </section> : null}
+
+    <section aria-labelledby="severity-heading">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3"><h3 id="severity-heading" className="text-sm font-semibold text-primary">Severity movement</h3><span className="text-xs text-tertiary">Select a severity to filter · Before → after → net change</span></div>
+      <SeverityComparison before={summary.baselineSeverity} after={summary.currentSeverity} onSelect={onSeverityChange} />
+    </section>
+
+    {!neutral ? <div className="flex flex-wrap gap-x-6 gap-y-2 border-t border-secondary pt-4 text-sm text-secondary"><span>Fixed rate <strong className="font-mono text-primary">{formatRatio(summary.fixedRate)}</strong></span><span>Risk reduction <strong className="font-mono text-primary">{formatRatio(summary.riskReduction)}</strong></span><span>Risk model <strong className="font-mono text-primary">v{summary.riskModelVersion}</strong></span></div> : null}
+  </div>
+}
+
+function TrendHighlights({ summary, neutral }: { summary: AssessmentComparisonSummary; neutral: boolean }) {
+  type TrendTone = 'critical' | 'success' | 'warning' | 'muted'
+  const criticalDelta = summary.currentSeverity.critical - summary.baselineSeverity.critical
+  const priorityBefore = summary.baselineSeverity.critical + summary.baselineSeverity.high
+  const priorityAfter = summary.currentSeverity.critical + summary.currentSeverity.high
+  const priorityDelta = priorityAfter - priorityBefore
+  const highlights: Array<{ label: string; value: string; detail: string; tone: TrendTone }> = [
+    { label: 'Critical trend', value: `${summary.baselineSeverity.critical.toLocaleString()} → ${summary.currentSeverity.critical.toLocaleString()}`, detail: trendLabel(criticalDelta), tone: criticalDelta > 0 ? 'critical' : criticalDelta < 0 ? 'success' : 'muted' },
+    { label: 'High + critical', value: `${priorityBefore.toLocaleString()} → ${priorityAfter.toLocaleString()}`, detail: trendLabel(priorityDelta), tone: priorityDelta > 0 ? 'critical' : priorityDelta < 0 ? 'success' : 'muted' },
+    neutral
+      ? { label: 'Snapshot difference', value: formatSignedNumber(summary.currentCount - summary.baselineCount), detail: 'net finding identities', tone: summary.currentCount > summary.baselineCount ? 'critical' : summary.currentCount < summary.baselineCount ? 'success' : 'muted' }
+      : { label: 'Remediation balance', value: `${summary.fixedCount.toLocaleString()} fixed`, detail: `${(summary.newCount + summary.reopenedCount).toLocaleString()} new or re-opened`, tone: summary.fixedCount >= summary.newCount + summary.reopenedCount ? 'success' : 'warning' },
+  ]
+  const styles: Record<TrendTone, string> = { critical: 'border-critical/25 bg-critical/5 text-criticaltext', success: 'border-success/25 bg-success/5 text-success-primary', warning: 'border-warning/25 bg-warning/5 text-warning-primary', muted: 'border-secondary bg-secondary/20 text-primary' }
+  return <section aria-labelledby="notable-changes-heading"><h3 id="notable-changes-heading" className="mb-3 text-sm font-semibold text-primary">Notable changes</h3><div className="grid gap-3 md:grid-cols-3">{highlights.map((item) => <div key={item.label} className={cn('rounded-lg border px-4 py-3', styles[item.tone])}><p className="text-[10px] font-semibold uppercase tracking-wider text-tertiary">{item.label}</p><p className="mt-1 font-mono text-lg font-semibold tabular-nums">{item.value}</p><p className="mt-1 text-xs text-tertiary">{item.detail}</p></div>)}</div></section>
+}
+
+function SnapshotCard({ eyebrow, snapshot, assessmentLabel, current = false }: { eyebrow: string; snapshot: AssessmentSnapshot | null; assessmentLabel: string; current?: boolean }) {
+  return <div className={cn('rounded-xl border p-4 shadow-xs', current ? 'border-brand/30 bg-brand-primary/10' : 'border-secondary bg-secondary/40')}>
+    <div className="flex items-center justify-between gap-3"><p className="text-[11px] font-semibold uppercase tracking-wider text-tertiary">{eyebrow}</p>{snapshot ? <Pill className={current ? 'bg-primary text-brand-secondary' : undefined}>Snapshot {snapshot.snapshotNumber}</Pill> : null}</div>
+    <p className="mt-3 font-semibold text-primary">{assessmentLabel}</p>
+    {snapshot ? <><p className="mt-1 text-sm text-secondary">{formatSnapshotTime(snapshot.finalizedAt || snapshot.createdAt)}</p><p className="mt-3 font-mono text-xs text-quaternary">{snapshot.id.slice(0, 12)}</p></> : <p className="mt-2 text-sm text-tertiary">No snapshot selected</p>}
+  </div>
+}
+
+function ScopeTabs({ scope, onChange }: { scope: AssessmentComparisonScope; onChange: (scope: AssessmentComparisonScope) => void }) {
+  return <div className="inline-flex max-w-full overflow-x-auto rounded-lg bg-secondary p-1" role="tablist" aria-label="Finding scope">
+    {SCOPES.map((item) => <button key={item.value} type="button" role="tab" aria-selected={scope === item.value} onClick={() => onChange(item.value)} className={cn('whitespace-nowrap rounded-md px-3 py-2 text-sm font-semibold transition', scope === item.value ? 'bg-primary text-primary shadow-xs' : 'text-tertiary hover:text-primary')}>{item.label}</button>)}
+  </div>
+}
+
+function LifecycleMetric({ label, value, tone = 'default', onClick }: { label: string; value: number; tone?: 'default' | 'success' | 'critical' | 'warning' | 'muted'; onClick: () => void }) {
+  const tones = { default: 'text-primary', success: 'text-success-primary', critical: 'text-critical', warning: 'text-warning-primary', muted: 'text-tertiary' }
+  return <button type="button" onClick={onClick} className="rounded-lg border border-secondary bg-secondary/30 p-3 text-left transition hover:border-primary hover:bg-secondary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60">
+    <span className="text-xs font-medium text-tertiary">{label}</span><span className={cn('mt-1 block font-mono text-xl font-semibold tabular-nums', tones[tone])}>{value.toLocaleString()}</span>
+  </button>
+}
+
+const SEVERITY_TONES: Record<Severity, { surface: string; bar: string; text: string; delta: string }> = {
+  critical: { surface: 'border-critical/30 bg-critical/5', bar: 'bg-critical', text: 'text-criticaltext', delta: 'bg-critical/10 text-criticaltext' },
+  high: { surface: 'border-high/30 bg-high/5', bar: 'bg-high', text: 'text-hightext', delta: 'bg-high/10 text-hightext' },
+  medium: { surface: 'border-medium/30 bg-medium/5', bar: 'bg-medium', text: 'text-mediumtext', delta: 'bg-medium/10 text-mediumtext' },
+  low: { surface: 'border-low/30 bg-low/5', bar: 'bg-low', text: 'text-lowtext', delta: 'bg-low/10 text-lowtext' },
+  info: { surface: 'border-infosev/30 bg-infosev/5', bar: 'bg-infosev', text: 'text-infosevtext', delta: 'bg-infosev/10 text-infosevtext' },
+  unknown: { surface: 'border-secondary bg-secondary/20', bar: 'bg-quaternary', text: 'text-tertiary', delta: 'bg-secondary text-tertiary' },
+}
+
+function severityTone(severity: Severity) {
+  return SEVERITY_TONES[severity]
+}
+
+function SeverityTag({ severity, emptyLabel = 'Unknown' }: { severity: Severity | null | undefined; emptyLabel?: string }) {
+  if (!severity) return <Pill>{emptyLabel}</Pill>
+  if (severity === 'unknown') return <Pill>Unknown</Pill>
+  return <SeverityBadge severity={severity} size="sm" />
+}
+
+function severityBarWidth(value: number, maximum: number) {
+  if (!Number.isFinite(value) || value <= 0) return '0%'
+  return `${Math.max(5, Math.min(100, (value / maximum) * 100))}%`
+}
+
+function SeverityComparison({ before, after, onSelect }: { before: Record<Severity, number>; after: Record<Severity, number>; onSelect: (severity: Severity) => void }) {
+  const severities: Severity[] = ['critical', 'high', 'medium', 'low', 'info', 'unknown']
+  const maximum = Math.max(1, ...severities.flatMap((severity) => [before[severity], after[severity]]))
+  return <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">{severities.map((severity) => {
+    const delta = after[severity] - before[severity]
+    const exposed = before[severity] > 0 || after[severity] > 0
+    const tone = severityTone(severity)
+    return <button type="button" key={severity} onClick={() => onSelect(severity)} aria-label={`${labelize(severity)}: ${before[severity]} before, ${after[severity]} after, ${delta === 0 ? 'no change' : `${formatSignedNumber(delta)} net change`}`} className={cn('relative overflow-hidden rounded-xl border p-4 text-left shadow-xs transition hover:-translate-y-0.5 hover:border-primary hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60', exposed ? tone.surface : 'border-secondary bg-secondary/20')}>
+      <span className={cn('absolute inset-x-0 top-0 h-0.5', tone.bar)} aria-hidden="true" />
+      <div className="flex items-center justify-between gap-3">
+        <SeverityTag severity={severity} />
+        <span className={cn('rounded-md px-2 py-1 font-mono text-xs font-semibold tabular-nums', delta < 0 ? 'bg-success/10 text-success-primary' : delta > 0 ? tone.delta : 'bg-secondary text-tertiary')}>{delta === 0 ? 'No change' : formatSignedNumber(delta)}</span>
+      </div>
+      <div className="mt-4 grid grid-cols-[1fr_auto_1fr] items-end gap-3">
+        <div><p className="text-[10px] font-semibold uppercase tracking-wider text-quaternary">Before</p><p className="mt-1 font-mono text-xl font-semibold tabular-nums text-secondary">{before[severity].toLocaleString()}</p></div>
+        <ArrowNarrowRight className="mb-1 size-4 text-quaternary" aria-hidden="true" />
+        <div className="text-right"><p className="text-[10px] font-semibold uppercase tracking-wider text-quaternary">After</p><p className={cn('mt-1 font-mono text-xl font-semibold tabular-nums', after[severity] > 0 ? tone.text : 'text-tertiary')}>{after[severity].toLocaleString()}</p></div>
+      </div>
+      <div className="mt-4 space-y-1.5" aria-hidden="true">
+        <div className="h-1 overflow-hidden rounded-full bg-secondary"><div className={cn('h-full rounded-full opacity-40', tone.bar)} style={{ width: severityBarWidth(before[severity], maximum) }} /></div>
+        <div className="h-1.5 overflow-hidden rounded-full bg-secondary"><div className={cn('h-full rounded-full', tone.bar)} style={{ width: severityBarWidth(after[severity], maximum) }} /></div>
+      </div>
+    </button>
+  })}</div>
+}
+
+function ComparisonSortableHeader({ label, column, active, direction, onSort, className }: { label: string; column: ComparisonSortKey; active: ComparisonSortKey; direction: SortDirection; onSort: (key: ComparisonSortKey) => void; className?: string }) {
+  const selected = active === column
+  const Icon = !selected ? SwitchVertical01 : direction === 'asc' ? ArrowUp : ArrowDown
+  return <th scope="col" aria-sort={selected ? direction === 'asc' ? 'ascending' : 'descending' : 'none'} className={className}><button type="button" onClick={() => onSort(column)} className="inline-flex items-center gap-1 font-bold uppercase tracking-wider text-secondary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-solid">{label}<Icon className={cn('size-3', selected ? 'text-primary' : 'text-quaternary')} aria-hidden="true" /></button></th>
+}
+
+function ItemTable({ loading, error, items, unfilteredCount, searchQuery, sortKey, sortDirection, expandedItemId, onSort, onToggle, onSelect }: { loading: boolean; error: string | null; items: AssessmentComparisonItem[]; unfilteredCount: number; searchQuery: string; sortKey: ComparisonSortKey; sortDirection: SortDirection; expandedItemId: string; onSort: (key: ComparisonSortKey) => void; onToggle: (id: string) => void; onSelect: (item: AssessmentComparisonItem) => void }) {
+  if (loading && !unfilteredCount) return <div className="p-8"><Spinner label="Loading compared findings…" /></div>
+  if (error) return <div className="p-4"><ErrorState message={error} /></div>
+  if (!items.length) return <div className="p-8 text-center"><p className="text-sm font-medium text-primary">No compared findings match</p><p className="mt-1 text-sm text-tertiary">{searchQuery ? `No item on this page matches “${searchQuery}”.` : 'Adjust the lifecycle, severity, or change filters to see more results.'}</p></div>
+  return <div className="w-full overflow-x-auto"><table className="w-full min-w-[980px] text-left text-sm"><thead><tr className="border-b border-secondary bg-secondary text-[11px] font-bold uppercase tracking-wider text-secondary"><th className="w-8 pl-3 py-2.5" /><ComparisonSortableHeader label="Lifecycle" column="lifecycle" active={sortKey} direction={sortDirection} onSort={onSort} className="px-2 py-2.5" /><ComparisonSortableHeader label="Severity" column="severity" active={sortKey} direction={sortDirection} onSort={onSort} className="px-2 py-2.5" /><ComparisonSortableHeader label="Finding & identity" column="identity" active={sortKey} direction={sortDirection} onSort={onSort} className="px-4 py-2.5" /><ComparisonSortableHeader label="Changed" column="change" active={sortKey} direction={sortDirection} onSort={onSort} className="px-4 py-2.5" /><ComparisonSortableHeader label="Coverage" column="coverage" active={sortKey} direction={sortDirection} onSort={onSort} className="px-4 py-2.5" /><th className="px-4 py-2.5">Review</th></tr></thead><tbody className="divide-y divide-secondary">{items.map((item) => {
+    const currentSeverity = item.currentObservation?.severity
+    const open = expandedItemId === item.id
+    const lifecycleState = item.presence ?? item.neutralPresence ?? ''
+    return <Fragment key={item.id}>
+      <tr onClick={() => onToggle(item.id)} className={cn('cursor-pointer transition-colors hover:bg-secondary', open && 'bg-secondary', currentSeverity === 'critical' && !open && 'bg-critical/5')}>
+        <td className="pl-3 py-3 align-top"><button type="button" aria-expanded={open} aria-label={`Toggle comparison details for ${item.identityId}`} onClick={(event) => { event.stopPropagation(); onToggle(item.id) }} className="rounded p-1 text-quaternary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-solid"><ChevronRight className={cn('size-4 transition-transform', open && 'rotate-90')} aria-hidden="true" /></button></td>
+        <td className="px-2 py-3 align-top" onClick={(event) => event.stopPropagation()}><button type="button" onClick={() => onSelect(item)} className="rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-solid"><LifecyclePill state={lifecycleState} /></button></td>
+        <td className="px-2 py-3 align-top"><div className="flex items-center gap-1.5"><SeverityTag severity={item.baselineObservation?.severity} emptyLabel="None" /><ArrowNarrowRight className="size-3.5 shrink-0 text-quaternary" aria-hidden="true" /><SeverityTag severity={currentSeverity} emptyLabel="None" /></div></td>
+        <td className="px-4 py-3 align-top"><div className="flex flex-wrap items-center gap-2"><span className="font-semibold text-primary">{item.producerKind || 'legacy'} / {item.findingKind || 'unknown'}</span>{item.currentActionable ? <Pill className="bg-brand-primary/10 text-brand-secondary">Actionable</Pill> : null}</div><p className="mt-1 max-w-sm truncate font-mono text-xs text-tertiary" title={item.targetCanonical || item.identityId}>{item.targetCanonical || item.identityId}</p><p className="mt-1 max-w-sm truncate text-xs text-quaternary">{comparisonItemSubtitle(item)}</p></td>
+        <td className="px-4 py-3 align-top"><div className="flex max-w-64 flex-wrap gap-1">{item.changeFlags.length ? item.changeFlags.map((flag) => <Pill key={flag}>{labelize(flag)}</Pill>) : <span className="text-tertiary">No field change</span>}</div></td>
+        <td className="px-4 py-3 align-top"><CoveragePill decision={item.coverageDecision} /></td>
+        <td className="px-4 py-3 align-top">{item.reviewCandidateIds.length ? <Pill className="bg-warning/10 text-warning-primary">{item.reviewCandidateIds.length} candidate(s)</Pill> : item.verificationId ? <Pill className="bg-success/10 text-success-primary">Verified</Pill> : <span className="text-tertiary">Clear</span>}</td>
+      </tr>
+      {open ? <tr className="border-t border-secondary bg-secondary"><td /><td colSpan={6} className="p-4"><ComparisonItemDetail item={item} onReview={() => onSelect(item)} /></td></tr> : null}
+    </Fragment>
+  })}</tbody></table></div>
+}
+
+function LifecyclePill({ state }: { state: string }) {
+  const style = state === 'new' || state === 'only_in_b' ? 'bg-critical/10 text-criticaltext ring-critical/25' : state === 'not_detected_under_comparable_coverage' ? 'bg-success/10 text-success-primary ring-success/25' : state === 'reopened' || state === 'needs_review' ? 'bg-warning/10 text-warning-primary ring-warning/25' : state === 'not_evaluated' || state === 'only_in_a' ? 'bg-secondary text-tertiary ring-secondary' : 'bg-brand-primary/10 text-brand-secondary ring-brand/25'
+  return <span className={cn('inline-flex whitespace-nowrap rounded-md px-2 py-1 text-xs font-semibold ring-1 ring-inset', style)}>{lifecycleLabel(state)}</span>
+}
+
+function CoveragePill({ decision }: { decision: AssessmentComparisonItem['coverageDecision'] }) {
+  const style = decision === 'comparable' ? 'bg-success/10 text-success-primary' : decision === 'not_comparable' ? 'bg-warning/10 text-warning-primary' : 'bg-secondary text-tertiary'
+  return <Pill className={style}>{labelize(decision || 'unknown')}</Pill>
+}
+
+function ComparisonItemDetail({ item, onReview }: { item: AssessmentComparisonItem; onReview: () => void }) {
+  return <div className="space-y-4">
+    <div className="flex flex-wrap items-center justify-between gap-3"><div><p className="text-sm font-semibold text-primary">Finding state transition</p><p className="mt-1 font-mono text-xs text-tertiary">{item.identityId}</p></div><div className="flex items-center gap-2"><Pill>{item.baselineObservation ? 'Detected' : 'Absent'}</Pill><ArrowNarrowRight className="size-4 text-quaternary" aria-hidden="true" /><LifecyclePill state={item.presence ?? item.neutralPresence ?? ''} /><ArrowNarrowRight className="size-4 text-quaternary" aria-hidden="true" /><Pill>{item.currentObservation ? 'Detected' : 'Absent'}</Pill></div></div>
+    <div className="grid gap-3 lg:grid-cols-2"><ObservationPanel label="Before" observation={item.baselineObservation} /><ObservationPanel label="After" observation={item.currentObservation} current /></div>
+    <div className="flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-secondary pt-3 text-xs text-tertiary"><span>Disposition <strong className="text-secondary">{item.currentActionable ? 'Current actionable' : item.baselineActionable ? 'Baseline only' : 'Non-actionable'}</strong></span><span>Match <strong className="text-secondary">{item.matchMethods.length ? item.matchMethods.join(', ') : 'Stored identity'}</strong></span><span>Fixed basis <strong className="text-secondary">{labelize(item.fixedBasis || 'none')}</strong></span>{item.reviewCandidateIds.length ? <Button variant="secondary" className="ml-auto h-8 text-xs" onClick={onReview}>Review match</Button> : null}</div>
+  </div>
+}
+
+function ObservationPanel({ label, observation, current = false }: { label: string; observation: AssessmentComparisonItem['baselineObservation']; current?: boolean }) {
+  if (!observation) return <section className="rounded-lg border border-dashed border-secondary p-4"><p className="text-[10px] font-semibold uppercase tracking-wider text-tertiary">{label}</p><p className="mt-3 text-sm text-tertiary">Finding was not observed in this snapshot.</p></section>
+  return <section className={cn('rounded-lg border p-4', current ? 'border-brand/25 bg-brand/5' : 'border-secondary bg-primary')}><div className="flex items-center justify-between gap-2"><p className="text-[10px] font-semibold uppercase tracking-wider text-tertiary">{label}</p><SeverityTag severity={observation.severity} /></div><dl className="mt-3 grid gap-x-4 gap-y-3 text-xs sm:grid-cols-2"><ObservationDetail label="Location" value={observation.location || 'Unknown'} /><ObservationDetail label="Component version" value={observation.componentVersion || 'Unknown'} /><ObservationDetail label="Reachability" value={observation.reachability || 'Unknown'} /><ObservationDetail label="Scanner" value={[observation.scanner.toolName, observation.scanner.toolVersion].filter(Boolean).join(' ') || 'Unknown'} /><ObservationDetail label="Rule" value={observation.scanner.ruleId || 'Unknown'} /><ObservationDetail label="Observed" value={formatSnapshotTime(observation.observedAt)} /></dl></section>
+}
+
+function ObservationDetail({ label, value }: { label: string; value: string }) {
+  return <div className="min-w-0"><dt className="font-semibold text-tertiary">{label}</dt><dd className="mt-0.5 truncate text-secondary" title={value}>{value}</dd></div>
+}
+
+function ComparisonPagination({ page, pageSize, count, canPrevious, canNext, onPrevious, onNext, onPageSizeChange }: { page: number; pageSize: number; count: number; canPrevious: boolean; canNext: boolean; onPrevious: () => void; onNext: () => void; onPageSizeChange: (size: number) => void }) {
+  return <div className="flex flex-wrap items-center justify-between gap-3 border-t border-secondary px-4 py-3"><span className="text-xs text-tertiary">Page <span className="font-semibold text-primary">{page}</span> · <span className="font-semibold text-primary">{count}</span> findings shown</span><div className="flex items-center gap-2"><Select value={String(pageSize)} onValueChange={(value) => onPageSizeChange(Number(value))} size="sm" ariaLabel="Compared findings per page" className="w-28" options={PAGE_SIZE_OPTIONS.map((size) => ({ value: String(size), label: `${size} / page` }))} /><button type="button" onClick={onPrevious} disabled={!canPrevious} aria-label="Previous comparison page" className="inline-flex size-8 items-center justify-center rounded-md border border-secondary text-secondary hover:bg-secondary hover:text-primary disabled:cursor-not-allowed disabled:text-quaternary"><ChevronLeft className="size-4" aria-hidden="true" /></button><span className="text-xs tabular-nums text-tertiary">Page <span className="font-semibold text-primary">{page}</span></span><button type="button" onClick={onNext} disabled={!canNext} aria-label="Next comparison page" className="inline-flex size-8 items-center justify-center rounded-md border border-secondary text-secondary hover:bg-secondary hover:text-primary disabled:cursor-not-allowed disabled:text-quaternary"><ChevronRight className="size-4" aria-hidden="true" /></button></div></div>
+}
+
+function ReviewDrawer({ comparison, item, onClose, onReplacement }: { comparison: AssessmentComparison | null; item: AssessmentComparisonItem; onClose: () => void; onReplacement: (id: string) => void }) {
+  const [candidateId, setCandidateId] = useState(item.reviewCandidateIds[0] ?? '')
+  const candidate = item.reviewCandidates.find((value) => value.id === candidateId)
+  const sourceOptions = candidate?.sourceObservationIds.map((id) => ({ value: id, label: id })) ?? []
+  const [sourceObservationId, setSourceObservationId] = useState(sourceOptions[0]?.value ?? '')
+  const [reason, setReason] = useState('operator_review')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+  useEffect(() => {
+    setSourceObservationId(item.reviewCandidates.find((value) => value.id === candidateId)?.sourceObservationIds[0] ?? '')
+  }, [candidateId, item.reviewCandidates])
+  async function submit(action: 'confirm' | 'unlink') {
+    if (!comparison || !candidateId || !sourceObservationId || !reason.trim()) return
+    setSubmitting(true); setError('')
+    try {
+      const result = await api.reviewAssessmentComparisonItem({ comparisonId: comparison.id, itemId: item.id, comparisonVersion: comparison.version, action, candidateId, sourceObservationId, reason: reason.trim() })
+      onReplacement(result.replacementComparisonId)
+    } catch (cause) { setError(cause instanceof ApiError && cause.status === 409 ? 'The review projection changed. Your filters and item context are preserved; refresh and retry.' : cause instanceof Error ? cause.message : 'Review failed.') }
+    finally { setSubmitting(false) }
+  }
+  return <SlideoutMenu isOpen onOpenChange={(open) => { if (!open) onClose() }}><SlideoutMenu.Header onClose={onClose}><h2 className="text-lg font-semibold text-primary">Immutable item detail</h2><p className="mt-1 font-mono text-xs text-tertiary">{item.id}</p></SlideoutMenu.Header><SlideoutMenu.Content><dl className="space-y-3 text-sm"><Detail label="Identity" value={item.identityId} /><Detail label="Identity explanation" value={`${item.producerKind || 'legacy'} / ${item.findingKind || 'unknown'} on ${item.targetCanonical || 'unknown target'}`} /><Detail label="Ancestry path" value={`${item.baselineObservationId || 'none'} → ${item.identityId} → ${item.currentObservationId || 'none'}`} /><Detail label="Match methods" value={item.matchMethods.length ? item.matchMethods.join(', ') : 'Stored identity; method provenance unavailable'} /><Detail label="Coverage" value={labelize(item.coverageDecision || 'unknown')} /><Detail label="Verification" value={item.verificationId ? `${item.verificationState} · ${item.verificationId}` : 'None'} /><Detail label="Evidence references" value={[item.baselineObservation?.evidenceDigest, item.currentObservation?.evidenceDigest].filter(Boolean).join(' → ') || 'None'} /></dl>{item.reviewCandidateIds.length ? <section className="space-y-4 border-t border-secondary pt-5"><Field label="Candidate"><Select ariaLabel="Review candidate" value={candidateId} onValueChange={setCandidateId} options={item.reviewCandidateIds.map((id) => ({ value: id, label: id }))} className="w-full" /></Field>{sourceOptions.length ? <Field label="Source observation"><Select ariaLabel="Review source observation" value={sourceObservationId} onValueChange={setSourceObservationId} options={sourceOptions} className="w-full" /></Field> : <ErrorState message="This immutable candidate has no reviewable source observation metadata." />}<Field label="Reason"><Input value={reason} maxLength={512} onChange={(event) => setReason(event.target.value)} /></Field>{error ? <ErrorState message={error} /> : null}<div className="flex gap-3"><Button disabled={!sourceObservationId} loading={submitting} onClick={() => submit('confirm')}>Confirm link</Button><Button disabled={!sourceObservationId} variant="danger" loading={submitting} onClick={() => submit('unlink')}>Unlink</Button></div><p className="text-xs text-tertiary">Review appends an override and follows a replacement comparison; this completed item is never mutated.</p></section> : <p className="rounded-lg bg-secondary p-3 text-sm text-tertiary">No open review candidate is attached to this item.</p>}</SlideoutMenu.Content></SlideoutMenu>
+}
+
+function comparisonAssessmentIds(lifecycle: AssessmentLifecycle | null, assessmentId: string, mode: AssessmentComparisonMode) {
+  if (!lifecycle) return []
+  if (mode === 'neutral_diff') return lifecycle.members.map((member) => member.assessmentId)
+  const byId = new Map(lifecycle.members.map((member) => [member.assessmentId, member]))
+  const result: string[] = []
+  let member = byId.get(assessmentId)
+  while (member?.predecessorAssessmentId) { result.push(member.predecessorAssessmentId); member = byId.get(member.predecessorAssessmentId) }
+  result.push(assessmentId)
+  return [...new Set(result)]
+}
+
+function chooseBaselineSnapshot(snapshots: AssessmentSnapshotListResponse, sameAssessment: boolean, currentId: string) {
+  const available = snapshots.items.filter((item) => item.id !== currentId)
+  if (!available.length) return ''
+  if (!sameAssessment) return snapshots.defaultSnapshotId && snapshots.defaultSnapshotId !== currentId ? snapshots.defaultSnapshotId : available.at(-1)?.id ?? ''
+  const currentIndex = snapshots.items.findIndex((item) => item.id === currentId)
+  return currentIndex > 0 ? snapshots.items[currentIndex - 1].id : available[0].id
+}
+
+function filterComparisonItems(items: AssessmentComparisonItem[], query: string) {
+  const normalized = query.trim().toLowerCase()
+  if (!normalized) return items
+  return items.filter((item) => [
+    item.identityId, item.producerKind, item.findingKind, item.targetCanonical,
+    item.presence, item.neutralPresence, item.coverageDecision, item.fixedBasis,
+    ...item.changeFlags, ...item.matchMethods,
+    item.baselineObservation?.location, item.currentObservation?.location,
+    item.baselineObservation?.scanner.toolName, item.currentObservation?.scanner.toolName,
+    item.baselineObservation?.scanner.ruleId, item.currentObservation?.scanner.ruleId,
+  ].filter(Boolean).join(' ').toLowerCase().includes(normalized))
+}
+
+function sortComparisonItems(items: AssessmentComparisonItem[], key: ComparisonSortKey, direction: SortDirection) {
+  const value = (item: AssessmentComparisonItem): string | number => {
+    if (key === 'severity') return sevRank(item.currentObservation?.severity ?? item.baselineObservation?.severity ?? 'unknown')
+    if (key === 'lifecycle') return lifecycleLabel(item.presence ?? item.neutralPresence ?? '')
+    if (key === 'identity') return `${item.producerKind} ${item.findingKind} ${item.targetCanonical || item.identityId}`
+    if (key === 'change') return item.changeFlags.join(' ')
+    return item.coverageDecision
+  }
+  const sign = direction === 'asc' ? 1 : -1
+  return items.map((item, index) => ({ item, index })).sort((left, right) => {
+    const a = value(left.item)
+    const b = value(right.item)
+    const comparison = typeof a === 'number' && typeof b === 'number' ? a - b : String(a).localeCompare(String(b))
+    return sign * comparison || left.index - right.index
+  }).map(({ item }) => item)
+}
+
+function lifecycleLabel(state: string) {
+  const labels: Record<string, string> = {
+    new: 'New',
+    still_detected: 'Still detected',
+    not_detected_under_comparable_coverage: 'Fixed',
+    not_evaluated: 'Not evaluated',
+    reopened: 'Re-opened',
+    needs_review: 'Needs review',
+    only_in_a: 'Only before',
+    both: 'Both snapshots',
+    only_in_b: 'Only after',
+  }
+  return labels[state] ?? labelize(state)
+}
+
+function comparisonItemSubtitle(item: AssessmentComparisonItem) {
+  const observation = item.currentObservation ?? item.baselineObservation
+  if (!observation) return item.identityId
+  return [observation.location, observation.scanner.toolName, observation.scanner.ruleId].filter(Boolean).join(' · ') || item.identityId
+}
+
+function coverageCounts(baseline: AssessmentSnapshot | null, current: AssessmentSnapshot | null) {
+  if (!baseline || !current) return { comparable: 0, partial: 0, notComparable: 1 }
+  const dimensionKey = (dimension: AssessmentSnapshot['dimensions'][number]) => JSON.stringify([dimension.producer, dimension.findingKind, dimension.target.kind, dimension.target.schemaVersion, dimension.target.canonical])
+  const currentByKey = new Map(current.dimensions.map((dimension) => [dimensionKey(dimension), dimension]))
+  const sameValues = (left: string[], right: string[]) => JSON.stringify([...left].sort()) === JSON.stringify([...right].sort())
+  const versionValues = (dimension: AssessmentSnapshot['dimensions'][number], kinds: string[]) => dimension.versions.filter((version) => kinds.includes(version.kind)).map((version) => JSON.stringify([version.kind, version.name, version.version, version.digest]))
+  let comparable = 0, partial = 0, notComparable = 0
+  for (const dimension of baseline.dimensions) {
+    const match = currentByKey.get(dimensionKey(dimension))
+    if (!match || match.state === 'unknown') notComparable++
+    else if (dimension.state !== 'complete' || match.state !== 'complete') partial++
+    else if (!sameValues(dimension.includedScope, match.includedScope) || !sameValues(dimension.excludedScope, match.excludedScope)) partial++
+    else if (!sameValues(versionValues(dimension, ['rule_pack', 'profile']), versionValues(match, ['rule_pack', 'profile']))) notComparable++
+    else if (!sameValues(versionValues(dimension, ['advisory_database', 'tool', 'scanner', 'correlation', 'schema']), versionValues(match, ['advisory_database', 'tool', 'scanner', 'correlation', 'schema']))) partial++
+    else comparable++
+  }
+  if (!baseline.dimensions.length) notComparable++
+  return { comparable, partial, notComparable }
+}
+
+function formatRatio(value: AssessmentComparisonRatio) { return value.naReason || value.denominator <= 0 ? 'N/A' : `${Math.round((value.numerator / value.denominator) * 100)}%` }
+function trendLabel(delta: number) { return delta === 0 ? 'No net change' : `${formatSignedNumber(delta)} ${delta > 0 ? 'increase' : 'reduction'}` }
+function snapshotOption(snapshot: AssessmentSnapshot) { return { value: snapshot.id, label: `Snapshot ${snapshot.snapshotNumber} · ${snapshot.id.slice(0, 8)} · ${snapshot.provenance} · ${snapshot.lifecycle}` } }
+function memberLabel(lifecycle: AssessmentLifecycle, id: string, includeId = true) { const member = lifecycle.members.find((value) => value.assessmentId === id); const label = member?.assessmentType === 'retest' ? `Re-test #${member.retestNumber}` : 'Initial assessment'; return includeId ? `${label} · ${id}` : label }
+function setOrDelete(params: URLSearchParams, key: string, value: string) { if (value) params.set(key, value); else params.delete(key) }
+function option(value: string) { return { value, label: labelize(value) } }
+function labelize(value: string) { return value ? value.replaceAll('_', ' ').replace(/\b\w/g, (letter) => letter.toUpperCase()) : 'Unknown' }
+function formatSignedNumber(value: number) { return value > 0 ? `+${value.toLocaleString()}` : value.toLocaleString() }
+function formatSignedPercent(value: number | null) { if (value === null || !Number.isFinite(value)) return 'N/A'; if (value === 0) return '0%'; return `${value > 0 ? '+' : '−'}${Math.abs(value).toLocaleString(undefined, { maximumFractionDigits: 1 })}%` }
+function scopeNoun(scope: AssessmentComparisonScope) { return scope === 'vulnerability' ? 'vulnerabilities' : scope === 'security' ? 'security findings' : 'findings' }
+function formatSnapshotTime(value: string) { const date = new Date(value); return Number.isNaN(date.valueOf()) ? 'Finalization time unavailable' : new Intl.DateTimeFormat(undefined, { dateStyle: 'medium', timeStyle: 'short' }).format(date) }
+function Detail({ label, value }: { label: string; value: string }) { return <div><dt className="text-xs font-semibold uppercase tracking-wide text-tertiary">{label}</dt><dd className="mt-1 break-all text-primary">{value}</dd></div> }

--- a/web/src/pages/EngagementDetail/AssessmentLifecyclePanel.test.tsx
+++ b/web/src/pages/EngagementDetail/AssessmentLifecyclePanel.test.tsx
@@ -1,0 +1,364 @@
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api, ApiError } from '../../lib/api'
+import type { AssessmentClosureManifest, AssessmentLifecycle, UploadedSourcePackage } from '../../lib/types'
+import { AssessmentLifecyclePanel } from './AssessmentLifecyclePanel'
+
+vi.mock('../../lib/api', () => ({
+  api: {
+    assessmentLifecycle: vi.fn(),
+    listAssessmentClosureManifests: vi.fn(),
+    me: vi.fn(),
+    createRetest: vi.fn(),
+    uploadedSource: vi.fn(),
+    getEngagement: vi.fn(),
+    previewAssessmentRelationshipChange: vi.fn(),
+    commitAssessmentRelationshipChange: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    status: number
+    constructor(status: number, message: string) {
+      super(message)
+      this.status = status
+    }
+  },
+}))
+
+const sourcePackage: UploadedSourcePackage = {
+  versionId: 'source-version-2', filename: 'payments-v2.zip', size: 2048, sha256: 'b'.repeat(64),
+  target: `uploaded-source/sha256/${'b'.repeat(64)}`, uploadedBy: 'alice', uploadedAt: '2026-09-08T00:00:00Z',
+}
+
+const lifecycle: AssessmentLifecycle = {
+  assessmentId: 'assessment-2',
+  cycle: {
+    id: 'cycle-1', name: 'Payments lifecycle', boundaryKind: 'asset_project', businessAssetId: 'asset-1', projectId: 'project-1',
+    status: 'open', rootAssessmentId: 'assessment-0', selectedHeadAssessmentId: 'assessment-2', nextRetestNumber: 4, version: 7,
+    createdAt: '2026-08-01T00:00:00Z', updatedAt: '2026-08-04T00:00:00Z', createdBy: 'alice', updatedBy: 'alice',
+  },
+  members: [
+    { assessmentId: 'assessment-0', assessmentStatus: 'completed', assessmentType: 'initial', predecessorAssessmentId: '', retestNumber: 0, relationshipVersion: 1, createdAt: '2026-08-01T00:00:00Z', createdBy: 'alice', archivedAt: null },
+    { assessmentId: 'assessment-1', assessmentStatus: 'completed', assessmentType: 'retest', predecessorAssessmentId: 'assessment-0', retestNumber: 1, relationshipVersion: 2, createdAt: '2026-08-02T00:00:00Z', createdBy: 'alice', archivedAt: null },
+    { assessmentId: 'assessment-2', assessmentStatus: 'completed', assessmentType: 'retest', predecessorAssessmentId: 'assessment-1', retestNumber: 2, relationshipVersion: 3, createdAt: '2026-08-03T00:00:00Z', createdBy: 'alice', archivedAt: null },
+    { assessmentId: 'assessment-3', assessmentStatus: 'completed', assessmentType: 'retest', predecessorAssessmentId: 'assessment-0', retestNumber: 3, relationshipVersion: 1, createdAt: '2026-08-04T00:00:00Z', createdBy: 'alice', archivedAt: '2026-08-05T00:00:00Z' },
+  ],
+  branchHeads: [
+    { assessmentId: 'assessment-2', assessmentStatus: 'completed', assessmentType: 'retest', predecessorAssessmentId: 'assessment-1', retestNumber: 2, relationshipVersion: 3, createdAt: '2026-08-03T00:00:00Z', createdBy: 'alice', archivedAt: null },
+    { assessmentId: 'assessment-3', assessmentStatus: 'completed', assessmentType: 'retest', predecessorAssessmentId: 'assessment-0', retestNumber: 3, relationshipVersion: 1, createdAt: '2026-08-04T00:00:00Z', createdBy: 'alice', archivedAt: '2026-08-05T00:00:00Z' },
+  ],
+}
+
+function renderPanel(status = 'completed') {
+  return render(<MemoryRouter><AssessmentLifecyclePanel assessmentId="assessment-2" engagementStatus={status} /></MemoryRouter>)
+}
+
+async function openHistory() {
+  fireEvent.click(await screen.findByRole('button', { name: /Details & history/ }))
+}
+
+describe('AssessmentLifecyclePanel', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(api.assessmentLifecycle).mockResolvedValue(lifecycle)
+    vi.mocked(api.uploadedSource).mockRejectedValue(new ApiError(404, 'No uploaded source'))
+    vi.mocked(api.getEngagement).mockResolvedValue({ inScope: [{ kind: 'repo', value: 'https://example.test/repo' }] } as never)
+    vi.mocked(api.listAssessmentClosureManifests).mockResolvedValue([])
+    vi.mocked(api.me).mockResolvedValue({ id: 'admin-1', name: 'Admin', role: 'admin', features: { assessmentLifecycleRead: true, assessmentLifecycleUIDefault: true } })
+  })
+
+  it('does not request lifecycle data when tenant UI rollout is disabled', async () => {
+    vi.mocked(api.me).mockResolvedValue({ id: 'admin-1', name: 'Admin', role: 'admin', features: { assessmentLifecycleRead: true, assessmentLifecycleUIDefault: false } })
+    const { container } = renderPanel()
+    await waitFor(() => expect(api.me).toHaveBeenCalledTimes(1))
+    expect(api.assessmentLifecycle).not.toHaveBeenCalled()
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders a deterministic branched tree with distinct lifecycle badges', async () => {
+    renderPanel()
+    await openHistory()
+
+    expect(await screen.findByRole('list', { name: 'Assessment Cycle history' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Initial · assessment-0' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Re-test #2 · assessment-2' })).toHaveAttribute('aria-current', 'page')
+    expect(screen.getAllByText('Selected head')).toHaveLength(2)
+    expect(screen.getAllByText('Branch head')).toHaveLength(2)
+    expect(screen.getAllByText('Display latest')).toHaveLength(2)
+    expect(screen.getByText('Archived')).toBeInTheDocument()
+    expect(screen.getByRole('navigation', { name: 'Assessment lifecycle breadcrumb' })).toHaveTextContent('Asset asset-1/Project project-1/Payments lifecycle/assessment-2')
+  })
+
+  it('marks final only from the active immutable manifest and requires reopen before another Re-test', async () => {
+    vi.mocked(api.assessmentLifecycle).mockResolvedValue({
+      ...lifecycle,
+      cycle: { ...lifecycle.cycle, status: 'completed', activeClosureManifestId: 'manifest-active', activeClosureCycleVersion: 8 },
+    })
+    vi.mocked(api.listAssessmentClosureManifests).mockResolvedValue([closureManifest()])
+    renderPanel()
+    await openHistory()
+
+    expect(await screen.findAllByText('Final')).toHaveLength(2)
+    expect(screen.getByText(/Snapshot snapshot-2/)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Review reopen' })).toHaveAttribute('href', '/assessment-cycles/cycle-1')
+    expect(screen.getByRole('button', { name: 'Create Re-test' })).toBeDisabled()
+  })
+
+  it('reuses one idempotency key when a non-executable draft is retried', async () => {
+    vi.mocked(api.createRetest).mockRejectedValueOnce(new Error('temporary network failure')).mockRejectedValueOnce(new Error('temporary network failure'))
+    renderPanel()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Create Re-test' }))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Create Re-test' })).toBeEnabled())
+    fireEvent.click(screen.getByRole('button', { name: 'Create Re-test' }))
+    expect(await screen.findByText('temporary network failure')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Create Re-test' }))
+
+    await waitFor(() => expect(api.createRetest).toHaveBeenCalledTimes(2))
+    const first = vi.mocked(api.createRetest).mock.calls[0]?.[1]
+    const second = vi.mocked(api.createRetest).mock.calls[1]?.[1]
+    if (!first || !second) throw new Error('expected two Create Re-test calls')
+    expect(first).toEqual({ predecessorAssessmentId: 'assessment-2', source: undefined, scopeStrategy: 'copy', profileStrategy: 'none', idempotencyKey: expect.any(String) })
+    expect(first.idempotencyKey).toBeTruthy()
+    expect(second.idempotencyKey).toBe(first.idempotencyKey)
+  })
+
+  it('creates a draft without typing a name, dates, timezone, or authorization and opens it within the app', async () => {
+    vi.mocked(api.createRetest).mockResolvedValue({
+      engagement: { id: 'assessment-new', name: 'Payments Re-test' },
+      cycle: lifecycle.cycle,
+      member: { ...lifecycle.members[2], assessmentId: 'assessment-new', assessmentStatus: 'draft', retestNumber: 4 },
+      inheritanceDiff: { scope: 'copy', authorization: 'explicit_only', roe: 'explicit_only', scannerProfile: 'none' },
+      warnings: ['authorization_not_copied'],
+    } as never)
+    render(<MemoryRouter><Routes>
+      <Route path="/" element={<AssessmentLifecyclePanel assessmentId="assessment-2" engagementStatus="completed" />} />
+      <Route path="/engagements/assessment-new" element={<h1>New Re-test opened</h1>} />
+    </Routes></MemoryRouter>)
+    fireEvent.click(await screen.findByRole('button', { name: 'Create Re-test' }))
+    const drawer = within(screen.getByRole('dialog'))
+    expect(drawer.queryByRole('textbox')).not.toBeInTheDocument()
+    for (const label of ['Name', 'Planned date', 'Authorized from', 'Authorized to', 'Timezone', 'Allowed tool classes']) {
+      expect(drawer.queryByLabelText(label)).not.toBeInTheDocument()
+    }
+    expect(drawer.getByRole('combobox', { name: 'Based on Assessment' })).toHaveTextContent('Re-test #2')
+    expect(drawer.getByText('Payments lifecycle')).toBeVisible()
+    expect(drawer.getByText('Re-test #2 · Completed')).toBeVisible()
+    expect(drawer.getByRole('button', { name: 'Cancel' })).toBeVisible()
+    await waitFor(() => expect(drawer.getByRole('button', { name: 'Create Re-test' })).toBeEnabled())
+    fireEvent.click(drawer.getByRole('button', { name: 'Create Re-test' }))
+    expect(await screen.findByText('Re-test created')).toBeInTheDocument()
+    expect(api.createRetest).toHaveBeenCalledTimes(1)
+    expect(api.createRetest).toHaveBeenCalledWith('assessment-2', {
+      predecessorAssessmentId: 'assessment-2', source: undefined, scopeStrategy: 'copy', profileStrategy: 'none', idempotencyKey: expect.any(String),
+    })
+    expect(screen.getByText('Payments Re-test')).toBeInTheDocument()
+    expect(screen.getByText(/Configure execution authorization in Re-test Settings/)).toBeInTheDocument()
+    expect(screen.getByText('Authorization Not Copied')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Create Re-test' })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Open Re-test' }))
+    expect(await screen.findByRole('heading', { name: 'New Re-test opened' })).toBeInTheDocument()
+  })
+
+  it('validates a new archive and keeps identical retries stable while edited source commands get a new key', async () => {
+    vi.mocked(api.uploadedSource).mockResolvedValue(sourcePackage)
+    vi.mocked(api.createRetest).mockRejectedValue(new Error('temporary upload failure'))
+    renderPanel()
+    fireEvent.click(await screen.findByRole('button', { name: 'Create Re-test' }))
+    fireEvent.click(await screen.findByRole('radio', { name: /Upload new source/ }))
+    const upload = screen.getByLabelText('Re-test source archive')
+    fireEvent.change(upload, { target: { files: [new File(['wrong type'], 'source.exe')] } })
+    expect(screen.getByRole('button', { name: 'Create Re-test' })).toBeDisabled()
+    expect(api.createRetest).not.toHaveBeenCalled()
+    fireEvent.change(upload, { target: { files: [] } })
+    expect(screen.getByRole('button', { name: 'Create Re-test' })).toBeDisabled()
+    const source = new File(['new revision'], 'source.zip', { type: 'application/zip' })
+    fireEvent.change(screen.getByLabelText('Re-test source archive'), { target: { files: [source] } })
+    expect(await screen.findByText(/Ready to upload when the Re-test is created/)).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Replace' })).toBeVisible()
+    expect(screen.getByRole('checkbox', { name: 'Force update source' })).toBeChecked()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove source archive' }))
+    expect(screen.getByRole('button', { name: 'Create Re-test' })).toBeDisabled()
+    fireEvent.change(screen.getByLabelText('Re-test source archive'), { target: { files: [source] } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create Re-test' }))
+    expect(await screen.findByText('temporary upload failure')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Create Re-test' }))
+    await waitFor(() => expect(api.createRetest).toHaveBeenCalledTimes(2))
+    expect(vi.mocked(api.createRetest).mock.calls[1]?.[1]?.source).toBe(source)
+    expect(vi.mocked(api.createRetest).mock.calls[0]?.[1]?.idempotencyKey).toBe(vi.mocked(api.createRetest).mock.calls[1]?.[1]?.idempotencyKey)
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Create Re-test' })).toBeEnabled())
+    fireEvent.click(screen.getByRole('radio', { name: /Use current source/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Create Re-test' }))
+    await waitFor(() => expect(api.createRetest).toHaveBeenCalledTimes(3))
+    const edited = vi.mocked(api.createRetest).mock.calls[2]?.[1]
+    expect(edited).toMatchObject({ sourceStrategy: 'reuse_current', sourceVersionId: 'source-version-2', source: undefined })
+    expect(edited?.idempotencyKey).not.toBe(vi.mocked(api.createRetest).mock.calls[1]?.[1]?.idempotencyKey)
+  })
+
+  it('defaults to the selected predecessor immutable source and keeps a draft minimal', async () => {
+    vi.mocked(api.uploadedSource).mockResolvedValue(sourcePackage)
+    vi.mocked(api.createRetest).mockRejectedValue(new Error('expected rejection'))
+    renderPanel()
+    fireEvent.click(await screen.findByRole('button', { name: 'Create Re-test' }))
+    expect(await screen.findByRole('radio', { name: /Use current source/ })).toBeChecked()
+    expect(api.uploadedSource).toHaveBeenCalledWith('assessment-2')
+    expect(screen.getByText('payments-v2.zip')).toBeVisible()
+    expect(screen.getByLabelText(`Source SHA-256 ${'b'.repeat(64)}`)).toBeVisible()
+    expect(screen.queryByLabelText('Re-test source archive')).not.toBeInTheDocument()
+    expect(screen.getByRole('combobox', { name: 'Assessment scope' })).toBeDisabled()
+    fireEvent.click(screen.getByRole('button', { name: 'Create Re-test' }))
+    await waitFor(() => expect(api.createRetest).toHaveBeenCalledWith('assessment-2', {
+      predecessorAssessmentId: 'assessment-2', scopeStrategy: 'copy', profileStrategy: 'none',
+      sourceStrategy: 'reuse_current', sourceVersionId: 'source-version-2', source: undefined, idempotencyKey: expect.any(String),
+    }))
+  })
+
+  it('blocks creation on source lookup errors and retries without losing the predecessor', async () => {
+    vi.mocked(api.uploadedSource).mockRejectedValueOnce(new ApiError(503, 'Source service unavailable')).mockResolvedValueOnce(sourcePackage)
+    renderPanel()
+    fireEvent.click(await screen.findByRole('button', { name: 'Create Re-test' }))
+    expect(await screen.findByRole('alert')).toHaveTextContent('Source service unavailable')
+    expect(screen.getByRole('button', { name: 'Create Re-test' })).toBeDisabled()
+    expect(screen.queryByRole('radio', { name: /Use current source/ })).not.toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry source lookup' }))
+    expect(await screen.findByRole('radio', { name: /Use current source/ })).toBeChecked()
+    expect(screen.getByRole('combobox', { name: 'Based on Assessment' })).toHaveTextContent('Re-test #2')
+    expect(screen.getByRole('button', { name: 'Create Re-test' })).toBeEnabled()
+    expect(api.uploadedSource).toHaveBeenCalledTimes(2)
+  })
+
+  it('can create a new-source child when the predecessor upload metadata is no longer available', async () => {
+    vi.mocked(api.getEngagement).mockResolvedValue({ inScope: [{ kind: 'repo', value: `uploaded-source/sha256/${'d'.repeat(64)}` }] } as never)
+    vi.mocked(api.createRetest).mockRejectedValue(new Error('expected request rejection'))
+    renderPanel()
+    fireEvent.click(await screen.findByRole('button', { name: 'Create Re-test' }))
+    expect(await screen.findByRole('radio', { name: /Use current source/ })).toBeDisabled()
+    expect(screen.getByRole('radio', { name: /Upload new source/ })).toBeChecked()
+    expect(screen.getByRole('combobox', { name: 'Assessment scope' })).toBeDisabled()
+    const source = new File(['new revision'], 'replacement.zip')
+    fireEvent.change(screen.getByLabelText('Re-test source archive'), { target: { files: [source] } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create Re-test' }))
+    await waitFor(() => expect(api.createRetest).toHaveBeenCalledWith('assessment-2', expect.objectContaining({
+      predecessorAssessmentId: 'assessment-2', scopeStrategy: 'copy', sourceStrategy: 'upload_new', sourceVersionId: undefined, source,
+    })))
+  })
+
+  it('refreshes eligible predecessors when the current Assessment completes without navigation', async () => {
+    vi.mocked(api.assessmentLifecycle).mockResolvedValueOnce({
+      ...lifecycle,
+      members: lifecycle.members.map((member) => ({ ...member, assessmentStatus: 'active' })),
+    })
+    const view = renderPanel('active')
+    await screen.findByRole('button', { name: /Details & history/ })
+    expect(screen.getByRole('button', { name: 'Create Re-test' })).toBeDisabled()
+    view.rerender(<MemoryRouter><AssessmentLifecyclePanel assessmentId="assessment-2" engagementStatus="completed" /></MemoryRouter>)
+    await waitFor(() => expect(api.assessmentLifecycle).toHaveBeenCalledTimes(2))
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Create Re-test' })).toBeEnabled())
+    fireEvent.click(screen.getByRole('button', { name: 'Create Re-test' }))
+    expect(screen.getByRole('combobox', { name: 'Based on Assessment' })).toHaveTextContent('Re-test #2')
+  })
+
+  it('uses the authoritative preview, requires a reason, and preserves input after a stale conflict', async () => {
+    vi.mocked(api.previewAssessmentRelationshipChange).mockResolvedValue({
+      cycleId: 'cycle-1', command: 'reparent_within_cycle', assessmentId: 'assessment-2',
+      oldPredecessorAssessmentId: 'assessment-1', newPredecessorAssessmentId: 'assessment-0',
+      oldSelectedHeadAssessmentId: 'assessment-2', newSelectedHeadAssessmentId: 'assessment-2', descendantAssessmentIds: ['assessment-child'],
+      impact: { memberIds: ['assessment-2'], snapshotIds: ['snapshot-1'], identityIds: ['identity-1'], comparisonIds: ['comparison-1'], projectionIds: ['projection-1'] },
+      locks: [], reasonRequired: true, commitAllowed: true, cycleVersion: 7, expiresAt: '2026-09-01T02:00:00Z', previewToken: 'signed-preview',
+    })
+    vi.mocked(api.commitAssessmentRelationshipChange).mockRejectedValue(new ApiError(409, 'stale'))
+    renderPanel()
+
+    await openHistory()
+    fireEvent.click(screen.getByRole('button', { name: 'Change relationship' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Preview server impact' }))
+    expect(await screen.findByText('1 members · 1 snapshots · 1 identities · 1 comparisons · 1 projections')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Commit authoritative preview' })).toBeDisabled()
+    fireEvent.change(screen.getByRole('textbox', { name: 'Reason' }), { target: { value: 'Correct imported ancestry' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Commit authoritative preview' }))
+
+    expect(await screen.findByText(/Preview is stale, expired, or already used/)).toBeInTheDocument()
+    expect(screen.getByRole('textbox', { name: 'Reason' })).toHaveValue('Correct imported ancestry')
+    expect(api.commitAssessmentRelationshipChange).toHaveBeenCalledWith(
+      'cycle-1', 7,
+      { command: 'reparent_within_cycle', assessmentId: 'assessment-2', newPredecessorAssessmentId: 'assessment-0' },
+      'signed-preview', 'Correct imported ancestry', expect.any(String),
+    )
+  })
+
+  it('keeps the summary compact and reveals full history with the keyboard', async () => {
+    const user = userEvent.setup()
+    renderPanel()
+    const toggle = await screen.findByRole('button', { name: /4 members · 2 branch heads.*Details & history/ })
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByRole('list', { name: 'Assessment Cycle history' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('navigation', { name: 'Assessment lifecycle breadcrumb' })).not.toBeInTheDocument()
+    expect(screen.getByRole('link', { name: 'Compare' })).toHaveAttribute('href', '/engagements/assessment-2/comparison')
+    expect(screen.getByRole('link', { name: 'Payments lifecycle' })).toHaveAttribute('href', '/assessment-cycles/cycle-1')
+
+    toggle.focus()
+    await user.keyboard('{Enter}')
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByRole('list', { name: 'Assessment Cycle history' })).toBeVisible()
+    expect(screen.getByRole('navigation', { name: 'Assessment lifecycle breadcrumb' })).toHaveTextContent('assessment-2')
+    await user.keyboard(' ')
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(toggle).toHaveFocus()
+    expect(screen.queryByRole('link', { name: 'Initial · assessment-0' })).not.toBeInTheDocument()
+    expect(api.assessmentLifecycle).toHaveBeenCalledTimes(1)
+  })
+
+  it('explains disabled Re-test access without exposing reviewer actions', async () => {
+    vi.mocked(api.me).mockResolvedValue({ id: 'viewer-1', name: 'Viewer', role: 'viewer', features: { assessmentLifecycleRead: true, assessmentLifecycleUIDefault: true } })
+    renderPanel('draft')
+    fireEvent.click(await screen.findByRole('button', { name: 'Re-test requirements' }))
+    expect(screen.getByRole('list', { name: 'Assessment Cycle history' })).toBeVisible()
+    expect(screen.getByText(/Re-test creation requires operate permission/, { selector: 'span' })).toBeVisible()
+    expect(screen.queryByRole('button', { name: 'Create Re-test' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Change relationship' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Select Cycle head' })).not.toBeInTheDocument()
+  })
+
+  it('navigates to Compare within the app without losing the in-memory session', async () => {
+    render(<MemoryRouter><Routes>
+      <Route path="/" element={<AssessmentLifecyclePanel assessmentId="assessment-2" engagementStatus="completed" />} />
+      <Route path="/engagements/assessment-2/comparison" element={<h1>Comparison opened</h1>} />
+    </Routes></MemoryRouter>)
+    fireEvent.click(await screen.findByRole('link', { name: 'Compare' }))
+    expect(await screen.findByRole('heading', { name: 'Comparison opened' })).toBeInTheDocument()
+  })
+
+	it('renders loading, migration-pending, and permission error states', async () => {
+		vi.mocked(api.assessmentLifecycle).mockImplementationOnce(() => new Promise<AssessmentLifecycle>(() => undefined))
+		const loading = renderPanel()
+		expect(await screen.findByText('Loading Assessment lifecycle…')).toBeInTheDocument()
+    loading.unmount()
+
+    vi.mocked(api.assessmentLifecycle).mockResolvedValueOnce(null as never)
+    const empty = renderPanel()
+    expect(await screen.findByText('Lifecycle migration pending')).toBeInTheDocument()
+    empty.unmount()
+
+    vi.mocked(api.assessmentLifecycle).mockRejectedValueOnce(new Error('Review permission is required.'))
+    renderPanel()
+    expect(await screen.findByText('Review permission is required.')).toBeInTheDocument()
+  })
+})
+
+function closureManifest(): AssessmentClosureManifest {
+  return {
+    id: 'manifest-active', cycleId: 'cycle-1', manifestVersion: 1, lifecycle: 'active', cycleVersion: 8,
+    rootAssessmentId: 'assessment-0', finalAssessmentId: 'assessment-2', initialSnapshotId: 'snapshot-0', finalSnapshotId: 'snapshot-2', comparisonId: 'comparison-1',
+    initialSnapshotHash: 'a'.repeat(64), finalSnapshotHash: 'b'.repeat(64), comparisonHash: 'c'.repeat(64), canonicalInputHash: 'd'.repeat(64), contentHash: 'e'.repeat(64),
+    policyVersion: 'closure-policy-v1', algorithmVersion: 'comparison-v1', fingerprintVersion: 'fingerprint-v1', riskVersion: 'risk-v1', rendererContractVersion: 'assessment-cycle-report-v1',
+    coverageDecisions: { initial: [], final: [] }, scopeProfileChanges: [], overrideBlockerIds: [], nonFinalBranches: [],
+    path: [
+      { pathPosition: 0, assessmentId: 'assessment-0', assessmentType: 'initial', retestNumber: 0, relationshipVersion: 1, snapshotId: 'snapshot-0' },
+      { pathPosition: 1, assessmentId: 'assessment-1', assessmentType: 'retest', retestNumber: 1, relationshipVersion: 2, snapshotId: 'snapshot-1' },
+      { pathPosition: 2, assessmentId: 'assessment-2', assessmentType: 'retest', retestNumber: 2, relationshipVersion: 3, snapshotId: 'snapshot-2' },
+    ],
+    references: [], reason: 'accepted', overrideReason: '', asOfAt: '2026-09-01T01:00:00Z', createdAt: '2026-09-01T01:00:00Z', createdBy: 'reviewer',
+    sealedAt: '2026-09-01T01:00:00Z', sealedBy: 'reviewer', supersededAt: null,
+  }
+}

--- a/web/src/pages/EngagementDetail/AssessmentLifecyclePanel.tsx
+++ b/web/src/pages/EngagementDetail/AssessmentLifecyclePanel.tsx
@@ -1,0 +1,251 @@
+import { AlertCircle, ChevronDown, GitBranch01, InfoCircle, Link01, Plus, RefreshCw01, XClose } from '@untitledui/icons'
+import { useId, useMemo, useState, type ReactNode } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
+import { Dialog, Modal, ModalOverlay } from '../../components/application/modals/modal'
+import { SlideoutMenu } from '../../components/application/slideout-menus/slideout-menu'
+import { styles as buttonStyles } from '../../components/base/buttons/button'
+import { Tooltip, TooltipTrigger } from '../../components/base/tooltip/tooltip'
+import { Button, cn, EmptyState, ErrorState, Field, Input, Pill, Select, Spinner } from '../../components/ui'
+import { useFetch } from '../../hooks'
+import { api, ApiError } from '../../lib/api'
+import { newIdempotencyKey } from '../../lib/api/client'
+import { useRequestIdempotency } from '../../hooks/useRequestIdempotency'
+import { useRetestSource } from '../../hooks/useRetestSource'
+import { RetestSourceChoice } from '../../components/synapse/RetestSourceChoice'
+import type { AssessmentClosureManifest, AssessmentCycleMember, AssessmentLifecycle, AssessmentRelationshipChangeRequest, AssessmentRelationshipPreview } from '../../lib/types'
+
+type Drawer = 'retest' | 'reparent' | 'select_head' | null
+const RETEST_REQUIREMENTS = 'Re-test creation requires operate permission and a completed Assessment in an open Cycle. Completed Cycles must be reopened first. No dates or authorization details are needed to create the draft; configure execution authorization before scanning.'
+const actionLinkClass = cn(buttonStyles.common.root, buttonStyles.sizes.sm.root, buttonStyles.colors.secondary.root)
+
+export function AssessmentLifecyclePanel({ assessmentId, engagementStatus }: { assessmentId: string; engagementStatus: string }) {
+  const meFetch = useFetch(() => api.me().catch(() => null), { deps: [] })
+  const lifecycleUIEnabled = meFetch.data?.features?.assessmentLifecycleUIDefault === true
+  const lifecycleFetch = useFetch(() => api.assessmentLifecycle(assessmentId), { enabled: lifecycleUIEnabled, deps: [assessmentId, lifecycleUIEnabled, engagementStatus] })
+  const [drawer, setDrawer] = useState<Drawer>(null)
+  const [expandedAssessmentId, setExpandedAssessmentId] = useState<string | null>(null)
+  const detailsId = useId()
+  const detailsExpanded = expandedAssessmentId === assessmentId
+  const lifecycle = lifecycleFetch.data
+  const manifestFetch = useFetch(() => api.listAssessmentClosureManifests(lifecycle?.cycle.id ?? ''), {
+    enabled: lifecycleUIEnabled && Boolean(lifecycle?.cycle.activeClosureManifestId), deps: [lifecycleUIEnabled, lifecycle?.cycle.activeClosureManifestId, lifecycle?.cycle.id],
+  })
+  const current = lifecycle?.members.find((member) => member.assessmentId === assessmentId)
+
+  if (meFetch.loading || !lifecycleUIEnabled) return null
+  if (lifecycleFetch.loading && !lifecycle) return <Spinner label="Loading Assessment lifecycle…" />
+  if (lifecycleFetch.error) return <ErrorState message={lifecycleFetch.error} />
+  if (!lifecycle) return <EmptyState icon={GitBranch01} title="Lifecycle migration pending" hint="This Assessment does not yet have a readable Cycle projection." />
+
+  const role = meFetch.data?.role ?? ''
+  const canOperate = ['admin', 'consultant', 'member'].includes(role)
+  const canReview = role === 'admin' || role === 'reviewer'
+  const canCreateRetest = canOperate && !lifecycleFetch.loading && lifecycle.cycle.status === 'open' && engagementStatus === 'completed'
+  const selectableHeads = lifecycle.branchHeads.filter((member) => member.assessmentId !== lifecycle.cycle.selectedHeadAssessmentId && !member.archivedAt)
+  const activeManifest = manifestFetch.data?.find((manifest) => manifest.lifecycle === 'active') ?? null
+  const finalAssessmentId = activeManifest?.finalAssessmentId ?? ''
+  return <>
+    <section aria-labelledby={`${detailsId}-title`} className="border-t border-secondary pt-4">
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
+            <h2 id={`${detailsId}-title`} className="flex items-center gap-2 text-sm font-semibold text-primary">
+              <GitBranch01 className="size-4 text-fg-brand-primary" aria-hidden="true" />Assessment lifecycle
+            </h2>
+            <div className="flex flex-wrap items-center gap-1.5">
+              <Pill>{current?.assessmentType === 'retest' ? `Re-test #${current.retestNumber}` : 'Initial'}</Pill>
+              <span className="text-xs capitalize text-tertiary">{engagementStatus || 'unknown'} Assessment</span>
+              <span aria-hidden="true" className="text-quaternary">·</span>
+              <span className="text-xs capitalize text-secondary">{lifecycle.cycle.status} Cycle</span>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Link to={`/engagements/${encodeURIComponent(assessmentId)}/comparison`} className={actionLinkClass}>Compare</Link>
+            {canOperate ? <Button disabled={!canCreateRetest} aria-describedby={!canCreateRetest ? `${detailsId}-eligibility` : undefined} onClick={() => setDrawer('retest')}>
+              <Plus className="size-4" aria-hidden="true" />Create Re-test
+            </Button> : null}
+            {!canCreateRetest ? <Tooltip title="Re-test requirements" description={RETEST_REQUIREMENTS} placement="bottom end">
+              <TooltipTrigger aria-label="Re-test requirements" onPress={() => setExpandedAssessmentId(assessmentId)} className="flex items-center justify-center rounded-lg p-2 text-tertiary hover:bg-secondary hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"><InfoCircle className="size-4" aria-hidden="true" /></TooltipTrigger>
+            </Tooltip> : null}
+            {canReview && lifecycle.cycle.status === 'completed' ? <Link to={`/assessment-cycles/${encodeURIComponent(lifecycle.cycle.id)}`} className={actionLinkClass}><RefreshCw01 className="size-4" aria-hidden="true" />Review reopen</Link> : null}
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+          <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1.5 text-xs">
+            <Link to={`/assessment-cycles/${encodeURIComponent(lifecycle.cycle.id)}`} className="max-w-full break-all rounded font-medium text-secondary hover:text-brand-secondary hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand">{lifecycle.cycle.name}</Link>
+            {assessmentId === lifecycle.cycle.selectedHeadAssessmentId ? <span className="inline-flex items-center gap-1.5 font-medium text-brand-secondary"><span aria-hidden="true" className="size-1.5 rounded-full bg-brand-solid" />Selected head</span> : null}
+            {assessmentId === displayLatest(lifecycle)?.assessmentId ? <span className="text-tertiary" title="Display-only recency; not semantic precedence.">Display latest</span> : null}
+            {assessmentId === finalAssessmentId ? <Pill className="text-success">Final</Pill> : null}
+          </div>
+          <button type="button" aria-expanded={detailsExpanded} aria-controls={detailsId} onClick={() => setExpandedAssessmentId(detailsExpanded ? null : assessmentId)} className="flex min-h-8 flex-wrap items-center gap-x-3 gap-y-1 rounded-lg text-xs text-tertiary hover:text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand">
+            <span className="tabular-nums">{lifecycle.members.length} {lifecycle.members.length === 1 ? 'member' : 'members'} · {lifecycle.branchHeads.length} {lifecycle.branchHeads.length === 1 ? 'branch head' : 'branch heads'}</span>
+            <span className="flex items-center gap-1.5 font-semibold text-secondary">Details &amp; history<ChevronDown className={cn('size-4 transition-transform motion-reduce:transition-none', detailsExpanded && 'rotate-180')} aria-hidden="true" /></span>
+          </button>
+        </div>
+        {!canCreateRetest ? <p id={`${detailsId}-eligibility`} className="sr-only">{RETEST_REQUIREMENTS} Open Details &amp; history for more information.</p> : null}
+      </div>
+      <div id={detailsId} hidden={!detailsExpanded} className="mt-3 space-y-4 border-t border-secondary pt-4">
+        <nav aria-label="Assessment lifecycle breadcrumb" className="flex flex-wrap items-center gap-2 text-xs text-tertiary">
+          {boundaryParts(lifecycle).map((part, index) => <span key={part} className="contents">{index ? <span aria-hidden="true">/</span> : null}<span className="break-all">{part}</span></span>)}
+          <span aria-hidden="true">/</span><span className="break-all">{lifecycle.cycle.name}</span><span aria-hidden="true">/</span><span className="break-all font-mono">{assessmentId}</span>
+        </nav>
+        {!canCreateRetest ? <p className="flex items-start gap-2 text-xs leading-relaxed text-tertiary"><AlertCircle className="mt-0.5 size-4 shrink-0" aria-hidden="true" /><span>{RETEST_REQUIREMENTS}</span></p> : null}
+        <LifecycleTree lifecycle={lifecycle} currentAssessmentId={assessmentId} activeManifest={activeManifest} />
+        {canReview && ((current?.assessmentType === 'retest' && !current.archivedAt && lifecycle.cycle.status === 'open') || selectableHeads.length > 0) ? <div className="flex flex-wrap gap-2 border-t border-secondary pt-3">
+          {current?.assessmentType === 'retest' && !current.archivedAt && lifecycle.cycle.status === 'open' ? <Button variant="secondary" onClick={() => setDrawer('reparent')}><Link01 className="size-4" aria-hidden="true" />Change relationship</Button> : null}
+          {selectableHeads.length ? <Button variant="secondary" onClick={() => setDrawer('select_head')}><GitBranch01 className="size-4" aria-hidden="true" />Select Cycle head</Button> : null}
+        </div> : null}
+      </div>
+    </section>
+    {drawer === 'retest' ? <RetestDrawer lifecycle={lifecycle} assessmentId={assessmentId} onClose={() => setDrawer(null)} onCreated={() => lifecycleFetch.refetch()} /> : null}
+    {drawer === 'reparent' && current ? <RelationshipDrawer lifecycle={lifecycle} member={current} command="reparent_within_cycle" onClose={() => setDrawer(null)} onCommitted={() => { setDrawer(null); lifecycleFetch.refetch() }} /> : null}
+    {drawer === 'select_head' ? <RelationshipDrawer lifecycle={lifecycle} command="select_head" onClose={() => setDrawer(null)} onCommitted={() => { setDrawer(null); lifecycleFetch.refetch() }} /> : null}
+  </>
+}
+
+function LifecycleTree({ lifecycle, currentAssessmentId, activeManifest }: { lifecycle: AssessmentLifecycle; currentAssessmentId: string; activeManifest: AssessmentClosureManifest | null }) {
+  const children = useMemo(() => {
+    const result = new Map<string, AssessmentCycleMember[]>()
+    for (const member of lifecycle.members) {
+      const key = member.predecessorAssessmentId
+      result.set(key, [...(result.get(key) ?? []), member])
+    }
+    for (const values of result.values()) values.sort((left, right) => left.retestNumber - right.retestNumber || left.assessmentId.localeCompare(right.assessmentId))
+    return result
+  }, [lifecycle.members])
+  const finalPath = new Map(activeManifest?.path.map((member) => [member.assessmentId, member.snapshotId]) ?? [])
+  function render(parentId: string, depth: number): ReactNode {
+    return (children.get(parentId) ?? []).map((member) => <li key={member.assessmentId} className="relative">
+      <Link to={`/engagements/${encodeURIComponent(member.assessmentId)}`} aria-label={memberLabel(member)} aria-current={member.assessmentId === currentAssessmentId ? 'page' : undefined} className={cn('flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1.5 rounded-lg px-3 py-2 text-sm hover:bg-secondary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand', member.assessmentId === currentAssessmentId && 'bg-secondary')} style={{ marginLeft: Math.min(depth, 4) * 12 }}>
+        <span className="font-semibold text-primary">{member.assessmentType === 'retest' ? `Re-test #${member.retestNumber}` : 'Initial'}</span><span className="break-all font-mono text-xs text-tertiary">{member.assessmentId}</span>
+        {member.assessmentId === lifecycle.cycle.selectedHeadAssessmentId ? <Pill className="text-brand-secondary">Selected head</Pill> : null}
+        {lifecycle.branchHeads.some((head) => head.assessmentId === member.assessmentId) ? <Pill>Branch head</Pill> : null}
+        {member.assessmentId === displayLatest(lifecycle)?.assessmentId ? <Pill>Display latest</Pill> : null}
+        {member.assessmentId === activeManifest?.finalAssessmentId ? <Pill className="text-success">Final</Pill> : null}
+        {member.archivedAt ? <Pill className="text-warning">Archived</Pill> : null}
+        {member.plannedDate ? <Pill>Planned {member.plannedDate}</Pill> : null}
+        <span className="ml-auto break-all text-xs text-tertiary">{finalPath.get(member.assessmentId) ? `Snapshot ${finalPath.get(member.assessmentId)} · ` : ''}{formatDate(member.createdAt)} · Relationship v{member.relationshipVersion}</span>
+      </Link>
+      {(children.get(member.assessmentId)?.length ?? 0) > 0 ? <ul role="list" className="mt-1 space-y-1">{render(member.assessmentId, depth + 1)}</ul> : null}
+    </li>)
+  }
+  return <div><h3 className="mb-2 text-xs font-semibold text-secondary">Cycle history</h3><ul role="list" aria-label="Assessment Cycle history" className="space-y-1">{render('', 0)}</ul></div>
+}
+
+function boundaryParts(lifecycle: AssessmentLifecycle) {
+  const parts: string[] = []
+  if (lifecycle.cycle.businessAssetId) parts.push(`Asset ${lifecycle.cycle.businessAssetId}`)
+  if (lifecycle.cycle.projectId) parts.push(`Project ${lifecycle.cycle.projectId}`)
+  return parts.length ? parts : ['Standalone']
+}
+
+function formatDate(value: string) {
+  return value ? new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' }).format(new Date(value)) : 'Unknown date'
+}
+
+function RetestDrawer({ lifecycle, assessmentId, onClose, onCreated }: { lifecycle: AssessmentLifecycle; assessmentId: string; onClose: () => void; onCreated: () => void }) {
+  const navigate = useNavigate()
+  const activeMembers = lifecycle.members.filter((member) => !member.archivedAt && member.assessmentStatus === 'completed')
+  const [predecessor, setPredecessor] = useState(activeMembers.some((member) => member.assessmentId === assessmentId) ? assessmentId : activeMembers[0]?.assessmentId ?? '')
+  const sourceSelection = useRetestSource(predecessor)
+  const [scopeStrategy, setScopeStrategy] = useState<'copy' | 'empty'>('copy')
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState('')
+  const [created, setCreated] = useState<Awaited<ReturnType<typeof api.createRetest>> | null>(null)
+  const requestKey = useRequestIdempotency()
+  const effectiveScopeStrategy = sourceSelection.hasUploadedSource ? 'copy' : scopeStrategy
+  const sourceInvalid = Boolean(sourceSelection.validationError(effectiveScopeStrategy))
+  async function submit() {
+    if (submitting || created) return
+    if (!predecessor) { setError('Choose a completed predecessor Assessment.'); return }
+    const sourceError = sourceSelection.validationError(effectiveScopeStrategy)
+    if (sourceError) { setError(sourceError); return }
+    setSubmitting(true); setError('')
+    try {
+      const input = {
+        source: undefined, ...sourceSelection.input, predecessorAssessmentId: predecessor, scopeStrategy: effectiveScopeStrategy, profileStrategy: 'none' as const,
+      }
+      const result = await api.createRetest(predecessor, { ...input, idempotencyKey: requestKey(input, input.source) })
+      setCreated(result); onCreated()
+    } catch (cause) { setError(cause instanceof Error && cause.message.includes('source_package_required_for_retest') ? 'The predecessor source is unavailable. Retry the source lookup or upload a new source archive.' : cause instanceof Error ? cause.message : 'Re-test creation failed.') }
+    finally { setSubmitting(false) }
+  }
+  const selectedPredecessor = activeMembers.find((member) => member.assessmentId === predecessor)
+  return <ModalOverlay isOpen onOpenChange={(open) => { if (!open) onClose() }}>
+    <Modal className="w-full max-w-2xl overflow-hidden rounded-2xl border border-secondary bg-primary shadow-2xl">
+      <Dialog aria-label="Create Re-test" className="flex max-h-[85vh] flex-col overflow-hidden">
+        <header className="flex shrink-0 items-start justify-between border-b border-secondary px-6 py-5">
+          <div className="min-w-0 pr-4">
+            <h2 className="text-lg font-semibold text-primary">Create Re-test</h2>
+            <p className="mt-1 text-sm leading-relaxed text-tertiary">Create a new assessment to verify remediation from a previous assessment.</p>
+          </div>
+          <button type="button" onClick={onClose} aria-label="Close dialog" className="flex size-10 shrink-0 items-center justify-center rounded-lg text-tertiary transition-colors hover:bg-secondary hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"><XClose className="size-4" aria-hidden="true" /></button>
+        </header>
+        <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+          {created ? <div role="status" className="space-y-4">
+            <div className="rounded-xl border border-success/30 bg-success/10 p-4">
+              <p className="font-semibold text-primary">Re-test created</p>
+              <p className="mt-1 break-words text-sm text-secondary">{created.engagement.name}</p>
+              <p className="mt-1 text-sm text-secondary">Scope: {created.inheritanceDiff.scope} · Authorization: {created.inheritanceDiff.authorization} · RoE: {created.inheritanceDiff.roe} · Scanner profile: {created.inheritanceDiff.scannerProfile}</p>
+              {created.sourceSelection ? <p className="mt-1 break-words text-sm text-secondary">Source: {created.sourceSelection.filename} · {created.sourceSelection.strategy === 'reuse_current' ? 'Previous archive reused' : 'New archive uploaded'}</p> : null}
+            </div>
+            <p className="text-sm text-tertiary">The draft is ready. Configure execution authorization in Re-test Settings before running a scan.</p>
+            {created.warnings.map((warning) => <p key={warning} className="flex gap-2 text-sm text-warning"><AlertCircle className="size-4 shrink-0" aria-hidden="true" />{labelize(warning)}</p>)}
+          </div> : <div className="space-y-7">
+            <section aria-labelledby="retest-context-title" className="rounded-xl border border-secondary bg-secondary/20 p-4">
+              <p id="retest-context-title" className="text-xs font-semibold uppercase tracking-wide text-tertiary">Based on</p>
+              <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1">
+                <p className="font-semibold text-primary">{lifecycle.cycle.name}</p>
+                <span aria-hidden="true" className="text-quaternary">·</span>
+                <span className="text-sm text-secondary">{selectedPredecessor ? memberShortLabel(selectedPredecessor) : 'Choose an assessment'} · Completed</span>
+              </div>
+              <div className="mt-4 max-w-md"><Field label="Based on assessment"><Select disabled={submitting} ariaLabel="Based on Assessment" value={predecessor} onValueChange={(value) => { setPredecessor(value); setError('') }} options={activeMembers.map((member) => ({ value: member.assessmentId, label: memberShortLabel(member) }))} className="w-full" /></Field></div>
+            </section>
+            <RetestSourceChoice selection={sourceSelection} disabled={submitting} onChange={() => setError('')} />
+            <section className="border-t border-secondary pt-6"><Field label="Assessment scope" hint={sourceSelection.hasUploadedSource ? 'This Re-test uses the same targets and scope as the previous assessment.' : 'Choose which targets and scope to carry forward.'}><Select disabled={submitting || sourceSelection.loading || sourceSelection.hasUploadedSource} ariaLabel="Assessment scope" value={effectiveScopeStrategy} onValueChange={(value) => setScopeStrategy(value as 'copy' | 'empty')} options={[{ value: 'copy', label: 'Copy previous scope' }, { value: 'empty', label: 'Start with empty scope' }]} className="w-full" /></Field></section>
+            <p className="text-xs leading-relaxed text-tertiary">Creating a Re-test does not start a scan. Configure execution authorization later in Settings.</p>
+            {error ? <ErrorState message={error} /> : null}
+          </div>}
+        </div>
+        <footer className="flex shrink-0 items-center justify-end gap-3 border-t border-secondary bg-primary px-6 py-4">
+          {created ? <><Button variant="secondary" onClick={onClose}>Close</Button><Button onClick={() => navigate(`/engagements/${encodeURIComponent(created.engagement.id)}`)}>Open Re-test</Button></> : <><Button variant="ghost" disabled={submitting} onClick={onClose}>Cancel</Button><Button loading={submitting} disabled={sourceSelection.loading || Boolean(sourceSelection.error) || sourceInvalid} onClick={submit}>Create Re-test</Button></>}
+        </footer>
+      </Dialog>
+    </Modal>
+  </ModalOverlay>
+}
+
+function RelationshipDrawer({ lifecycle, member, command, onClose, onCommitted }: { lifecycle: AssessmentLifecycle; member?: AssessmentCycleMember; command: 'reparent_within_cycle' | 'select_head'; onClose: () => void; onCommitted: () => void }) {
+  const options = command === 'reparent_within_cycle'
+    ? lifecycle.members.filter((value) => !value.archivedAt && value.assessmentId !== member?.assessmentId).map((value) => ({ value: value.assessmentId, label: memberLabel(value) }))
+    : lifecycle.branchHeads.filter((value) => !value.archivedAt && value.assessmentId !== lifecycle.cycle.selectedHeadAssessmentId).map((value) => ({ value: value.assessmentId, label: memberLabel(value) }))
+  const [target, setTarget] = useState(options[0]?.value ?? '')
+  const [preview, setPreview] = useState<AssessmentRelationshipPreview | null>(null)
+  const [reason, setReason] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [idempotencyKey, setIdempotencyKey] = useState('')
+  const change: AssessmentRelationshipChangeRequest = command === 'reparent_within_cycle'
+    ? { command, assessmentId: member?.assessmentId, newPredecessorAssessmentId: target }
+    : { command, selectedHeadAssessmentId: target }
+  async function loadPreview() {
+    if (!target) return
+    setLoading(true); setError('')
+    try { setPreview(await api.previewAssessmentRelationshipChange(lifecycle.cycle.id, change)); setIdempotencyKey(newIdempotencyKey()) }
+    catch (cause) { setError(cause instanceof ApiError && cause.status === 403 ? 'Review permission is required.' : cause instanceof Error ? cause.message : 'Preview failed.') }
+    finally { setLoading(false) }
+  }
+  async function commit() {
+    if (!preview?.commitAllowed || !preview.previewToken || preview.reasonRequired && !reason.trim()) return
+    setLoading(true); setError('')
+    try { await api.commitAssessmentRelationshipChange(lifecycle.cycle.id, preview.cycleVersion, change, preview.previewToken, reason.trim(), idempotencyKey); onCommitted() }
+    catch (cause) { setError(cause instanceof ApiError && cause.status === 409 ? 'Preview is stale, expired, or already used. Refresh the authoritative preview; your selection and reason are preserved.' : cause instanceof Error ? cause.message : 'Commit failed.') }
+    finally { setLoading(false) }
+  }
+  return <SlideoutMenu isOpen onOpenChange={(open) => { if (!open) onClose() }}><SlideoutMenu.Header onClose={onClose}><h2 className="text-lg font-semibold text-primary">{command === 'reparent_within_cycle' ? 'Change relationship' : 'Select Cycle head'}</h2><p className="mt-1 text-sm text-tertiary">Only supported same-Cycle commands are exposed. Raw scans and evidence are never deleted.</p></SlideoutMenu.Header><SlideoutMenu.Content><div className="space-y-4"><Field label={command === 'reparent_within_cycle' ? 'New predecessor' : 'Eligible branch head'}><Select ariaLabel="Relationship target" value={target} onValueChange={(value) => { setTarget(value); setPreview(null) }} options={options} className="w-full" /></Field><Button variant="secondary" loading={loading} disabled={!target} onClick={loadPreview}><RefreshCw01 className="size-4" aria-hidden="true" />Preview server impact</Button>{preview ? <div role="status" aria-live="polite" className="space-y-3 rounded-lg border border-secondary p-4 text-sm"><p><strong>Selected head:</strong> {preview.oldSelectedHeadAssessmentId} → {preview.newSelectedHeadAssessmentId}</p>{command === 'reparent_within_cycle' ? <p><strong>Predecessor:</strong> {preview.oldPredecessorAssessmentId} → {preview.newPredecessorAssessmentId}</p> : null}<p><strong>Descendants:</strong> {preview.descendantAssessmentIds.join(', ') || 'None'}</p><p><strong>Impacted:</strong> {preview.impact.memberIds.length} members · {preview.impact.snapshotIds.length} snapshots · {preview.impact.identityIds.length} identities · {preview.impact.comparisonIds.length} comparisons · {preview.impact.projectionIds.length} projections</p>{preview.locks.length ? <div className="rounded-lg bg-warning/10 p-3 text-warning"><strong>Commit locked:</strong> {preview.locks.map(labelize).join(', ')}</div> : <p className="text-success">No server lock is active.</p>}<p className="font-mono text-xs text-tertiary">Preview v{preview.cycleVersion} · expires {preview.expiresAt || 'not issued'}</p></div> : null}{preview?.reasonRequired ? <Field label="Reason"><Input aria-label="Reason" value={reason} maxLength={512} onChange={(event) => setReason(event.target.value)} /></Field> : null}{error ? <ErrorState message={error} /> : null}<Button loading={loading} disabled={!preview?.commitAllowed || !preview.previewToken || Boolean(preview.reasonRequired && !reason.trim())} onClick={commit}>Commit authoritative preview</Button></div></SlideoutMenu.Content></SlideoutMenu>
+}
+
+function displayLatest(lifecycle: AssessmentLifecycle) { return [...lifecycle.members].filter((member) => !member.archivedAt).sort((left, right) => right.retestNumber - left.retestNumber || right.assessmentId.localeCompare(left.assessmentId))[0] }
+function memberLabel(member: AssessmentCycleMember) { return `${memberShortLabel(member)} · ${member.assessmentId}` }
+function memberShortLabel(member: AssessmentCycleMember) { return member.assessmentType === 'retest' ? `Re-test #${member.retestNumber}` : 'Initial' }
+function labelize(value: string) { return value.replaceAll('_', ' ').replace(/\b\w/g, (letter) => letter.toUpperCase()) }

--- a/web/src/pages/EngagementDetail/EngagementDetail.test.tsx
+++ b/web/src/pages/EngagementDetail/EngagementDetail.test.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { api } from '../../lib/api'
+import { api, ApiError } from '../../lib/api'
+import type { AssessmentLifecycle } from '../../lib/types'
 import { EngagementDetail } from './index'
 
 vi.mock('../../lib/api', () => ({
@@ -16,6 +17,12 @@ vi.mock('../../lib/api', () => ({
     evidence: vi.fn(),
     listBusinessAssets: vi.fn(),
     assignEngagementAsset: vi.fn(),
+    assessmentLifecycle: vi.fn(),
+    listAssessmentClosureManifests: vi.fn(),
+    me: vi.fn(),
+    createRetest: vi.fn(),
+    previewAssessmentRelationshipChange: vi.fn(),
+    commitAssessmentRelationshipChange: vi.fn(),
   },
   ApiError: class ApiError extends Error {
     status: number
@@ -37,8 +44,49 @@ const mockEngagement = {
   authorizedTo: null,
   roe: { allowedToolClasses: [], blackouts: [] },
   liveReconEnabled: false,
+  requiresExplicitExecutionAuthorization: false,
   createdAt: '2026-08-15T00:00:00Z',
   businessAssetId: '',
+}
+
+const mockLifecycle: AssessmentLifecycle = {
+  assessmentId: 'eng-123456',
+  cycle: {
+    id: 'cycle-1',
+    name: 'Acme Core Security Audit',
+    boundaryKind: 'standalone',
+    businessAssetId: '',
+    projectId: '',
+    status: 'open',
+    rootAssessmentId: 'eng-123456',
+    selectedHeadAssessmentId: 'eng-123456',
+    nextRetestNumber: 1,
+    version: 1,
+    createdAt: '2026-08-15T00:00:00Z',
+    updatedAt: '2026-08-15T00:00:00Z',
+    createdBy: 'operator',
+    updatedBy: 'operator',
+  },
+  members: [{
+    assessmentId: 'eng-123456',
+    assessmentType: 'initial',
+    predecessorAssessmentId: '',
+    retestNumber: 0,
+    relationshipVersion: 1,
+    createdAt: '2026-08-15T00:00:00Z',
+    createdBy: 'operator',
+    archivedAt: null,
+  }],
+  branchHeads: [{
+    assessmentId: 'eng-123456',
+    assessmentType: 'initial',
+    predecessorAssessmentId: '',
+    retestNumber: 0,
+    relationshipVersion: 1,
+    createdAt: '2026-08-15T00:00:00Z',
+    createdBy: 'operator',
+    archivedAt: null,
+  }],
 }
 
 describe('EngagementDetail Page Shell', () => {
@@ -52,6 +100,9 @@ describe('EngagementDetail Page Shell', () => {
     vi.mocked(api.uploadedSource).mockResolvedValue(null as any)
     vi.mocked(api.evidence).mockResolvedValue(null)
     vi.mocked(api.listBusinessAssets).mockResolvedValue({ items: [], total: 0, limit: 200, offset: 0 })
+    vi.mocked(api.assessmentLifecycle).mockResolvedValue(mockLifecycle)
+    vi.mocked(api.listAssessmentClosureManifests).mockResolvedValue([])
+    vi.mocked(api.me).mockResolvedValue({ id: 'operator', name: 'Operator', role: 'member' })
   })
 
   it('renders breadcrumb, engagement name, and status pill', async () => {
@@ -70,6 +121,43 @@ describe('EngagementDetail Page Shell', () => {
     expect(screen.getAllByTitle('github.com/acme/core-service').length).toBeGreaterThan(0)
   })
 
+  it('groups lifecycle below scan controls in the Engagement summary, before the content tabs', async () => {
+    vi.mocked(api.me).mockResolvedValue({ id: 'operator', name: 'Operator', role: 'member', features: { assessmentLifecycleRead: true, assessmentLifecycleUIDefault: true } })
+    render(
+      <MemoryRouter initialEntries={['/engagements/eng-123456']}>
+        <Routes><Route path="/engagements/:id" element={<EngagementDetail />} /></Routes>
+      </MemoryRouter>,
+    )
+
+    const lifecycle = await screen.findByRole('region', { name: 'Assessment lifecycle' })
+    const summary = screen.getByRole('region', { name: 'Engagement summary' })
+    expect(summary).toContainElement(screen.getByRole('heading', { level: 1, name: mockEngagement.name }))
+    expect(summary).toContainElement(lifecycle)
+    const scanButton = within(summary).getByRole('button', { name: 'Run scan' })
+    expect(scanButton.compareDocumentPosition(lifecycle) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(lifecycle.compareDocumentPosition(screen.getByRole('tablist', { name: 'Engagement Views' })) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(within(lifecycle).getByRole('link', { name: 'Compare' })).toHaveAttribute('href', '/engagements/eng-123456/comparison')
+    const disclosure = within(lifecycle).getByRole('button', { name: /Details & history/ })
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByRole('list', { name: 'Assessment Cycle history' })).not.toBeInTheDocument()
+    fireEvent.click(disclosure)
+    expect(within(lifecycle).getByRole('list', { name: 'Assessment Cycle history' })).toBeInTheDocument()
+  })
+
+  it('does not add an empty lifecycle section when tenant UI rollout is disabled', async () => {
+    render(
+      <MemoryRouter initialEntries={['/engagements/eng-123456']}>
+        <Routes><Route path="/engagements/:id" element={<EngagementDetail />} /></Routes>
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByRole('region', { name: 'Engagement summary' })).toBeInTheDocument()
+    await waitFor(() => expect(api.me).toHaveBeenCalled())
+    expect(screen.queryByRole('region', { name: 'Assessment lifecycle' })).not.toBeInTheDocument()
+    expect(api.assessmentLifecycle).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Run scan' })).toBeInTheDocument()
+  })
+
   it('renders tab list with accessible roles and switches tabs', async () => {
     render(
       <MemoryRouter initialEntries={['/engagements/eng-123456']}>
@@ -84,6 +172,10 @@ describe('EngagementDetail Page Shell', () => {
 
     const findingsTab = screen.getByRole('tab', { name: /Findings/i })
     expect(findingsTab).toBeInTheDocument()
+    const comparisonTab = screen.getByRole('tab', { name: 'Comparison' })
+    const supplyChainTab = screen.getByRole('tab', { name: /Supply Chain/i })
+    expect(findingsTab.compareDocumentPosition(comparisonTab) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(comparisonTab.compareDocumentPosition(supplyChainTab) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
 
     fireEvent.click(findingsTab)
 
@@ -94,6 +186,7 @@ describe('EngagementDetail Page Shell', () => {
       expect(panel).toHaveAttribute('id', 'engagement-tabpanel')
       expect(panel).toHaveAttribute('aria-labelledby', 'tab-findings')
     })
+    expect(screen.queryByRole('button', { name: 'Comparison' })).not.toBeInTheDocument()
   })
 
   it('moves between tabs with the arrow keys and keeps one tab stop', async () => {
@@ -176,6 +269,31 @@ describe('EngagementDetail Page Shell', () => {
     await waitFor(() => expect(api.startScan).toHaveBeenCalledWith('eng-123456', '', 'upload', '', 'full', false))
   })
 
+  it('shows source metadata failures with retry instead of treating them as a source-less engagement', async () => {
+    vi.mocked(api.uploadedSource).mockRejectedValueOnce(new ApiError(503, 'Source service unavailable')).mockResolvedValueOnce({
+      versionId: 'source-version', filename: 'restored.zip', size: 123, sha256: 'c'.repeat(64), target: '',
+      uploadedBy: 'operator', uploadedAt: '2026-09-08T00:00:00Z',
+    })
+    render(<MemoryRouter initialEntries={['/engagements/eng-123456']}><Routes>
+      <Route path="/engagements/:id" element={<EngagementDetail />} />
+    </Routes></MemoryRouter>)
+    expect(await screen.findByText('Could not load source metadata: Source service unavailable')).toBeVisible()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry source lookup' }))
+    expect(await screen.findByText('Source: restored.zip')).toBeVisible()
+    expect(screen.queryByText('Could not load source metadata: Source service unavailable')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText('Immutable source details'))
+    expect(screen.getByLabelText(`Source SHA-256 ${'c'.repeat(64)}`)).toBeVisible()
+  })
+
+  it('does not show a source metadata error for a linked engagement without an uploaded package', async () => {
+    vi.mocked(api.uploadedSource).mockRejectedValue(new ApiError(404, 'No source package'))
+    render(<MemoryRouter initialEntries={['/engagements/eng-123456']}><Routes>
+      <Route path="/engagements/:id" element={<EngagementDetail />} />
+    </Routes></MemoryRouter>)
+    expect(await screen.findByRole('heading', { name: 'Acme Core Security Audit' })).toBeVisible()
+    expect(screen.queryByRole('button', { name: 'Retry source lookup' })).not.toBeInTheDocument()
+  })
+
   it('locks uploaded source scans before package metadata loads', async () => {
     vi.mocked(api.getEngagement).mockResolvedValue({
       ...mockEngagement,
@@ -202,4 +320,48 @@ describe('EngagementDetail Page Shell', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save & Run scan' }))
     await waitFor(() => expect(api.startScan).toHaveBeenCalledWith('eng-123456', '', 'upload', '', 'full', false))
   })
+
+  it('guides an unauthorized Re-test to Settings without starting a scan', async () => {
+    vi.mocked(api.getEngagement).mockResolvedValue({ ...mockEngagement, requiresExplicitExecutionAuthorization: true } as never)
+    render(<MemoryRouter initialEntries={['/engagements/eng-123456']}><Routes>
+      <Route path="/engagements/:id" element={<EngagementDetail />} />
+      <Route path="/engagements/:id/:tabSlug" element={<EngagementDetail />} />
+    </Routes></MemoryRouter>)
+
+    expect(await screen.findByText('Scan authorization required.')).toBeVisible()
+    expect(screen.getByText('Set both authorization window bounds and allow SCA tools before scanning this Re-test.')).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Run scan' })).toBeDisabled()
+    expect(api.startScan).not.toHaveBeenCalled()
+
+    const settings = screen.getByRole('link', { name: 'Configure in Settings' })
+    expect(settings).toHaveAttribute('href', '/engagements/eng-123456/settings')
+    fireEvent.click(settings)
+    expect(await screen.findByText('Authorization window')).toBeVisible()
+    expect(screen.getByText('Rules of engagement')).toBeVisible()
+  })
+
+  it('names only the missing SCA permission for a partially configured Re-test', async () => {
+    vi.mocked(api.getEngagement).mockResolvedValue({
+      ...mockEngagement,
+      requiresExplicitExecutionAuthorization: true,
+      authorizedFrom: '2026-09-01T00:00:00Z',
+      authorizedTo: '2026-10-01T00:00:00Z',
+    } as never)
+    render(<MemoryRouter initialEntries={['/engagements/eng-123456']}><Routes>
+      <Route path="/engagements/:id" element={<EngagementDetail />} />
+    </Routes></MemoryRouter>)
+
+    expect(await screen.findByText('Allow SCA tools before scanning this Re-test.')).toBeVisible()
+    expect(screen.queryByText('Set both authorization window bounds before scanning this Re-test.')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Run scan' })).toBeDisabled()
+  })
+})
+
+it('disables scan actions for a completed Assessment and explains the Re-test path', async () => {
+  vi.mocked(api.getEngagement).mockResolvedValue({ ...mockEngagement, status: 'completed' } as never)
+  render(<MemoryRouter initialEntries={['/engagements/eng-123456']}><Routes><Route path="/engagements/:id" element={<EngagementDetail />} /></Routes></MemoryRouter>)
+  expect(await screen.findByRole('button', { name: 'Run scan' })).toBeDisabled()
+  expect(screen.getByRole('button', { name: 'Scan settings' })).toBeDisabled()
+  expect(screen.getByText(/Completed Assessments keep their finalized Snapshots/)).toBeInTheDocument()
+  expect(api.startScan).not.toHaveBeenCalled()
 })

--- a/web/src/pages/EngagementDetail/ScanPanel.tsx
+++ b/web/src/pages/EngagementDetail/ScanPanel.tsx
@@ -12,6 +12,7 @@ import { ARCHIVED_REASON, isReadOnly } from './readOnly'
 import { EvidenceBadge, ScopeBadge } from './components/ScanBadges'
 import { ScanConfigModal, detectKind } from './components/ScanConfigModal'
 import { ScanDebugTimeline } from './components/ScanDebugTimeline'
+import { SourcePackageSummary } from '../../components/synapse/SourcePackageSummary'
 
 // Re-export shared helpers consumed by sibling modules (ReportBuilderModal).
 export { trapTabFocus } from './components/ScanConfigModal'
@@ -26,6 +27,8 @@ export function ScanPanel({
   eng,
   importedSBOM,
   uploadedSource,
+  uploadedSourceError,
+  onRetryUploadedSource,
   initialError,
   onImportedSBOMChanged,
   job,
@@ -35,6 +38,8 @@ export function ScanPanel({
   eng: Engagement
   importedSBOM: ImportedSBOMMetadata | null
   uploadedSource: UploadedSourcePackage | null
+  uploadedSourceError?: string | null
+  onRetryUploadedSource?: () => void
   initialError?: string
   onImportedSBOMChanged: () => void
   job: ScanJob | null
@@ -64,8 +69,18 @@ export function ScanPanel({
   )
 
   const running = job?.status === 'running'
-  // Archived is terminal: no scan may start against it.
   const archived = isReadOnly(eng)
+  const completed = eng.status === 'completed'
+  const authorizationWindowConfigured = Boolean(eng.authorizedFrom && eng.authorizedTo)
+  const scaAllowed = eng.roe.allowedToolClasses.includes('sca')
+  const explicitAuthorizationIncomplete = eng.requiresExplicitExecutionAuthorization && (!authorizationWindowConfigured || !scaAllowed)
+  const lifecycleBlocked = archived || completed
+  const scanBlocked = lifecycleBlocked || explicitAuthorizationIncomplete
+  const scanBlockedReason = archived
+    ? ARCHIVED_REASON
+    : completed
+      ? 'Completed Assessments keep their finalized Snapshots. Create a Re-test to run another assessment.'
+      : 'Configure the Re-test authorization window and allow SCA tools before running a scan.'
   const debugEvents = job?.debugEvents?.length ? job.debugEvents : (summary?.debugEvents ?? [])
   const usingImportedSBOM = Boolean(importedSBOM) && !usingUploadedSource
 
@@ -126,6 +141,10 @@ export function ScanPanel({
   }, [eng.id])
 
   async function run() {
+    if (scanBlocked) {
+      setError(scanBlockedReason)
+      return
+    }
     if (!usingUploadedSource && !usingImportedSBOM && !target.trim()) {
       setError('Enter a target in Scan Settings.')
       setConfigOpen(true)
@@ -215,18 +234,20 @@ export function ScanPanel({
             type="button"
             variant="secondary"
             onClick={() => setConfigOpen(true)}
+            disabled={lifecycleBlocked}
+            aria-describedby={completed ? 'engagement-completed-note' : archived ? 'engagement-archived-note' : undefined}
             className="h-10 px-5 text-sm font-semibold rounded-xl shadow-xs transition-transform active:scale-[0.98]"
           >
             <Settings01 className="size-4 text-secondary" />
             <span>Scan settings</span>
           </Button>
 
-          <span title={archived ? ARCHIVED_REASON : undefined}>
+          <span title={scanBlocked ? scanBlockedReason : undefined}>
             <Button
               onClick={run}
               loading={running}
-              disabled={running || outsideWindow || archived}
-              aria-describedby={archived ? 'engagement-archived-note' : undefined}
+              disabled={running || outsideWindow || scanBlocked}
+              aria-describedby={completed ? 'engagement-completed-note' : archived ? 'engagement-archived-note' : undefined}
               variant="primary"
               className="h-10 px-6 text-sm font-bold rounded-xl shadow-xs transition-transform active:scale-[0.98]"
             >
@@ -236,6 +257,15 @@ export function ScanPanel({
           </span>
         </div>
       </div>
+
+      {uploadedSource ? <details className="rounded-lg border border-secondary px-3 py-2">
+        <summary className="cursor-pointer text-xs font-semibold text-secondary">Immutable source details</summary>
+        <div className="mt-3"><SourcePackageSummary source={uploadedSource} /></div>
+      </details> : null}
+      {uploadedSourceError ? <div role="alert" className="rounded-lg border border-error/30 p-3 text-sm text-error-primary">
+        <p>Could not load source metadata: {uploadedSourceError}</p>
+        {onRetryUploadedSource ? <button type="button" className="mt-2 font-semibold underline" onClick={onRetryUploadedSource}>Retry source lookup</button> : null}
+      </div> : null}
 
       {(sbomError || sbomMessage) && (
         <div
@@ -250,6 +280,12 @@ export function ScanPanel({
         </div>
       )}
 
+      {completed && (
+        <div id="engagement-completed-note" className="rounded-lg border border-secondary bg-secondary p-3 text-xs text-tertiary">
+          {scanBlockedReason}
+        </div>
+      )}
+
       {archived && (
         <div
           id="engagement-archived-note"
@@ -257,6 +293,27 @@ export function ScanPanel({
         >
           <AlertTriangle className="mt-0.5 size-4 shrink-0 text-fg-quaternary" />
           <span>{ARCHIVED_REASON} Scans, new findings and triage changes are disabled.</span>
+        </div>
+      )}
+
+      {!lifecycleBlocked && explicitAuthorizationIncomplete && (
+        <div role="status" className="flex items-start justify-between gap-3 rounded-lg border border-medium/40 bg-medium/10 p-3 text-xs text-medium">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+            <div>
+              <p className="font-semibold">Scan authorization required.</p>
+              <p className="mt-1 text-secondary">
+                {!authorizationWindowConfigured && !scaAllowed
+                  ? 'Set both authorization window bounds and allow SCA tools before scanning this Re-test.'
+                  : !authorizationWindowConfigured
+                    ? 'Set both authorization window bounds before scanning this Re-test.'
+                    : 'Allow SCA tools before scanning this Re-test.'}
+              </p>
+            </div>
+          </div>
+          <Link to={`/engagements/${encodeURIComponent(eng.id)}/settings`} className="shrink-0 font-semibold text-brand-secondary hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand">
+            Configure in Settings
+          </Link>
         </div>
       )}
 

--- a/web/src/pages/EngagementDetail/ScanRunsTab.test.tsx
+++ b/web/src/pages/EngagementDetail/ScanRunsTab.test.tsx
@@ -79,4 +79,33 @@ describe('ScanRunsTab', () => {
     render(<ScanRunsTab engagementId="eng-001" />)
     expect(await screen.findByText('No scan runs yet')).toBeInTheDocument()
   })
+
+  it('renders each run immutable archive without replacing old evidence with the newest source', async () => {
+    const first = run('run-first', '2026-09-01T00:00:00Z', 100, ['first'])
+    const second = run('run-second', '2026-09-08T00:00:00Z', 100, ['second'])
+    first.sourcePackage = { versionId: 'source-v1', filename: 'original.zip', size: 1024, sha256: 'a'.repeat(64), target: '', uploadedBy: 'alice', uploadedAt: '2026-09-01T00:00:00Z' }
+    second.sourcePackage = { versionId: 'source-v2', filename: 'updated.zip', size: 2048, sha256: 'b'.repeat(64), target: '', uploadedBy: 'bob', uploadedAt: '2026-09-08T00:00:00Z' }
+    vi.mocked(api.scanRuns).mockResolvedValue([first, second])
+    render(<ScanRunsTab engagementId="eng-001" />)
+    expect(await screen.findByText('original.zip')).toBeVisible()
+    expect(screen.getByText('updated.zip')).toBeVisible()
+    expect(screen.getByLabelText(`Source SHA-256 ${'a'.repeat(64)}`)).toBeVisible()
+    expect(screen.getByLabelText(`Source SHA-256 ${'b'.repeat(64)}`)).toBeVisible()
+    expect(screen.getByText(/Uploaded by alice/)).toBeVisible()
+    expect(screen.getByText(/Uploaded by bob/)).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Scan run run-first' })).toHaveTextContent('original.zip')
+    expect(screen.getByRole('button', { name: 'Scan run run-first' })).not.toHaveTextContent('updated.zip')
+  })
+
+  it('labels legacy missing source metadata neutrally and keeps non-upload target kinds', async () => {
+    vi.mocked(api.scanRuns).mockResolvedValue([
+      { ...run('legacy', '2026-09-01T00:00:00Z', 0, []), provenance: 'legacy' },
+      { ...run('git-run', '2026-09-02T00:00:00Z', 100, []), targetKind: 'git', target: 'https://example.test/repo' },
+      { ...run('image-run', '2026-09-03T00:00:00Z', 100, []), targetKind: 'image', target: 'example/image@sha256:abc' },
+    ])
+    render(<ScanRunsTab engagementId="eng-001" />)
+    expect(await screen.findByText('Source metadata unavailable')).toBeVisible()
+    expect(screen.getByText('git target · https://example.test/repo')).toBeVisible()
+    expect(screen.getByText('image target · example/image@sha256:abc')).toBeVisible()
+  })
 })

--- a/web/src/pages/EngagementDetail/ScanRunsTab.tsx
+++ b/web/src/pages/EngagementDetail/ScanRunsTab.tsx
@@ -13,6 +13,7 @@ import { Button, Card, EmptyState, ErrorState, Pill, Spinner, cn } from '../../c
 import { useParallelFetch } from '../../hooks'
 import { api } from '../../lib/api'
 import type { ScanDrift, ScanRun } from '../../lib/types'
+import { SourcePackageSummary } from '../../components/synapse/SourcePackageSummary'
 
 // A scan run's reproducibility score maps to a semantic tone: a run built entirely
 // from pinned inputs (100) is reproducible; a run with live inputs (osv.dev) is not.
@@ -111,6 +112,11 @@ function RunRow({
         <Pill>{pinned} pinned</Pill>
         {unpinned > 0 && <Pill className="text-warning-primary">{unpinned} live</Pill>}
       </span>
+      <div className="w-full border-t border-secondary pt-2">
+        <p className="mb-1 text-xs font-semibold text-secondary">Source recorded for this run</p>
+        {run.sourcePackage ? <SourcePackageSummary source={run.sourcePackage} /> :
+          <p className="text-xs text-tertiary">{run.targetKind && run.targetKind !== 'upload' ? `${run.targetKind} target` : 'Source metadata unavailable'}{run.targetKind && run.targetKind !== 'upload' && run.target ? ` · ${run.target}` : ''}</p>}
+      </div>
     </button>
   )
 }

--- a/web/src/pages/EngagementDetail/index.tsx
+++ b/web/src/pages/EngagementDetail/index.tsx
@@ -9,6 +9,7 @@ import {
   ShieldTick,
   ShieldZap,
   Sliders04,
+  SwitchHorizontal01,
   Target04,
 } from '@untitledui/icons'
 import { Button, cn, EmptyState, Spinner } from '../../components/ui'
@@ -53,6 +54,9 @@ import { SettingsTab } from './SettingsTab'
 import { JudgmentReviewTab } from './ReviewsTab'
 import { ARCHIVED_REASON, isReadOnly } from './readOnly'
 
+import { AssessmentComparisonTab } from './AssessmentComparisonTab'
+import { AssessmentLifecyclePanel } from './AssessmentLifecyclePanel'
+
 // Lazy-loaded so React Flow stays out of the initial bundle (only the Graph tab needs it).
 const DependencyGraphTab = lazy(() => import('../DependencyGraph').then((m) => ({ default: m.DependencyGraphTab })))
 
@@ -60,6 +64,8 @@ export type Tab =
   | 'overview'
   | 'findings'
   | 'imported'
+
+  | 'comparison'
   | 'sla'
   | 'risk-stories'
   | 'vuln-posture'
@@ -115,6 +121,11 @@ export const TAB_GROUPS: TabGroupDefinition[] = [
       { id: 'vuln-posture', label: 'Vuln Posture' },
       { id: 'sla', label: 'Remediation SLA' },
     ],
+  },
+  {
+    id: 'comparison',
+    label: 'Comparison',
+    icon: SwitchHorizontal01,
   },
   {
     id: 'supply-chain',
@@ -266,8 +277,11 @@ export function EngagementDetail() {
     () => api.importedSBOM(id).catch(() => null),
     { deps: [id] },
   )
-  const { data: uploadedSource } = useFetch<UploadedSourcePackage | null>(
-    () => api.uploadedSource(id).catch(() => null),
+  const { data: uploadedSource, error: uploadedSourceError, refetch: refetchUploadedSource } = useFetch<UploadedSourcePackage | null>(
+    () => api.uploadedSource(id).catch((error) => {
+      if (error instanceof ApiError && error.status === 404) return null
+      throw error
+    }),
     { deps: [id] },
   )
 
@@ -395,12 +409,14 @@ export function EngagementDetail() {
         <ExportButtons engagementId={eng.id} scan={scan} onChanged={refreshAll} />
       </div>
 
-      {/* Single Unified Hero Card for Engagement Details and Scan Console */}
-      <div className="bg-hero rounded-2xl border border-secondary p-5 sm:p-6 shadow-xs space-y-4">
+      {/* Keep the Engagement identity first; lifecycle is supporting context below the scan console. */}
+      <section aria-label="Engagement summary" className="bg-hero rounded-2xl border border-secondary p-5 sm:p-6 shadow-xs space-y-4">
         <ScanPanel
           eng={eng}
           importedSBOM={importedSBOM}
           uploadedSource={uploadedSource}
+          uploadedSourceError={uploadedSourceError}
+          onRetryUploadedSource={refetchUploadedSource}
           initialError={scanStartError}
           onImportedSBOMChanged={refreshAll}
           job={job}
@@ -416,7 +432,8 @@ export function EngagementDetail() {
             }
           }}
         />
-      </div>
+        <AssessmentLifecyclePanel assessmentId={id} engagementStatus={eng.status} />
+      </section>
 
       {/* 2-Tier Navigation Section. Sticky so a tab switch does not leave the
           reader hunting for the content below a tall hero. */}
@@ -529,6 +546,8 @@ export function EngagementDetail() {
         {tab === 'sla' && <SLATab key={id} engagementId={id} findings={findings} />}
         {tab === 'risk-stories' && <RiskStoriesTab key={id} engagementId={id} />}
         {tab === 'vuln-posture' && <VulnPostureTab key={id} engagementId={id} />}
+
+        {tab === 'comparison' && <AssessmentComparisonTab assessmentId={id} />}
         {tab === 'components' && <ComponentsTab scan={scan} />}
         {tab === 'vulns' && <VulnsTab scan={scan} />}
         {tab === 'graph' && (

--- a/web/src/pages/Engagements/Engagements.test.tsx
+++ b/web/src/pages/Engagements/Engagements.test.tsx
@@ -93,7 +93,7 @@ describe('Engagements', () => {
       id: 'eng-upload', name: 'Uploaded assessment', client: '', status: 'draft',
       inScope: [{ kind: 'repo', value: `uploaded-source/sha256/${'b'.repeat(64)}` }], outOfScope: [],
       authorizedFrom: null, authorizedTo: null, roe: { allowedToolClasses: [], blackouts: [] },
-      liveReconEnabled: false, createdAt: '2026-08-28T00:00:00Z', businessAssetId: '',
+      liveReconEnabled: false, requiresExplicitExecutionAuthorization: false, createdAt: '2026-08-28T00:00:00Z', businessAssetId: '',
     }
     vi.mocked(api.createEngagementFromSource).mockResolvedValue(created)
     vi.mocked(api.startScan).mockResolvedValue({
@@ -135,6 +135,7 @@ describe('Engagements', () => {
         authorizedTo: null,
         roe: { allowedToolClasses: [], blackouts: [] },
         liveReconEnabled: false,
+        requiresExplicitExecutionAuthorization: false,
         createdAt: '2026-08-20T10:00:00Z',
         businessAssetId: 'a1',
       },
@@ -149,6 +150,7 @@ describe('Engagements', () => {
         authorizedTo: null,
         roe: { allowedToolClasses: [], blackouts: [] },
         liveReconEnabled: false,
+        requiresExplicitExecutionAuthorization: false,
         createdAt: '2026-08-10T10:00:00Z',
         businessAssetId: '',
       },

--- a/web/src/pages/Engagements/NewEngagementPage.tsx
+++ b/web/src/pages/Engagements/NewEngagementPage.tsx
@@ -1,10 +1,12 @@
 import type { FC } from 'react'
 import { Link, useNavigate, useSearchParams } from 'react-router-dom'
+import { useOptionalAuth } from '../../auth/AuthContext'
 import { CreateEngagementForm } from './components/CreateEngagementForm'
 
 export const NewEngagementPage: FC = () => {
   const [searchParams] = useSearchParams()
   const navigate = useNavigate()
+  const auth = useOptionalAuth()
   const initialAssetId = searchParams.get('assetId') ?? ''
 
   return (
@@ -31,11 +33,16 @@ export const NewEngagementPage: FC = () => {
       {/* Form */}
       <CreateEngagementForm
         initialAssetId={initialAssetId}
-        onCreated={(engagement, sourceMode, scanStartError) => {
-          if (sourceMode === 'upload') {
+        assessmentLifecycleEnabled={auth?.currentUser?.features?.assessmentLifecycleUIDefault === true}
+        onCreated={(engagement, creationKind, scanStartError) => {
+          if (creationKind === 'upload') {
             navigate(`/engagements/${encodeURIComponent(engagement.id)}`, {
               state: scanStartError ? { scanStartError } : undefined,
             })
+            return
+          }
+          if (creationKind === 'retest') {
+            navigate(`/engagements/${encodeURIComponent(engagement.id)}`)
             return
           }
           navigate('/engagements')

--- a/web/src/pages/Engagements/components/CreateEngagementForm.test.tsx
+++ b/web/src/pages/Engagements/components/CreateEngagementForm.test.tsx
@@ -1,0 +1,185 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { api, ApiError } from '../../../lib/api'
+import type { AssessmentCycleSummary } from '../../../lib/types'
+import { CreateEngagementForm } from './CreateEngagementForm'
+
+vi.mock('../../../lib/api', async (importOriginal) => ({
+  ...await importOriginal<typeof import('../../../lib/api')>(),
+  api: {
+    listBusinessAssets: vi.fn(),
+    listProjects: vi.fn(),
+    listAssessmentCycles: vi.fn(),
+    listAssessmentCycleMembers: vi.fn(),
+    createRetest: vi.fn(),
+    uploadedSource: vi.fn(),
+    getEngagement: vi.fn(),
+    createEngagement: vi.fn(),
+    createEngagementFromSource: vi.fn(),
+    startScan: vi.fn(),
+  },
+}))
+
+const cycle: AssessmentCycleSummary = {
+  id: 'cycle-1', name: 'Payments Cycle', boundaryKind: 'asset_project', businessAssetId: 'asset-1', projectId: 'project-1', status: 'open',
+  rootAssessmentId: 'assessment-0', selectedHeadAssessmentId: 'assessment-1', activeClosureManifestId: '', activeClosureCycleVersion: 0,
+  nextRetestNumber: 2, version: 3, createdAt: '2026-08-20T00:00:00Z', updatedAt: '2026-09-01T00:00:00Z', createdBy: 'operator', updatedBy: 'operator',
+  memberCount: 2, activeBranchCount: 1, latestAssessmentId: 'assessment-1', latestRetestNumber: 1,
+  members: [
+    { assessmentId: 'assessment-0', assessmentStatus: 'completed', assessmentType: 'initial', predecessorAssessmentId: '', retestNumber: 0, relationshipVersion: 1, createdAt: '2026-08-20T00:00:00Z', createdBy: 'operator', archivedAt: null },
+    { assessmentId: 'assessment-1', assessmentStatus: 'completed', assessmentType: 'retest', predecessorAssessmentId: 'assessment-0', retestNumber: 1, relationshipVersion: 1, createdAt: '2026-08-25T00:00:00Z', createdBy: 'operator', archivedAt: null },
+  ],
+  membersNextCursor: '', rootSnapshotId: 'snapshot-0', currentSnapshotId: 'snapshot-1', comparisonId: 'comparison-1', comparisonStatus: 'complete', comparisonSummary: null,
+  selectedHeadLastScanAt: '2026-09-01T00:00:00Z', scanStaleness: 'fresh',
+}
+
+describe('CreateEngagementForm Re-test purpose', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(api.listProjects).mockResolvedValue([])
+    vi.mocked(api.listBusinessAssets).mockResolvedValue({ items: [], total: 0, limit: 200, offset: 0 })
+    vi.mocked(api.listAssessmentCycles).mockResolvedValue({ items: [cycle], nextCursor: '', migrationPending: [], migrationPendingTotal: 0 })
+    vi.mocked(api.uploadedSource).mockResolvedValue(null as never)
+  })
+
+  it('submits only lifecycle input and reuses the idempotency key for a draft retry', async () => {
+    vi.mocked(api.createRetest).mockRejectedValue(new Error('temporary network failure'))
+    render(<CreateEngagementForm assessmentLifecycleEnabled onCreated={vi.fn()} />)
+
+    fireEvent.click(screen.getByRole('radio', { name: /Re-test existing assessment/ }))
+    expect(await screen.findByRole('combobox', { name: 'Based on Assessment' })).toHaveTextContent('Payments Cycle · Re-test #1')
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Save non-executable draft' })).toBeEnabled())
+    fireEvent.change(screen.getByRole('textbox', { name: /Name/ }), { target: { value: 'Payments verification' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save non-executable draft' }))
+    expect(await screen.findByText('temporary network failure')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Save non-executable draft' }))
+
+    await waitFor(() => expect(api.createRetest).toHaveBeenCalledTimes(2))
+    const first = vi.mocked(api.createRetest).mock.calls[0]
+    const second = vi.mocked(api.createRetest).mock.calls[1]
+    expect(first?.[0]).toBe('assessment-1')
+    expect(first?.[1]).toMatchObject({ name: 'Payments verification', predecessorAssessmentId: 'assessment-1', scopeStrategy: 'copy', profileStrategy: 'none', authorizedFrom: '', authorizedTo: '', roe: undefined })
+    expect(first?.[1]?.idempotencyKey).toBeTruthy()
+    expect(second?.[1]?.idempotencyKey).toBe(first?.[1]?.idempotencyKey)
+    expect(first?.[1]).not.toHaveProperty('cycleId')
+    expect(first?.[1]).not.toHaveProperty('boundaryKind')
+  })
+
+  it('only offers completed members even when the selected head is still a draft', async () => {
+    vi.mocked(api.listAssessmentCycles).mockResolvedValue({
+      items: [{ ...cycle, members: cycle.members.map((member) => ({ ...member, assessmentStatus: member.assessmentId === 'assessment-1' ? 'draft' : 'completed' })) }],
+      nextCursor: '', migrationPending: [], migrationPendingTotal: 0,
+    })
+    vi.mocked(api.createRetest).mockRejectedValue(new Error('expected test rejection'))
+    render(<CreateEngagementForm assessmentLifecycleEnabled onCreated={vi.fn()} />)
+    fireEvent.click(screen.getByRole('radio', { name: /Re-test existing assessment/ }))
+    expect(await screen.findByRole('combobox', { name: 'Based on Assessment' })).toHaveTextContent('Payments Cycle · Initial')
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Save non-executable draft' })).toBeEnabled())
+    fireEvent.change(screen.getByRole('textbox', { name: /Name/ }), { target: { value: 'New branch' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save non-executable draft' }))
+    await waitFor(() => expect(api.createRetest).toHaveBeenCalledWith('assessment-0', expect.objectContaining({ predecessorAssessmentId: 'assessment-0' })))
+    expect(api.listAssessmentCycles).toHaveBeenCalledWith({ status: 'open', limit: 50 })
+  })
+
+  it('hydrates paged members and offers completed predecessors outside the inline preview', async () => {
+    vi.mocked(api.listAssessmentCycles).mockResolvedValue({ items: [{ ...cycle, members: [], membersNextCursor: 'inline-next' }], nextCursor: '', migrationPending: [], migrationPendingTotal: 0 })
+    vi.mocked(api.listAssessmentCycleMembers).mockResolvedValue({ items: cycle.members, nextCursor: '' })
+    render(<CreateEngagementForm assessmentLifecycleEnabled onCreated={vi.fn()} />)
+    fireEvent.click(screen.getByRole('radio', { name: /Re-test existing assessment/ }))
+    expect(await screen.findByRole('combobox', { name: 'Based on Assessment' })).toHaveTextContent('Payments Cycle · Re-test #1')
+    expect(api.listAssessmentCycleMembers).toHaveBeenCalledWith('cycle-1', '', 100)
+  })
+
+  it('blocks the authorized action without a separate window and tool classes', async () => {
+    render(<CreateEngagementForm assessmentLifecycleEnabled onCreated={vi.fn()} />)
+    fireEvent.click(screen.getByRole('radio', { name: /Re-test existing assessment/ }))
+    await screen.findByRole('combobox', { name: 'Based on Assessment' })
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Save non-executable draft' })).toBeEnabled())
+    fireEvent.change(screen.getByRole('textbox', { name: /Name/ }), { target: { value: 'New Re-test' } })
+    fireEvent.submit(screen.getByRole('textbox', { name: /Name/ }).closest('form')!)
+    expect(await screen.findByText('Enter a separate authorization window and allowed tool classes, or save a non-executable draft.')).toBeInTheDocument()
+    expect(api.createRetest).not.toHaveBeenCalled()
+  })
+
+  it('reuses the current uploaded source for a draft and gives edited requests a different key', async () => {
+    vi.mocked(api.uploadedSource).mockResolvedValue({
+      versionId: 'version-current', filename: 'current.zip', size: 1234, sha256: 'a'.repeat(64), target: '', uploadedBy: 'alice', uploadedAt: '2026-09-08T00:00:00Z',
+    })
+    vi.mocked(api.createRetest).mockRejectedValue(new Error('temporary network failure'))
+    render(<CreateEngagementForm assessmentLifecycleEnabled onCreated={vi.fn()} />)
+    fireEvent.click(screen.getByRole('radio', { name: /Re-test existing assessment/ }))
+    expect(await screen.findByRole('radio', { name: /Use current source/ })).toBeChecked()
+    expect(api.uploadedSource).toHaveBeenCalledWith('assessment-1')
+    fireEvent.change(screen.getByRole('textbox', { name: /Name/ }), { target: { value: 'Current source verification' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save non-executable draft' }))
+    expect(await screen.findByText('temporary network failure')).toBeInTheDocument()
+    const first = vi.mocked(api.createRetest).mock.calls[0]?.[1]
+    expect(first).toMatchObject({ sourceStrategy: 'reuse_current', sourceVersionId: 'version-current', source: undefined, authorizedFrom: '', authorizedTo: '' })
+    fireEvent.change(screen.getByRole('textbox', { name: /Name/ }), { target: { value: 'Renamed source verification' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save non-executable draft' }))
+    await waitFor(() => expect(api.createRetest).toHaveBeenCalledTimes(2))
+    expect(vi.mocked(api.createRetest).mock.calls[1]?.[1]?.idempotencyKey).not.toBe(first?.idempotencyKey)
+  })
+
+  it('requires a new archive only after selecting upload and never starts a Re-test scan automatically', async () => {
+    vi.mocked(api.uploadedSource).mockResolvedValue({
+      versionId: 'version-current', filename: 'current.zip', size: 1234, sha256: 'a'.repeat(64), target: '', uploadedBy: 'alice', uploadedAt: '2026-09-08T00:00:00Z',
+    })
+    vi.mocked(api.createRetest).mockResolvedValue({ engagement: { id: 'new-retest' } } as never)
+    const onCreated = vi.fn()
+    render(<CreateEngagementForm assessmentLifecycleEnabled onCreated={onCreated} />)
+    fireEvent.click(screen.getByRole('radio', { name: /Re-test existing assessment/ }))
+    fireEvent.click(await screen.findByRole('radio', { name: /Upload new source/ }))
+    fireEvent.change(screen.getByRole('textbox', { name: /Name/ }), { target: { value: 'New source verification' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save non-executable draft' }))
+    expect(await screen.findByText('Choose a source archive to upload.')).toBeInTheDocument()
+    expect(api.createRetest).not.toHaveBeenCalled()
+    const file = new File(['new revision'], 'updated.tar.gz')
+    fireEvent.change(screen.getByLabelText('Re-test source archive'), { target: { files: [file] } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save non-executable draft' }))
+    await waitFor(() => expect(api.createRetest).toHaveBeenCalledWith('assessment-1', expect.objectContaining({ source: file, sourceStrategy: 'upload_new', sourceVersionId: undefined })))
+    expect(onCreated).toHaveBeenCalledWith({ id: 'new-retest' }, 'retest')
+    expect(api.startScan).not.toHaveBeenCalled()
+  })
+
+  it('creates a child with a new archive when the predecessor package was lost', async () => {
+    vi.mocked(api.uploadedSource).mockRejectedValue(new ApiError(404, 'No source package'))
+    vi.mocked(api.getEngagement).mockResolvedValue({ inScope: [{ kind: 'repo', value: `uploaded-source/sha256/${'a'.repeat(64)}` }] } as never)
+    vi.mocked(api.createRetest).mockResolvedValue({ engagement: { id: 'new-retest' } } as never)
+    render(<CreateEngagementForm assessmentLifecycleEnabled onCreated={vi.fn()} />)
+    fireEvent.click(screen.getByRole('radio', { name: /Re-test existing assessment/ }))
+    expect(await screen.findByRole('radio', { name: /Use current source/ })).toBeDisabled()
+    expect(screen.getByRole('radio', { name: /Upload new source/ })).toBeChecked()
+    expect(api.getEngagement).toHaveBeenCalledWith('assessment-1')
+    fireEvent.change(screen.getByRole('textbox', { name: /Name/ }), { target: { value: 'Replacement source verification' } })
+    const file = new File(['new revision'], 'replacement.zip')
+    fireEvent.change(screen.getByLabelText('Re-test source archive'), { target: { files: [file] } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save non-executable draft' }))
+    await waitFor(() => expect(api.createRetest).toHaveBeenCalledWith('assessment-1', expect.objectContaining({
+      predecessorAssessmentId: 'assessment-1', scopeStrategy: 'copy', source: file, sourceStrategy: 'upload_new', sourceVersionId: undefined,
+    })))
+    expect(api.startScan).not.toHaveBeenCalled()
+  })
+
+  it('hides Re-test controls outside the tenant lifecycle rollout', () => {
+    render(<CreateEngagementForm onCreated={vi.fn()} />)
+    expect(screen.queryByRole('radio', { name: /Re-test existing assessment/ })).not.toBeInTheDocument()
+  })
+
+  it('reuses one idempotency key when an initial Assessment request is retried', async () => {
+    vi.mocked(api.createEngagement).mockRejectedValue(new Error('temporary network failure'))
+    render(<CreateEngagementForm onCreated={vi.fn()} />)
+
+    fireEvent.change(screen.getByRole('textbox', { name: /Name/ }), { target: { value: 'Initial assessment' } })
+    fireEvent.change(screen.getByRole('textbox', { name: 'Target value for row 1' }), { target: { value: 'app.example.com' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Create Engagement' }))
+    expect(await screen.findByText('temporary network failure')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Create Engagement' }))
+
+    await waitFor(() => expect(api.createEngagement).toHaveBeenCalledTimes(2))
+    const firstKey = vi.mocked(api.createEngagement).mock.calls[0]?.[1]
+    const secondKey = vi.mocked(api.createEngagement).mock.calls[1]?.[1]
+    expect(firstKey).toBeTruthy()
+    expect(secondKey).toBe(firstKey)
+  })
+})

--- a/web/src/pages/Engagements/components/CreateEngagementForm.tsx
+++ b/web/src/pages/Engagements/components/CreateEngagementForm.tsx
@@ -1,25 +1,32 @@
 import { useEffect, useMemo, useState, type FC, type FormEvent } from 'react'
 import { Check, Link01, Plus, Trash01, Upload01 } from '@untitledui/icons'
 import { api } from '../../../lib/api'
+import { useRequestIdempotency } from '../../../hooks/useRequestIdempotency'
+import { useRetestSource } from '../../../hooks/useRetestSource'
+import { RetestSourceChoice } from '../../../components/synapse/RetestSourceChoice'
 import { kindLabel } from '../../../lib/format'
-import type { BusinessAsset, Engagement, ScopeTarget } from '../../../lib/types'
+import type { AssessmentCycleSummary, BusinessAsset, Engagement, Project, ScopeTarget } from '../../../lib/types'
 import { Select } from '../../../components/ui'
 
 const KINDS = ['repo', 'domain', 'host', 'url', 'image', 'cidr']
 const MAX_SOURCE_BYTES = 512 * 1024 * 1024
 type SourceMode = 'linked' | 'upload'
+type CreationKind = SourceMode | 'retest'
 
 export interface CreateEngagementFormProps {
   initialAssetId?: string
-  onCreated: (engagement: Engagement, sourceMode: SourceMode, scanStartError?: string) => void
+  assessmentLifecycleEnabled?: boolean
+  onCreated: (engagement: Engagement, creationKind: CreationKind, scanStartError?: string) => void
 }
 
 export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
   initialAssetId,
+  assessmentLifecycleEnabled = false,
   onCreated,
 }) => {
   const [name, setName] = useState('')
   const [client, setClient] = useState('')
+  const [purpose, setPurpose] = useState<'initial' | 'retest'>('initial')
   const [sourceMode, setSourceMode] = useState<SourceMode>('linked')
   const [sourceFile, setSourceFile] = useState<File | null>(null)
   const [scope, setScope] = useState<ScopeTarget[]>([{ kind: 'repo', value: '' }])
@@ -29,6 +36,34 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
   const [error, setError] = useState<string | null>(null)
   const [assets, setAssets] = useState<BusinessAsset[]>([])
   const [assetId, setAssetId] = useState(initialAssetId ?? '')
+  const [projects, setProjects] = useState<Project[]>([])
+  const [assessmentProjectId, setAssessmentProjectId] = useState('')
+  const [projectsLoading, setProjectsLoading] = useState(false)
+  const [projectsError, setProjectsError] = useState('')
+  const [projectRetry, setProjectRetry] = useState(0)
+  const [eligibleCycles, setEligibleCycles] = useState<AssessmentCycleSummary[]>([])
+  const [eligibleCursor, setEligibleCursor] = useState('')
+  const [eligibleRetry, setEligibleRetry] = useState(0)
+  const [eligibleLoading, setEligibleLoading] = useState(false)
+  const [eligibleError, setEligibleError] = useState('')
+  const [basedOnAssessmentId, setBasedOnAssessmentId] = useState('')
+  const [toolClasses, setToolClasses] = useState('')
+  const initialRequestKey = useRequestIdempotency()
+  const retestRequestKey = useRequestIdempotency()
+  const retestSource = useRetestSource(purpose === 'retest' ? basedOnAssessmentId : '')
+
+  useEffect(() => {
+    if (!assessmentLifecycleEnabled) return
+    let live = true
+    setProjectsLoading(true)
+    setProjectsError('')
+    api.listProjects().then((items) => {
+      if (live) setProjects(items)
+    }).catch(() => {
+      if (live) setProjectsError('Could not load Projects. Retry to choose an association.')
+    }).finally(() => { if (live) setProjectsLoading(false) })
+    return () => { live = false }
+  }, [assessmentLifecycleEnabled, projectRetry])
 
   useEffect(() => {
     let live = true
@@ -51,6 +86,37 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
     }
   }, [initialAssetId])
 
+  useEffect(() => {
+    if (purpose !== 'retest') return
+    let live = true
+    setEligibleLoading(true)
+    setEligibleError('')
+    api.listAssessmentCycles({ status: 'open', limit: 50 })
+      .then(async (result) => ({
+        ...result,
+        items: await Promise.all(result.items.map(async (cycle) => {
+          if (!cycle.membersNextCursor) return cycle
+          const members = await api.listAssessmentCycleMembers(cycle.id, '', 100)
+          return { ...cycle, members: members.items, membersNextCursor: members.nextCursor }
+        })),
+      }))
+      .then((result) => {
+        if (!live) return
+        setEligibleCycles(result.items)
+        setEligibleCursor(result.nextCursor)
+        const ids = result.items.flatMap((cycle) => cycle.members.filter((member) => !member.archivedAt && member.assessmentStatus === 'completed').map((member) => member.assessmentId))
+        setBasedOnAssessmentId((current) => (ids.includes(current) ? current : (ids.includes(result.items[0]?.selectedHeadAssessmentId) ? result.items[0].selectedHeadAssessmentId : ids[0]) ?? ''))
+      })
+      .catch((cause) => {
+        if (!live) return
+        setEligibleCycles([])
+        setBasedOnAssessmentId('')
+        setEligibleError(cause instanceof Error ? cause.message : 'Eligible Assessment lookup failed.')
+      })
+      .finally(() => { if (live) setEligibleLoading(false) })
+    return () => { live = false }
+  }, [purpose, eligibleRetry])
+
   const assetOptions = useMemo(() => [
     { value: '__unassigned__', label: 'Unassigned' },
     ...assets.map((asset) => ({
@@ -63,6 +129,34 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
     value: kind,
     label: kindLabel(kind),
   })), [])
+  const predecessorOptions = useMemo(() => {
+    const seen = new Set<string>()
+    return eligibleCycles.flatMap((cycle) => cycle.members.filter((member) => !member.archivedAt && member.assessmentStatus === 'completed' && !seen.has(member.assessmentId)).map((member) => {
+      seen.add(member.assessmentId)
+      return { value: member.assessmentId, label: `${cycle.name} · ${member.assessmentType === 'retest' ? `Re-test #${member.retestNumber}` : 'Initial'} · ${member.assessmentId}` }
+    }))
+  }, [eligibleCycles])
+
+  async function loadMoreEligible() {
+    if (!eligibleCursor || eligibleLoading) return
+    setEligibleLoading(true)
+    setEligibleError('')
+    try {
+      const page = await api.listAssessmentCycles({ status: 'open', limit: 50, cursor: eligibleCursor })
+      const cycles = await Promise.all(page.items.map(async (cycle) => {
+        if (!cycle.membersNextCursor) return cycle
+        const members = await api.listAssessmentCycleMembers(cycle.id, '', 100)
+        return { ...cycle, members: members.items, membersNextCursor: members.nextCursor }
+      }))
+      setEligibleCycles((current) => [...current, ...cycles])
+      setEligibleCursor(page.nextCursor)
+      setBasedOnAssessmentId((current) => current || cycles.flatMap((cycle) => cycle.members).find((member) => !member.archivedAt && member.assessmentStatus === 'completed')?.assessmentId || '')
+    } catch (cause) {
+      setEligibleError(cause instanceof Error ? cause.message : 'Eligible Assessment lookup failed.')
+    } finally {
+      setEligibleLoading(false)
+    }
+  }
 
   function setRow(index: number, patch: Partial<ScopeTarget>) {
     setScope((rows) => rows.map((row, rowIndex) => (rowIndex === index ? { ...row, ...patch } : row)))
@@ -86,26 +180,46 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
 
   async function handleSubmit(event: FormEvent) {
     event.preventDefault()
+    await submit(false)
+  }
+
+  async function submit(draft: boolean) {
     const inScope = sourceMode === 'linked' ? scope.filter((row) => row.value.trim() !== '') : []
     if (!name.trim()) {
       setError('Name is required.')
       return
     }
-    if (sourceMode === 'linked' && inScope.length === 0) {
+    if (purpose === 'retest' && !basedOnAssessmentId) {
+      setError('Choose an eligible completed Assessment in an open Cycle.')
+      return
+    }
+    if (purpose === 'retest') {
+      const sourceError = retestSource.validationError('copy')
+      if (sourceError) { setError(sourceError); return }
+    }
+    if (purpose === 'initial' && sourceMode === 'linked' && inScope.length === 0) {
       setError('Add at least one in-scope target.')
       return
     }
-    if (sourceMode === 'upload' && !sourceFile) {
+    if (purpose === 'initial' && sourceMode === 'upload' && !sourceFile) {
       setError('Choose a source package to upload.')
       return
     }
-    if (assetId && !assets.some((asset) => asset.id === assetId)) {
+    if (purpose === 'initial' && assetId && !assets.some((asset) => asset.id === assetId)) {
       setError('Select a valid Asset.')
       return
     }
+    if (purpose === 'retest' && !draft && (!authFrom || !authTo || !toolClasses.split(',').some((value) => value.trim()))) {
+      setError('Enter a separate authorization window and allowed tool classes, or save a non-executable draft.')
+      return
+    }
+    if ((!draft || purpose !== 'retest') && [authFrom, authTo].some((value) => value && Number.isNaN(new Date(value).getTime()))) {
+      setError('Enter valid authorization dates.')
+      return
+    }
     const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
-    const from = authFrom ? new Date(authFrom).toISOString() : undefined
-    const to = authTo ? new Date(authTo).toISOString() : undefined
+    const from = (purpose !== 'retest' || !draft) && authFrom ? new Date(authFrom).toISOString() : undefined
+    const to = (purpose !== 'retest' || !draft) && authTo ? new Date(authTo).toISOString() : undefined
     if (from && to && new Date(from) >= new Date(to)) {
       setError('Authorization start must be before end.')
       return
@@ -114,6 +228,17 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
     setSubmitting(true)
     setError(null)
     try {
+      if (purpose === 'retest') {
+        const input = {
+          name: name.trim(), predecessorAssessmentId: basedOnAssessmentId, scopeStrategy: 'copy' as const, profileStrategy: 'none' as const,
+          authorizedFrom: draft ? '' : from ?? '', authorizedTo: draft ? '' : to ?? '', timezone: timezone || 'UTC',
+          roe: draft ? undefined : { allowedToolClasses: toolClasses.split(',').map((value) => value.trim()).filter(Boolean), blackouts: [] },
+          ...retestSource.input,
+        }
+        const result = await api.createRetest(basedOnAssessmentId, { ...input, idempotencyKey: retestRequestKey(input, input.source) })
+        onCreated(result.engagement, 'retest')
+        return
+      }
       const input = {
         name: name.trim(),
         client: client.trim(),
@@ -123,10 +248,11 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
         authorizedTo: to,
         timezone: from || to ? timezone : undefined,
         assetId,
+        assessmentProjectId: assessmentLifecycleEnabled ? assessmentProjectId : undefined,
       }
       const engagement = sourceMode === 'upload'
-        ? await api.createEngagementFromSource(input, sourceFile!)
-        : await api.createEngagement(input)
+        ? await api.createEngagementFromSource(input, sourceFile!, initialRequestKey(input, sourceFile!))
+        : await api.createEngagement(input, initialRequestKey(input))
       if (sourceMode === 'upload') {
         try {
           await api.startScan(engagement.id, '', 'upload')
@@ -162,6 +288,16 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
             </span>
             Assessment context
           </div>
+          <div role="radiogroup" aria-label="Assessment purpose" className="mb-4 grid gap-3 sm:grid-cols-2">
+            <label className="flex cursor-pointer gap-3 rounded-xl border border-secondary bg-secondary/30 p-4">
+              <input type="radio" name="assessment-purpose" checked={purpose === 'initial'} disabled={submitting} onChange={() => { setPurpose('initial'); setError(null) }} className="mt-1 size-4 accent-brand-solid" />
+              <span><span className="block text-sm font-semibold text-primary">Initial assessment</span><span className="mt-1 block text-xs text-tertiary">Create a new standalone or Asset-bound Cycle.</span></span>
+            </label>
+            {assessmentLifecycleEnabled ? <label className="flex cursor-pointer gap-3 rounded-xl border border-secondary bg-secondary/30 p-4">
+              <input type="radio" name="assessment-purpose" checked={purpose === 'retest'} disabled={submitting} onChange={() => { setPurpose('retest'); setError(null) }} className="mt-1 size-4 accent-brand-solid" />
+              <span><span className="block text-sm font-semibold text-primary">Re-test existing assessment</span><span className="mt-1 block text-xs text-tertiary">Cycle, boundary, type, scope, and profile are server-derived.</span></span>
+            </label> : null}
+          </div>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
             <div>
               <label htmlFor="engagement-name-input" className="block text-xs font-medium text-secondary">
@@ -180,6 +316,7 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
               />
             </div>
 
+            {purpose === 'initial' ? <>
             <div>
               <label htmlFor="engagement-client-input" className="block text-xs font-medium text-secondary">
                 Client <span className="text-tertiary">(Optional)</span>
@@ -208,11 +345,32 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
                 className="mt-1.5 h-10 w-full border-primary bg-primary shadow-xs"
               />
             </div>
+            {assessmentLifecycleEnabled ? <div>
+              <label htmlFor="engagement-project-select" className="block text-xs font-medium text-secondary">
+                Project <span className="text-tertiary">(Optional)</span>
+              </label>
+              <Select id="engagement-project-select" ariaLabel="Assessment Project" disabled={submitting || projectsLoading || Boolean(projectsError)}
+                value={assessmentProjectId || '__unassigned__'} onValueChange={(value) => setAssessmentProjectId(value === '__unassigned__' ? '' : value)}
+                options={[{ value: '__unassigned__', label: 'No Project' }, ...projects.map((project) => ({ value: project.id, label: project.name }))]}
+                className="mt-1.5 h-10 w-full border-primary bg-primary shadow-xs" />
+              {projectsLoading ? <p role="status" className="mt-1.5 text-xs text-tertiary">Loading Projects…</p> : null}
+              {projectsError ? <p role="alert" className="mt-1.5 text-xs text-error-primary">{projectsError} <button type="button" disabled={submitting} onClick={() => setProjectRetry((value) => value + 1)} className="font-medium underline">Retry</button></p> : null}
+              {!projectsLoading && !projectsError && projects.length === 0 ? <p className="mt-1.5 text-xs text-tertiary">No Projects available. You can create an Assessment without one.</p> : null}
+              <p className="mt-1.5 text-xs text-tertiary">Asset and Project become fixed for this Cycle. A selected Project must belong to the selected Asset.</p>
+            </div> : null}
+            </> : <div className="sm:col-span-1 xl:col-span-2">
+              <label className="block text-xs font-medium text-secondary">Based on Assessment <span className="text-utility-red-600">*</span></label>
+              {predecessorOptions.length ? <Select ariaLabel="Based on Assessment" disabled={submitting || eligibleLoading} value={basedOnAssessmentId || predecessorOptions[0]!.value} onValueChange={(value) => { setBasedOnAssessmentId(value); setError(null) }} options={predecessorOptions} className="mt-1.5 h-10 w-full border-primary bg-primary shadow-xs" /> : null}
+              {eligibleLoading ? <p role="status" className="mt-1.5 text-xs text-tertiary">Loading eligible completed Assessments…</p> : null}
+              {!eligibleLoading && !eligibleError && predecessorOptions.length === 0 ? <p role="status" className="mt-1.5 text-xs text-warning">No eligible completed Assessment in the loaded Cycles. Reopen the Cycle first if it is completed.</p> : null}
+              {eligibleError ? <div role="alert" className="mt-1.5 text-xs text-error-primary">{eligibleError} <button type="button" disabled={eligibleLoading} className="underline" onClick={() => eligibleCursor ? loadMoreEligible() : setEligibleRetry((value) => value + 1)}>Retry</button></div> : null}
+              {eligibleCursor ? <button type="button" disabled={eligibleLoading || submitting} onClick={loadMoreEligible} className="mt-2 text-sm font-semibold text-brand-secondary underline disabled:opacity-50">Load more Cycles</button> : null}
+            </div>}
           </div>
         </div>
 
         {/* Step 2: Source */}
-        <div className="border-t border-secondary pt-6">
+        {purpose === 'initial' ? <div className="border-t border-secondary pt-6">
           <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-primary">
             <span className="flex size-6 items-center justify-center rounded-full bg-brand-solid text-xs font-bold text-white">
               2
@@ -334,7 +492,7 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
               </div>
             )}
           </div>
-        </div>
+        </div> : <div className="border-t border-secondary pt-6"><div className="mb-3 flex items-center gap-2 text-sm font-semibold text-primary"><span className="flex size-6 items-center justify-center rounded-full bg-brand-solid text-xs font-bold text-white">2</span>Derived lifecycle context</div><div className="rounded-xl border border-secondary bg-secondary/30 p-4 text-sm text-secondary"><p><strong>Assessment type:</strong> Re-test</p><p className="mt-1"><strong>Scope/profile:</strong> copied only by the server contract; no Cycle or boundary selector is writable.</p></div><div className="mt-4"><RetestSourceChoice selection={retestSource} disabled={submitting} onChange={() => setError(null)} /></div></div>}
 
         {/* Step 3: Authorization Window */}
         <div className="border-t border-secondary pt-6">
@@ -373,19 +531,21 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
                 className="mt-1.5 w-full rounded-lg border border-primary bg-primary px-3.5 py-2 text-sm text-primary shadow-xs outline-none focus:border-brand focus:ring-2 focus:ring-brand/20 disabled:cursor-not-allowed disabled:opacity-50"
               />
             </div>
+            {purpose === 'retest' ? <div className="sm:col-span-2"><label htmlFor="retest-tool-classes" className="block text-xs font-medium text-secondary">Allowed tool classes <span className="text-tertiary">(Required for executable authorization)</span></label><input id="retest-tool-classes" value={toolClasses} disabled={submitting} onChange={(event) => setToolClasses(event.target.value)} placeholder="sca, sast" className="mt-1.5 w-full rounded-lg border border-primary bg-primary px-3.5 py-2 text-sm text-primary shadow-xs outline-none focus:border-brand focus:ring-2 focus:ring-brand/20 disabled:cursor-not-allowed disabled:opacity-50" /><p className="mt-1.5 text-xs text-tertiary">Planned dates never authorize execution. Missing, expired, reversed, or invalid authorization/RoE remains a non-executable draft.</p></div> : null}
           </div>
         </div>
 
         {error && (
-          <div className="rounded-lg border border-utility-red-200 bg-utility-red-50 p-3 text-xs font-medium text-utility-red-700 dark:border-utility-red-800 dark:bg-utility-red-950/40 dark:text-utility-red-300">
+          <div role="alert" className="rounded-lg border border-utility-red-200 bg-utility-red-50 p-3 text-xs font-medium text-utility-red-700 dark:border-utility-red-800 dark:bg-utility-red-950/40 dark:text-utility-red-300">
             {error}
           </div>
         )}
 
-        <div className="flex items-center justify-end gap-3 border-t border-secondary pt-6">
+        <div className="flex flex-wrap items-center justify-end gap-3 border-t border-secondary pt-6">
+          {purpose === 'retest' ? <button type="button" disabled={submitting || eligibleLoading || retestSource.loading || Boolean(retestSource.error)} onClick={() => submit(true)} className="inline-flex items-center justify-center rounded-lg border border-secondary bg-primary px-4 py-2.5 text-sm font-semibold text-secondary shadow-xs transition hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-brand/30 disabled:cursor-not-allowed disabled:opacity-50">Save non-executable draft</button> : null}
           <button
             type="submit"
-            disabled={submitting}
+            disabled={submitting || purpose === 'retest' && (eligibleLoading || retestSource.loading || Boolean(retestSource.error))}
             className="inline-flex items-center justify-center gap-2 rounded-lg bg-brand-solid px-4 py-2.5 text-sm font-semibold text-white shadow-xs transition hover:bg-brand-solid_hover focus:outline-none focus:ring-2 focus:ring-brand/30 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {submitting ? (
@@ -393,7 +553,7 @@ export const CreateEngagementForm: FC<CreateEngagementFormProps> = ({
             ) : (
               <Check className="size-4" />
             )}
-            {sourceMode === 'upload' ? 'Create & Scan' : 'Create Engagement'}
+            {purpose === 'retest' ? 'Create Re-test' : sourceMode === 'upload' ? 'Create & Scan' : 'Create Engagement'}
           </button>
         </div>
       </form>

--- a/web/src/pages/Settings/AssessmentRelationships.test.tsx
+++ b/web/src/pages/Settings/AssessmentRelationships.test.tsx
@@ -1,0 +1,122 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApiError, api } from '../../lib/api'
+import type { AssessmentRelationshipCandidate } from '../../lib/types'
+import { AssessmentRelationships } from './AssessmentRelationships'
+
+vi.mock('../../lib/api', () => {
+  class MockApiError extends Error {
+    constructor(public status: number, message: string) {
+      super(message)
+      this.name = 'ApiError'
+    }
+  }
+  return {
+    ApiError: MockApiError,
+    api: {
+      listAssessmentRelationshipCandidates: vi.fn(),
+      generateAssessmentRelationshipCandidate: vi.fn(),
+      decideAssessmentRelationshipCandidate: vi.fn(),
+    },
+  }
+})
+
+const candidate: AssessmentRelationshipCandidate = {
+  id: 'candidate-1',
+  predecessorCycleId: 'cycle-predecessor',
+  predecessorAssessmentId: 'assessment-predecessor',
+  predecessorRelationshipVersion: 1,
+  predecessorSnapshotId: 'snapshot-predecessor',
+  successorCycleId: 'cycle-successor',
+  successorAssessmentId: 'assessment-successor',
+  successorRelationshipVersion: 1,
+  successorSnapshotId: 'snapshot-successor',
+  boundaryKeyHash: 'b'.repeat(64),
+  signals: [
+    { kind: 'exact_frozen_boundary', evidenceHash: 'b'.repeat(64), matchCount: 0, scoreMilli: 0, schemaVersion: 1 },
+    { kind: 'explicit_imported_reference', evidenceHash: 'a'.repeat(64), matchCount: 1, scoreMilli: 1000, schemaVersion: 1 },
+  ],
+  inputHash: 'c'.repeat(64),
+  confidence: 'medium',
+  status: 'open',
+  version: 1,
+  expiresAt: '2026-10-01T12:00:00Z',
+  createdBy: 'operator',
+  createdAt: '2026-09-01T12:00:00Z',
+}
+
+const confirmed: AssessmentRelationshipCandidate = {
+  ...candidate,
+  status: 'confirmed',
+  version: 2,
+  decision: { id: 'decision-1', action: 'confirm', actor: 'reviewer', reason: 'Validated deterministic evidence', version: 2, createdAt: '2026-09-01T12:05:00Z' },
+  repairPlan: {
+    id: 'plan-1', inputHash: candidate.inputHash, planHash: 'd'.repeat(64), createdBy: 'reviewer', createdAt: '2026-09-01T12:05:00Z',
+    body: { command: 'assessment_cycle.merge_legacy_relationship', execution: 'blocked', requires: 'separately_approved_move_merge_command' },
+  },
+}
+
+describe('Assessment relationship settings', () => {
+  beforeEach(() => vi.resetAllMocks())
+
+  it('renders loading and empty states with accessible generation controls', async () => {
+    let resolveList: (items: AssessmentRelationshipCandidate[]) => void = () => undefined
+    vi.mocked(api.listAssessmentRelationshipCandidates).mockReturnValue(new Promise((resolve) => { resolveList = resolve }))
+
+    render(<AssessmentRelationships />)
+
+    expect(screen.getByText('Loading relationship candidates…')).toBeInTheDocument()
+    expect(screen.getByLabelText('Predecessor Cycle ID')).toBeRequired()
+    expect(screen.getByLabelText('Successor Cycle ID')).toBeRequired()
+    expect(screen.getByLabelText(/Imported reference SHA-256/)).toHaveAttribute('pattern', '[0-9a-f]{64}')
+    expect(screen.getByRole('combobox', { name: 'Filter relationship candidates by status' })).toBeInTheDocument()
+
+    await act(async () => resolveList([]))
+    expect(await screen.findByText('No relationship candidates')).toBeInTheDocument()
+  })
+
+  it('renders an error and retries the queue load', async () => {
+    vi.mocked(api.listAssessmentRelationshipCandidates).mockRejectedValueOnce(new ApiError(403, 'forbidden')).mockResolvedValueOnce([])
+
+    render(<AssessmentRelationships />)
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Review permission is required')
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(await screen.findByText('No relationship candidates')).toBeInTheDocument()
+    expect(api.listAssessmentRelationshipCandidates).toHaveBeenCalledTimes(2)
+  })
+
+  it('reviews and confirms a candidate with an audit reason', async () => {
+    const user = userEvent.setup()
+    vi.mocked(api.listAssessmentRelationshipCandidates).mockResolvedValue([candidate])
+    vi.mocked(api.decideAssessmentRelationshipCandidate).mockResolvedValue(confirmed)
+
+    render(<AssessmentRelationships />)
+
+    expect(await screen.findByText(candidate.id)).toBeInTheDocument()
+    expect(screen.getByLabelText('Candidate evidence signals')).toHaveTextContent('Exact frozen boundary')
+    await user.click(screen.getByRole('button', { name: 'Review candidate' }))
+    const reason = screen.getByLabelText('Audit reason')
+    await user.type(reason, 'Validated deterministic evidence')
+    await user.click(screen.getByRole('button', { name: 'Confirm and seal plan' }))
+
+    await waitFor(() => expect(api.decideAssessmentRelationshipCandidate).toHaveBeenCalledWith(candidate, 'confirm', 'Validated deterministic evidence'))
+    expect(await screen.findByText(`Candidate ${candidate.id} was confirmed.`)).toBeInTheDocument()
+  })
+
+  it('refreshes the queue after a decision conflict', async () => {
+    const user = userEvent.setup()
+    vi.mocked(api.listAssessmentRelationshipCandidates).mockResolvedValueOnce([candidate]).mockResolvedValueOnce([{ ...candidate, version: 1 }])
+    vi.mocked(api.decideAssessmentRelationshipCandidate).mockRejectedValue(new ApiError(409, 'version conflict'))
+
+    render(<AssessmentRelationships />)
+
+    await user.click(await screen.findByRole('button', { name: 'Review candidate' }))
+    await user.type(screen.getByLabelText('Audit reason'), 'Conflicting review')
+    await user.click(screen.getByRole('button', { name: 'Reject' }))
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('changed or expired')
+    await waitFor(() => expect(api.listAssessmentRelationshipCandidates).toHaveBeenCalledTimes(2))
+  })
+})

--- a/web/src/pages/Settings/AssessmentRelationships.tsx
+++ b/web/src/pages/Settings/AssessmentRelationships.tsx
@@ -1,0 +1,228 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Link01 } from '@untitledui/icons'
+import { ApiError, api } from '../../lib/api'
+import type {
+  AssessmentRelationshipCandidate,
+  AssessmentRelationshipDecisionAction,
+  AssessmentRelationshipStatus,
+} from '../../lib/types'
+import { Button, Card, EmptyState, ErrorState, Input, Pill, Select, Spinner } from '../../components/ui'
+
+const STATUS_OPTIONS = [
+  { value: 'open', label: 'Open candidates' },
+  { value: 'all', label: 'All candidates' },
+  { value: 'confirmed', label: 'Confirmed' },
+  { value: 'rejected', label: 'Rejected' },
+  { value: 'dismissed', label: 'Dismissed' },
+  { value: 'expired', label: 'Expired' },
+]
+
+const SIGNAL_LABELS: Record<string, string> = {
+  exact_frozen_boundary: 'Exact frozen boundary',
+  explicit_imported_reference: 'Imported reference',
+  trusted_manifest_compatible: 'Trusted manifest match',
+  deterministic_finding_overlap: 'Deterministic finding overlap',
+}
+
+function message(error: unknown): string {
+  if (error instanceof ApiError && error.status === 403) return 'Review permission is required to access relationship candidates.'
+  if (error instanceof Error) return error.message
+  return 'The relationship review queue could not be loaded.'
+}
+
+export function AssessmentRelationships() {
+  const [status, setStatus] = useState<AssessmentRelationshipStatus | 'all'>('open')
+  const [items, setItems] = useState<AssessmentRelationshipCandidate[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  const [notice, setNotice] = useState('')
+  const [predecessorCycleId, setPredecessorCycleId] = useState('')
+  const [successorCycleId, setSuccessorCycleId] = useState('')
+  const [importedReferenceHash, setImportedReferenceHash] = useState('')
+  const [generating, setGenerating] = useState(false)
+  const [selectedId, setSelectedId] = useState('')
+  const [reason, setReason] = useState('')
+  const [busy, setBusy] = useState<AssessmentRelationshipDecisionAction | ''>('')
+
+  const load = useCallback(async (preserveError = false) => {
+    setLoading(true)
+    if (!preserveError) setError('')
+    try {
+      setItems(await api.listAssessmentRelationshipCandidates(status))
+    } catch (caught) {
+      setError(message(caught))
+    } finally {
+      setLoading(false)
+    }
+  }, [status])
+
+  useEffect(() => { void load() }, [load])
+
+  async function generate(event: React.FormEvent) {
+    event.preventDefault()
+    setGenerating(true)
+    setError('')
+    setNotice('')
+    try {
+      const candidate = await api.generateAssessmentRelationshipCandidate({
+        predecessorCycleId: predecessorCycleId.trim(),
+        successorCycleId: successorCycleId.trim(),
+        importedReferenceHash: importedReferenceHash.trim() || undefined,
+      })
+      setNotice(`Candidate ${candidate.id} is ready for review.`)
+      setPredecessorCycleId('')
+      setSuccessorCycleId('')
+      setImportedReferenceHash('')
+      if (status === 'open' || status === 'all') {
+        setItems((current) => [candidate, ...current.filter((item) => item.id !== candidate.id)])
+      }
+    } catch (caught) {
+      setError(message(caught))
+    } finally {
+      setGenerating(false)
+    }
+  }
+
+  async function decide(candidate: AssessmentRelationshipCandidate, action: AssessmentRelationshipDecisionAction) {
+    if (reason.trim().length < 3) {
+      setError('An audit reason of at least 3 characters is required.')
+      return
+    }
+    setBusy(action)
+    setError('')
+    setNotice('')
+    try {
+      const updated = await api.decideAssessmentRelationshipCandidate(candidate, action, reason.trim())
+      setItems((current) => current.map((item) => item.id === updated.id ? updated : item).filter((item) => status === 'all' || item.status === status))
+      setSelectedId('')
+      setReason('')
+      setNotice(`Candidate ${candidate.id} was ${updated.status}.`)
+    } catch (caught) {
+      if (caught instanceof ApiError && caught.status === 409) {
+        setError('This candidate changed or expired. The queue has been refreshed; review the latest state before retrying.')
+        await load(true)
+      } else {
+        setError(message(caught))
+      }
+    } finally {
+      setBusy('')
+    }
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-primary">Historical relationship review</h2>
+          <p className="mt-1 max-w-3xl text-sm text-tertiary">
+            Review deterministic candidates between singleton Assessment Cycles. Confirmation seals a blocked repair plan and never changes the Cycle graph.
+          </p>
+        </div>
+        <Select
+          ariaLabel="Filter relationship candidates by status"
+          value={status}
+          onValueChange={(value) => setStatus(value as AssessmentRelationshipStatus | 'all')}
+          options={STATUS_OPTIONS}
+          className="w-48"
+        />
+      </div>
+
+      <Card title="Generate candidate">
+        <form className="grid gap-4 lg:grid-cols-[1fr_1fr_1.4fr_auto] lg:items-end" onSubmit={generate}>
+          <label className="space-y-1.5 text-sm font-medium text-secondary">
+            Predecessor Cycle ID
+            <Input required value={predecessorCycleId} onChange={(event) => setPredecessorCycleId(event.target.value)} autoComplete="off" />
+          </label>
+          <label className="space-y-1.5 text-sm font-medium text-secondary">
+            Successor Cycle ID
+            <Input required value={successorCycleId} onChange={(event) => setSuccessorCycleId(event.target.value)} autoComplete="off" />
+          </label>
+          <label className="space-y-1.5 text-sm font-medium text-secondary">
+            Imported reference SHA-256 (optional)
+            <Input
+              value={importedReferenceHash}
+              onChange={(event) => setImportedReferenceHash(event.target.value)}
+              pattern="[0-9a-f]{64}"
+              minLength={64}
+              maxLength={64}
+              autoComplete="off"
+              aria-describedby="relationship-reference-hint"
+            />
+            <span id="relationship-reference-hint" className="block text-xs font-normal text-quaternary">Raw imported metadata is never submitted or stored.</span>
+          </label>
+          <Button type="submit" loading={generating}>Generate</Button>
+        </form>
+      </Card>
+
+      <div aria-live="polite" className="space-y-3">
+        {notice ? <p className="rounded-lg border border-success/30 bg-success/10 px-4 py-3 text-sm text-success">{notice}</p> : null}
+        {error && (loading || items.length > 0) ? <p role="alert" className="rounded-lg border border-critical/30 bg-critical/10 px-4 py-3 text-sm text-critical">{error}</p> : null}
+      </div>
+
+      {loading ? <Spinner label="Loading relationship candidates…" /> : null}
+      {!loading && error && items.length === 0 ? <div className="space-y-3"><ErrorState message={error} /><Button variant="secondary" onClick={() => void load()}>Retry</Button></div> : null}
+      {!loading && !error && items.length === 0 ? (
+        <EmptyState icon={Link01} title="No relationship candidates" hint="Generate a candidate only when exact boundary plus deterministic evidence is available." />
+      ) : null}
+
+      {!loading && items.length > 0 ? (
+        <div className="space-y-4">
+          {items.map((candidate) => {
+            const selected = selectedId === candidate.id
+            return (
+              <Card
+                key={candidate.id}
+                title={<span className="font-mono text-xs">{candidate.id}</span>}
+                actions={<div className="flex gap-2"><Pill>{candidate.confidence}</Pill><Pill>{candidate.status}</Pill></div>}
+                bodyClass="space-y-4"
+              >
+                <dl className="grid gap-3 text-sm md:grid-cols-2">
+                  <div><dt className="text-xs font-semibold uppercase tracking-wide text-quaternary">Proposed predecessor</dt><dd className="mt-1 font-mono text-xs text-secondary">{candidate.predecessorCycleId}<br />{candidate.predecessorAssessmentId}</dd></div>
+                  <div><dt className="text-xs font-semibold uppercase tracking-wide text-quaternary">Proposed successor</dt><dd className="mt-1 font-mono text-xs text-secondary">{candidate.successorCycleId}<br />{candidate.successorAssessmentId}</dd></div>
+                </dl>
+                <div className="flex flex-wrap gap-2" aria-label="Candidate evidence signals">
+                  {candidate.signals.map((signal) => <Pill key={signal.kind}>{SIGNAL_LABELS[signal.kind] ?? signal.kind}{signal.matchCount ? ` · ${signal.matchCount}` : ''}</Pill>)}
+                </div>
+                <p className="text-xs text-quaternary">Expires {new Date(candidate.expiresAt).toLocaleString()} · input <span className="font-mono">{candidate.inputHash}</span></p>
+
+                {candidate.repairPlan ? (
+                  <details className="rounded-lg border border-secondary bg-secondary/30 p-3">
+                    <summary className="cursor-pointer text-sm font-semibold text-primary">Blocked repair plan</summary>
+                    <pre className="mt-3 overflow-x-auto whitespace-pre-wrap break-all text-xs text-secondary">{JSON.stringify(candidate.repairPlan.body, null, 2)}</pre>
+                  </details>
+                ) : null}
+
+                {candidate.status === 'open' ? (
+                  selected ? (
+                    <div className="space-y-3 rounded-lg border border-secondary bg-secondary/30 p-4">
+                      <label className="block space-y-1.5 text-sm font-medium text-secondary">
+                        Audit reason
+                        <textarea
+                          className="min-h-24 w-full rounded-lg border border-primary bg-primary px-3 py-2 text-sm text-primary outline-none focus:ring-2 focus:ring-brand/50"
+                          value={reason}
+                          onChange={(event) => setReason(event.target.value)}
+                          maxLength={2000}
+                          required
+                        />
+                      </label>
+                      <div className="flex flex-wrap gap-2">
+                        <Button loading={busy === 'confirm'} onClick={() => void decide(candidate, 'confirm')}>Confirm and seal plan</Button>
+                        <Button variant="danger" loading={busy === 'reject'} onClick={() => void decide(candidate, 'reject')}>Reject</Button>
+                        <Button variant="secondary" loading={busy === 'dismiss'} onClick={() => void decide(candidate, 'dismiss')}>Dismiss</Button>
+                        <Button variant="ghost" onClick={() => { setSelectedId(''); setReason(''); setError('') }}>Cancel</Button>
+                      </div>
+                    </div>
+                  ) : <Button variant="secondary" onClick={() => { setSelectedId(candidate.id); setReason(''); setError('') }}>Review candidate</Button>
+                ) : candidate.decision ? (
+                  <p className="rounded-lg bg-secondary px-3 py-2 text-sm text-secondary"><strong>{candidate.decision.action}</strong> by {candidate.decision.actor}: {candidate.decision.reason}</p>
+                ) : null}
+              </Card>
+            )
+          })}
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export default AssessmentRelationships

--- a/web/src/pages/Settings/Settings.test.tsx
+++ b/web/src/pages/Settings/Settings.test.tsx
@@ -22,6 +22,8 @@ describe('Settings Layout', () => {
     expect(screen.getByRole('link', { name: 'Audit' })).toHaveAttribute('href', '/settings')
     expect(screen.getByRole('link', { name: 'Team' })).toHaveAttribute('href', '/settings/team')
     expect(screen.getByRole('link', { name: 'Integrations' })).toHaveAttribute('href', '/settings/integrations')
+
+    expect(screen.getByRole('link', { name: 'Relationships' })).toHaveAttribute('href', '/settings/relationships')
     expect(screen.getByRole('link', { name: 'Config' })).toHaveAttribute('href', '/settings/config')
     expect(screen.getByText('Audit Log Content')).toBeInTheDocument()
   })

--- a/web/src/pages/Settings/Settings.tsx
+++ b/web/src/pages/Settings/Settings.tsx
@@ -10,6 +10,8 @@ const TABS = [
   { label: 'Offensive policy', to: '/settings/offensive-policy' },
   { label: 'Alerting', to: '/settings/alerting' },
   { label: 'Telemetry Privacy', to: '/settings/privacy' },
+
+  { label: 'Relationships', to: '/settings/relationships' },
   { label: 'Config', to: '/settings/config' },
 ]
 
@@ -19,7 +21,7 @@ export function Settings() {
       <header>
         <h1 className="text-2xl font-bold tracking-tight text-primary sm:text-display-xs">Settings</h1>
         <p className="mt-1 text-sm text-secondary">
-          Audit trail, team management, external integrations, and platform configuration
+          Audit trail, team management, external integrations, assessment relationships, and platform configuration
         </p>
       </header>
 


### PR DESCRIPTION
Add assessment cycle pages, lifecycle comparisons, closure and relationship review, and immutable-source choices in retest creation. Preserve local UI behavior and main navigation.

Phase 9/10. Base: `codex/868-phase-09-api-worker-integration`. Keep #868 as tracking/reference only; do not merge it.

## Review follow-up: migration 0145 collision

Addressed the new review on #884 and the dependent holds on #885–#893. Main `9a7bae2d` includes #921's `0145_advisory_alias_index.sql`; the entire unmerged assessment block moves from 0145–0159 to **0146–0160**. #884 adds only 0146; #885 adds 0147–0160. All 15 assessment SQL bodies and their relative order are preserved. Existing main migrations (including 0145), core ScanRun and governed response/correlation code remain unchanged.

Updated migration test filenames and embedded-file references, Goose UpTo/DownTo targets, upgrade fixtures from main version 0145, diagnostics, and operational documentation. The complete payload is preserved through an explicit old/new filename map; runtime assessment code is unchanged by renumbering. Each PR still contains one capability commit against its immediate predecessor.

## Validation

Local validation after this update: all 10 phases passed scoped tests and repository-wide Go builds; the final stack passed repository-wide Go tests and vet. Isolated PostgreSQL 17 tests passed for duplicate migration inventory, authoritative main migrations, assessment upgrade/rollback paths, tenant isolation, immutable evidence and source bindings. Frontend typecheck, 116 test files / 694 tests, production build and lint passed (0 errors, 10 existing warnings); Helm lint/render assertions passed. CI is disabled, so these are explicitly local results. Final GitHub heads, bases and incremental file diffs are checked against the tested commits.

## Stack merge order

#884 → #885 → #886 → #887 → #888 → #889 → #890 → #891 → #892 → #893

Merge #884 first, then proceed in order. Prefer merge commits to retain ancestry; after each predecessor merges, retarget the next PR to `main` and inspect its remaining diff. Branch names remain stable. See the [preservation and migration audit](https://github.com/KKloudTarus/synapse-ce/blob/codex/868-phase-11-operations-docs/docs/architecture/assessment-stack-868-audit.md).
