### PR TITLE
fix(ownsbom): skip TOML comments and strings in uv.lock edge scan

### DIFF
--- a/internal/infrastructure/tools/ownsbom/uv.go
+++ b/internal/infrastructure/tools/ownsbom/uv.go
@@ -87,20 +87,45 @@ func uvRegistrySource(value string) bool {
 // uvDependencyNames extracts the dependency package names from a uv.lock `dependencies` inline-table array
 // (`[{ name = "a" }, { name = "b", marker = "..." }]`), which may span several lines. Each entry's name is
 // uv's always-first field, read as the first quoted string of the object, so an `extra = [...]` or `marker`
-// field on the same entry is ignored. `{`/`}` depth delimits entries; the array's own `[]` are not counted
-// here (the caller handles multi-line accumulation).
+// field on the same entry is ignored. The scan is TOML comment- and string-aware: a `{`/`}` (or a `name`
+// token) inside a basic ("...") or literal ('...') string, or after an unquoted `#` comment, is NOT treated
+// as structure, so a commented-out `# { name = "x" }` entry or a marker string containing a brace never
+// produces a false edge. `{`/`}` depth delimits top-level entries; the array's own `[]` are ignored here (the
+// caller handles multi-line accumulation).
 func uvDependencyNames(arrayText string) []string {
 	var names []string
+	var inBasic, inLiteral bool
 	depth := 0
 	start := -1
 	for i := 0; i < len(arrayText); i++ {
-		switch arrayText[i] {
-		case '{':
+		c := arrayText[i]
+		switch {
+		case inBasic:
+			if c == '\\' { // skip an escaped char inside a basic string
+				i++
+				continue
+			}
+			if c == '"' {
+				inBasic = false
+			}
+		case inLiteral:
+			if c == '\'' {
+				inLiteral = false
+			}
+		case c == '#': // a comment runs to end of line; its bytes are not structure
+			for i < len(arrayText) && arrayText[i] != '\n' {
+				i++
+			}
+		case c == '"':
+			inBasic = true
+		case c == '\'':
+			inLiteral = true
+		case c == '{':
 			if depth == 0 {
 				start = i + 1
 			}
 			depth++
-		case '}':
+		case c == '}':
 			if depth > 0 {
 				depth--
 				if depth == 0 && start >= 0 {
@@ -113,6 +138,43 @@ func uvDependencyNames(arrayText string) []string {
 		}
 	}
 	return names
+}
+
+// uvNetBrackets returns the net count of '[' minus ']' in one line, ignoring brackets inside a basic
+// ("...") or literal ('...') string and after an unquoted '#' comment. It drives multi-line array
+// termination so a marker/comment containing a bracket cannot end the array early or hold it open. TOML
+// basic/literal strings do not span lines in a dependency array, so string state is per line.
+func uvNetBrackets(line string) int {
+	net := 0
+	var inBasic, inLiteral bool
+	for i := 0; i < len(line); i++ {
+		c := line[i]
+		switch {
+		case inBasic:
+			if c == '\\' {
+				i++
+				continue
+			}
+			if c == '"' {
+				inBasic = false
+			}
+		case inLiteral:
+			if c == '\'' {
+				inLiteral = false
+			}
+		case c == '#':
+			return net // comment to end of line
+		case c == '"':
+			inBasic = true
+		case c == '\'':
+			inLiteral = true
+		case c == '[':
+			net++
+		case c == ']':
+			net--
+		}
+	}
+	return net
 }
 
 // uvFirstName reads the `name = "..."` value from a dependency inline-table object's content. uv always
@@ -186,7 +248,7 @@ func (UV) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.De
 		if collectingDeps {
 			depsText.WriteString(raw)
 			depsText.WriteByte('\n')
-			bracket += strings.Count(raw, "[") - strings.Count(raw, "]")
+			bracket += uvNetBrackets(raw)
 			if bracket <= 0 {
 				finishDeps()
 			}
@@ -220,7 +282,7 @@ func (UV) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.De
 				depsText.Reset()
 				depsText.WriteString(value)
 				depsText.WriteByte('\n')
-				bracket = strings.Count(value, "[") - strings.Count(value, "]")
+				bracket = uvNetBrackets(value)
 				if bracket <= 0 {
 					finishDeps()
 				} else {

--- a/internal/infrastructure/tools/ownsbom/uv_test.go
+++ b/internal/infrastructure/tools/ownsbom/uv_test.go
@@ -659,3 +659,33 @@ source = { registry = "https://pypi.org/simple" }`
 		t.Errorf("want 0 dependencies, got %+v", doc.Dependencies)
 	}
 }
+
+// A commented-out dependency entry, or a marker string containing brace/bracket bytes, must not produce a
+// false edge or break array termination (TOML comment/string awareness).
+func TestUVParseIgnoresCommentedAndQuotedDependencies(t *testing.T) {
+	fixture := `[[package]]
+name = "app"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    # { name = "evil" }
+    { name = "real", marker = "platform_release == '{'" },
+]
+
+[[package]]
+name = "evil"
+version = "9.9.9"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "real"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }`
+	_, deps := parseUVTest(t, "uv.lock", fixture)
+	if len(deps) != 1 || deps[0].Ref != "pkg:pypi/app@1.0.0" {
+		t.Fatalf("want one edge from app, got %+v", deps)
+	}
+	if len(deps[0].DependsOn) != 1 || deps[0].DependsOn[0] != "pkg:pypi/real@2.0.0" {
+		t.Errorf("want app -> real@2.0.0 only (evil is commented out), got %v", deps[0].DependsOn)
+	}
+}


### PR DESCRIPTION
## What

Fix-forward for the uv.lock dependency-graph edges added in #882. The dependency-array scanner counted `{}`/`[]` bytes without regard for TOML comments or quoted strings, so:

- a commented-out `# { name = "evil" }` entry inside a `dependencies` array was read as a real inline table and emitted a **false edge**, and
- a marker string containing a bracket (`marker = "platform_release == '{'"`) could end or hold open the multi-line array at the wrong point.

A false edge corrupts `PathToRoot` and the introducing-dependency set, which the owned engine must never invent.

## Fix

Both the entry scan (`uvDependencyNames`) and the multi-line array termination (`uvNetBrackets`) are now comment- and string-aware: a `{`/`}`/`[`/`]`/`name`/`#` byte inside a basic (`"..."`) or literal (`'...'`) string, or after an unquoted `#` to end of line, is no longer treated as structure. Escapes inside a basic string are honored.

## Tests

`TestUVParseIgnoresCommentedAndQuotedDependencies` asserts a commented-out entry produces no edge and a brace inside a marker string does not break termination (the real dependency still resolves). Existing uv edge tests unchanged. Gate green: build, `CGO_ENABLED=0` cmd build, vet, golangci-lint (0 issues), full ownsbom suite.

## Review

Found by the Codex read-only reviewer on the #882 change (a defect my own review missed); this fix was then re-reviewed by Codex and returned SOUND.
