### PR TITLE
feat(advisory): record signature-verified status on csaf observations

### DIFF
--- a/internal/domain/advisory/observation.go
+++ b/internal/domain/advisory/observation.go
@@ -45,6 +45,12 @@ type Observation struct {
 	EPSSPercentile     *float64
 	PublicExploit      *bool
 	ActiveExploitation *bool
+	// SignatureVerified records that this observation's source document carried a valid provider OpenPGP
+	// signature that was verified before ingest (D1.8). It is persisted in the observation's normalized
+	// payload as the authenticity audit trail. omitempty: a provider without signature verification (most
+	// feeds) simply omits it. Because verification is fail-closed, an ingested observation is never marked
+	// with a failed verification; the field is set true only on a document that verified.
+	SignatureVerified bool `json:",omitempty"`
 }
 
 // ObservationRecord is the bounded persistence envelope for one provider record.

--- a/internal/infrastructure/tools/vulnerabilityprovider/csaf_verify_wiring_test.go
+++ b/internal/infrastructure/tools/vulnerabilityprovider/csaf_verify_wiring_test.go
@@ -113,3 +113,44 @@ func TestDocumentProviderRejectsBadKey(t *testing.T) {
 		t.Fatal("an invalid armored key must be rejected at construction")
 	}
 }
+
+// TestDocumentProviderRecordsVerifiedStatus covers the D1.8 "status recorded" acceptance: an advisory from a
+// validly-signed CSAF document is ingested with SignatureVerified=true on its observation.
+func TestDocumentProviderRecordsVerifiedStatus(t *testing.T) {
+	const csafAdvisoryDoc = `{"product_tree":{"full_product_names":[{"product_id":"PA","product_identification_helper":{"cpe":"cpe:2.3:a:x:requests:*:*:*:*:*:python:*:*"}},{"product_id":"PF","product_identification_helper":{"cpe":"cpe:2.3:a:x:requests:2.20.0:*:*:*:*:python:*:*"}}]},"vulnerabilities":[{"cve":"CVE-2020-1","product_status":{"known_affected":["PA"],"fixed":["PF"]}}]}`
+	const csafAdvisorySig = `-----BEGIN PGP SIGNATURE-----
+
+iQEzBAABCgAdFiEEskoqIL3PDxcH4Nm6VUA+aadBa1cFAmqiqkUACgkQVUA+aadB
+a1dXnQf+OeY5sokmux+WyzW+Zq90/mEHsKowhPFLuC6kXRIONhT8Ww+qhAgIwEeo
+T+8gDMrPcy76cm3dVgMfvqs0hI5kWXmKqgttLwXmqHivTn52TZo+Ud5gikzPDM18
+lJV21EaIEEZZQvB0yLpqzTJDbizwmzMECN5bSM9pXg2g1fdaW+3i/nAgoebg7YBK
+z41lg5wuq3/6+2ahMcuBz6YvkWQz/Y8Gys5asyDKGTanrZ7lMeqgPq5D0EEg7zje
+w9R3Ydh/rzeyja8pwl2exhnUh76shsOOUGqy6eEmM9kg8XZPOeyfPZJ+N+1ImWmA
+v5dJrLa554JDtcsf0jXL3pIfzU2Iag==
+=DmLg
+-----END PGP SIGNATURE-----
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/advisory.json":
+			_, _ = w.Write([]byte(csafAdvisoryDoc))
+		case "/advisory.json.asc":
+			_, _ = w.Write([]byte(csafAdvisorySig))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	p, err := NewDocumentProvider(csafSourceWithKey(t, srv.URL, csafDocPubKey), Dependencies{ResolveSecret: func(context.Context, string) ([]byte, error) { return nil, nil }})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.client = srv.Client()
+	var got []advisory.ObservationRecord
+	if _, _, err := p.Fetch(context.Background(), nil, func(rec advisory.ObservationRecord) error { got = append(got, rec); return nil }); err != nil {
+		t.Fatalf("signed CSAF must ingest: %v", err)
+	}
+	if len(got) != 1 || !got[0].Observation.SignatureVerified {
+		t.Fatalf("observation must be marked SignatureVerified: %+v", got)
+	}
+}

--- a/internal/infrastructure/tools/vulnerabilityprovider/document.go
+++ b/internal/infrastructure/tools/vulnerabilityprovider/document.go
@@ -113,8 +113,11 @@ func (p *DocumentProvider) Fetch(ctx context.Context, _ []byte, emit func(adviso
 				stats.Skipped++
 				continue
 			}
+			// Reaching here with a key configured means the document's signature verified (a failure returned
+			// above), so mark the observation as signature-verified for the authenticity audit trail (D1.8).
 			record := advisory.ObservationRecord{Observation: advisory.Observation{
 				SourceType: p.typeName, SourceID: p.sourceID.String(), RecordID: item.ID, Advisory: item, Status: advisory.StatusActive,
+				SignatureVerified: p.pubKey != "",
 			}, RawReference: safeReference(endpoint)}
 			if err := emit(record); err != nil {
 				return nil, stats, err


### PR DESCRIPTION
## What

An advisory ingested from a CSAF document whose OpenPGP signature was verified now carries `SignatureVerified=true` on its observation. Completes the "status recorded" acceptance of EPIC #860 D1.8, alongside the fail-closed verification in #945.

## How

`advisory.Observation` gains a `SignatureVerified bool` (omitempty), and the `DocumentProvider` sets it true on records emitted from a verified document (reaching that code path means the signature verified, since a failure returns first). The flag rides in the existing JSONB observation payload, so there is **no schema change**.

Because verification is fail-closed, the flag is only ever set true on a document that verified; providers without signature verification omit it.

## Tests

`TestDocumentProviderRecordsVerifiedStatus`: a real gpg-signed CSAF advisory document ingests with `SignatureVerified=true` on its observation.

Small follow-on to the Codex-reviewed #945; `go vet`, `golangci-lint` (0 issues), and the advisory/provider tests pass.

Refs #860
