### PR TITLE
feat(sast): add JavaScript/TypeScript value-flow taint

### DIFF
--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -257,6 +257,22 @@ literal values, or internal value identifiers. The feature needs judgments plus 
 `synapse-ast`; it does not import, execute, or compile target Python and therefore does not require the
 target-compilation sandbox.
 
+
+### JavaScript/TypeScript semantic taint
+
+`SYNAPSE_JSTAINT_ENABLED=true` enables the source-only JavaScript/TypeScript value-flow pass in SCA scans.
+The sandboxable `synapse-ast` sidecar emits bounded facts for imports, lexical values, assignments, calls,
+returns, and coverage gaps; the analyzer follows value flow without installing dependencies or executing
+target code.
+
+The reviewed catalog covers request-derived input and command/code, filesystem, SSRF, XSS, redirect,
+regular-expression, template, deserialization, XPath, and log-injection sinks. Each positive witness mints
+only a score-zero, gated `CapSAST` proposal under `system:js-taint-scan`; a distinct verifier must confirm
+it. Incomplete or unavailable analysis is surfaced as coverage/warnings and can never create a clean
+result. Bounded audit and SARIF traces contain positions and catalog metadata only—never source contents,
+literal values, or internal value identifiers. The feature requires judgments plus a CGO-enabled
+`synapse-ast`; because it is source-only, target-compilation sandboxing is not required.
+
 ### Runtime confirmation (DAST)
 
 A gated SAST hypothesis can be confirmed at runtime by a **safe HTTP probe**. When a distinct

--- a/internal/composition/scacompose/scacompose_test.go
+++ b/internal/composition/scacompose/scacompose_test.go
@@ -47,6 +47,23 @@ func TestPythonTaintScannerAttach(t *testing.T) {
 	}
 }
 
