### PR TITLE
test(pyreach): pass supersedes arg to OpenVEX after signature change

### DIFF
--- a/internal/usecase/pyreach/e2e_test.go
+++ b/internal/usecase/pyreach/e2e_test.go
@@ -130,7 +130,7 @@ func TestPyReachToOpenVEXEndToEnd(t *testing.T) {
 	}
 	exp := export.NewService(findingRepo, clock{}, "test")
 	exp.SetJudgments(store)
-	doc, err := exp.OpenVEX(context.Background(), eng)
+	doc, err := exp.OpenVEX(context.Background(), eng, "")
 	if err != nil {
 		t.Fatalf("openvex: %v", err)
 	}

--- a/internal/usecase/pyreach/tier2_recorder_test.go
+++ b/internal/usecase/pyreach/tier2_recorder_test.go
@@ -70,7 +70,7 @@ func TestTier2RecorderMintsSemanticClaimsAndFiltersIncompleteNegative(t *testing
 				}
 				exporter := exportuc.NewService(findings, tier2Clock{}, "test")
 				exporter.SetJudgments(store)
-				document, err := exporter.OpenVEX(context.Background(), "eng")
+				document, err := exporter.OpenVEX(context.Background(), "eng", "")
 				if err != nil || len(document.Statements) != 1 || document.Statements[0].Status != "not_affected" ||
 					document.Statements[0].Justification != "vulnerable_code_not_in_execute_path" {
 					t.Fatalf("Tier-2 OpenVEX = %+v err=%v", document, err)


### PR DESCRIPTION
## What

`export.Service.OpenVEX` takes `(ctx, engagementID shared.ID, supersedes string)`, but two pyreach tests still called it with two arguments, so `go test ./internal/usecase/pyreach/` failed to build. Both call sites now pass an empty `supersedes`.

## Changes

- `tier2_recorder_test.go`: `OpenVEX(ctx, "eng")` to `OpenVEX(ctx, "eng", "")`.
- `e2e_test.go`: `OpenVEX(ctx, eng)` to `OpenVEX(ctx, eng, "")`.

## Verification

`go test ./internal/usecase/pyreach/` builds and passes.

Refs #860
