### PR TITLE
feat(sca): preserve dependency scope per edge

### DIFF
--- a/internal/infrastructure/tools/ownsbom/cargo.go
+++ b/internal/infrastructure/tools/ownsbom/cargo.go
@@ -119,7 +119,9 @@ func (Cargo) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom
 		return "", false // unresolvable (not in the lock, or ambiguous without a version) -> no edge
 	}
 
-	// Pass 2: emit components + resolve edges.
+	// Pass 2: emit components + resolve edges. Cargo.lock does not encode dependency kinds per edge, so the
+	// relationship inherits the lockfile's path-derived base scope; direct dev roots then carry development
+	// through ReachableScopes to their transitive descendants.
 	set := newComponentSet()
 	var deps []sbom.Dependency
 	for _, p := range pkgs {
@@ -142,7 +144,7 @@ func (Cargo) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom
 			}
 		}
 		if len(on) > 0 {
-			deps = append(deps, sbom.Dependency{Ref: ref, DependsOn: on})
+			deps = append(deps, sbom.Dependency{Ref: ref, DependsOn: on, Scope: scope})
 		}
 	}
 	return set.components(), deps, nil
@@ -151,8 +153,8 @@ func (Cargo) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom
 // cargoDevDeps reads the companion Cargo.toml beside Cargo.lock (if present) and returns the set of DIRECT
 // [dev-dependencies] names, so the lock's resolved crates can be scoped dev vs prod. Best-effort – no
 // manifest, or an unreadable one, yields no dev refinement (everything stays prod/path-scoped). Their
-// transitive dev-deps stay prod (Cargo.lock is a flat resolved set; precise dev-transitivity needs the
-// graph) – same limitation as the Syft path, which Cargo.lock's lack of a dev flag forces.
+// transitive dev-deps are later classified by graph scope propagation, which preserves development along
+// every path rooted at a direct dev dependency.
 func cargoDevDeps(dir string) map[string]bool {
 	dev := map[string]bool{}
 	if dir == "" {

--- a/internal/infrastructure/tools/ownsbom/conan.go
+++ b/internal/infrastructure/tools/ownsbom/conan.go
@@ -160,8 +160,10 @@ func (Conan) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom
 		}
 	}
 
-	// Pass 2: Aggregate valid dependency edges according to PURL identity, ignoring self-edges.
-	edgesByRef := make(map[string]map[string]struct{})
+	// Pass 2: aggregate valid edges by PURL identity while preserving the relationship kind. A Conan
+	// requires edge is production/path-scoped; build_requires is development (or the enclosing background
+	// path). If the same target appears in both lists, the production relationship wins.
+	edgesByRef := make(map[string]map[string]string)
 	for _, id := range nodeIDs {
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
@@ -171,40 +173,50 @@ func (Conan) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom
 			continue
 		}
 		node := lock.GraphLock.Nodes[id]
-		targetIDs := make([]string, 0, len(node.Requires)+len(node.BuildRequires))
-		targetIDs = append(targetIDs, node.Requires...)
-		targetIDs = append(targetIDs, node.BuildRequires...)
-
-		for _, targetID := range targetIDs {
+		addEdge := func(targetID, scope string) {
 			target := nodePURL[targetID]
 			if target == "" || target == source {
-				continue
+				return
 			}
 			if edgesByRef[source] == nil {
-				edgesByRef[source] = make(map[string]struct{})
+				edgesByRef[source] = make(map[string]string)
 			}
-			edgesByRef[source][target] = struct{}{}
+			old, exists := edgesByRef[source][target]
+			if !exists || scope == prod || old == "" {
+				edgesByRef[source][target] = scope
+			}
+		}
+		for _, targetID := range node.Requires {
+			addEdge(targetID, prod)
+		}
+		for _, targetID := range node.BuildRequires {
+			addEdge(targetID, dev)
 		}
 	}
 
-	// Materialize deterministic graph edges
+	// Materialize deterministic graph edges, split by scope because Dependency metadata applies to the
+	// whole DependsOn group.
 	var deps []sbom.Dependency
 	refs := make([]string, 0, len(edgesByRef))
 	for ref := range edgesByRef {
-		refs = append(refs, ref) // every entry has at least one target by construction
+		refs = append(refs, ref)
 	}
 	sort.Strings(refs)
-
 	for _, ref := range refs {
-		dependsOn := make([]string, 0, len(edgesByRef[ref]))
-		for target := range edgesByRef[ref] {
-			dependsOn = append(dependsOn, target)
+		byScope := map[string][]string{}
+		for target, scope := range edgesByRef[ref] {
+			byScope[scope] = append(byScope[scope], target)
 		}
-		sort.Strings(dependsOn)
-		deps = append(deps, sbom.Dependency{
-			Ref:       ref,
-			DependsOn: dependsOn,
-		})
+		scopes := make([]string, 0, len(byScope))
+		for scope := range byScope {
+			scopes = append(scopes, scope)
+		}
+		sort.Strings(scopes)
+		for _, scope := range scopes {
+			dependsOn := byScope[scope]
+			sort.Strings(dependsOn)
+			deps = append(deps, sbom.Dependency{Ref: ref, DependsOn: dependsOn, Scope: scope})
+		}
 	}
 
 	comps := set.components()

--- a/internal/infrastructure/tools/ownsbom/conan_test.go
+++ b/internal/infrastructure/tools/ownsbom/conan_test.go
@@ -168,22 +168,13 @@ func TestConanParseV1GraphEdges(t *testing.T) {
 		}
 	}
 