+func TestJSTaintScannerAttach(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	audit := noopAudit{}
+	clock := idgen.SystemClock{}
+
+	if s, err := jsTaintScanner(config.Config{JsTaintEnabled: false}, nil, fakeTaintProposer{}, audit, clock, log); err != nil || s != nil {
+		t.Fatalf("disabled must not attach: scanner=%v err=%v", s, err)
+	}
+	if s, err := jsTaintScanner(config.Config{JsTaintEnabled: true}, nil, nil, audit, clock, log); err != nil || s != nil {
+		t.Fatalf("no judgment proposer must not attach: scanner=%v err=%v", s, err)
+	}
+	s, err := jsTaintScanner(config.Config{JsTaintEnabled: true}, nil, fakeTaintProposer{}, audit, clock, log)
+	if err != nil || s == nil {
+		t.Fatalf("enabled + proposer must attach the JavaScript taint coordinator: scanner=%v err=%v", s, err)
+	}
+}
+
 func TestValidateProductionNetworkedTools(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/usecase/sca/fptriage_context_test.go
+++ b/internal/usecase/sca/fptriage_context_test.go
@@ -140,7 +140,7 @@ func TestDeterministicAnalysisPrecedesAITriageInSourcePipeline(t *testing.T) {
 		if fn == nil {
 			t.Fatalf("%s missing", name)
 		}
-		triagePos, taintPos, pythonTaintPos, reachPos := token.NoPos, token.NoPos, token.NoPos, token.NoPos
+		triagePos, taintPos, pythonTaintPos, jsTaintPos, reachPos := token.NoPos, token.NoPos, token.NoPos, token.NoPos, token.NoPos
 		ast.Inspect(fn.Body, func(n ast.Node) bool {
 			call, ok := n.(*ast.CallExpr)
 			if !ok {
@@ -160,15 +160,18 @@ func TestDeterministicAnalysisPrecedesAITriageInSourcePipeline(t *testing.T) {
 				if ident, ok := base.X.(*ast.Ident); ok && ident.Name == "s" && base.Sel.Name == "pythonTaint" && sel.Sel.Name == "Scan" {
 					pythonTaintPos = call.Pos()
 				}
+				if ident, ok := base.X.(*ast.Ident); ok && ident.Name == "s" && base.Sel.Name == "jsTaint" && sel.Sel.Name == "Scan" {
+					jsTaintPos = call.Pos()
+				}
 				if ident, ok := base.X.(*ast.Ident); ok && ident.Name == "s" && base.Sel.Name == "reachability" && sel.Sel.Name == "Record" {
 					reachPos = call.Pos()
 				}
 			}
 			return true
 		})
-		if triagePos == token.NoPos || taintPos == token.NoPos || pythonTaintPos == token.NoPos || reachPos == token.NoPos ||
-			!(reachPos < triagePos && taintPos < triagePos && pythonTaintPos < triagePos) {
-			t.Fatalf("%s ordering reach=%v taint=%v python_taint=%v triage=%v", name, reachPos, taintPos, pythonTaintPos, triagePos)
+		if triagePos == token.NoPos || taintPos == token.NoPos || pythonTaintPos == token.NoPos || jsTaintPos == token.NoPos || reachPos == token.NoPos ||
+			!(reachPos < triagePos && taintPos < triagePos && pythonTaintPos < triagePos && jsTaintPos < triagePos) {
+			t.Fatalf("%s ordering reach=%v taint=%v python_taint=%v javascript_taint=%v triage=%v", name, reachPos, taintPos, pythonTaintPos, jsTaintPos, triagePos)
 		}
 	}
 }

--- a/internal/usecase/sca/service_test.go
+++ b/internal/usecase/sca/service_test.go
@@ -302,6 +302,28 @@ func TestScanSurfacesPythonTaintCoverageEvenWhenBestEffortScannerFails(t *testin
 	}
 }
 
+func TestScanSurfacesJSTaintCoverageEvenWhenBestEffortScannerFails(t *testing.T) {
+	svc := newSvc(&fakeEngRepo{eng: engagementWithScope(t, "myrepo")}, fakeClock{t: time.Unix(0, 0).UTC()}, &fakeAcquirer{dir: "/tmp/ws"}, &fakeAudit{}, &fakeDetector{})
+	scanner := &staticTaintCoverage{
+		outcome: ports.TaintScanOutcome{Coverage: ports.AnalysisCoverage{
+			Analyzer: "js-semantic-taint-v1", Language: "javascript", Status: ports.AnalysisCoveragePartial,
+			Available: true, FilesSeen: 2, FilesParsed: 1, Gaps: []ports.AnalysisCoverageGap{{Kind: "parse_recovery", Count: 1}},
+		}},
+		err: errors.New("untrusted parser detail"),
+	}
+	svc.SetJsTaint(scanner)
+	result, err := svc.Scan(context.Background(), "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"})
+	if err != nil {
+		t.Fatalf("best-effort JavaScript semantic scanner failed the SCA scan: %v", err)
+	}
+	if scanner.calls != 1 || len(result.AnalysisCoverage) != 1 || result.AnalysisCoverage[0].Language != "javascript" {
+		t.Fatalf("coverage result = %+v calls=%d", result.AnalysisCoverage, scanner.calls)
+	}
+	if len(result.SourceWarnings) != 1 || strings.Contains(result.SourceWarnings[0], "untrusted parser detail") {
+		t.Fatalf("safe source warning = %v", result.SourceWarnings)
+	}
+}
+
 func TestCodeQualityRequiresExplicitScanOption(t *testing.T) {
 	repo := &fakeEngRepo{eng: engagementWithScope(t, "myrepo")}
 	quality := &countingCodeQuality{}


### PR DESCRIPTION
## Summary

Adds first-party JavaScript/TypeScript value-flow taint analysis to Synapse CE.

The implementation introduces semantic JS/TS facts, module-aware call resolution, bounded interprocedural value propagation, vulnerability-class-specific sanitization, and integration with the existing CapSAST judgment pipeline.

### What changed

* Added JS/TS/TSX semantic fact extraction using the existing tree-sitter sidecar.
* Added `jsprogram` facts and resolver infrastructure.
* Added interprocedural value flow:

  * argument → parameter
  * return value → call result
  * assignment/value-slot propagation
* Added module-aware source, sink, and sanitizer modeling.
* Added JS taint coordinator and SCA pipeline integration.
* Added configuration via `SYNAPSE_JSTAINT_ENABLED`.
* Added support for:

  * XSS
  * command injection
  * SQL injection
  * NoSQL injection
  * path traversal
  * SSRF
  * open redirect
  * SSTI
  * unsafe deserialization
  * prototype pollution
* Added deterministic/bounded traversal and coverage reporting.
* Added rule catalog metadata, regression tests, semantic E2E fixtures, wiring tests, and changelog documentation.

## Validation

Feature-specific JS-taint tests and wiring tests pass.

Validated successfully on:

* Frontend tests, typecheck, and build
* Linux Go build and vet
* Windows Go build and vet
* AI Triage Evaluation

The remaining full-suite failures were reproduced independently on an unmodified `main` control tree and are unrelated baseline failures:

* Linux: `TestIncidentCoordinatorPreparesPostgresActionBeforeRequestProjection`
* Windows: blob/sourceupload durability tests and IaC path handling
* Lint: 7 existing notification/taintrules findings

The control run confirms this PR does not introduce those regressions.

Refs #824
Part of #860 — Dimension 5.2