-	if len(deps) != 2 {
-		t.Fatalf("want 2 dependencies, got %d: %+v", len(deps), deps)
+	wantDeps := []sbom.Dependency{
+		{Ref: "pkg:conan/app@1.0", DependsOn: []string{"pkg:conan/cmake@3.29.0"}, Scope: sbom.ScopeDevelopment},
+		{Ref: "pkg:conan/app@1.0", DependsOn: []string{"pkg:conan/lib-a@2.0", "pkg:conan/lib-b@3.0"}, Scope: sbom.ScopeProduction},
+		{Ref: "pkg:conan/lib-a@2.0", DependsOn: []string{"pkg:conan/openssl@3.0.0"}, Scope: sbom.ScopeProduction},
 	}
-
-	if deps[0].Ref != "pkg:conan/app@1.0" {
-		t.Errorf("dep 0 ref want pkg:conan/app@1.0, got %s", deps[0].Ref)
-	}
-	if len(deps[0].DependsOn) != 3 || deps[0].DependsOn[0] != "pkg:conan/cmake@3.29.0" || deps[0].DependsOn[1] != "pkg:conan/lib-a@2.0" || deps[0].DependsOn[2] != "pkg:conan/lib-b@3.0" {
-		t.Errorf("dep 0 DependsOn wrong: %v", deps[0].DependsOn)
-	}
-
-	if deps[1].Ref != "pkg:conan/lib-a@2.0" {
-		t.Errorf("dep 1 ref want pkg:conan/lib-a@2.0, got %s", deps[1].Ref)
-	}
-	if len(deps[1].DependsOn) != 1 || deps[1].DependsOn[0] != "pkg:conan/openssl@3.0.0" {
-		t.Errorf("dep 1 DependsOn wrong: %v", deps[1].DependsOn)
+	if !reflect.DeepEqual(deps, wantDeps) {
+		t.Fatalf("dependencies = %+v, want %+v", deps, wantDeps)
 	}
 }
 
@@ -409,8 +400,8 @@ func TestConanRegistryGenerateIncludesGraphEdges(t *testing.T) {
 		t.Errorf("want 5 components, got %d", len(doc.Components))
 	}
 
-	if len(doc.Dependencies) != 2 {
-		t.Fatalf("want 2 dependencies, got %d: %+v", len(doc.Dependencies), doc.Dependencies)
+	if len(doc.Dependencies) != 3 {
+		t.Fatalf("want 3 dependencies, got %d: %+v", len(doc.Dependencies), doc.Dependencies)
 	}
 }
 
@@ -642,11 +633,12 @@ func TestConanParseV1PythonRequiresMixedEdgeKinds(t *testing.T) {
 	if len(comps) != 4 {
 		t.Fatalf("want 4 components")
 	}
-	if len(deps) != 1 || len(deps[0].DependsOn) != 2 {
-		t.Fatalf("want 1 dep with 2 edges, got %+v", deps)
+	wantDeps := []sbom.Dependency{
+		{Ref: "pkg:conan/app@1.0", DependsOn: []string{"pkg:conan/cmake@2.0"}, Scope: sbom.ScopeDevelopment},
+		{Ref: "pkg:conan/app@1.0", DependsOn: []string{"pkg:conan/runtime@1.0"}, Scope: sbom.ScopeProduction},
 	}
-	if deps[0].DependsOn[0] != "pkg:conan/cmake@2.0" || deps[0].DependsOn[1] != "pkg:conan/runtime@1.0" {
-		t.Errorf("DependsOn wrong: %v", deps[0].DependsOn)
+	if !reflect.DeepEqual(deps, wantDeps) {
+		t.Fatalf("dependencies = %+v, want %+v", deps, wantDeps)
 	}
 }
 

--- a/internal/infrastructure/tools/ownsbom/npm.go
+++ b/internal/infrastructure/tools/ownsbom/npm.go
@@ -56,6 +56,17 @@ type npmV3Pkg struct {
 	OptionalDependencies map[string]string `json:"optionalDependencies"`
 }
 
+type npmEdgeSpec struct {
+	name     string
+	scope    string
+	optional bool
+}
+
+type npmEdgeMeta struct {
+	scope    string
+	optional bool
+}
+
 // Parse extracts the resolved npm packages (+ v2/v3 edges) from a package-lock.json.
 func (NPM) Parse(_ context.Context, in ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
 	var lock struct {
@@ -72,7 +83,7 @@ func (NPM) Parse(_ context.Context, in ParseInput) ([]sbom.Component, []sbom.Dep
 		// Syft path + the PURL conformance test), while Component.Name keeps the @scope/name.
 		purlName := name
 		if strings.HasPrefix(purlName, "@") {
-			purlName = "%40" + purlName[1:]
+			purlName = "%40" + purlName[1:] // PURL spec: scoped @ → %40 (matches the npm/yarn parsers)
 		}
 		return "pkg:npm/" + purlName + "@" + version
 	}
@@ -95,8 +106,8 @@ func (NPM) Parse(_ context.Context, in ParseInput) ([]sbom.Component, []sbom.Dep
 				pathPURL[path] = add(name, p.Version, p.Integrity, p.Dev)
 			}
 		}
-		// Pass 2: resolve each package's direct deps to PURLs via npm's nearest-wins hoisting. Deterministic:
-		// iterate paths + dep names sorted. Resolution-as-filter – a dep not present in the tree yields no edge.
+		// Pass 2: resolve each package's direct deps to PURLs via npm's nearest-wins hoisting. Edge scope and
+		// optionality stay attached to the relationship; records are split when one source has mixed metadata.
 		paths := make([]string, 0, len(lock.Packages))
 		for path := range lock.Packages {
 			paths = append(paths, path)
@@ -108,20 +119,49 @@ func (NPM) Parse(_ context.Context, in ParseInput) ([]sbom.Component, []sbom.Dep
 			if !ok {
 				continue // root project / unnamed – not a component, so no edges from it
 			}
-			seen := map[string]bool{ref: true} // drop self-edges + duplicate targets
-			var on []string
-			for _, depName := range npmDepNames(lock.Packages[path]) {
-				tp := resolveNpmDep(path, depName, lock.Packages)
+			sourceScope := prodScope
+			if lock.Packages[path].Dev {
+				sourceScope = sbom.ScopeDevelopment
+			}
+			targetMeta := make(map[string]npmEdgeMeta)
+			for _, dep := range npmEdgeSpecs(lock.Packages[path], sourceScope) {
+				tp := resolveNpmDep(path, dep.name, lock.Packages)
 				if tp == "" {
 					continue
 				}
-				if t := pathPURL[tp]; t != "" && !seen[t] {
-					seen[t] = true
-					on = append(on, t)
+				t := pathPURL[tp]
+				if t == "" || t == ref {
+					continue
 				}
+				meta := npmEdgeMeta{scope: dep.scope, optional: dep.optional}
+				if existing, exists := targetMeta[t]; exists {
+					meta = mergeNPMEdgeMeta(existing, meta)
+				}
+				targetMeta[t] = meta
 			}
-			if len(on) > 0 {
-				edges = append(edges, sbom.Dependency{Ref: ref, DependsOn: on})
+			type groupKey struct {
+				scope    string
+				optional bool
+			}
+			groups := make(map[groupKey][]string)
+			for target, meta := range targetMeta {
+				key := groupKey(meta)
+				groups[key] = append(groups[key], target)
+			}
+			keys := make([]groupKey, 0, len(groups))
+			for key := range groups {
+				keys = append(keys, key)
+			}
+			sort.Slice(keys, func(i, j int) bool {
+				if keys[i].scope != keys[j].scope {
+					return keys[i].scope < keys[j].scope
+				}
+				return !keys[i].optional && keys[j].optional
+			})
+			for _, key := range keys {
+				on := groups[key]
+				sort.Strings(on)
+				edges = append(edges, sbom.Dependency{Ref: ref, DependsOn: on, Scope: key.scope, Optional: key.optional})
 			}
 		}
 		return set.components(), edges, nil
@@ -163,22 +203,50 @@ func parseSubresourceIntegrity(s string) []sbom.Checksum {
 	return out
 }
 
-// npmDepNames returns the sorted, unique direct-dependency names of a v2/v3 package: its dependencies +
-// devDependencies (chiefly on the root, but npm may write them on nested entries too) + optionalDependencies
-// – i.e. everything npm installs into the tree for it. peerDependencies are excluded (a "the host must
-// provide" expectation, not a "this depends on").
-func npmDepNames(p npmV3Pkg) []string {
-	set := map[string]bool{}
-	for _, m := range []map[string]string{p.Dependencies, p.DevDependencies, p.OptionalDependencies} {
-		for name := range m {
-			set[name] = true
+// npmEdgeSpecs returns sorted, unique direct-dependency declarations with their per-edge semantics.
+// If the same package is listed as both runtime and dev, the runtime relationship wins: one shipping path is
+// sufficient to make that edge shipping. Optionality is retained independently from scope.
+func npmEdgeSpecs(p npmV3Pkg, prodScope string) []npmEdgeSpec {
+	byName := map[string]npmEdgeSpec{}
+	for name := range p.Dependencies {
+		byName[name] = npmEdgeSpec{name: name, scope: prodScope}
+	}
+	for name := range p.DevDependencies {
+		if _, exists := byName[name]; exists {
+			continue // an existing runtime declaration is the stronger shipping relationship
 		}
+		byName[name] = npmEdgeSpec{name: name, scope: sbom.ScopeDevelopment}
 	}
-	out := make([]string, 0, len(set))
-	for name := range set {
-		out = append(out, name)
+	for name := range p.OptionalDependencies {
+		spec := byName[name]
+		spec.name = name
+		if spec.scope == "" {
+			spec.scope = prodScope
+		}
+		spec.optional = true
+		byName[name] = spec
 	}
-	sort.Strings(out)
+	names := make([]string, 0, len(byName))
+	for name := range byName {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	out := make([]npmEdgeSpec, 0, len(names))
+	for _, name := range names {
+		out = append(out, byName[name])
+	}
+	return out
+}
+
+func mergeNPMEdgeMeta(a, b npmEdgeMeta) npmEdgeMeta {
+	out := npmEdgeMeta{scope: a.scope, optional: a.optional && b.optional}
+	if a.scope == sbom.ScopeProduction || b.scope == sbom.ScopeProduction {
+		out.scope = sbom.ScopeProduction
+	} else if a.scope == sbom.ScopeDevelopment || b.scope == sbom.ScopeDevelopment {
+		out.scope = sbom.ScopeDevelopment
+	} else if out.scope == "" {
+		out.scope = b.scope
+	}
 	return out
 }
 

--- a/internal/infrastructure/tools/ownsbom/npm_edge_scope_test.go
+++ b/internal/infrastructure/tools/ownsbom/npm_edge_scope_test.go
@@ -1,0 +1,70 @@
+package ownsbom
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+type npmTestEdgeMeta struct {
+	scope    string
+	optional bool
+}
+
+func TestNPMEdgeScopeAndOptional(t *testing.T) {
+	tests := []struct {
+		name string
+		lock string
+		want map[string]npmTestEdgeMeta
+	}{
+		{
+			name: "mixed runtime dev optional and shared runtime wins",
+			lock: `{"lockfileVersion":3,"packages":{"":{"name":"app","version":"1.0.0"},"node_modules/parent":{"version":"1.0.0","dependencies":{"runtime":"1.0.0","shared":"1.0.0"},"devDependencies":{"dev-only":"1.0.0","shared":"1.0.0"},"optionalDependencies":{"optional":"1.0.0"}},"node_modules/runtime":{"version":"1.0.0"},"node_modules/dev-only":{"version":"1.0.0"},"node_modules/shared":{"version":"1.0.0"},"node_modules/optional":{"version":"1.0.0"}}}`,
+			want: map[string]npmTestEdgeMeta{
+				"pkg:npm/parent@1.0.0->pkg:npm/runtime@1.0.0":  {sbom.ScopeProduction, false},
+				"pkg:npm/parent@1.0.0->pkg:npm/dev-only@1.0.0": {sbom.ScopeDevelopment, false},
+				"pkg:npm/parent@1.0.0->pkg:npm/shared@1.0.0":   {sbom.ScopeProduction, false},
+				"pkg:npm/parent@1.0.0->pkg:npm/optional@1.0.0": {sbom.ScopeProduction, true},
+			},
+		},
+		{
+			name: "dev package carries restriction to normal child edge",
+			lock: `{"lockfileVersion":3,"packages":{"":{"name":"app","version":"1.0.0"},"node_modules/dev-parent":{"version":"1.0.0","dev":true,"dependencies":{"child":"1.0.0"}},"node_modules/child":{"version":"1.0.0","dev":true}}}`,
+			want: map[string]npmTestEdgeMeta{
+				"pkg:npm/dev-parent@1.0.0->pkg:npm/child@1.0.0": {sbom.ScopeDevelopment, false},
+			},
+		},
+		{
+			name: "cycle keeps deterministic production edge metadata",
+			lock: `{"lockfileVersion":3,"packages":{"":{"name":"app","version":"1.0.0"},"node_modules/a":{"version":"1.0.0","dependencies":{"b":"1.0.0"}},"node_modules/b":{"version":"1.0.0","dependencies":{"a":"1.0.0"}}}}`,
+			want: map[string]npmTestEdgeMeta{
+				"pkg:npm/a@1.0.0->pkg:npm/b@1.0.0": {sbom.ScopeProduction, false},
+				"pkg:npm/b@1.0.0->pkg:npm/a@1.0.0": {sbom.ScopeProduction, false},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, deps, err := NPM{}.Parse(context.Background(), ParseInput{Path: "package-lock.json", Content: []byte(tt.lock)})
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			got := map[string]npmTestEdgeMeta{}
+			for _, d := range deps {
+				for _, target := range d.DependsOn {
+					got[d.Ref+"->"+target] = npmTestEdgeMeta{d.Scope, d.Optional}
+				}
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %d edges, want %d: %#v", len(got), len(tt.want), got)
+			}
+			for edge, want := range tt.want {
+				if got[edge] != want {
+					t.Errorf("%s = %#v, want %#v", edge, got[edge], want)
+				}
+			}
+		})
+	}
+}

--- a/internal/infrastructure/tools/ownsbom/nuget.go
+++ b/internal/infrastructure/tools/ownsbom/nuget.go
@@ -153,7 +153,7 @@ func (NuGet) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom
 	var edges []sbom.Dependency
 	for _, ref := range refs {
 		if on := edgeTargets[ref]; len(on) > 0 {
-			edges = append(edges, sbom.Dependency{Ref: ref, DependsOn: on})
+			edges = append(edges, sbom.Dependency{Ref: ref, DependsOn: on, Scope: scope})
 		}
 	}
 	return comps, edges, nil

--- a/internal/infrastructure/tools/ownsbom/pnpm.go
+++ b/internal/infrastructure/tools/ownsbom/pnpm.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
@@ -33,11 +34,16 @@ func (Pnpm) Ecosystem() string { return "npm" }
 // Markers are the lockfile basenames Pnpm claims.
 func (Pnpm) Markers() []string { return []string{"pnpm-lock.yaml"} }
 
+type pnpmRawDep struct {
+	key      string
+	optional bool
+}
+
 // pnpmRawEdge is one package's accumulated dependency keys, resolved to PURLs after the full scan (so a
 // forward reference to a package defined later in the file still resolves).
 type pnpmRawEdge struct {
-	parent string   // the package/snapshot key spec (edge source)
-	deps   []string // "name@version" dependency keys (edge targets)
+	parent string       // the package/snapshot key spec (edge source)
+	deps   []pnpmRawDep // resolved dependency keys with per-edge optionality
 }
 
 // Parse extracts the resolved npm packages from a pnpm-lock.yaml `packages:` block as npm components, and the
@@ -55,7 +61,8 @@ func (Pnpm) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.
 	var cur *sbom.Component // current component (packages section only), held so its integrity (SRI) attaches
 	curKey := ""            // current package/snapshot key spec (edge source), set in packages AND snapshots
 	inDeps := false         // inside a dependencies:/optionalDependencies: sub-block
-	var curDeps []string    // "name@version" dep keys accumulated for curKey
+	depsOptional := false   // whether the current dependency sub-block is optionalDependencies
+	var curDeps []pnpmRawDep
 	var rawEdges []pnpmRawEdge
 
 	// flush completes the current package block: emit its component (packages only), index it, and record its
@@ -69,7 +76,7 @@ func (Pnpm) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.
 		if curKey != "" && len(curDeps) > 0 {
 			rawEdges = append(rawEdges, pnpmRawEdge{parent: curKey, deps: curDeps})
 		}
-		curKey, curDeps, inDeps = "", nil, false
+		curKey, curDeps, inDeps, depsOptional = "", nil, false, false
 	}
 
 	sc := bufio.NewScanner(bytes.NewReader(in.Content))
@@ -121,6 +128,7 @@ func (Pnpm) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.
 			// other sub-key (resolution:/engines:/…) closes it, and may carry the integrity (tamper evidence).
 			key := strings.TrimSuffix(line, ":")
 			inDeps = key == "dependencies" || key == "optionalDependencies"
+			depsOptional = inDeps && key == "optionalDependencies"
 			if !inDeps && cur != nil && cur.Checksums == nil {
 				if v := pnpmIntegrityFromLine(raw); v != "" {
 					cur.Checksums = parseSubresourceIntegrity(v)
@@ -129,7 +137,7 @@ func (Pnpm) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.
 		default: // indent >= 6: a dep entry inside a deps block, or a block-form integrity line
 			if inDeps && curKey != "" {
 				if dk, ok := pnpmDepKey(line); ok {
-					curDeps = append(curDeps, dk)
+					curDeps = append(curDeps, pnpmRawDep{key: dk, optional: depsOptional})
 				}
 			} else if cur != nil && cur.Checksums == nil {
 				if v := pnpmIntegrityFromLine(raw); v != "" {
@@ -142,7 +150,7 @@ func (Pnpm) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.
 	if err := sc.Err(); err != nil {
 		return nil, nil, fmt.Errorf("scan pnpm-lock.yaml: %w", err)
 	}
-	return set.components(), pnpmResolveEdges(rawEdges, purlByKey), nil
+	return set.components(), pnpmResolveEdges(rawEdges, purlByKey, baseScope), nil
 }
 
 // pnpmDepKey parses one dependency entry line from a `dependencies:`/`optionalDependencies:` sub-map into the
@@ -189,16 +197,12 @@ func pnpmDepKey(line string) (string, bool) {
 	return name + "@" + val, true
 }
 
-// pnpmResolveEdges turns the raw per-package dependency keys into sbom.Dependency edges, resolved against the
-// emitted-component index. An edge (and each target) is kept only when it names an emitted component
-// (resolution-as-filter); self-edges and duplicate targets are dropped. Because components are deduped at
-// name/version granularity, several peer-context snapshot variants of one package (e.g.
-// `plugin@1.0.0(react@17)` and `plugin@1.0.0(react@18)`) collapse to the same Ref; their targets are MERGED
-// into a single Dependency, preserving first-seen order, so the graph has one edge object per Ref.
-func pnpmResolveEdges(rawEdges []pnpmRawEdge, purlByKey map[string]string) []sbom.Dependency {
-	var order []string                   // Refs in first-seen order (deterministic output)
-	targets := map[string][]string{}     // Ref → ordered target PURLs
-	seen := map[string]map[string]bool{} // Ref → set of already-added targets (+ the Ref itself)
+// pnpmResolveEdges turns raw dependency keys into sbom.Dependency records resolved against the emitted
+// component index. Required/optional metadata is retained even when peer-context snapshot variants collapse
+// to the same component Ref; if the same target is seen as both required and optional, required wins.
+func pnpmResolveEdges(rawEdges []pnpmRawEdge, purlByKey map[string]string, scope string) []sbom.Dependency {
+	var order []string
+	targetOptional := map[string]map[string]bool{} // Ref -> target PURL -> optional
 	for _, re := range rawEdges {
 		pn, pv, ok := pnpmSpecNameVersion(re.parent)
 		if !ok {
@@ -206,25 +210,44 @@ func pnpmResolveEdges(rawEdges []pnpmRawEdge, purlByKey map[string]string) []sbo
 		}
 		ref := purlByKey[pn+"@"+pv]
 		if ref == "" {
-			continue // the source package is not an emitted component (e.g. a snapshot with no packages entry)
+			continue // source not emitted (e.g. snapshot without a packages entry)
 		}
-		if seen[ref] == nil {
-			seen[ref] = map[string]bool{ref: true} // no self-edge
+		if targetOptional[ref] == nil {
+			targetOptional[ref] = map[string]bool{}
 			order = append(order, ref)
 		}
-		for _, dk := range re.deps {
-			t := purlByKey[dk]
-			if t == "" || seen[ref][t] {
+		for _, dep := range re.deps {
+			target := purlByKey[dep.key]
+			if target == "" || target == ref {
 				continue
 			}
-			seen[ref][t] = true
-			targets[ref] = append(targets[ref], t)
+			old, exists := targetOptional[ref][target]
+			if !exists {
+				targetOptional[ref][target] = dep.optional
+				continue
+			}
+			if old && !dep.optional {
+				targetOptional[ref][target] = false
+			}
 		}
 	}
 	var edges []sbom.Dependency
 	for _, ref := range order {
-		if on := targets[ref]; len(on) > 0 {
-			edges = append(edges, sbom.Dependency{Ref: ref, DependsOn: on})
+		var required, optional []string
+		for target, isOptional := range targetOptional[ref] {
+			if isOptional {
+				optional = append(optional, target)
+			} else {
+				required = append(required, target)
+			}
+		}
+		sort.Strings(required)
+		sort.Strings(optional)
+		if len(required) > 0 {
+			edges = append(edges, sbom.Dependency{Ref: ref, DependsOn: required, Scope: scope})
+		}
+		if len(optional) > 0 {
+			edges = append(edges, sbom.Dependency{Ref: ref, DependsOn: optional, Scope: scope, Optional: true})
 		}
 	}
 	return edges

--- a/internal/infrastructure/tools/ownsbom/pnpm_test.go
+++ b/internal/infrastructure/tools/ownsbom/pnpm_test.go
@@ -157,9 +157,10 @@ func TestPnpmParseV9Edges(t *testing.T) {
 	}
 	byRef := map[string][]string{}
 	for _, d := range deps {
-		byRef[d.Ref] = d.DependsOn
+		byRef[d.Ref] = append(byRef[d.Ref], d.DependsOn...)
 	}
-	// express depends on body-parser (dependencies) AND bytes (optionalDependencies).
+	// express depends on body-parser (dependencies) AND bytes (optionalDependencies). D3.3 may split these
+	// into separate records because optionality is relationship metadata, so aggregate records by source.
 	exp := byRef["pkg:npm/express@4.18.2"]
 	if !contains(exp, "pkg:npm/body-parser@1.20.1") || !contains(exp, "pkg:npm/bytes@3.1.2") {
 		t.Errorf("express edges = %v, want body-parser + bytes", exp)

--- a/internal/infrastructure/tools/ownsbom/poetry.go
+++ b/internal/infrastructure/tools/ownsbom/poetry.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
@@ -27,12 +28,17 @@ func (Poetry) Ecosystem() string { return "pypi" }
 // Markers are the lockfile basenames Poetry claims.
 func (Poetry) Markers() []string { return []string{"poetry.lock"} }
 
+type poetryDep struct {
+	name     string
+	optional bool
+}
+
 // poetryPkg is a [[package]] block collected in pass 1: identity + the direct dependency names from its
 // [package.dependencies] sub-table (resolved to edges in pass 2).
 type poetryPkg struct {
 	name, version, category string
-	hash                    string   // first artifact hash ("sha256:<hex>") from the package's own `files = [...]` (lock v2.0)
-	deps                    []string // raw direct-dependency names from [package.dependencies]
+	hash                    string      // first artifact hash ("sha256:<hex>") from the package's own `files = [...]` (lock v2.0)
+	deps                    []poetryDep // direct dependencies + explicit optional=true metadata
 }
 
 // Parse extracts the resolved packages + their dependency edges from a poetry.lock. The artifact-hash
@@ -112,11 +118,13 @@ func (Poetry) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbo
 		case inPkg && line == "files = [": // lock v2.0 per-package artifact hashes
 			inFiles = true
 		case inDeps && strings.ContainsRune(line, '='):
-			// a dep entry `name = "constraint"` or `name = {version=…}`: the KEY (before the first =) is the
-			// dep name. A non-package-name key (e.g. a "{" array element) is filtered; an unresolvable name
-			// produces no edge in pass 2, so a stray entry is harmless.
-			if k := strings.Trim(strings.TrimSpace(line[:strings.IndexByte(line, '=')]), `"`); isPoetryDepKey(k) {
-				cur.deps = append(cur.deps, k)
+			// A dep entry is `name = "constraint"` or `name = {version=…, optional=true}`. The key names the
+			// package; optionality is captured only when the same TOML value explicitly says optional=true.
+			// Multi-line continuation elements are filtered by isPoetryDepKey and never guessed as optional.
+			i := strings.IndexByte(line, '=')
+			if k := strings.Trim(strings.TrimSpace(line[:i]), `"`); isPoetryDepKey(k) {
+				value := strings.ToLower(strings.ReplaceAll(line[i+1:], " ", ""))
+				cur.deps = append(cur.deps, poetryDep{name: k, optional: strings.Contains(value, "optional=true")})
 			}
 		case inPkg && strings.HasPrefix(line, "name = "):
 			cur.name = tomlString(line[len("name = "):])
@@ -141,7 +149,7 @@ func (Poetry) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbo
 		versionsOf[n] = append(versionsOf[n], p.version)
 	}
 
-	// Pass 2: emit components + resolve edges.
+	// Pass 2: emit components + resolve edges, splitting required and optional relationships.
 	set := newComponentSet()
 	var deps []sbom.Dependency
 	for _, p := range pkgs {
@@ -156,21 +164,42 @@ func (Poetry) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbo
 			hash = metaHashes[n]
 		}
 		set.add(sbom.Component{Name: n, Version: p.version, PURL: ref, Location: in.Path, Scope: scope, Checksums: pyHashChecksums([]string{hash})})
-		seen := map[string]bool{ref: true} // drop self-edges + duplicate targets
-		var on []string
+		targetOptional := map[string]bool{}
+		seen := map[string]bool{ref: true}
 		for _, d := range p.deps {
-			dn := normalizePyPI(d)
+			dn := normalizePyPI(d.name)
 			vs := versionsOf[dn]
 			if len(vs) != 1 {
 				continue // no [[package]] entry (e.g. the python constraint) OR an ambiguous duplicate name – no edge
 			}
-			if t := purlOf(dn, vs[0]); !seen[t] {
+			t := purlOf(dn, vs[0])
+			if t == ref {
+				continue
+			}
+			if !seen[t] {
 				seen[t] = true
-				on = append(on, t)
+				targetOptional[t] = d.optional
+				continue
+			}
+			if !d.optional { // required wins over an alternate optional declaration
+				targetOptional[t] = false
 			}
 		}
-		if len(on) > 0 {
-			deps = append(deps, sbom.Dependency{Ref: ref, DependsOn: on})
+		var required, optional []string
+		for target, isOptional := range targetOptional {
+			if isOptional {
+				optional = append(optional, target)
+			} else {
+				required = append(required, target)
+			}
+		}
+		sort.Strings(required)
+		sort.Strings(optional)
+		if len(required) > 0 {
+			deps = append(deps, sbom.Dependency{Ref: ref, DependsOn: required, Scope: scope})
+		}
+		if len(optional) > 0 {
+			deps = append(deps, sbom.Dependency{Ref: ref, DependsOn: optional, Scope: scope, Optional: true})
 		}
 	}
 	return set.components(), deps, nil

--- a/internal/infrastructure/tools/ownsbom/source_scope_test.go
+++ b/internal/infrastructure/tools/ownsbom/source_scope_test.go
@@ -1,0 +1,61 @@
+package ownsbom
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+)
+
+func TestDevPackageScopeIsEncodedOnOutgoingEdges(t *testing.T) {
+	t.Run("cargo direct dev root", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "Cargo.toml"), []byte("[dev-dependencies]\ndevroot = \"1\"\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		lock := []byte(`version = 3
+
+[[package]]
+name = "devroot"
+version = "1.0.0"
+dependencies = ["leaf 1.0.0"]
+
+[[package]]
+name = "leaf"
+version = "1.0.0"
+`)
+		_, deps, err := Cargo{}.Parse(context.Background(), ParseInput{Dir: dir, Path: filepath.Join(dir, "Cargo.lock"), Content: lock})
+		if err != nil {
+			t.Fatal(err)
+		}
+		leaf := "pkg:cargo/leaf@1.0.0"
+		if sbom.ProductionReachable(deps)[leaf] {
+			t.Fatalf("dev-root transitive leaf must not be production-reachable: %+v", deps)
+		}
+	})
+
+	t.Run("poetry dev category", func(t *testing.T) {
+		lock := []byte(`[[package]]
+name = "devroot"
+version = "1.0.0"
+category = "dev"
+[package.dependencies]
+leaf = "1.0.0"
+
+[[package]]
+name = "leaf"
+version = "1.0.0"
+category = "main"
+`)
+		_, deps, err := Poetry{}.Parse(context.Background(), ParseInput{Path: "poetry.lock", Content: lock})
+		if err != nil {
+			t.Fatal(err)
+		}
+		leaf := "pkg:pypi/leaf@1.0.0"
+		if sbom.ProductionReachable(deps)[leaf] {
+			t.Fatalf("dev-category transitive leaf must not be production-reachable: %+v", deps)
+		}
+	})
+}

--- a/internal/infrastructure/tools/ownsbom/uv.go
+++ b/internal/infrastructure/tools/ownsbom/uv.go
@@ -340,7 +340,7 @@ func (UV) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.De
 			}
 		}
 		if len(on) > 0 {
-			deps = append(deps, sbom.Dependency{Ref: ref, DependsOn: on})
+			deps = append(deps, sbom.Dependency{Ref: ref, DependsOn: on, Scope: scope})
 		}
 	}
 

--- a/internal/infrastructure/tools/ownsbom/yarn.go
+++ b/internal/infrastructure/tools/ownsbom/yarn.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
@@ -32,15 +33,18 @@ func (Yarn) Ecosystem() string { return "npm" }
 func (Yarn) Markers() []string { return []string{"yarn.lock"} }
 
 // yarnEntry is one lock entry collected in pass 1: its resolved name+version, the descriptors its key line
-// claims (for edge resolution), and the direct deps from its dependencies: block.
+// claims (for edge resolution), and the direct deps from its dependencies/optionalDependencies blocks.
 type yarnEntry struct {
 	name, version string
 	integrity     string    // the `integrity` Subresource Integrity value (Yarn v1), when present
 	descriptors   []string  // full `name@range` specs from the key line(s)
-	deps          []yarnDep // direct deps from the dependencies: block
+	deps          []yarnDep // direct deps with per-edge optionality
 }
 
-type yarnDep struct{ name, rng string }
+type yarnDep struct {
+	name, rng string
+	optional  bool
+}
 
 // Parse extracts the resolved packages + dependency edges from a yarn.lock.
 func (Yarn) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.Dependency, error) {
@@ -54,6 +58,7 @@ func (Yarn) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.
 	var entries []*yarnEntry
 	var cur *yarnEntry
 	inDeps := false
+	depsOptional := false
 	depsIndent := 0
 	sc := bufio.NewScanner(bytes.NewReader(in.Content))
 	sc.Buffer(make([]byte, 0, 64*1024), 4<<20)
@@ -67,7 +72,7 @@ func (Yarn) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.
 			// a col-0 key line starts a new entry. A `name@workspace:…` key is the project/workspace ITSELF
 			// (its version is the non-matchable 0.0.0-use.local), not a dependency – skip it; a non-spec line
 			// (Berry's __metadata) has no name and is skipped too.
-			inDeps, cur = false, nil
+			inDeps, depsOptional, cur = false, false, nil
 			if strings.HasSuffix(line, ":") && !strings.Contains(line, "@workspace:") {
 				if descs, name := yarnDescriptors(line); name != "" {
 					cur = &yarnEntry{name: name, descriptors: descs}
@@ -81,20 +86,20 @@ func (Yarn) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.
 		}
 		indent := leadingIndent(raw)
 		if inDeps {
-			if indent > depsIndent { // a member of the dependencies: block (more indented than it)
+			if indent > depsIndent { // a member of the dependencies block (more indented than it)
 				if d, ok := parseYarnDep(line); ok {
+					d.optional = depsOptional
 					cur.deps = append(cur.deps, d)
 				}
 				continue
 			}
-			inDeps = false // dedented back to an entry field – the dependencies: block ended
+			inDeps, depsOptional = false, false // dedented back to an entry field – the block ended
 		}
 		switch {
-		case strings.HasPrefix(line, "dependencies:") || strings.HasPrefix(line, "optionalDependencies:"):
-			// Both are real installed edges (optional ones are present in the tree when satisfiable; an
-			// unsatisfied one fails the descriptor lookup → no edge anyway) – parity with the npm parser,
-			// which also merges optionalDependencies. peerDependencies stays excluded (host-provides).
-			inDeps, depsIndent = true, indent
+		case strings.HasPrefix(line, "dependencies:"):
+			inDeps, depsOptional, depsIndent = true, false, indent
+		case strings.HasPrefix(line, "optionalDependencies:"):
+			inDeps, depsOptional, depsIndent = true, true, indent
 		case strings.HasPrefix(line, "version ") || strings.HasPrefix(line, "version:"):
 			cur.version = strings.Trim(strings.TrimSpace(strings.TrimPrefix(line, "version")), `:" `)
 		case strings.HasPrefix(line, "integrity "):
@@ -118,7 +123,8 @@ func (Yarn) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.
 		}
 	}
 
-	// Pass 2: emit components + resolve edges via the descriptor map.
+	// Pass 2: emit components + resolve edges via the descriptor map. Edge records are split by optionality;
+	// if the same resolved target is declared both required and optional, required wins.
 	set := newComponentSet()
 	var edges []sbom.Dependency
 	for _, e := range entries {
@@ -131,20 +137,41 @@ func (Yarn) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbom.
 		}
 		ref := yarnPURL(e.name, e.version)
 		set.add(sbom.Component{Name: e.name, Version: e.version, PURL: ref, Location: in.Path, Scope: scope, Checksums: parseSubresourceIntegrity(e.integrity)})
-		seen := map[string]bool{ref: true} // drop self-edges + duplicate targets
-		var on []string
+		targetOptional := map[string]bool{}
+		seen := map[string]bool{ref: true}
 		for _, d := range e.deps {
 			v, ok := descVer[d.name+"@"+d.rng]
 			if !ok {
 				continue // descriptor not claimed by any lock entry – no edge
 			}
-			if t := yarnPURL(d.name, v); !seen[t] {
+			t := yarnPURL(d.name, v)
+			if t == ref {
+				continue
+			}
+			if !seen[t] {
 				seen[t] = true
-				on = append(on, t)
+				targetOptional[t] = d.optional
+				continue
+			}
+			if !d.optional { // required wins when duplicate declarations resolve to the same package
+				targetOptional[t] = false
 			}
 		}
-		if len(on) > 0 {
-			edges = append(edges, sbom.Dependency{Ref: ref, DependsOn: on})
+		var required, optional []string
+		for target, isOptional := range targetOptional {
+			if isOptional {
+				optional = append(optional, target)
+			} else {
+				required = append(required, target)
+			}
+		}
+		sort.Strings(required)
+		sort.Strings(optional)
+		if len(required) > 0 {
+			edges = append(edges, sbom.Dependency{Ref: ref, DependsOn: required, Scope: prodScope})
+		}
+		if len(optional) > 0 {
+			edges = append(edges, sbom.Dependency{Ref: ref, DependsOn: optional, Scope: prodScope, Optional: true})
 		}
 	}
 	return set.components(), edges, nil

--- a/internal/usecase/projectuc/dependency_graph.go
+++ b/internal/usecase/projectuc/dependency_graph.go
@@ -154,6 +154,7 @@ func buildProjectDependencyGraph(analysisID string, scan scauc.ScanResult) (Depe
 		byNameVersion[component.Name+"\x00"+component.Version] = append(byNameVersion[component.Name+"\x00"+component.Version], id)
 	}
 	sort.Slice(components, func(i, j int) bool { return components[i].id < components[j].id })
+	prodReach := sbom.ProductionReachable(scan.SBOM.Dependencies)
 
 	edgeSeen := make(map[string]bool)
 	children := make(map[string][]string)
@@ -268,9 +269,14 @@ func buildProjectDependencyGraph(analysisID string, scan scauc.ScanResult) (Depe
 		vulns := vulnsByID[ref.id]
 		verdict := licenseVerdict[ref.id]
 		licenseRisk := verdict == string(ports.LicenseWarn) || verdict == string(ports.LicenseDeny) || verdict == "" && riskyCategory
+		effectiveScope := ref.component.Scope
+		if reachable, ok := prodReach[ref.id]; ok && !reachable &&
+			(effectiveScope == "" || effectiveScope == sbom.ScopeProduction || effectiveScope == sbom.ScopeUnknown) {
+			effectiveScope = sbom.ScopeDevelopment
+		}
 		node := DependencyGraphNode{
 			ID: ref.id, Name: ref.component.Name, Version: ref.component.Version, PURL: ref.component.PURL,
-			Scope: ref.component.Scope, Reachability: ref.component.Reachability,
+			Scope: effectiveScope, Reachability: ref.component.Reachability,
 			Direct: itemDepth == 0, Depth: itemDepth, Licenses: licenses,
 			LicenseRisk: licenseRisk, LicenseVerdict: verdict, Vulnerabilities: vulns,
 			VulnerabilityCount: len(vulns), WorstSeverity: worstDependencySeverity(vulns),
@@ -485,7 +491,7 @@ func dependencySubtree(doc *sbom.SBOM, root string) (*sbom.SBOM, error) {
 		if !selected[dependency.Ref] {
 			continue
 		}
-		next := sbom.Dependency{Ref: dependency.Ref}
+		next := sbom.Dependency{Ref: dependency.Ref, Scope: dependency.Scope, Optional: dependency.Optional}
 		for _, child := range dependency.DependsOn {
 			if selected[child] {
 				next.DependsOn = append(next.DependsOn, child)
@@ -499,7 +505,10 @@ func dependencySubtree(doc *sbom.SBOM, root string) (*sbom.SBOM, error) {
 func cloneDependencies(in []sbom.Dependency) []sbom.Dependency {
 	out := make([]sbom.Dependency, len(in))
 	for i, dependency := range in {
-		out[i] = sbom.Dependency{Ref: dependency.Ref, DependsOn: append([]string(nil), dependency.DependsOn...)}
+		out[i] = sbom.Dependency{
+			Ref: dependency.Ref, DependsOn: append([]string(nil), dependency.DependsOn...),
+			Scope: dependency.Scope, Optional: dependency.Optional,
+		}
 	}
 	return out
 }

--- a/internal/usecase/projectuc/dependency_scope_test.go
+++ b/internal/usecase/projectuc/dependency_scope_test.go
@@ -1,0 +1,59 @@
+package projectuc
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	scauc "github.com/KKloudTarus/synapse-ce/internal/usecase/sca"
+)
+
+func TestBuildProjectDependencyGraphUsesProductionReachability(t *testing.T) {
+	c := func(name, scope string) sbom.Component { return component(name, "1", "pkg:generic/"+name+"@1", scope) }
+	d := func(from, scope string, to ...string) sbom.Dependency {
+		targets := make([]string, len(to))
+		for i, name := range to {
+			targets[i] = "pkg:generic/" + name + "@1"
+		}
+		return sbom.Dependency{Ref: "pkg:generic/" + from + "@1", DependsOn: targets, Scope: scope}
+	}
+	tests := []struct {
+		name       string
+		components []sbom.Component
+		deps       []sbom.Dependency
+		target     string
+		want       string
+	}{
+		{"dev-only transitive", []sbom.Component{c("root", sbom.ScopeProduction), c("leaf", sbom.ScopeProduction)}, []sbom.Dependency{d("root", sbom.ScopeDevelopment, "leaf")}, "leaf", sbom.ScopeDevelopment},
+		{"production path wins diamond", []sbom.Component{c("root", sbom.ScopeProduction), c("p", sbom.ScopeProduction), c("d", sbom.ScopeProduction), c("leaf", sbom.ScopeProduction)}, []sbom.Dependency{d("root", sbom.ScopeProduction, "p"), d("root", sbom.ScopeDevelopment, "d"), d("p", sbom.ScopeProduction, "leaf"), d("d", sbom.ScopeProduction, "leaf")}, "leaf", sbom.ScopeProduction},
+		{"rootless cycle conservative", []sbom.Component{c("a", sbom.ScopeProduction), c("b", sbom.ScopeProduction)}, []sbom.Dependency{d("a", sbom.ScopeDevelopment, "b"), d("b", sbom.ScopeDevelopment, "a")}, "b", sbom.ScopeProduction},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			graph, err := buildProjectDependencyGraph("analysis", scauc.ScanResult{SBOM: &sbom.SBOM{Components: tt.components, Dependencies: tt.deps}})
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := graphNodesByID(graph.Nodes)["pkg:generic/"+tt.target+"@1"].Scope
+			if got != tt.want {
+				t.Fatalf("scope = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDependencySubtreePreservesEdgeMetadata(t *testing.T) {
+	a := component("a", "1", "pkg:generic/a@1", sbom.ScopeProduction)
+	b := component("b", "1", "pkg:generic/b@1", sbom.ScopeDevelopment)
+	doc := &sbom.SBOM{Components: []sbom.Component{a, b}, Dependencies: []sbom.Dependency{{Ref: a.PURL, DependsOn: []string{b.PURL}, Scope: sbom.ScopeDevelopment, Optional: true}}}
+	got, err := dependencySubtree(doc, a.PURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Dependencies) != 1 || got.Dependencies[0].Scope != sbom.ScopeDevelopment || !got.Dependencies[0].Optional {
+		t.Fatalf("edge metadata lost from subtree: %+v", got.Dependencies)
+	}
+	cloned := cloneDependencies(doc.Dependencies)
+	if cloned[0].Scope != sbom.ScopeDevelopment || !cloned[0].Optional {
+		t.Fatalf("edge metadata lost from clone: %+v", cloned)
+	}
+}

--- a/internal/usecase/sca/dependency_scope_test.go
+++ b/internal/usecase/sca/dependency_scope_test.go
@@ -1,0 +1,73 @@
+package sca
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/sbom"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
+)
+
+func TestClassifyVulnsGraphScopeRefinement(t *testing.T) {
+	component := func(name string, scope string) sbom.Component {
+		return sbom.Component{Name: name, Version: "1.0.0", PURL: "pkg:generic/" + name + "@1.0.0", Scope: scope}
+	}
+	dep := func(from string, scope string, to ...string) sbom.Dependency {
+		targets := make([]string, len(to))
+		for i, name := range to {
+			targets[i] = "pkg:generic/" + name + "@1.0.0"
+		}
+		return sbom.Dependency{Ref: "pkg:generic/" + from + "@1.0.0", DependsOn: targets, Scope: scope}
+	}
+
+	tests := []struct {
+		name       string
+		components []sbom.Component
+		deps       []sbom.Dependency
+		target     string
+		want       string
+	}{
+		{
+			name:       "dev-only transitive is downgraded",
+			components: []sbom.Component{component("root", sbom.ScopeProduction), component("leaf", sbom.ScopeProduction)},
+			deps:       []sbom.Dependency{dep("root", sbom.ScopeDevelopment, "leaf")}, target: "leaf", want: sbom.ScopeDevelopment,
+		},
+		{
+			name:       "production path wins a mixed diamond",
+			components: []sbom.Component{component("root", sbom.ScopeProduction), component("prod", sbom.ScopeProduction), component("dev", sbom.ScopeProduction), component("leaf", sbom.ScopeProduction)},
+			deps: []sbom.Dependency{
+				dep("root", sbom.ScopeProduction, "prod"), dep("root", sbom.ScopeDevelopment, "dev"),
+				dep("prod", sbom.ScopeProduction, "leaf"), dep("dev", sbom.ScopeProduction, "leaf"),
+			}, target: "leaf", want: sbom.ScopeProduction,
+		},
+		{
+			name:       "provided-only Maven-style path is actionable development",
+			components: []sbom.Component{component("root", sbom.ScopeProduction), component("leaf", sbom.ScopeProduction)},
+			deps:       []sbom.Dependency{dep("root", "provided", "leaf")}, target: "leaf", want: sbom.ScopeDevelopment,
+		},
+		{
+			name:       "background graph evidence is monotonically clamped",
+			components: []sbom.Component{component("root", sbom.ScopeProduction), component("leaf", sbom.ScopeProduction)},
+			deps:       []sbom.Dependency{dep("root", sbom.ScopeTest, "leaf")}, target: "leaf", want: sbom.ScopeDevelopment,
+		},
+		{
+			name:       "rootless cycle remains conservative production",
+			components: []sbom.Component{component("a", sbom.ScopeProduction), component("b", sbom.ScopeProduction)},
+			deps:       []sbom.Dependency{dep("a", sbom.ScopeDevelopment, "b"), dep("b", sbom.ScopeDevelopment, "a")}, target: "b", want: sbom.ScopeProduction,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := &sbom.SBOM{Components: tt.components, Dependencies: tt.deps}
+			vulns := []vulnerability.Vulnerability{{ID: "CVE-TEST-0001", Component: tt.target, Version: "1.0.0", Severity: shared.SeverityHigh}}
+			classifyVulns(doc, vulns)
+			if got := vulns[0].Scope; got != tt.want {
+				t.Fatalf("scope = %q, want %q", got, tt.want)
+			}
+			if tt.name == "background graph evidence is monotonically clamped" && sbom.IsBackgroundScope(vulns[0].Scope) {
+				t.Fatalf("graph refinement moved shipping vuln into background scope %q", vulns[0].Scope)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Preserves dependency scope on each SBOM relationship instead of flattening it onto a component.

* Adds per-edge `Scope` and `Optional` metadata to `sbom.Dependency`; owned lockfile parsers split mixed edge groups deterministically.
* Computes effective scope through the dependency graph: dev/test/background paths stay non-shipping transitively, while any production path wins.
* Uses effective scope in SCA vulnerability classification and the project dependency graph.
* Handles CycloneDX synthetic project roots so an explicit root-edge scope is not overridden by a production-shaped target component.
* Adds regression coverage for dev-only transitive paths, mixed prod/dev diamonds, optional edges, and synthetic-root propagation.

## Validation

Rebased as one commit (`94d88b49`) directly on current `main` (`03c8271d`).

Passed:

* Go lint
* Frontend test, typecheck, and build
* Windows Go build, vet, and full test suite
* Linux D3.3 packages: `internal/domain/sbom` and `internal/usecase/sca`

Linux `go test ./...` remains blocked by the pre-existing, untouched `internal/usecase/response.TestIncidentCoordinatorPreparesPostgresActionBeforeRequestProjection` Postgres conflict. It reproduces consistently and is outside this PR’s diff.
