### PR TITLE
feat(jsprogram): add js/ts source-only facts extractor

### DIFF
--- a/cmd/synapse-ast/main.go
+++ b/cmd/synapse-ast/main.go
@@ -21,8 +21,8 @@ import (
 )
 
 func main() {
-	if len(os.Args) != 3 || (os.Args[1] != "functions" && os.Args[1] != "metrics" && os.Args[1] != "bugs" && os.Args[1] != "quality" && os.Args[1] != "python-facts") {
-		fmt.Fprintln(os.Stderr, "usage: synapse-ast functions|metrics|bugs|quality|python-facts <dir>")
+	if len(os.Args) != 3 || (os.Args[1] != "functions" && os.Args[1] != "metrics" && os.Args[1] != "bugs" && os.Args[1] != "quality" && os.Args[1] != "python-facts" && os.Args[1] != "js-facts") {
+		fmt.Fprintln(os.Stderr, "usage: synapse-ast functions|metrics|bugs|quality|python-facts|js-facts <dir>")
 		os.Exit(2)
 	}
 	var (
@@ -40,6 +40,8 @@ func main() {
 		out, err = astwalk.QualityFor(context.Background(), os.Args[2])
 	case "python-facts":
 		out, err = astwalk.PythonFactsFor(context.Background(), os.Args[2])
+	case "js-facts":
+		out, err = astwalk.JsFactsFor(context.Background(), os.Args[2])
 	}
 	if errors.Is(err, astwalk.ErrUnavailable) {
 		fmt.Fprintln(os.Stderr, "synapse-ast:", err)

--- a/internal/domain/jsprogram/facts.go
+++ b/internal/domain/jsprogram/facts.go
@@ -1,0 +1,742 @@
+// Package jsprogram defines the deterministic, source-only semantic facts used by JavaScript/TypeScript
+// value-flow taint. It is the JS/TS twin of pythonprogram: the model is parser-independent, tree-sitter is
+// confined to the synapse-ast infrastructure sidecar, and every document is validated here before a use
+// case trusts it. The differences from Python are language-level: `$` is a legal identifier character,
+// modules are identified by their source PATH (not a dotted package name), imports carry a JS ImportKind,
+// and symbol ids use a "js:" prefix.
+package jsprogram
+
+import (
+	"fmt"
+	"path"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+const (
+	// SchemaVersion is the only semantic-facts wire version this build understands.
+	SchemaVersion = 1
+
+	maxFiles       = 200_000
+	maxSymbols     = 2_000_000
+	maxFacts       = 4_000_000
+	maxParameters  = 1_024
+	maxArguments   = 4_096
+	maxSegments    = 256
+	maxStringBytes = 4_096
+)
+
+// SymbolKind identifies a JS/TS declaration that owns a lexical scope or can appear in a call graph.
+type SymbolKind string
+
+const (
+	SymbolModule   SymbolKind = "module"
+	SymbolClass    SymbolKind = "class"
+	SymbolFunction SymbolKind = "function"
+	SymbolMethod   SymbolKind = "method"
+	SymbolArrow    SymbolKind = "arrow" // the JS analog of a Python lambda (arrow / anonymous function expression)
+)
+
+func (k SymbolKind) Valid() bool {
+	switch k {
+	case SymbolModule, SymbolClass, SymbolFunction, SymbolMethod, SymbolArrow:
+		return true
+	}
+	return false
+}
+
+// ParameterKind preserves JS/TS argument-binding semantics without carrying annotations/default text.
+type ParameterKind string
+
+const (
+	ParameterPositional   ParameterKind = "positional"
+	ParameterRest         ParameterKind = "rest"         // ...args
+	ParameterDestructured ParameterKind = "destructured" // {a}/[a] pattern-bound name
+	ParameterDefault      ParameterKind = "default"      // a = expr
+)
+
+func (k ParameterKind) Valid() bool {
+	return k == ParameterPositional || k == ParameterRest || k == ParameterDestructured || k == ParameterDefault
+}
+
+// ImportKind records how a binding entered the module. Together with Module (the specifier) it lets the
+// taint catalog match a sink/source to its package without resolving the module graph.
+type ImportKind string
+
+const (
+	ImportNamed     ImportKind = "named"     // import { a as b } from 'm'
+	ImportDefault   ImportKind = "default"   // import d from 'm'
+	ImportNamespace ImportKind = "namespace" // import * as ns from 'm'
+	ImportRequire   ImportKind = "require"   // const x = require('m')
+	ImportReexport  ImportKind = "reexport"  // export ... from 'm'
+)
+
+func (k ImportKind) Valid() bool {
+	switch k {
+	case ImportNamed, ImportDefault, ImportNamespace, ImportRequire, ImportReexport:
+		return true
+	}
+	return false
+}
+
+// ReferenceKind describes a bounded expression shape. It intentionally excludes arbitrary source text.
+type ReferenceKind string
+
+const (
+	ReferenceName       ReferenceKind = "name"
+	ReferenceAttribute  ReferenceKind = "attribute" // member access a.b.c
+	ReferenceCall       ReferenceKind = "call"
+	ReferenceExpression ReferenceKind = "expression"
+	ReferenceLiteral    ReferenceKind = "literal"
+	ReferenceUnknown    ReferenceKind = "unknown"
+)
+
+func (k ReferenceKind) Valid() bool {
+	switch k {
+	case ReferenceName, ReferenceAttribute, ReferenceCall, ReferenceExpression, ReferenceLiteral, ReferenceUnknown:
+		return true
+	}
+	return false
+}
+
+// GapKind is a closed reason code explaining why absence cannot be treated as proof.
+type GapKind string
+
+const (
+	GapParseRecovery    GapKind = "parse_recovery"
+	GapDynamicImport    GapKind = "dynamic_import"
+	GapDynamicExecution GapKind = "dynamic_execution"
+	GapUnresolvedImport GapKind = "unresolved_import"
+	GapUnresolvedCall   GapKind = "unresolved_call"
+	GapUnresolvedValue  GapKind = "unresolved_value"
+	GapDynamicAttribute GapKind = "dynamic_attribute"
+	GapBudget           GapKind = "budget"
+	GapUnreadable       GapKind = "unreadable"
+)
+
+func (k GapKind) Valid() bool {
+	switch k {
+	case GapParseRecovery, GapDynamicImport, GapDynamicExecution, GapUnresolvedImport, GapUnresolvedCall,
+		GapUnresolvedValue, GapDynamicAttribute, GapBudget, GapUnreadable:
+		return true
+	}
+	return false
+}
+
+// Position is a normalized, relative source location. Column is zero-based, Line is one-based.
+type Position struct {
+	File   string `json:"file"`
+	Line   int    `json:"line"`
+	Column int    `json:"column"`
+}
+
+// Reference is a safe expression summary such as ["req", "query", "id"]. No source body or literal value
+// is retained. Literal references only carry Kind, not their value.
+type Reference struct {
+	Kind     ReferenceKind `json:"kind"`
+	Segments []string      `json:"segments,omitempty"`
+}
+
+// Parameter is one callable parameter in declaration order.
+type Parameter struct {
+	Name    string        `json:"name"`
+	Kind    ParameterKind `json:"kind"`
+	ValueID string        `json:"value_id,omitempty"`
+	Pos     Position      `json:"position"`
+}
+
+// Module associates a canonical module candidate (its source path without extension) with its source file.
+type Module struct {
+	Name string   `json:"name"`
+	File string   `json:"file"`
+	Pos  Position `json:"position"`
+}
+
+// Symbol is a module, class, function, method, or arrow declaration.
+type Symbol struct {
+	ID            string      `json:"id"`
+	Module        string      `json:"module"`
+	QualifiedName string      `json:"qualified_name"`
+	Name          string      `json:"name"`
+	ParentID      string      `json:"parent_id,omitempty"`
+	Kind          SymbolKind  `json:"kind"`
+	Pos           Position    `json:"position"`
+	Parameters    []Parameter `json:"parameters,omitempty"`
+	Decorators    []Reference `json:"decorators,omitempty"`
+	Bases         []Reference `json:"bases,omitempty"` // the class's `extends` clause (at most one in JS)
+	Async         bool        `json:"async,omitempty"`
+}
+
+// Import records one import/require binding. Module is the specifier ("express", "./util", "@scope/pkg").
+type Import struct {
+	ScopeID string     `json:"scope_id"`
+	Kind    ImportKind `json:"kind"`
+	Module  string     `json:"module"`
+	Name    string     `json:"name,omitempty"`  // imported binding name (a named import's original name, or "default")
+	Alias   string     `json:"alias,omitempty"` // the local binding introduced in this module
+	Pos     Position   `json:"position"`
+}
+
+// Argument is one positional or spread call argument. Spread values carry Spread=true.
+type Argument struct {
+	Spread  bool      `json:"spread,omitempty"`
+	Value   Reference `json:"value"`
+	ValueID string    `json:"value_id,omitempty"`
+	Pos     Position  `json:"position,omitempty"`
+}
+
+// Call is one syntactic call (or `new`) expression owned by CallerID. Callee is a name/member reference
+// when statically expressible, otherwise ReferenceUnknown; the extractor then also records a coverage gap
+// (GapUnresolvedCall) so absence is not read as proof. Validate stays lenient about this pairing on purpose:
+// a valid source file must never have its whole facts document rejected, so a missing gap is not an error.
+type Call struct {
+	ID              string     `json:"id"`
+	CallerID        string     `json:"caller_id"`
+	Callee          Reference  `json:"callee"`
+	Arguments       []Argument `json:"arguments,omitempty"`
+	ResultID        string     `json:"result_id,omitempty"`
+	ReceiverValueID string     `json:"receiver_value_id,omitempty"`
+	Pos             Position   `json:"position"`
+	Await           bool       `json:"await,omitempty"`
+	New             bool       `json:"new,omitempty"` // a `new X(...)` constructor call
+}
+
+// Assignment captures a binding/value relationship without retaining expression text.
+type Assignment struct {
+	ScopeID   string      `json:"scope_id"`
+	Targets   []Reference `json:"targets"`
+	TargetIDs []string    `json:"target_ids,omitempty"`
+	Value     Reference   `json:"value"`
+	ValueID   string      `json:"value_id,omitempty"`
+	Pos       Position    `json:"position"`
+}
+
+// Return captures a function return expression summary.
+type Return struct {
+	ScopeID string    `json:"scope_id"`
+	Value   Reference `json:"value"`
+	ValueID string    `json:"value_id,omitempty"`
+	SlotID  string    `json:"slot_id,omitempty"`
+	Pos     Position  `json:"position"`
+}
+
+// ValueKind identifies a source-level value slot used by the interprocedural taint engine.
+type ValueKind string
+
+const (
+	ValueParameter  ValueKind = "parameter"
+	ValueBinding    ValueKind = "binding"
+	ValueReference  ValueKind = "reference"
+	ValueCallResult ValueKind = "call_result"
+	ValueExpression ValueKind = "expression"
+	ValueLiteral    ValueKind = "literal"
+	ValueReturn     ValueKind = "return"
+)
+
+func (k ValueKind) Valid() bool {
+	switch k {
+	case ValueParameter, ValueBinding, ValueReference, ValueCallResult, ValueExpression, ValueLiteral, ValueReturn:
+		return true
+	}
+	return false
+}
+
+// Value is one stable value slot. Ref carries only a bounded semantic shape; source text is never kept.
+type Value struct {
+	ID      string    `json:"id"`
+	ScopeID string    `json:"scope_id"`
+	Kind    ValueKind `json:"kind"`
+	Name    string    `json:"name,omitempty"`
+	Ref     Reference `json:"reference"`
+	Pos     Position  `json:"position"`
+}
+
+// ValueFlowKind is a closed intra-procedural propagation operation emitted by the sidecar.
+type ValueFlowKind string
+
+const (
+	FlowExpression ValueFlowKind = "expression"
+	FlowAttribute  ValueFlowKind = "attribute"
+	FlowAssignment ValueFlowKind = "assignment"
+	FlowReturn     ValueFlowKind = "return"
+)
+
+func (k ValueFlowKind) Valid() bool {
+	return k == FlowExpression || k == FlowAttribute || k == FlowAssignment || k == FlowReturn
+}
+
+// ValueFlow says a value can propagate from one slot to another inside the same JS function.
+type ValueFlow struct {
+	FromID string        `json:"from_id"`
+	ToID   string        `json:"to_id"`
+	Kind   ValueFlowKind `json:"kind"`
+	Pos    Position      `json:"position"`
+}
+
+// EntrypointHint is a syntactic framework/application entrypoint cue.
+type EntrypointHint struct {
+	SymbolID string   `json:"symbol_id"`
+	Kind     string   `json:"kind"`
+	Pos      Position `json:"position"`
+}
+
+// CoverageGap is an explicit reason a complete negative is unsafe. Detail is a trusted closed label.
+type CoverageGap struct {
+	Kind     GapKind  `json:"kind"`
+	SymbolID string   `json:"symbol_id,omitempty"`
+	Detail   string   `json:"detail,omitempty"`
+	Pos      Position `json:"position"`
+}
+
+// Document is the complete versioned facts result for one source root.
+type Document struct {
+	SchemaVersion int              `json:"schema_version"`
+	Modules       []Module         `json:"modules"`
+	Symbols       []Symbol         `json:"symbols"`
+	Imports       []Import         `json:"imports"`
+	Calls         []Call           `json:"calls"`
+	Assignments   []Assignment     `json:"assignments"`
+	Returns       []Return         `json:"returns"`
+	Values        []Value          `json:"values"`
+	Flows         []ValueFlow      `json:"flows"`
+	Entrypoints   []EntrypointHint `json:"entrypoint_hints"`
+	CoverageGaps  []CoverageGap    `json:"coverage_gaps"`
+	FilesSeen     int              `json:"files_seen"`
+	FilesParsed   int              `json:"files_parsed"`
+	NodesSeen     int              `json:"nodes_seen"`
+	Truncated     bool             `json:"truncated"`
+}
+
+// Complete reports whether the document can support a negative proof.
+func (d Document) Complete() bool {
+	return !d.Truncated && len(d.CoverageGaps) == 0 && d.FilesSeen > 0 && d.FilesSeen == d.FilesParsed
+}
+
+// Validate rejects malformed or unbounded sidecar output at the trust boundary.
+func (d Document) Validate() error {
+	if d.SchemaVersion != SchemaVersion {
+		return fmt.Errorf("%w: unsupported js facts schema version %d", shared.ErrValidation, d.SchemaVersion)
+	}
+	if d.FilesSeen < 0 || d.FilesParsed < 0 || d.FilesParsed > d.FilesSeen || d.FilesSeen > maxFiles || d.NodesSeen < 0 {
+		return fmt.Errorf("%w: invalid js facts coverage counters", shared.ErrValidation)
+	}
+	if len(d.Modules) > maxFiles || len(d.Symbols) > maxSymbols || len(d.Imports) > maxFacts ||
+		len(d.Calls) > maxFacts || len(d.Assignments) > maxFacts || len(d.Returns) > maxFacts ||
+		len(d.Values) > maxFacts || len(d.Flows) > maxFacts || len(d.Entrypoints) > maxFacts || len(d.CoverageGaps) > maxFacts {
+		return fmt.Errorf("%w: js facts document exceeds bounds", shared.ErrValidation)
+	}
+	moduleSet := make(map[string]bool, len(d.Modules))
+	fileSet := make(map[string]bool, len(d.Modules))
+	moduleFiles := make(map[string]string, len(d.Modules))
+	for _, m := range d.Modules {
+		if !validModulePath(m.Name) || validatePosition(m.Pos, true) != nil || m.File != m.Pos.File {
+			return fmt.Errorf("%w: invalid js module fact", shared.ErrValidation)
+		}
+		if moduleSet[m.Name] || fileSet[m.File] {
+			return fmt.Errorf("%w: duplicate js module or file", shared.ErrValidation)
+		}
+		moduleSet[m.Name], fileSet[m.File] = true, true
+		moduleFiles[m.Name] = m.File
+	}
+	symbolSet := make(map[string]Symbol, len(d.Symbols))
+	for _, s := range d.Symbols {
+		if !s.Kind.Valid() || s.ID != canonicalSymbolID(s.Module, s.QualifiedName) || !moduleSet[s.Module] ||
+			!validQualified(s.QualifiedName) || !validSymbolName(s) || validatePosition(s.Pos, true) != nil || len(s.Parameters) > maxParameters {
+			return fmt.Errorf("%w: invalid js symbol fact", shared.ErrValidation)
+		}
+		if _, duplicate := symbolSet[s.ID]; duplicate {
+			return fmt.Errorf("%w: duplicate js symbol %q", shared.ErrValidation, s.ID)
+		}
+		if s.Pos.File != moduleFiles[s.Module] {
+			return fmt.Errorf("%w: js symbol position is outside its module", shared.ErrValidation)
+		}
+		for _, p := range s.Parameters {
+			if !validName(p.Name) || !p.Kind.Valid() || validatePosition(p.Pos, true) != nil || p.Pos.File != s.Pos.File {
+				return fmt.Errorf("%w: invalid js parameter fact", shared.ErrValidation)
+			}
+		}
+		for _, decorator := range s.Decorators {
+			if err := validateReference(decorator); err != nil {
+				return err
+			}
+		}
+		for _, base := range s.Bases {
+			if err := validateReference(base); err != nil {
+				return err
+			}
+		}
+		symbolSet[s.ID] = s
+	}
+	for module := range moduleSet {
+		root, ok := symbolSet[canonicalSymbolID(module, "<module>")]
+		if !ok || root.Kind != SymbolModule {
+			return fmt.Errorf("%w: js module has no canonical module symbol", shared.ErrValidation)
+		}
+	}
+	for _, s := range d.Symbols {
+		if s.Kind == SymbolModule {
+			if s.ParentID != "" || s.QualifiedName != "<module>" {
+				return fmt.Errorf("%w: invalid js module symbol", shared.ErrValidation)
+			}
+			continue
+		}
+		if s.ParentID == "" {
+			return fmt.Errorf("%w: non-module js symbol needs a parent", shared.ErrValidation)
+		}
+		if parent, ok := symbolSet[s.ParentID]; !ok {
+			return fmt.Errorf("%w: js symbol parent does not exist", shared.ErrValidation)
+		} else if parent.Module != s.Module {
+			return fmt.Errorf("%w: js symbol parent crosses modules", shared.ErrValidation)
+		}
+	}
+	validScope := func(scope string) bool { _, ok := symbolSet[scope]; return ok }
+	positionMatchesScope := func(scope string, pos Position) bool {
+		symbol, ok := symbolSet[scope]
+		return ok && symbol.Pos.File == pos.File
+	}
+	valueSet := make(map[string]Value, len(d.Values))
+	for _, value := range d.Values {
+		if !validText(value.ID) || !validScope(value.ScopeID) || !value.Kind.Valid() ||
+			validatePosition(value.Pos, true) != nil || !positionMatchesScope(value.ScopeID, value.Pos) {
+			return fmt.Errorf("%w: invalid js value fact", shared.ErrValidation)
+		}
+		if value.Name != "" && !validName(value.Name) {
+			return fmt.Errorf("%w: invalid js value name", shared.ErrValidation)
+		}
+		if err := validateReference(value.Ref); err != nil {
+			return err
+		}
+		if _, duplicate := valueSet[value.ID]; duplicate {
+			return fmt.Errorf("%w: duplicate js value fact", shared.ErrValidation)
+		}
+		valueSet[value.ID] = value
+	}
+	for _, flow := range d.Flows {
+		from, fromOK := valueSet[flow.FromID]
+		to, toOK := valueSet[flow.ToID]
+		if !fromOK || !toOK || from.ScopeID != to.ScopeID || !flow.Kind.Valid() ||
+			validatePosition(flow.Pos, true) != nil || !positionMatchesScope(from.ScopeID, flow.Pos) {
+			return fmt.Errorf("%w: invalid js intra-procedural value flow", shared.ErrValidation)
+		}
+	}
+	for _, symbol := range d.Symbols {
+		for _, parameter := range symbol.Parameters {
+			if parameter.ValueID == "" {
+				continue
+			}
+			value, ok := valueSet[parameter.ValueID]
+			if !ok || value.ScopeID != symbol.ID || value.Kind != ValueParameter || value.Name != parameter.Name {
+				return fmt.Errorf("%w: js parameter references an invalid value", shared.ErrValidation)
+			}
+		}
+	}
+	for _, item := range d.Imports {
+		if !validScope(item.ScopeID) || !item.Kind.Valid() || !validSpecifier(item.Module) ||
+			!validOptionalName(item.Name) || !validOptionalName(item.Alias) || validatePosition(item.Pos, true) != nil ||
+			!positionMatchesScope(item.ScopeID, item.Pos) {
+			return fmt.Errorf("%w: invalid js import fact", shared.ErrValidation)
+		}
+	}
+	callSet := make(map[string]bool, len(d.Calls))
+	for _, item := range d.Calls {
+		if !validText(item.ID) || callSet[item.ID] || !validScope(item.CallerID) || len(item.Arguments) > maxArguments ||
+			validatePosition(item.Pos, true) != nil || !positionMatchesScope(item.CallerID, item.Pos) {
+			return fmt.Errorf("%w: invalid js call fact", shared.ErrValidation)
+		}
+		if err := validateReference(item.Callee); err != nil {
+			return err
+		}
+		for _, arg := range item.Arguments {
+			if err := validateReference(arg.Value); err != nil {
+				return err
+			}
+			if arg.ValueID != "" {
+				if value, ok := valueSet[arg.ValueID]; !ok || value.ScopeID != item.CallerID ||
+					validatePosition(arg.Pos, true) != nil || !positionMatchesScope(item.CallerID, arg.Pos) {
+					return fmt.Errorf("%w: js call argument references an invalid value", shared.ErrValidation)
+				}
+			}
+		}
+		if item.ResultID != "" {
+			if value, ok := valueSet[item.ResultID]; !ok || value.ScopeID != item.CallerID || value.Kind != ValueCallResult {
+				return fmt.Errorf("%w: js call references an invalid result value", shared.ErrValidation)
+			}
+		}
+		if item.ReceiverValueID != "" {
+			if value, ok := valueSet[item.ReceiverValueID]; !ok || value.ScopeID != item.CallerID {
+				return fmt.Errorf("%w: js call references an invalid receiver value", shared.ErrValidation)
+			}
+		}
+		callSet[item.ID] = true
+	}
+	for _, item := range d.Assignments {
+		if !validScope(item.ScopeID) || len(item.Targets) == 0 || len(item.Targets) > maxArguments ||
+			validatePosition(item.Pos, true) != nil || !positionMatchesScope(item.ScopeID, item.Pos) {
+			return fmt.Errorf("%w: invalid js assignment fact", shared.ErrValidation)
+		}
+		for _, target := range item.Targets {
+			if err := validateReference(target); err != nil {
+				return err
+			}
+		}
+		if err := validateReference(item.Value); err != nil {
+			return err
+		}
+		if item.ValueID != "" {
+			if value, ok := valueSet[item.ValueID]; !ok || value.ScopeID != item.ScopeID {
+				return fmt.Errorf("%w: js assignment references an invalid source value", shared.ErrValidation)
+			}
+		}
+		for _, id := range item.TargetIDs {
+			if value, ok := valueSet[id]; !ok || value.ScopeID != item.ScopeID || value.Kind != ValueBinding {
+				return fmt.Errorf("%w: js assignment references an invalid target value", shared.ErrValidation)
+			}
+		}
+	}
+	for _, item := range d.Returns {
+		if !validScope(item.ScopeID) || validatePosition(item.Pos, true) != nil || !positionMatchesScope(item.ScopeID, item.Pos) {
+			return fmt.Errorf("%w: invalid js return fact", shared.ErrValidation)
+		}
+		if err := validateReference(item.Value); err != nil {
+			return err
+		}
+		if item.ValueID != "" {
+			if value, ok := valueSet[item.ValueID]; !ok || value.ScopeID != item.ScopeID {
+				return fmt.Errorf("%w: js return references an invalid value", shared.ErrValidation)
+			}
+		}
+		if item.SlotID != "" {
+			if value, ok := valueSet[item.SlotID]; !ok || value.ScopeID != item.ScopeID || value.Kind != ValueReturn {
+				return fmt.Errorf("%w: js return references an invalid slot", shared.ErrValidation)
+			}
+		}
+	}
+	for _, item := range d.Entrypoints {
+		if !validScope(item.SymbolID) || !validText(item.Kind) || validatePosition(item.Pos, true) != nil || !positionMatchesScope(item.SymbolID, item.Pos) {
+			return fmt.Errorf("%w: invalid js entrypoint hint", shared.ErrValidation)
+		}
+	}
+	for _, gap := range d.CoverageGaps {
+		if !gap.Kind.Valid() || gap.SymbolID != "" && !validScope(gap.SymbolID) || !validOptionalText(gap.Detail) || validatePosition(gap.Pos, false) != nil ||
+			gap.SymbolID != "" && gap.Pos.File != "" && !positionMatchesScope(gap.SymbolID, gap.Pos) {
+			return fmt.Errorf("%w: invalid js coverage gap", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+func validateReference(ref Reference) error {
+	if !ref.Kind.Valid() || len(ref.Segments) > maxSegments {
+		return fmt.Errorf("%w: invalid js reference", shared.ErrValidation)
+	}
+	if (ref.Kind == ReferenceName || ref.Kind == ReferenceAttribute || ref.Kind == ReferenceCall) && len(ref.Segments) == 0 {
+		return fmt.Errorf("%w: named js reference needs segments", shared.ErrValidation)
+	}
+	if (ref.Kind == ReferenceLiteral || ref.Kind == ReferenceExpression || ref.Kind == ReferenceUnknown) && len(ref.Segments) != 0 {
+		return fmt.Errorf("%w: opaque js reference cannot carry text", shared.ErrValidation)
+	}
+	for _, segment := range ref.Segments {
+		if !validName(segment) {
+			return fmt.Errorf("%w: invalid js reference segment", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+func validatePosition(pos Position, requireFile bool) error {
+	if pos.Line < 0 || pos.Column < 0 || requireFile && pos.Line == 0 {
+		return fmt.Errorf("invalid position counters")
+	}
+	if pos.File == "" {
+		if requireFile {
+			return fmt.Errorf("position file is required")
+		}
+		return nil
+	}
+	if !validText(pos.File) || strings.ContainsAny(pos.File, "\\:") || strings.HasPrefix(pos.File, "/") || path.IsAbs(pos.File) || path.Clean(pos.File) != pos.File {
+		return fmt.Errorf("position file must be normalized and relative")
+	}
+	for _, segment := range strings.Split(pos.File, "/") {
+		if segment == ".." || segment == "." || segment == "" {
+			return fmt.Errorf("position file contains an unsafe segment")
+		}
+	}
+	return nil
+}
+
+// validModulePath validates a module name derived from a source path, e.g. "src/routes/user" or "index".
+func validModulePath(value string) bool {
+	if !validText(value) {
+		return false
+	}
+	parts := strings.Split(value, "/")
+	if len(parts) == 0 || len(parts) > maxSegments {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" || part == "." || part == ".." || !validPathSegment(part) {
+			return false
+		}
+	}
+	return true
+}
+
+func validPathSegment(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r == '_' || r == '$' || r == '-' || r == '.' || unicode.IsLetter(r) || unicode.IsDigit(r) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// validSpecifier validates a module specifier: a bare package, a relative path, a scoped package, or a
+// subpath ("express", "./util", "../lib/db", "@scope/pkg", "lodash/fp").
+func validSpecifier(value string) bool {
+	if !validText(value) {
+		return false
+	}
+	for _, r := range value {
+		if r == '_' || r == '$' || r == '-' || r == '.' || r == '/' || r == '@' || unicode.IsLetter(r) || unicode.IsDigit(r) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func validSymbolName(s Symbol) bool {
+	if s.Kind == SymbolArrow {
+		return validSyntheticFnName(s.Name)
+	}
+	return validName(s.Name)
+}
+
+func validQualified(value string) bool {
+	if strings.Contains(value, "<module>") {
+		return value == "<module>"
+	}
+	for _, part := range strings.Split(value, ".") {
+		if validName(part) || validSyntheticFnName(part) || validDisambiguatedName(part) {
+			continue
+		}
+		return false
+	}
+	return validText(value)
+}
+
+// validSyntheticFnName recognizes the extractor's name for an anonymous function/arrow, "<fn@line_col>".
+func validSyntheticFnName(value string) bool {
+	return strings.HasPrefix(value, "<fn@") && strings.HasSuffix(value, ">") && validText(value)
+}
+
+// validDisambiguatedName recognizes a position-suffixed qualified segment "<name>@<line>_<col>", which the
+// extractor emits when two valid declarations share a name (a TS overload signature, a duplicate method), so
+// each keeps a unique symbol id instead of the whole document being rejected as a duplicate.
+func validDisambiguatedName(value string) bool {
+	at := strings.LastIndexByte(value, '@')
+	if at <= 0 {
+		return false
+	}
+	name, suffix := value[:at], value[at+1:]
+	if !validName(name) {
+		return false
+	}
+	us := strings.IndexByte(suffix, '_')
+	if us <= 0 || us == len(suffix)-1 {
+		return false
+	}
+	return isDigits(suffix[:us]) && isDigits(suffix[us+1:])
+}
+
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// validName accepts a JS identifier. Unlike Python, '$' is a legal identifier character.
+func validName(value string) bool {
+	if !validText(value) || value == "*" {
+		return false
+	}
+	for i, r := range value {
+		if r == '_' || r == '$' || unicode.IsLetter(r) || i > 0 && unicode.IsDigit(r) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func validOptionalName(value string) bool { return value == "" || value == "*" || validName(value) }
+func validOptionalText(value string) bool { return value == "" || validText(value) }
+
+func validText(value string) bool {
+	if value == "" || len(value) > maxStringBytes || !utf8.ValidString(value) {
+		return false
+	}
+	for _, r := range value {
+		if r == 0 || unicode.IsControl(r) {
+			return false
+		}
+	}
+	return true
+}
+
+// CanonicalSymbolID builds the stable id for a JS symbol: "js:" + module path + ":" + qualified name.
+func CanonicalSymbolID(module, qualified string) string { return canonicalSymbolID(module, qualified) }
+
+func canonicalSymbolID(module, qualified string) string {
+	return "js:" + module + ":" + qualified
+}
+
+// SortCanonical makes serialization and downstream graph construction independent of map/parser order.
+func (d *Document) SortCanonical() {
+	if d == nil {
+		return
+	}
+	sort.Slice(d.Modules, func(i, j int) bool { return d.Modules[i].File < d.Modules[j].File })
+	sort.Slice(d.Symbols, func(i, j int) bool { return d.Symbols[i].ID < d.Symbols[j].ID })
+	sort.Slice(d.Imports, func(i, j int) bool {
+		a, b := d.Imports[i], d.Imports[j]
+		return factKey(a.Pos, a.ScopeID, a.Module+"."+a.Name+"."+a.Alias) < factKey(b.Pos, b.ScopeID, b.Module+"."+b.Name+"."+b.Alias)
+	})
+	sort.Slice(d.Calls, func(i, j int) bool { return d.Calls[i].ID < d.Calls[j].ID })
+	sort.Slice(d.Assignments, func(i, j int) bool {
+		return factKey(d.Assignments[i].Pos, d.Assignments[i].ScopeID, "") < factKey(d.Assignments[j].Pos, d.Assignments[j].ScopeID, "")
+	})
+	sort.Slice(d.Returns, func(i, j int) bool {
+		return factKey(d.Returns[i].Pos, d.Returns[i].ScopeID, "") < factKey(d.Returns[j].Pos, d.Returns[j].ScopeID, "")
+	})
+	sort.Slice(d.Values, func(i, j int) bool { return d.Values[i].ID < d.Values[j].ID })
+	sort.Slice(d.Flows, func(i, j int) bool {
+		left := d.Flows[i].FromID + "\x00" + d.Flows[i].ToID + "\x00" + string(d.Flows[i].Kind)
+		right := d.Flows[j].FromID + "\x00" + d.Flows[j].ToID + "\x00" + string(d.Flows[j].Kind)
+		return left < right
+	})
+	sort.Slice(d.Entrypoints, func(i, j int) bool {
+		return d.Entrypoints[i].SymbolID+"\x00"+d.Entrypoints[i].Kind < d.Entrypoints[j].SymbolID+"\x00"+d.Entrypoints[j].Kind
+	})
+	sort.Slice(d.CoverageGaps, func(i, j int) bool {
+		return factKey(d.CoverageGaps[i].Pos, string(d.CoverageGaps[i].Kind), d.CoverageGaps[i].SymbolID) < factKey(d.CoverageGaps[j].Pos, string(d.CoverageGaps[j].Kind), d.CoverageGaps[j].SymbolID)
+	})
+}
+
+func factKey(pos Position, first, second string) string {
+	return fmt.Sprintf("%s\x00%010d\x00%010d\x00%s\x00%s", pos.File, pos.Line, pos.Column, first, second)
+}

--- a/internal/domain/jsprogram/facts_test.go
+++ b/internal/domain/jsprogram/facts_test.go
@@ -1,0 +1,134 @@
+package jsprogram
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+)
+
+func validDoc() Document {
+	pos := Position{File: "src/app.js", Line: 1}
+	moduleID := CanonicalSymbolID("src/app", "<module>")
+	fnID := CanonicalSymbolID("src/app", "$init")
+	fnPos := Position{File: "src/app.js", Line: 2, Column: 0}
+	paramValue := fnID + "#param:0:$el"
+	return Document{
+		SchemaVersion: SchemaVersion,
+		Modules:       []Module{{Name: "src/app", File: "src/app.js", Pos: pos}},
+		Symbols: []Symbol{
+			{ID: moduleID, Module: "src/app", QualifiedName: "<module>", Name: "app", Kind: SymbolModule, Pos: pos},
+			{ID: fnID, Module: "src/app", QualifiedName: "$init", Name: "$init", ParentID: moduleID, Kind: SymbolFunction, Pos: fnPos,
+				Parameters: []Parameter{{Name: "$el", Kind: ParameterPositional, ValueID: paramValue, Pos: fnPos}}},
+		},
+		Values: []Value{
+			{ID: paramValue, ScopeID: fnID, Kind: ValueParameter, Name: "$el", Ref: Reference{Kind: ReferenceName, Segments: []string{"$el"}}, Pos: fnPos},
+		},
+		Imports: []Import{
+			{ScopeID: moduleID, Kind: ImportNamed, Module: "@scope/pkg", Name: "query", Alias: "q", Pos: pos},
+			{ScopeID: moduleID, Kind: ImportRequire, Module: "./util", Alias: "util", Pos: pos},
+		},
+		FilesSeen:   1,
+		FilesParsed: 1,
+	}
+}
+
+func TestValidateAcceptsValidDocumentWithDollarIdentifiers(t *testing.T) {
+	d := validDoc()
+	if err := d.Validate(); err != nil {
+		t.Fatalf("valid document (with $ identifiers) rejected: %v", err)
+	}
+	if !d.Complete() {
+		t.Errorf("document with no gaps and seen==parsed must be Complete")
+	}
+}
+
+func TestValidateRejectsMalformed(t *testing.T) {
+	cases := map[string]func(*Document){
+		"wrong schema":           func(d *Document) { d.SchemaVersion = 99 },
+		"parsed exceeds seen":    func(d *Document) { d.FilesParsed = 5 },
+		"bad module path":        func(d *Document) { d.Modules[0].Name = "src/../app"; d.Symbols[0].Module = "src/../app" },
+		"module file mismatch":   func(d *Document) { d.Modules[0].File = "other.js" },
+		"missing module symbol":  func(d *Document) { d.Symbols = d.Symbols[1:] },
+		"symbol crosses module":  func(d *Document) { d.Symbols[1].Module = "src/other" },
+		"bad value name":         func(d *Document) { d.Values[0].Name = "has space" },
+		"bad import kind":        func(d *Document) { d.Imports[0].Kind = "bogus" },
+		"bad import specifier":   func(d *Document) { d.Imports[0].Module = "bad specifier!" },
+		"absolute position file": func(d *Document) { d.Modules[0].Pos.File = "/etc/passwd"; d.Modules[0].File = "/etc/passwd" },
+		"reference with control": func(d *Document) { d.Values[0].Ref = Reference{Kind: ReferenceName, Segments: []string{"a\x00b"}} },
+	}
+	for name, mutate := range cases {
+		t.Run(name, func(t *testing.T) {
+			d := validDoc()
+			mutate(&d)
+			err := d.Validate()
+			if err == nil {
+				t.Fatalf("expected validation error for %q", name)
+			}
+			if !errors.Is(err, shared.ErrValidation) {
+				t.Errorf("error must wrap shared.ErrValidation, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidModulePath(t *testing.T) {
+	ok := []string{"index", "src/app", "src/routes/user", "a-b/c.d", "$x/_y"}
+	bad := []string{"", "src//app", "../lib", "src/./x", "a b", "a:b"}
+	for _, v := range ok {
+		if !validModulePath(v) {
+			t.Errorf("expected %q to be a valid module path", v)
+		}
+	}
+	for _, v := range bad {
+		if validModulePath(v) {
+			t.Errorf("expected %q to be an invalid module path", v)
+		}
+	}
+}
+
+func TestValidNameAllowsDollar(t *testing.T) {
+	for _, v := range []string{"$", "$x", "jQuery", "_x9", "$_$"} {
+		if !validName(v) {
+			t.Errorf("expected %q to be a valid JS identifier", v)
+		}
+	}
+	for _, v := range []string{"", "1x", "a-b", "a.b", "*"} {
+		if validName(v) {
+			t.Errorf("expected %q to be an invalid JS identifier", v)
+		}
+	}
+}
+
+func TestSortCanonicalDeterministic(t *testing.T) {
+	a := validDoc()
+	b := validDoc()
+	// Reverse b's independent slices; after SortCanonical both must be identical.
+	for i, j := 0, len(b.Symbols)-1; i < j; i, j = i+1, j-1 {
+		b.Symbols[i], b.Symbols[j] = b.Symbols[j], b.Symbols[i]
+	}
+	for i, j := 0, len(b.Imports)-1; i < j; i, j = i+1, j-1 {
+		b.Imports[i], b.Imports[j] = b.Imports[j], b.Imports[i]
+	}
+	a.SortCanonical()
+	b.SortCanonical()
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("SortCanonical is not order-independent:\n%+v\n%+v", a, b)
+	}
+}
+
+func TestValidQualifiedAcceptsDisambiguated(t *testing.T) {
+	ok := []string{"<module>", "f", "C.m", "C.m@6_2", "outer.inner", "C@1_0.m", "<fn@3_5>", "C.<fn@9_2>"}
+	bad := []string{"", "C.m@", "C.m@x_2", "C.m@6", "C.m@6_", "a b", "1x.y", "C.m@6_2_3"}
+	for _, v := range ok {
+		if !validQualified(v) {
+			t.Errorf("expected qualified %q to be valid", v)
+		}
+	}
+	for _, v := range bad {
+		if validQualified(v) {
+			t.Errorf("expected qualified %q to be invalid", v)
+		}
+	}
+}

--- a/internal/infrastructure/tools/ast/provider.go
+++ b/internal/infrastructure/tools/ast/provider.go
@@ -17,6 +17,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsprogram"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/measure"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/pythonprogram"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
@@ -102,6 +103,7 @@ var (
 	_ ports.BugDetector         = (*Provider)(nil)
 	_ ports.CodeAnalyzer        = (*Provider)(nil)
 	_ ports.PythonFactsProvider = (*Provider)(nil)
+	_ ports.JsFactsProvider     = (*Provider)(nil)
 )
 
 // PythonFacts runs `synapse-ast python-facts <root>`. The wire document is validated here because the
@@ -123,6 +125,29 @@ func (p *Provider) PythonFacts(ctx context.Context, root string) (pythonprogram.
 	}
 	if err := document.Validate(); err != nil {
 		return pythonprogram.Document{}, false, fmt.Errorf("validate synapse-ast python facts: %w", err)
+	}
+	return document, true, nil
+}
+
+// JsFacts runs `synapse-ast js-facts <root>`. The wire document is validated here because the sidecar is
+// outside the application trust boundary and parses attacker-controlled repositories.
+func (p *Provider) JsFacts(ctx context.Context, root string) (jsprogram.Document, bool, error) {
+	if strings.TrimSpace(root) == "" {
+		return jsprogram.Document{}, false, nil
+	}
+	out, exit, err := p.run(ctx, "js-facts", root)
+	if exit == exitUnavailable {
+		return jsprogram.Document{}, false, nil
+	}
+	if err != nil {
+		return jsprogram.Document{}, false, err
+	}
+	var document jsprogram.Document
+	if err := json.Unmarshal(out, &document); err != nil {
+		return jsprogram.Document{}, false, fmt.Errorf("parse synapse-ast js facts: %w", err)
+	}
+	if err := document.Validate(); err != nil {
+		return jsprogram.Document{}, false, fmt.Errorf("validate synapse-ast js facts: %w", err)
 	}
 	return document, true, nil
 }

--- a/internal/infrastructure/tools/astwalk/js_facts_cgo.go
+++ b/internal/infrastructure/tools/astwalk/js_facts_cgo.go
@@ -1,0 +1,1300 @@
+//go:build cgo
+
+package astwalk
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsprogram"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// jsFactBudget is the total-fact budget the extractor stops at. It is a var (not a const) ONLY so a test
+// can lower it to exercise the mid-structure budget path; production always uses maxJsFacts.
+var jsFactBudget = maxJsFacts
+
+const (
+	maxJsFactNodes = 2_000_000
+	maxJsFacts     = 4_000_000
+
+	// Per-item bounds mirror the jsprogram domain validator, enforced INSIDE the emitters so a hostile huge
+	// expression/arg-list/param-list/destructuring never produces a fact that would fail Validate and reject
+	// the whole document. Exceeding a bound records a GapBudget (so Complete() is false) and stops that item.
+	maxJsRefSegments = 256
+	maxJsParams      = 1_024
+	maxJsArgs        = 4_096
+	maxJsTargets     = 4_096
+	maxJsNameBytes   = 256   // a symbol name longer than this is sanitized (Validate caps at 4096)
+	maxJsQualBytes   = 3_000 // a qualified name longer than this collapses to a flat synthetic name
+	maxJsSegBytes    = 256   // a reference segment / value name longer than this is sanitized
+	maxJsSpecBytes   = 1_024 // an import specifier longer than this is skipped with a gap
+)
+
+// JsFactsFor extracts a bounded, versioned JavaScript/TypeScript semantic-facts document without importing
+// or executing target code. Parser recovery and unresolved dynamic shapes (eval, dynamic import,
+// computed reflection) are explicit coverage gaps. Subscript/member and object/array literals are tracked
+// at CONTAINER granularity, never field-sensitively, so a value-flow read is conservative (no false
+// negative it could turn into an unsound "not detected").
+func JsFactsFor(ctx context.Context, root string) (jsprogram.Document, error) {
+	doc := jsprogram.Document{SchemaVersion: jsprogram.SchemaVersion}
+	modules := map[string]bool{}
+	walkTruncated, err := walkSourceWithIssues(ctx, root, func(rel, lang string, content []byte) {
+		grammar, ok := jsGrammarFor(rel, lang)
+		if !ok {
+			return
+		}
+		doc.FilesSeen++
+		rel = filepath.ToSlash(rel)
+		module, ok := jsModuleName(rel)
+		if !ok {
+			doc.CoverageGaps = append(doc.CoverageGaps, jsprogram.CoverageGap{
+				Kind: jsprogram.GapUnresolvedImport, Detail: "invalid_module_path", Pos: jsprogram.Position{File: rel, Line: 1},
+			})
+			return
+		}
+		if modules[module] {
+			doc.CoverageGaps = append(doc.CoverageGaps, jsprogram.CoverageGap{
+				Kind: jsprogram.GapUnresolvedImport, Detail: "ambiguous_module_path", Pos: jsprogram.Position{File: rel, Line: 1},
+			})
+			return
+		}
+		modules[module] = true
+		rootNode := parseRoot(ctx, grammar, content)
+		if rootNode == nil {
+			doc.CoverageGaps = append(doc.CoverageGaps, jsprogram.CoverageGap{
+				Kind: jsprogram.GapParseRecovery, Detail: "parse_failed", Pos: jsprogram.Position{File: rel, Line: 1},
+			})
+			return
+		}
+		doc.FilesParsed++
+		modulePos := jsprogram.Position{File: rel, Line: 1}
+		moduleID := jsprogram.CanonicalSymbolID(module, "<module>")
+		doc.Modules = append(doc.Modules, jsprogram.Module{Name: module, File: rel, Pos: modulePos})
+		doc.Symbols = append(doc.Symbols, jsprogram.Symbol{
+			ID: moduleID, Module: module, QualifiedName: "<module>", Name: jsModuleLeaf(module), Kind: jsprogram.SymbolModule, Pos: modulePos,
+		})
+		doc.Entrypoints = append(doc.Entrypoints, jsprogram.EntrypointHint{SymbolID: moduleID, Kind: "module_import", Pos: modulePos})
+		extractor := jsFactExtractor{
+			doc: &doc, module: module, file: rel, source: content,
+			values: map[string]bool{}, flows: map[string]bool{},
+		}
+		if rootNode.HasError() {
+			extractor.gap(jsprogram.GapParseRecovery, moduleID, "parser_recovery", rootNode)
+		}
+		extractor.walk(rootNode, jsScope{id: moduleID, qualified: "", kind: jsprogram.SymbolModule})
+	}, func(issue sourceIssue) {
+		// The shared walker only reports issues for python-shaped files; a JS file that is oversized or
+		// unreadable is simply not visited. That is a coverage-recall limitation (a missed file), never a
+		// soundness one, so it needs no gap here.
+	})
+	if err != nil {
+		return jsprogram.Document{}, err
+	}
+	if walkTruncated {
+		doc.Truncated = true
+		doc.CoverageGaps = append(doc.CoverageGaps, jsprogram.CoverageGap{Kind: jsprogram.GapBudget, Detail: "file_budget"})
+	}
+	doc.SortCanonical()
+	if err := doc.Validate(); err != nil {
+		return jsprogram.Document{}, fmt.Errorf("validate extracted js facts: %w", err)
+	}
+	return doc, nil
+}
+
+// jsGrammarFor picks the tree-sitter grammar for a JS-family file. It re-derives the language from the
+// EXTENSION because enry mislabels a bare `.ts` file (ambiguous with XML/typescript); a non-JS file returns
+// ok=false so JsFactsFor skips it.
+func jsGrammarFor(rel, lang string) (spec, bool) {
+	switch strings.ToLower(filepath.Ext(rel)) {
+	case ".ts", ".cts", ".mts":
+		return specs["TypeScript"], true
+	case ".tsx":
+		return specs["TSX"], true
+	case ".js", ".jsx", ".mjs", ".cjs":
+		return specs["JavaScript"], true
+	}
+	switch lang {
+	case "JavaScript":
+		return specs["JavaScript"], true
+	case "TypeScript":
+		return specs["TypeScript"], true
+	case "TSX":
+		return specs["TSX"], true
+	}
+	return spec{}, false
+}
+
+type jsScope struct {
+	id        string
+	qualified string
+	kind      jsprogram.SymbolKind
+}
+
+type jsFactExtractor struct {
+	doc        *jsprogram.Document
+	module     string
+	file       string
+	source     []byte
+	budgetHit  bool
+	values     map[string]bool
+	flows      map[string]bool
+	symbolQual map[string]bool // qualified names already emitted in this module, to disambiguate duplicates
+}
+
+// boundedQualified builds a unique, length-bounded qualified name from a parent scope and a (possibly
+// invalid or over-long) declaration name. The name is sanitized to a valid identifier, and a qualified name
+// that would exceed the string bound (a pathologically deep nesting) collapses to a flat synthetic name.
+// This keeps every symbol fact acceptable to Validate by construction.
+func (e *jsFactExtractor) boundedQualified(parentQual, name string, node *sitter.Node) string {
+	q := joinJsQualified(parentQual, e.safeName(name, node))
+	if len(q) > maxJsQualBytes {
+		q = "<fn@" + e.posSuffix(node) + ">"
+	}
+	return e.uniqueQualified(q, node)
+}
+
+// safeName returns a valid JS identifier for a declaration name. A synthetic arrow/anon name ("<fn@..>") is
+// returned unchanged; a name that is already a valid, bounded identifier is kept; anything else (an escaped
+// identifier, a non-identifier character, an over-long name) is reduced to its valid leading characters, or
+// to a deterministic position-based fallback, so the symbol fact is never rejected by Validate.
+func (e *jsFactExtractor) safeName(name string, node *sitter.Node) string {
+	if strings.HasPrefix(name, "<fn@") {
+		return name
+	}
+	name = jsDecodeIdentEscapes(name) // an escaped declaration name decodes to its plain identifier
+	if jsValidSegment(name) && len(name) <= maxJsNameBytes {
+		return name
+	}
+	var b strings.Builder
+	for _, r := range name {
+		if b.Len() >= 48 {
+			break
+		}
+		first := b.Len() == 0
+		if r == '_' || r == '$' || unicode.IsLetter(r) || (!first && unicode.IsDigit(r)) {
+			b.WriteRune(r)
+		}
+	}
+	if out := b.String(); jsValidSegment(out) {
+		return out
+	}
+	return "_id" + e.posSuffix(node)
+}
+
+// uniqueQualified returns qualified unless it has already been used in this module, in which case it appends
+// a position suffix ("Name@line_col") so a duplicate/overloaded declaration keeps a distinct symbol id rather
+// than colliding and getting the whole document rejected by Validate. Position is unique per declaration.
+func (e *jsFactExtractor) uniqueQualified(qualified string, node *sitter.Node) string {
+	if e.symbolQual == nil {
+		e.symbolQual = map[string]bool{}
+	}
+	candidate := qualified
+	if e.symbolQual[candidate] {
+		candidate = qualified + "@" + e.posSuffix(node)
+		for i := 1; e.symbolQual[candidate]; i++ {
+			candidate = qualified + "@" + e.posSuffix(node) + strconv.Itoa(i)
+		}
+	}
+	e.symbolQual[candidate] = true
+	return candidate
+}
+
+func (e *jsFactExtractor) walk(node *sitter.Node, scope jsScope) {
+	if node == nil || e.budgetHit {
+		return
+	}
+	e.doc.NodesSeen++
+	if e.factsExhausted() {
+		return
+	}
+	switch node.Type() {
+	case "function_declaration", "generator_function_declaration":
+		e.walkFunction(node, scope, false)
+		return
+	case "function_expression", "generator_function", "arrow_function":
+		e.walkAnonymousFunction(node, scope)
+		return
+	case "method_definition":
+		e.walkMethod(node, scope)
+		return
+	case "class_declaration", "class":
+		e.walkClass(node, scope)
+		return
+	case "import_statement":
+		e.importFacts(node, scope)
+		return
+	case "export_statement":
+		e.exportFacts(node, scope)
+		// keep walking children so an `export const x = ...` still yields its assignment/value facts
+	case "call_expression":
+		e.callFact(node, scope, false)
+	case "new_expression":
+		e.callFact(node, scope, true)
+	case "assignment_expression", "augmented_assignment_expression":
+		e.assignmentFact(node, scope)
+	case "variable_declarator":
+		e.variableDeclaratorFact(node, scope)
+	case "return_statement":
+		e.returnFact(node, scope)
+	case "with_statement":
+		e.gap(jsprogram.GapDynamicAttribute, scope.id, "with_statement", node)
+	case "subscript_expression":
+		// A computed member with a NON-literal key resolves a property we cannot name. The flow is still
+		// tracked container-granular (in valueFor/targets), but record the dynamic property so a reader knows
+		// the specific field is unresolved. A string/number literal key ("obj['x']", "arr[0]") is effectively
+		// static and not gapped, so ordinary indexing does not flood the coverage gaps.
+		if idx := node.ChildByFieldName("index"); idx != nil && !jsIsLiteralKeyNode(idx) {
+			e.gap(jsprogram.GapDynamicAttribute, scope.id, "computed_member", node)
+		}
+	}
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		e.walk(node.NamedChild(i), scope)
+	}
+}
+
+func (e *jsFactExtractor) walkFunction(node *sitter.Node, parent jsScope, _ bool) {
+	nameNode := node.ChildByFieldName("name")
+	if nameNode == nil {
+		e.walkAnonymousFunction(node, parent)
+		return
+	}
+	name := nameNode.Content(e.source)
+	kind := jsprogram.SymbolFunction
+	if parent.kind == jsprogram.SymbolClass {
+		kind = jsprogram.SymbolMethod
+	}
+	e.emitCallable(node, parent, name, kind)
+}
+
+// walkDecorators walks the @decorator expressions attached to a class or method. A decorator executes in the
+// ENCLOSING scope when the declaration is evaluated, so its calls/flows (and any nested dynamic construct
+// such as import()) are recorded there rather than silently skipped by the class/method short-circuit in
+// walk(). Tree-sitter attaches decorators as named `decorator` children of the class/method node.
+func (e *jsFactExtractor) walkDecorators(node *sitter.Node, parent jsScope) {
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		if child := node.NamedChild(i); child != nil && child.Type() == "decorator" {
+			e.walk(child, parent)
+		}
+	}
+}
+
+func (e *jsFactExtractor) walkMethod(node *sitter.Node, parent jsScope) {
+	nameNode := node.ChildByFieldName("name")
+	name := "<fn@" + e.posSuffix(node) + ">"
+	kind := jsprogram.SymbolArrow
+	if nameNode != nil && (nameNode.Type() == "property_identifier" || nameNode.Type() == "identifier") {
+		name = nameNode.Content(e.source)
+		kind = jsprogram.SymbolMethod
+	}
+	e.emitCallable(node, parent, name, kind)
+}
+
+// walkAnonymousFunction handles arrow functions and unnamed function expressions: a synthetic name keyed to
+// its position, so its parameters (a request handler's req/res) and body are still extracted for value flow.
+func (e *jsFactExtractor) walkAnonymousFunction(node *sitter.Node, parent jsScope) {
+	name := "<fn@" + e.posSuffix(node) + ">"
+	e.emitCallable(node, parent, name, jsprogram.SymbolArrow)
+}
+
+func (e *jsFactExtractor) emitCallable(node *sitter.Node, parent jsScope, name string, kind jsprogram.SymbolKind) {
+	name = e.safeName(name, node) // sanitize an escaped/over-long identifier so the symbol fact stays valid
+	qualified := e.boundedQualified(parent.qualified, name, node)
+	id := jsprogram.CanonicalSymbolID(e.module, qualified)
+	params := node.ChildByFieldName("parameters")
+	if params == nil {
+		params = node.ChildByFieldName("parameter") // an arrow with a single un-parenthesized param
+	}
+	symbol := jsprogram.Symbol{
+		ID: id, Module: e.module, QualifiedName: qualified, Name: name, ParentID: parent.id, Kind: kind,
+		Pos: e.position(node), Parameters: e.parameters(params, id), Async: jsNodeHasToken(node, "async"),
+	}
+	e.doc.Symbols = append(e.doc.Symbols, symbol)
+	e.entrypointHints(symbol)
+	// A COMPUTED member name (`[sink(source())]() {}`) is an expression evaluated in the ENCLOSING scope when
+	// the class is defined, so its calls/flows are walked in the parent scope. Without this the walk would
+	// short-circuit past it (method_definition returns from walk() before the default child recursion).
+	if nameNode := node.ChildByFieldName("name"); nameNode != nil && nameNode.Type() == "computed_property_name" {
+		e.walk(nameNode, parent)
+	}
+	e.walkDecorators(node, parent) // @decorator expressions on a method execute in the enclosing scope
+	if params != nil {
+		e.walk(params, parent) // default expressions execute in the parent scope
+	}
+	body := node.ChildByFieldName("body")
+	if body != nil {
+		e.walk(body, jsScope{id: id, qualified: qualified, kind: kind})
+	}
+}
+
+func (e *jsFactExtractor) walkClass(node *sitter.Node, parent jsScope) {
+	e.walkDecorators(node, parent) // @decorator expressions on a class execute in the enclosing scope
+	nameNode := node.ChildByFieldName("name")
+	name := "<fn@" + e.posSuffix(node) + ">"
+	kind := jsprogram.SymbolArrow // an anonymous class expression still owns a scope
+	if nameNode != nil {
+		name = nameNode.Content(e.source)
+		kind = jsprogram.SymbolClass
+	}
+	// Only a named class becomes a class symbol; an anonymous class expression is uncommon and treated as a
+	// synthetic scope so its methods still bind.
+	name = e.safeName(name, node)
+	qualified := e.boundedQualified(parent.qualified, name, node)
+	id := jsprogram.CanonicalSymbolID(e.module, qualified)
+	symbol := jsprogram.Symbol{
+		ID: id, Module: e.module, QualifiedName: qualified, Name: name, ParentID: parent.id,
+		Kind: firstClassKind(kind), Pos: e.position(node),
+	}
+	if heritage := jsClassHeritage(node); heritage != nil {
+		// Only a plain name/member superclass (`extends Base`, `extends ns.Base`) is a resolvable base. A
+		// computed heritage (`extends mixin(source())`) carries calls/flows this walk does not analyze, so it is
+		// recorded as a coverage gap rather than silently dropped (its inner flow could be a taint path).
+		switch heritage.Type() {
+		case "identifier", "member_expression":
+			base := e.reference(heritage)
+			if base.Kind == jsprogram.ReferenceUnknown {
+				e.gap(jsprogram.GapUnresolvedValue, parent.id, "class_base", heritage)
+			} else {
+				symbol.Bases = append(symbol.Bases, base)
+			}
+		default:
+			e.gap(jsprogram.GapUnresolvedValue, parent.id, "class_heritage", heritage)
+		}
+	}
+	e.doc.Symbols = append(e.doc.Symbols, symbol)
+	if body := node.ChildByFieldName("body"); body != nil {
+		e.walk(body, jsScope{id: id, qualified: qualified, kind: symbol.Kind})
+	}
+}
+
+func firstClassKind(kind jsprogram.SymbolKind) jsprogram.SymbolKind {
+	if kind == jsprogram.SymbolClass {
+		return jsprogram.SymbolClass
+	}
+	return jsprogram.SymbolArrow
+}
+
+// jsClassHeritage returns the superclass expression of `extends X`, or nil. In tree-sitter-javascript the
+// class node has a `class_heritage` child whose named child is the superclass expression.
+func jsClassHeritage(node *sitter.Node) *sitter.Node {
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		child := node.NamedChild(i)
+		if child.Type() == "class_heritage" && child.NamedChildCount() > 0 {
+			return child.NamedChild(0)
+		}
+	}
+	return nil
+}
+
+func (e *jsFactExtractor) importFacts(node *sitter.Node, scope jsScope) {
+	source := node.ChildByFieldName("source")
+	spec, ok := jsStringLiteral(source, e.source)
+	if !ok {
+		// `import(expr)` dynamic import or a missing source: a dependency could be loaded invisibly.
+		e.gap(jsprogram.GapDynamicImport, scope.id, "dynamic_import", node)
+		return
+	}
+	clause := jsImportClause(node)
+	if clause == nil {
+		// bare `import 'm'` (side-effect import): no binding, still a known dependency, nothing to bind.
+		return
+	}
+	e.bindImportClause(clause, spec, scope, node)
+}
+
+func (e *jsFactExtractor) bindImportClause(clause *sitter.Node, spec string, scope jsScope, node *sitter.Node) {
+	for i := 0; i < int(clause.NamedChildCount()); i++ {
+		child := clause.NamedChild(i)
+		switch child.Type() {
+		case "identifier": // default import: import d from 'm'
+			e.addImport(scope, jsprogram.ImportDefault, spec, "default", child.Content(e.source), node)
+		case "namespace_import": // import * as ns from 'm'
+			if id := jsFirstIdentifier(child, e.source); id != "" {
+				e.addImport(scope, jsprogram.ImportNamespace, spec, "", id, node)
+			}
+		case "named_imports":
+			for j := 0; j < int(child.NamedChildCount()); j++ {
+				sp := child.NamedChild(j)
+				if sp.Type() != "import_specifier" {
+					continue
+				}
+				name := jsSpecifierName(sp, "name", e.source)
+				alias := jsSpecifierName(sp, "alias", e.source)
+				if alias == "" {
+					alias = name
+				}
+				if name != "" && alias != "" {
+					e.addImport(scope, jsprogram.ImportNamed, spec, name, alias, node)
+				}
+			}
+		}
+	}
+}
+
+func (e *jsFactExtractor) exportFacts(node *sitter.Node, scope jsScope) {
+	// A re-export `export ... from 'm'` republishes a dependency; record it so its specifier is known.
+	source := node.ChildByFieldName("source")
+	if spec, ok := jsStringLiteral(source, e.source); ok {
+		e.addImport(scope, jsprogram.ImportReexport, spec, "", "", node)
+	}
+}
+
+func (e *jsFactExtractor) addImport(scope jsScope, kind jsprogram.ImportKind, spec, name, alias string, node *sitter.Node) {
+	if !jsValidSpecifier(spec) || len(spec) > maxJsSpecBytes {
+		// An unresolvable or over-long specifier is skipped WITH a gap rather than emitting an import fact the
+		// validator rejects (a truncated specifier would be wrong for package matching, so skip, not truncate).
+		e.gap(jsprogram.GapUnresolvedImport, scope.id, "import_specifier", node)
+		return
+	}
+	e.doc.Imports = append(e.doc.Imports, jsprogram.Import{
+		// The local binding names go through the bounded segment sanitizer (not jsSafeName, which has no length
+		// bound), so an over-long import alias cannot emit an Import fact the validator rejects.
+		ScopeID: scope.id, Kind: kind, Module: spec, Name: jsSanitizeSegment(name), Alias: jsSanitizeSegment(alias), Pos: e.position(node),
+	})
+}
+
+func (e *jsFactExtractor) variableDeclaratorFact(node *sitter.Node, scope jsScope) {
+	nameNode := node.ChildByFieldName("name")
+	valueNode := node.ChildByFieldName("value")
+	if nameNode == nil {
+		return
+	}
+	// `const x = require('m')` / `const {a,b} = require('m')`: a synchronous dependency load. A dynamic
+	// require(expr) is gapped by callFact when the walk reaches the require call, so here we only bind the
+	// static-specifier form and then return (the require binding is an import, not a data assignment).
+	if valueNode != nil && jsIsRequireCall(valueNode, e.source) {
+		if spec, ok := jsRequireSpecifier(valueNode, e.source); ok {
+			e.bindRequire(nameNode, spec, scope, node)
+		}
+		return
+	}
+	if valueNode == nil {
+		return
+	}
+	e.recordAssignment(nameNode, valueNode, scope, node)
+}
+
+func (e *jsFactExtractor) bindRequire(target *sitter.Node, spec string, scope jsScope, node *sitter.Node) {
+	switch target.Type() {
+	case "identifier":
+		e.addImport(scope, jsprogram.ImportRequire, spec, "", target.Content(e.source), node)
+	case "object_pattern":
+		for i := 0; i < int(target.NamedChildCount()); i++ {
+			if name := jsPatternName(target.NamedChild(i), e.source); name != "" {
+				e.addImport(scope, jsprogram.ImportRequire, spec, name, name, node)
+			}
+		}
+	default:
+		if id := jsFirstIdentifier(target, e.source); id != "" {
+			e.addImport(scope, jsprogram.ImportRequire, spec, "", id, node)
+		}
+	}
+}
+
+func (e *jsFactExtractor) callFact(node *sitter.Node, scope jsScope, isNew bool) {
+	calleeNode := node.ChildByFieldName("function")
+	if isNew {
+		calleeNode = node.ChildByFieldName("constructor")
+	}
+	callee := e.reference(calleeNode)
+	call := jsprogram.Call{
+		ID: jsFactID(e.file, node), CallerID: scope.id, Callee: callee, ResultID: e.valueFor(node, scope),
+		Pos: e.position(node), Await: node.Parent() != nil && node.Parent().Type() == "await_expression", New: isNew,
+	}
+	if calleeNode != nil && calleeNode.Type() == "member_expression" {
+		call.ReceiverValueID = e.valueFor(calleeNode.ChildByFieldName("object"), scope)
+	}
+	// A dynamic `import(expr)` parses with an `import`-typed callee node (not an identifier): a dependency
+	// loaded invisibly. Record it before the generic unresolved-call gap.
+	if calleeNode != nil && calleeNode.Type() == "import" {
+		e.gap(jsprogram.GapDynamicImport, scope.id, "dynamic_import", node)
+	} else if callee.Kind == jsprogram.ReferenceUnknown {
+		e.gap(jsprogram.GapUnresolvedCall, scope.id, "call_target", node)
+	}
+	joined := strings.Join(callee.Segments, ".")
+	last := ""
+	if len(callee.Segments) > 0 {
+		last = callee.Segments[len(callee.Segments)-1]
+	}
+	switch {
+	// Dynamic code construction/execution, matched on the LAST segment so a receiver-qualified form is caught
+	// too (globalThis.eval, window.Function). Function(...) is dynamic with or without `new`. Over-matching a
+	// user method that happens to be named eval/Function only marks coverage incomplete (a conservative gap),
+	// never a false finding, so it is the safe direction.
+	case last == "eval" || last == "Function":
+		e.gap(jsprogram.GapDynamicExecution, scope.id, "dynamic_code", node)
+	case (last == "call" || last == "apply") && len(callee.Segments) >= 2 &&
+		(callee.Segments[len(callee.Segments)-2] == "eval" || callee.Segments[len(callee.Segments)-2] == "Function"):
+		// Indirect invocation `eval.call(...)` / `Function.apply(...)`. Deeper indirections (Reflect.apply(eval,
+		// ...), window["eval"](...), an aliased const e = eval) are a documented recall limitation, not gapped:
+		// they are vanishingly rare and this extractor produces no findings, so a missed gap is at worst a
+		// missed downstream finding, never a false positive or a false suppression.
+		e.gap(jsprogram.GapDynamicExecution, scope.id, "dynamic_code", node)
+	case last == "runInContext" || last == "runInNewContext" || last == "runInThisContext" || last == "compileFunction":
+		e.gap(jsprogram.GapDynamicExecution, scope.id, "dynamic_code", node)
+	case joined == "import":
+		e.gap(jsprogram.GapDynamicImport, scope.id, "dynamic_import", node)
+	case joined == "require" && !jsFirstArgIsStringLiteral(node):
+		// require(expr) with a non-string-literal argument loads a dependency invisibly, in ANY call
+		// position (foo(require(x)), module.exports = require(x), require(x).y). require('literal') is a known
+		// dependency and is not gapped.
+		e.gap(jsprogram.GapDynamicImport, scope.id, "dynamic_require", node)
+	}
+	if args := node.ChildByFieldName("arguments"); args != nil {
+		for i := 0; i < int(args.NamedChildCount()); i++ {
+			if len(call.Arguments) >= maxJsArgs {
+				e.gap(jsprogram.GapBudget, scope.id, "argument_budget", node)
+				break
+			}
+			argNode := args.NamedChild(i)
+			arg := jsprogram.Argument{}
+			valueNode := argNode
+			if argNode.Type() == "spread_element" {
+				arg.Spread = true
+				valueNode = firstNamedChild(argNode)
+			}
+			arg.Value = e.reference(valueNode)
+			arg.ValueID = e.valueFor(valueNode, scope)
+			arg.Pos = e.position(valueNode)
+			if arg.Value.Kind == jsprogram.ReferenceUnknown && arg.ValueID == "" {
+				e.gap(jsprogram.GapUnresolvedValue, scope.id, "call_argument", argNode)
+			}
+			call.Arguments = append(call.Arguments, arg)
+		}
+	}
+	e.doc.Calls = append(e.doc.Calls, call)
+}
+
+func (e *jsFactExtractor) assignmentFact(node *sitter.Node, scope jsScope) {
+	left := node.ChildByFieldName("left")
+	right := node.ChildByFieldName("right")
+	e.recordAssignmentNodes(left, right, scope, node, node.Type() == "augmented_assignment_expression")
+}
+
+func (e *jsFactExtractor) recordAssignment(left, right *sitter.Node, scope jsScope, node *sitter.Node) {
+	e.recordAssignmentNodes(left, right, scope, node, false)
+}
+
+func (e *jsFactExtractor) recordAssignmentNodes(left, right *sitter.Node, scope jsScope, node *sitter.Node, augmented bool) {
+	if left == nil {
+		return
+	}
+	targets := e.targets(left)
+	if len(targets) == 0 {
+		return
+	}
+	if len(targets) > maxJsTargets {
+		targets = targets[:maxJsTargets]
+		e.gap(jsprogram.GapBudget, scope.id, "target_budget", node)
+	}
+	value := e.reference(right)
+	valueID := e.valueFor(right, scope)
+	if value.Kind == jsprogram.ReferenceUnknown && valueID == "" {
+		e.gap(jsprogram.GapUnresolvedValue, scope.id, "assignment_value", node)
+	}
+	targetIDs := e.bindingValues(left, scope)
+	if len(targetIDs) > maxJsTargets {
+		targetIDs = targetIDs[:maxJsTargets]
+		e.gap(jsprogram.GapBudget, scope.id, "target_budget", node)
+	}
+	for _, targetID := range targetIDs {
+		e.addValueFlow(valueID, targetID, jsprogram.FlowAssignment, node)
+		if augmented {
+			e.addValueFlow(e.valueFor(left, scope), targetID, jsprogram.FlowAssignment, node)
+		}
+	}
+	e.doc.Assignments = append(e.doc.Assignments, jsprogram.Assignment{
+		ScopeID: scope.id, Targets: targets, TargetIDs: targetIDs, Value: value, ValueID: valueID, Pos: e.position(node),
+	})
+}
+
+func (e *jsFactExtractor) returnFact(node *sitter.Node, scope jsScope) {
+	value := jsprogram.Reference{Kind: jsprogram.ReferenceLiteral}
+	if node.NamedChildCount() > 0 {
+		value = e.reference(node.NamedChild(0))
+	}
+	valueNode := firstNamedChild(node)
+	valueID := e.valueFor(valueNode, scope)
+	if value.Kind == jsprogram.ReferenceUnknown && valueID == "" {
+		e.gap(jsprogram.GapUnresolvedValue, scope.id, "return_value", node)
+	}
+	slotID := scope.id + "#return"
+	if !e.addValue(jsprogram.Value{
+		ID: slotID, ScopeID: scope.id, Kind: jsprogram.ValueReturn,
+		Ref: jsprogram.Reference{Kind: jsprogram.ReferenceUnknown}, Pos: e.position(node),
+	}) {
+		slotID = "" // budget: record the return without a dangling slot id
+	} else {
+		e.addValueFlow(valueID, slotID, jsprogram.FlowReturn, node)
+	}
+	e.doc.Returns = append(e.doc.Returns, jsprogram.Return{ScopeID: scope.id, Value: value, ValueID: valueID, SlotID: slotID, Pos: e.position(node)})
+}
+
+func (e *jsFactExtractor) valueFor(node *sitter.Node, scope jsScope) string {
+	if node == nil {
+		return ""
+	}
+	id := jsValueID(e.file, node, "value")
+	if e.values[id] {
+		return id
+	}
+	if e.budgetHit {
+		return ""
+	}
+	ref := e.reference(node)
+	kind := jsprogram.ValueExpression
+	switch {
+	case node.Type() == "call_expression" || node.Type() == "new_expression":
+		kind = jsprogram.ValueCallResult
+	case node.Type() == "identifier" || node.Type() == "member_expression":
+		kind = jsprogram.ValueReference
+	case ref.Kind == jsprogram.ReferenceLiteral && node.NamedChildCount() == 0:
+		kind = jsprogram.ValueLiteral
+	default:
+		ref = jsprogram.Reference{Kind: jsprogram.ReferenceExpression}
+	}
+	if !e.addValue(jsprogram.Value{ID: id, ScopeID: scope.id, Kind: kind, Ref: ref, Pos: e.position(node)}) {
+		return "" // budget: the slot was not emitted, so no fact may reference this id
+	}
+
+	switch node.Type() {
+	case "call_expression", "new_expression":
+		// Argument-to-result propagation is function-model/interprocedural behavior, not a syntax flow.
+		return id
+	case "member_expression":
+		from := e.valueFor(node.ChildByFieldName("object"), scope)
+		e.addValueFlow(from, id, jsprogram.FlowAttribute, node)
+		return id
+	case "subscript_expression":
+		// Container-granular: the value of a[k] flows from the container `a`, never a specific field.
+		from := e.valueFor(node.ChildByFieldName("object"), scope)
+		e.addValueFlow(from, id, jsprogram.FlowAttribute, node)
+		return id
+	case "identifier":
+		return id
+	case "function_declaration", "function_expression", "arrow_function", "generator_function",
+		"generator_function_declaration", "method_definition", "class", "class_declaration":
+		// A nested function/class introduces its own scope, walked separately; never flow its body into the
+		// enclosing expression (that would create a cross-scope value flow).
+		return id
+	case "await_expression", "parenthesized_expression":
+		if inner := firstNamedChild(node); inner != nil {
+			e.addValueFlow(e.valueFor(inner, scope), id, jsprogram.FlowExpression, node)
+		}
+		return id
+	}
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		child := node.NamedChild(i)
+		e.addValueFlow(e.valueFor(child, scope), id, jsprogram.FlowExpression, node)
+	}
+	return id
+}
+
+func (e *jsFactExtractor) bindingValues(node *sitter.Node, scope jsScope) []string {
+	if node == nil {
+		return nil
+	}
+	switch node.Type() {
+	case "subscript_expression", "member_expression":
+		// Container-granular write: a[k] = v / a.b = v / this.x = v taints the container `a`/`this`.
+		return e.bindingValues(node.ChildByFieldName("object"), scope)
+	case "pair_pattern": // { key: target } = v -> the binding is the value node
+		return e.bindingValues(node.ChildByFieldName("value"), scope)
+	case "assignment_pattern", "object_assignment_pattern": // { a = default } -> the binding is the left
+		left := node.ChildByFieldName("left")
+		if left == nil {
+			return nil
+		}
+		ids := e.bindingValues(left, scope)
+		// The default initializer flows into the bound name, so `const { x = source() } = {}` taints x.
+		if right := node.ChildByFieldName("right"); right != nil {
+			defID := e.valueFor(right, scope)
+			for _, id := range ids {
+				e.addValueFlow(defID, id, jsprogram.FlowAssignment, node)
+			}
+		}
+		return ids
+	case "rest_pattern": // [ ...rest ] / { ...rest }
+		return e.bindingValues(firstNamedChild(node), scope)
+	case "array_pattern", "object_pattern", "array", "object":
+		var out []string
+		for i := 0; i < int(node.NamedChildCount()); i++ {
+			out = append(out, e.bindingValues(node.NamedChild(i), scope)...)
+		}
+		return out
+	}
+	ref := e.reference(node)
+	if ref.Kind == jsprogram.ReferenceName || ref.Kind == jsprogram.ReferenceAttribute {
+		id := jsValueID(e.file, node, "binding")
+		name := ref.Segments[len(ref.Segments)-1]
+		if !e.addValue(jsprogram.Value{ID: id, ScopeID: scope.id, Kind: jsprogram.ValueBinding, Name: name, Ref: ref, Pos: e.position(node)}) {
+			return nil // budget: do not return a binding id whose value was not emitted
+		}
+		return []string{id}
+	}
+	return nil
+}
+
+// addValue appends a value slot and reports whether the slot is now available (either just emitted or
+// already present). It returns false when the budget is exhausted so a caller can avoid returning a value
+// id that was never emitted (which would leave a dangling reference the validator rejects).
+func (e *jsFactExtractor) addValue(value jsprogram.Value) bool {
+	if value.ID == "" {
+		return false
+	}
+	if e.values[value.ID] {
+		return true
+	}
+	if e.factsExhausted() {
+		return false
+	}
+	e.values[value.ID] = true
+	e.doc.Values = append(e.doc.Values, value)
+	return true
+}
+
+func (e *jsFactExtractor) addValueFlow(from, to string, kind jsprogram.ValueFlowKind, node *sitter.Node) {
+	if from == "" || to == "" || from == to {
+		return
+	}
+	key := from + "\x00" + to + "\x00" + string(kind)
+	if e.flows[key] {
+		return
+	}
+	if e.factsExhausted() {
+		return
+	}
+	e.flows[key] = true
+	e.doc.Flows = append(e.doc.Flows, jsprogram.ValueFlow{FromID: from, ToID: to, Kind: kind, Pos: e.position(node)})
+}
+
+func (e *jsFactExtractor) reference(node *sitter.Node) jsprogram.Reference {
+	if node == nil {
+		return jsprogram.Reference{Kind: jsprogram.ReferenceUnknown}
+	}
+	switch node.Type() {
+	case "identifier", "shorthand_property_identifier", "shorthand_property_identifier_pattern", "property_identifier", "this":
+		content := jsSanitizeSegment(node.Content(e.source))
+		if content == "" {
+			return jsprogram.Reference{Kind: jsprogram.ReferenceUnknown}
+		}
+		return jsprogram.Reference{Kind: jsprogram.ReferenceName, Segments: []string{content}}
+	case "member_expression":
+		base := e.reference(node.ChildByFieldName("object"))
+		prop := node.ChildByFieldName("property")
+		if prop == nil || (base.Kind != jsprogram.ReferenceName && base.Kind != jsprogram.ReferenceAttribute) {
+			return jsprogram.Reference{Kind: jsprogram.ReferenceUnknown}
+		}
+		propName := jsSanitizeSegment(prop.Content(e.source))
+		if propName == "" {
+			return jsprogram.Reference{Kind: jsprogram.ReferenceUnknown}
+		}
+		if len(base.Segments) >= maxJsRefSegments {
+			// A pathologically deep member chain would exceed the reference-segment bound; fall back to an
+			// opaque reference AND record honest incompleteness rather than emitting a fact the validator
+			// rejects (which would drop the whole document) or silently claiming completeness.
+			e.gap(jsprogram.GapBudget, "", "reference_depth", nil)
+			return jsprogram.Reference{Kind: jsprogram.ReferenceUnknown}
+		}
+		return jsprogram.Reference{Kind: jsprogram.ReferenceAttribute, Segments: append(append([]string{}, base.Segments...), propName)}
+	case "call_expression", "new_expression":
+		fn := node.ChildByFieldName("function")
+		if node.Type() == "new_expression" {
+			fn = node.ChildByFieldName("constructor")
+		}
+		callee := e.reference(fn)
+		if callee.Kind == jsprogram.ReferenceUnknown {
+			return callee
+		}
+		callee.Kind = jsprogram.ReferenceCall
+		return callee
+	case "parenthesized_expression", "await_expression":
+		if node.NamedChildCount() == 1 {
+			return e.reference(node.NamedChild(0))
+		}
+	case "string", "template_string", "number", "true", "false", "null", "undefined", "regex", "object", "array":
+		return jsprogram.Reference{Kind: jsprogram.ReferenceLiteral}
+	}
+	return jsprogram.Reference{Kind: jsprogram.ReferenceUnknown}
+}
+
+func (e *jsFactExtractor) targets(node *sitter.Node) []jsprogram.Reference {
+	if node == nil {
+		return nil
+	}
+	switch node.Type() {
+	case "subscript_expression", "member_expression":
+		return e.targets(node.ChildByFieldName("object"))
+	case "pair_pattern":
+		return e.targets(node.ChildByFieldName("value"))
+	case "assignment_pattern", "object_assignment_pattern":
+		if left := node.ChildByFieldName("left"); left != nil {
+			return e.targets(left)
+		}
+		return nil
+	case "rest_pattern":
+		return e.targets(firstNamedChild(node))
+	case "array_pattern", "object_pattern", "array", "object":
+		var out []jsprogram.Reference
+		for i := 0; i < int(node.NamedChildCount()); i++ {
+			out = append(out, e.targets(node.NamedChild(i))...)
+		}
+		return out
+	}
+	ref := e.reference(node)
+	if ref.Kind == jsprogram.ReferenceName || ref.Kind == jsprogram.ReferenceAttribute {
+		return []jsprogram.Reference{ref}
+	}
+	return nil
+}
+
+func (e *jsFactExtractor) parameters(node *sitter.Node, scopeID string) []jsprogram.Parameter {
+	if node == nil {
+		return nil
+	}
+	var out []jsprogram.Parameter
+	// A single un-parenthesized arrow parameter is an identifier node itself, not a formal_parameters list.
+	if node.Type() == "identifier" {
+		e.appendParameter(&out, scopeID, node.Content(e.source), jsprogram.ParameterPositional, node)
+		return out
+	}
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		e.parameterFrom(&out, node.NamedChild(i), scopeID)
+	}
+	return out
+}
+
+func (e *jsFactExtractor) parameterFrom(out *[]jsprogram.Parameter, child *sitter.Node, scopeID string) {
+	switch child.Type() {
+	case "identifier":
+		e.appendParameter(out, scopeID, child.Content(e.source), jsprogram.ParameterPositional, child)
+	case "required_parameter", "optional_parameter":
+		// TypeScript: unwrap the `pattern` field (an identifier or a binding pattern).
+		if pattern := child.ChildByFieldName("pattern"); pattern != nil {
+			e.parameterFrom(out, pattern, scopeID)
+		}
+	case "rest_pattern":
+		if id := jsFirstIdentifier(child, e.source); id != "" {
+			e.appendParameter(out, scopeID, id, jsprogram.ParameterRest, child)
+		}
+	case "assignment_pattern":
+		if left := child.ChildByFieldName("left"); left != nil {
+			e.appendDefaultParams(out, left, scopeID)
+		}
+	case "object_pattern", "array_pattern":
+		e.appendPatternParams(out, child, scopeID)
+	}
+}
+
+func (e *jsFactExtractor) appendDefaultParams(out *[]jsprogram.Parameter, left *sitter.Node, scopeID string) {
+	if left.Type() == "identifier" {
+		e.appendParameter(out, scopeID, left.Content(e.source), jsprogram.ParameterDefault, left)
+		return
+	}
+	e.appendPatternParams(out, left, scopeID)
+}
+
+func (e *jsFactExtractor) appendPatternParams(out *[]jsprogram.Parameter, pattern *sitter.Node, scopeID string) {
+	for i := 0; i < int(pattern.NamedChildCount()); i++ {
+		child := pattern.NamedChild(i)
+		if name := jsPatternName(child, e.source); name != "" {
+			e.appendParameter(out, scopeID, name, jsprogram.ParameterDestructured, child)
+			continue
+		}
+		if child.Type() == "object_pattern" || child.Type() == "array_pattern" {
+			e.appendPatternParams(out, child, scopeID)
+		}
+	}
+}
+
+func (e *jsFactExtractor) appendParameter(out *[]jsprogram.Parameter, scopeID, name string, kind jsprogram.ParameterKind, node *sitter.Node) {
+	name = jsSanitizeSegment(name) // bounded + valid, so the parameter and its value slot never fail Validate
+	if name == "" {
+		return
+	}
+	if len(*out) >= maxJsParams {
+		// A nil node gives every overflow parameter the same (zero) position, so gap() dedups them to a
+		// single budget gap instead of one per excess parameter (which could itself exceed the fact bound).
+		e.gap(jsprogram.GapBudget, scopeID, "parameter_budget", nil)
+		return
+	}
+	valueID := scopeID + "#param:" + strconv.Itoa(len(*out)) + ":" + name
+	pos := e.position(node)
+	if !e.addValue(jsprogram.Value{
+		ID: valueID, ScopeID: scopeID, Kind: jsprogram.ValueParameter, Name: name,
+		Ref: jsprogram.Reference{Kind: jsprogram.ReferenceName, Segments: []string{name}}, Pos: pos,
+	}) {
+		valueID = "" // budget: keep the parameter's shape but do not reference a value slot that was not emitted
+	}
+	*out = append(*out, jsprogram.Parameter{Name: name, Kind: kind, ValueID: valueID, Pos: pos})
+}
+
+func (e *jsFactExtractor) entrypointHints(symbol jsprogram.Symbol) {
+	if symbol.Name == "main" || symbol.Name == "handler" {
+		e.doc.Entrypoints = append(e.doc.Entrypoints, jsprogram.EntrypointHint{SymbolID: symbol.ID, Kind: "conventional_handler", Pos: symbol.Pos})
+	}
+}
+
+func (e *jsFactExtractor) gap(kind jsprogram.GapKind, symbolID, detail string, node *sitter.Node) {
+	pos := jsprogram.Position{}
+	if node != nil {
+		pos = e.position(node)
+	}
+	for _, existing := range e.doc.CoverageGaps {
+		if existing.Kind == kind && existing.SymbolID == symbolID && existing.Detail == detail && existing.Pos == pos {
+			return
+		}
+	}
+	if len(e.doc.CoverageGaps) >= jsFactBudget {
+		return // the coverage gaps must not themselves exceed the fact bound
+	}
+	e.doc.CoverageGaps = append(e.doc.CoverageGaps, jsprogram.CoverageGap{Kind: kind, SymbolID: symbolID, Detail: detail, Pos: pos})
+}
+
+// factsExhausted reports whether the document has reached its fact budget. On the first time it trips it
+// records a single budget gap and marks the document truncated, so every subsequent emitter stops. This is
+// the by-construction guard that keeps the document within the bounds Validate enforces, whatever the input.
+func (e *jsFactExtractor) factsExhausted() bool {
+	if e.budgetHit {
+		return true
+	}
+	if e.doc.NodesSeen > maxJsFactNodes || e.factCount() >= jsFactBudget {
+		e.budgetHit = true
+		e.doc.Truncated = true
+		e.gap(jsprogram.GapBudget, "", "fact_budget", nil)
+		return true
+	}
+	return false
+}
+
+func (e *jsFactExtractor) position(node *sitter.Node) jsprogram.Position {
+	if node == nil {
+		return jsprogram.Position{File: e.file, Line: 1}
+	}
+	point := node.StartPoint()
+	return jsprogram.Position{File: e.file, Line: int(point.Row) + 1, Column: int(point.Column)}
+}
+
+func (e *jsFactExtractor) posSuffix(node *sitter.Node) string {
+	point := node.StartPoint()
+	return strconv.Itoa(int(point.Row)+1) + "_" + strconv.Itoa(int(point.Column))
+}
+
+func (e *jsFactExtractor) factCount() int {
+	return len(e.doc.Symbols) + len(e.doc.Imports) + len(e.doc.Calls) + len(e.doc.Assignments) + len(e.doc.Returns) +
+		len(e.doc.Values) + len(e.doc.Flows) + len(e.doc.CoverageGaps)
+}
+
+// --- pure helpers ---
+
+func jsModuleName(rel string) (string, bool) {
+	rel = filepath.ToSlash(strings.TrimSpace(rel))
+	ext := strings.ToLower(filepath.Ext(rel))
+	rel = strings.TrimSuffix(rel, filepath.Ext(rel))
+	// A ".d" left from a ".d.ts" declaration file is stripped so the module path is clean.
+	if ext == ".ts" && strings.HasSuffix(strings.ToLower(rel), ".d") {
+		rel = rel[:len(rel)-2]
+	}
+	parts := strings.Split(rel, "/")
+	if len(parts) == 0 {
+		return "", false
+	}
+	for i, part := range parts {
+		parts[i] = jsSanitizePathSegment(part)
+		if parts[i] == "" {
+			return "", false
+		}
+	}
+	return strings.Join(parts, "/"), true
+}
+
+// jsSanitizePathSegment keeps only the module-path characters the domain validator accepts, so a directory
+// with an unusual character still yields a stable, valid module name.
+func jsSanitizePathSegment(part string) string {
+	part = strings.TrimSpace(part)
+	if part == "" || part == "." || part == ".." {
+		return ""
+	}
+	var b strings.Builder
+	for _, r := range part {
+		switch {
+		case r == '_' || r == '$' || r == '-' || r == '.' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	out := b.String()
+	if out == "." || out == ".." {
+		return ""
+	}
+	return out
+}
+
+func jsModuleLeaf(module string) string {
+	if at := strings.LastIndexByte(module, '/'); at >= 0 {
+		return jsSafeLeaf(module[at+1:])
+	}
+	return jsSafeLeaf(module)
+}
+
+// jsSafeLeaf reduces a path leaf to a valid JS identifier for the module symbol's Name (letters/digits/_/$).
+func jsSafeLeaf(leaf string) string {
+	var b strings.Builder
+	for i, r := range leaf {
+		switch {
+		case r == '_' || r == '$' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z'):
+			b.WriteRune(r)
+		case i > 0 && r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	out := b.String()
+	if out == "" {
+		return "_"
+	}
+	// ensure the first char is a valid start
+	if r := rune(out[0]); !(r == '_' || r == '$' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')) {
+		return "_" + out
+	}
+	return out
+}
+
+func joinJsQualified(parent, name string) string {
+	if parent == "" {
+		return name
+	}
+	return parent + "." + name
+}
+
+func jsFactID(file string, node *sitter.Node) string {
+	// Key on BOTH start and end: a chained call `f()()` (or any nested expression) has an outer and inner node
+	// that share a start position, so a start-only id would collide and make the two facts duplicate, which
+	// Validate rejects (dropping the whole document). Including the end disambiguates them.
+	start, end := node.StartPoint(), node.EndPoint()
+	return file + ":" + strconv.Itoa(int(start.Row)+1) + ":" + strconv.Itoa(int(start.Column)) + ":" +
+		strconv.Itoa(int(end.Row)+1) + ":" + strconv.Itoa(int(end.Column))
+}
+
+func jsValueID(file string, node *sitter.Node, role string) string {
+	start, end := node.StartPoint(), node.EndPoint()
+	return file + ":" + strconv.Itoa(int(start.Row)+1) + ":" + strconv.Itoa(int(start.Column)) + ":" +
+		strconv.Itoa(int(end.Row)+1) + ":" + strconv.Itoa(int(end.Column)) + ":" + role
+}
+
+func jsNodeHasToken(node *sitter.Node, token string) bool {
+	for i := 0; i < int(node.ChildCount()); i++ {
+		if node.Child(i).Type() == token {
+			return true
+		}
+	}
+	return false
+}
+
+func jsFirstIdentifier(node *sitter.Node, source []byte) string {
+	if node == nil {
+		return ""
+	}
+	stack := []*sitter.Node{node}
+	for len(stack) > 0 {
+		current := stack[0]
+		stack = stack[1:]
+		if current.Type() == "identifier" || current.Type() == "shorthand_property_identifier_pattern" {
+			return current.Content(source)
+		}
+		for i := 0; i < int(current.NamedChildCount()); i++ {
+			stack = append(stack, current.NamedChild(i))
+		}
+	}
+	return ""
+}
+
+// jsPatternName returns the bound identifier of a destructuring pattern element, or "".
+func jsPatternName(node *sitter.Node, source []byte) string {
+	if node == nil {
+		return ""
+	}
+	switch node.Type() {
+	case "shorthand_property_identifier_pattern", "identifier":
+		return node.Content(source)
+	case "pair_pattern":
+		if v := node.ChildByFieldName("value"); v != nil {
+			return jsPatternName(v, source)
+		}
+	case "assignment_pattern":
+		if left := node.ChildByFieldName("left"); left != nil {
+			return jsPatternName(left, source)
+		}
+	case "rest_pattern":
+		return jsFirstIdentifier(node, source)
+	}
+	return ""
+}
+
+func jsStringLiteral(node *sitter.Node, source []byte) (string, bool) {
+	if node == nil || node.Type() != "string" {
+		return "", false
+	}
+	// The string's content is between the quote children; use the fragment child if present, else strip.
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		if node.NamedChild(i).Type() == "string_fragment" {
+			return node.NamedChild(i).Content(source), true
+		}
+	}
+	raw := node.Content(source)
+	if len(raw) >= 2 {
+		return raw[1 : len(raw)-1], true
+	}
+	return "", false
+}
+
+func jsImportClause(node *sitter.Node) *sitter.Node {
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		if node.NamedChild(i).Type() == "import_clause" {
+			return node.NamedChild(i)
+		}
+	}
+	return nil
+}
+
+func jsSpecifierName(sp *sitter.Node, field string, source []byte) string {
+	if n := sp.ChildByFieldName(field); n != nil {
+		return n.Content(source)
+	}
+	return ""
+}
+
+// jsIsLiteralKeyNode reports whether a computed-member index is a static string/number literal.
+func jsIsLiteralKeyNode(node *sitter.Node) bool {
+	switch node.Type() {
+	case "string", "number":
+		return true
+	}
+	return false
+}
+
+// jsFirstArgIsStringLiteral reports whether a call's first argument is a string literal.
+func jsFirstArgIsStringLiteral(node *sitter.Node) bool {
+	args := node.ChildByFieldName("arguments")
+	if args == nil || args.NamedChildCount() == 0 {
+		return false
+	}
+	return args.NamedChild(0).Type() == "string"
+}
+
+func jsIsRequireCall(node *sitter.Node, source []byte) bool {
+	if node == nil || node.Type() != "call_expression" {
+		return false
+	}
+	fn := node.ChildByFieldName("function")
+	return fn != nil && fn.Type() == "identifier" && fn.Content(source) == "require"
+}
+
+func jsRequireSpecifier(node *sitter.Node, source []byte) (string, bool) {
+	args := node.ChildByFieldName("arguments")
+	if args == nil || args.NamedChildCount() == 0 {
+		return "", false
+	}
+	return jsStringLiteral(args.NamedChild(0), source)
+}
+
+// jsValidSegment mirrors jsprogram's identifier rule (a JS identifier, '$' allowed) so the extractor only
+// emits reference/name segments the domain validator will accept.
+func jsValidSegment(value string) bool {
+	if value == "" || value == "*" {
+		return false
+	}
+	for i, r := range value {
+		if r == '_' || r == '$' || unicode.IsLetter(r) || (i > 0 && unicode.IsDigit(r)) {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// jsDecodeIdentEscapes decodes the JS unicode escape forms (\uXXXX and \u{...}) that a source identifier may
+// use, so an escaped spelling and its plain spelling map to the SAME identifier. A malformed or non-\u
+// backslash is left as-is (the sanitizer then drops the stray character). It scans raw once.
+func jsDecodeIdentEscapes(raw string) string {
+	if !strings.Contains(raw, `\u`) {
+		return raw
+	}
+	var b strings.Builder
+	for i := 0; i < len(raw); {
+		if raw[i] == '\\' && i+1 < len(raw) && raw[i+1] == 'u' {
+			if i+2 < len(raw) && raw[i+2] == '{' { // \u{ hex... }
+				j := i + 3
+				for j < len(raw) && raw[j] != '}' {
+					j++
+				}
+				if j < len(raw) && j > i+3 {
+					if cp, err := strconv.ParseInt(raw[i+3:j], 16, 32); err == nil && cp >= 0 && cp <= 0x10FFFF {
+						b.WriteRune(rune(cp))
+						i = j + 1
+						continue
+					}
+				}
+			} else if i+6 <= len(raw) { // \uXXXX
+				if cp, err := strconv.ParseInt(raw[i+2:i+6], 16, 32); err == nil && cp >= 0 && cp <= 0x10FFFF {
+					b.WriteRune(rune(cp))
+					i += 6
+					continue
+				}
+			}
+		}
+		b.WriteByte(raw[i])
+		i++
+	}
+	return b.String()
+}
+
+// jsSanitizeSegment is the SINGLE choke point every identifier/property/name passes through before it
+// becomes a Reference segment, Value name, or Parameter name. It returns a bounded, valid JS-identifier
+// segment (jsprogram.validName-compatible, length <= maxJsSegBytes < maxStringBytes), or "" when no valid
+// segment can be produced. It is deterministic: the same raw text always yields the same segment, so an
+// escaped or over-long identifier still binds and reads consistently (its write and read connect), never an
+// invalid fact that Validate would reject.
+func jsSanitizeSegment(raw string) string {
+	// Decode JS unicode identifier escapes first, so an escaped spelling (a) and its plain spelling (a)
+	// produce the SAME segment and a flow between the two connects instead of being silently lost.
+	raw = jsDecodeIdentEscapes(raw)
+	if len(raw) <= maxJsSegBytes && jsValidSegment(raw) {
+		return raw
+	}
+	var b strings.Builder
+	for _, r := range raw {
+		if b.Len() >= maxJsSegBytes-8 {
+			break
+		}
+		first := b.Len() == 0
+		if r == '_' || r == '$' || unicode.IsLetter(r) || (!first && unicode.IsDigit(r)) {
+			b.WriteRune(r)
+		}
+	}
+	if out := b.String(); out != "" && jsValidSegment(out) {
+		return out
+	}
+	return ""
+}
+
+// jsValidSpecifier mirrors jsprogram's module-specifier rule (character set only).
+func jsValidSpecifier(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r == '_' || r == '$' || r == '-' || r == '.' || r == '/' || r == '@' || unicode.IsLetter(r) || unicode.IsDigit(r) {
+			continue
+		}
+		return false
+	}
+	return true
+}

--- a/internal/infrastructure/tools/astwalk/js_facts_cgo_test.go
+++ b/internal/infrastructure/tools/astwalk/js_facts_cgo_test.go
@@ -1,0 +1,927 @@
+//go:build cgo
+
+package astwalk
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsprogram"
+)
+
+func TestJsFactsForExtractsSemanticFactsDeterministically(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "app/api.js", ""+
+		"const express = require('express');\n"+
+		"import { execSync } from 'child_process';\n"+
+		"import lodash from 'lodash';\n"+
+		"import * as fs from 'fs';\n"+
+		"const app = express();\n"+
+		"app.get('/x', (req, res) => {\n"+
+		"  const id = req.query.id;\n"+
+		"  const q = `select * from t where id=${id}`;\n"+
+		"  db.query(q);\n"+
+		"  res.send(id);\n"+
+		"});\n")
+	writeFile(t, root, "app/util.js", ""+
+		"function helper(name, ...rest) {\n"+
+		"  const { a, b } = name;\n"+
+		"  return a;\n"+
+		"}\n"+
+		"function withOpts({ host, port }) {\n"+
+		"  return host;\n"+
+		"}\n"+
+		"class Svc extends Base {\n"+
+		"  handle(x) { return x; }\n"+
+		"}\n")
+
+	first, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	second, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor second run: %v", err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		l, _ := json.Marshal(first)
+		r, _ := json.Marshal(second)
+		t.Fatalf("facts are not deterministic:\n%s\n%s", l, r)
+	}
+	if !first.Complete() || first.FilesSeen != 2 || first.FilesParsed != 2 {
+		t.Fatalf("coverage seen=%d parsed=%d complete=%v gaps=%+v", first.FilesSeen, first.FilesParsed, first.Complete(), first.CoverageGaps)
+	}
+
+	// Imports: kind + specifier + local binding.
+	wantImports := []jsprogram.Import{
+		{Kind: jsprogram.ImportRequire, Module: "express", Alias: "express"},
+		{Kind: jsprogram.ImportNamed, Module: "child_process", Name: "execSync", Alias: "execSync"},
+		{Kind: jsprogram.ImportDefault, Module: "lodash", Name: "default", Alias: "lodash"},
+		{Kind: jsprogram.ImportNamespace, Module: "fs", Alias: "fs"},
+	}
+	for _, want := range wantImports {
+		if !hasJsImport(first, want) {
+			t.Errorf("missing import %+v (imports: %+v)", want, first.Imports)
+		}
+	}
+
+	// Symbols with parameter kinds.
+	helper, ok := jsSymbolByQualified(first, "app/util", "helper")
+	if !ok || helper.Kind != jsprogram.SymbolFunction || len(helper.Parameters) != 2 {
+		t.Fatalf("helper = %+v ok=%v", helper, ok)
+	}
+	if helper.Parameters[0].Kind != jsprogram.ParameterPositional || helper.Parameters[1].Kind != jsprogram.ParameterRest {
+		t.Errorf("helper params should be [positional, rest], got %+v", helper.Parameters)
+	}
+	// Destructured PARAMETERS (not a body destructuring) bind each contained name.
+	withOpts, ok := jsSymbolByQualified(first, "app/util", "withOpts")
+	if !ok || len(withOpts.Parameters) != 2 {
+		t.Fatalf("withOpts params = %+v ok=%v", withOpts.Parameters, ok)
+	}
+	for _, p := range withOpts.Parameters {
+		if p.Kind != jsprogram.ParameterDestructured || (p.Name != "host" && p.Name != "port") {
+			t.Errorf("withOpts param should be destructured host/port, got %+v", p)
+		}
+	}
+	svc, ok := jsSymbolByQualified(first, "app/util", "Svc")
+	if !ok || svc.Kind != jsprogram.SymbolClass || len(svc.Bases) != 1 || joinJsRef(svc.Bases[0]) != "Base" {
+		t.Errorf("Svc class/extends = %+v ok=%v", svc, ok)
+	}
+	if _, ok := jsSymbolByQualified(first, "app/util", "Svc.handle"); !ok {
+		t.Errorf("missing method Svc.handle (symbols: %+v)", first.Symbols)
+	}
+	// The request handler arrow carries req/res as parameters (the taint sources PR2 will mark).
+	if !hasJsArrowWithParam(first, "req") || !hasJsArrowWithParam(first, "res") {
+		t.Errorf("request-handler arrow should bind req and res params")
+	}
+
+	// Calls: receiver + argument captured.
+	if !hasJsCall(first, "db.query") || !hasJsCall(first, "res.send") {
+		t.Errorf("missing db.query / res.send calls (calls: %+v)", first.Calls)
+	}
+
+	// Template-literal substitution flow: the tainted `id` reaches the template value, which is the
+	// assignment source for q. This is the SQLi flow PR2 relies on.
+	qValueID := jsAssignmentValueID(first, "q")
+	if qValueID == "" {
+		t.Fatalf("no assignment for q found")
+	}
+	if !jsFlowReaches(first, "id", qValueID) {
+		t.Errorf("id must flow into the template literal assigned to q (flows: %+v)", first.Flows)
+	}
+}
+
+func TestJsFactsForContainerGranularSubscript(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "s.js", ""+
+		"function f(input) {\n"+
+		"  const d = {};\n"+
+		"  d['k'] = input;\n"+
+		"  return d['other'];\n"+
+		"}\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	// A subscript WRITE d['k']=input binds the container `d` (never a synthetic field), and a subscript READ
+	// d['other'] reads the same container — the conservative, no-false-positive model.
+	if !hasJsBindingTarget(doc, "d") {
+		t.Errorf("subscript write must bind the container d (assignments: %+v)", doc.Assignments)
+	}
+}
+
+func TestJsFactsForRecordsDynamicGaps(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want jsprogram.GapKind
+	}{
+		{"eval", "function f(x){ eval(x); }\n", jsprogram.GapDynamicExecution},
+		{"new Function", "function f(x){ const g = new Function(x); return g; }\n", jsprogram.GapDynamicExecution},
+		{"dynamic import", "async function f(m){ await import(m); }\n", jsprogram.GapDynamicImport},
+		{"dynamic require", "function f(m){ const x = require(m); return x; }\n", jsprogram.GapDynamicImport},
+		{"with", "function f(o){ with (o) { return q; } }\n", jsprogram.GapDynamicAttribute},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeFile(t, root, "d.js", tc.src)
+			doc, err := JsFactsFor(context.Background(), root)
+			if err != nil {
+				t.Fatalf("JsFactsFor: %v", err)
+			}
+			if !hasJsGap(doc, tc.want) {
+				t.Errorf("expected coverage gap %q for %q; gaps=%+v", tc.want, tc.name, doc.CoverageGaps)
+			}
+			if doc.Complete() {
+				t.Errorf("a document with a dynamic gap must not be Complete")
+			}
+		})
+	}
+}
+
+func TestJsFactsForParseRecoveryGap(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "broken.js", "function f( { return\n") // unbalanced, forces parser recovery
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	if doc.Complete() {
+		t.Fatal("a recovered parse must not support a negative proof")
+	}
+	if !hasJsGap(doc, jsprogram.GapParseRecovery) {
+		t.Errorf("expected a parse-recovery gap, got %+v", doc.CoverageGaps)
+	}
+}
+
+func TestJsFactsForTypeScriptAndTsx(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "h.ts", ""+
+		"export function handler(req: Request, res: Response): void {\n"+
+		"  const id: string = req.params.id;\n"+
+		"  res.end(id);\n"+
+		"}\n")
+	writeFile(t, root, "c.tsx", "const App = (props: Props) => { const x = props.name; return null; };\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	if doc.FilesSeen != 2 || doc.FilesParsed != 2 || !doc.Complete() {
+		t.Fatalf("ts/tsx coverage seen=%d parsed=%d complete=%v gaps=%+v", doc.FilesSeen, doc.FilesParsed, doc.Complete(), doc.CoverageGaps)
+	}
+	if _, ok := jsSymbolByQualified(doc, "h", "handler"); !ok {
+		t.Errorf("missing TypeScript function handler (symbols: %+v)", doc.Symbols)
+	}
+	// The TS handler's typed params (req/res) must be extracted despite the annotations.
+	h, _ := jsSymbolByQualified(doc, "h", "handler")
+	if len(h.Parameters) != 2 || h.Parameters[0].Name != "req" {
+		t.Errorf("TS typed params not unwrapped: %+v", h.Parameters)
+	}
+	if !hasJsCall(doc, "res.end") {
+		t.Errorf("missing res.end call in the .ts file")
+	}
+}
+
+func TestJsFactsForDestructuredRequire(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "r.js", "const { exec, spawn } = require('child_process');\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	for _, name := range []string{"exec", "spawn"} {
+		if !hasJsImport(doc, jsprogram.Import{Kind: jsprogram.ImportRequire, Module: "child_process", Name: name, Alias: name}) {
+			t.Errorf("missing destructured require binding %q (imports: %+v)", name, doc.Imports)
+		}
+	}
+}
+
+// --- test helpers ---
+
+func hasJsImport(doc jsprogram.Document, want jsprogram.Import) bool {
+	for _, im := range doc.Imports {
+		if im.Kind == want.Kind && im.Module == want.Module && im.Name == want.Name && im.Alias == want.Alias {
+			return true
+		}
+	}
+	return false
+}
+
+func jsSymbolByQualified(doc jsprogram.Document, module, qualified string) (jsprogram.Symbol, bool) {
+	for _, s := range doc.Symbols {
+		if s.Module == module && s.QualifiedName == qualified {
+			return s, true
+		}
+	}
+	return jsprogram.Symbol{}, false
+}
+
+func hasJsArrowWithParam(doc jsprogram.Document, param string) bool {
+	for _, s := range doc.Symbols {
+		if s.Kind != jsprogram.SymbolArrow {
+			continue
+		}
+		for _, p := range s.Parameters {
+			if p.Name == param {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasJsCall(doc jsprogram.Document, callee string) bool {
+	for _, c := range doc.Calls {
+		if joinJsRef(c.Callee) == callee {
+			return true
+		}
+	}
+	return false
+}
+
+func hasJsBindingTarget(doc jsprogram.Document, name string) bool {
+	for _, a := range doc.Assignments {
+		for _, target := range a.Targets {
+			if joinJsRef(target) == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func hasJsGap(doc jsprogram.Document, kind jsprogram.GapKind) bool {
+	for _, g := range doc.CoverageGaps {
+		if g.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func jsAssignmentValueID(doc jsprogram.Document, target string) string {
+	for _, a := range doc.Assignments {
+		for _, tref := range a.Targets {
+			if joinJsRef(tref) == target {
+				return a.ValueID
+			}
+		}
+	}
+	return ""
+}
+
+// jsFlowReaches reports whether a value referencing `fromName` reaches `toValueID` along the intra-procedural
+// value flows (a small BFS over the flow edges).
+func jsFlowReaches(doc jsprogram.Document, fromName, toValueID string) bool {
+	adj := map[string][]string{}
+	for _, f := range doc.Flows {
+		adj[f.FromID] = append(adj[f.FromID], f.ToID)
+	}
+	seen := map[string]bool{}
+	var queue []string
+	for _, v := range doc.Values {
+		if len(v.Ref.Segments) >= 1 && v.Ref.Segments[len(v.Ref.Segments)-1] == fromName {
+			queue = append(queue, v.ID)
+			seen[v.ID] = true
+		}
+	}
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+		if cur == toValueID {
+			return true
+		}
+		for _, nxt := range adj[cur] {
+			if !seen[nxt] {
+				seen[nxt] = true
+				queue = append(queue, nxt)
+			}
+		}
+	}
+	return false
+}
+
+func joinJsRef(ref jsprogram.Reference) string {
+	out := ""
+	for _, s := range ref.Segments {
+		if out != "" {
+			out += "."
+		}
+		out += s
+	}
+	return out
+}
+
+// TestJsFactsForDuplicateSymbolsNotRejected guards review finding 6: valid source with duplicate/overloaded
+// declarations (a TS overload set, a duplicate method name) must NOT have its whole facts document rejected;
+// each colliding declaration keeps a distinct, position-disambiguated symbol id.
+func TestJsFactsForDuplicateSymbolsNotRejected(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "o.ts", ""+
+		"export function f(a: string): string;\n"+ // TS overload signatures (no body): not emitted as symbols
+		"export function f(a: number): string;\n"+
+		"export function f(a: any): string { return String(a); }\n"+
+		"function g(x) { return x; }\n"+
+		"function g(y) { return y; }\n"+ // a real duplicate top-level function (valid; the second shadows)
+		"class C {\n"+
+		"  m() { return 1; }\n"+
+		"  m() { return 2; }\n"+ // a duplicate method name (valid to parse)
+		"}\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("valid duplicate/overloaded declarations must not be rejected: %v", err)
+	}
+	if err := doc.Validate(); err != nil {
+		t.Fatalf("extracted document must validate: %v", err)
+	}
+	// The colliding declarations (two `g`, two `C.m`) each keep a distinct symbol rather than being dropped.
+	gCount, mCount := 0, 0
+	seen := map[string]bool{}
+	for _, s := range doc.Symbols {
+		if seen[s.ID] {
+			t.Errorf("duplicate symbol id %q must not appear twice", s.ID)
+		}
+		seen[s.ID] = true
+		if s.Name == "g" {
+			gCount++
+		}
+		if s.Name == "m" {
+			mCount++
+		}
+	}
+	if gCount != 2 || mCount != 2 {
+		t.Errorf("expected 2 g + 2 m distinct symbols, got g=%d m=%d (symbols: %+v)", gCount, mCount, doc.Symbols)
+	}
+}
+
+// TestJsFactsForBoundedHostileConstruct guards review finding 5: a valid file with a construct that exceeds a
+// per-item bound (a very deep member chain) still yields a VALID document, capped, rather than an emitted
+// fact that fails Validate and drops every fact for the file.
+func TestJsFactsForBoundedHostileConstruct(t *testing.T) {
+	root := t.TempDir()
+	// A multi-line member chain deeper than the 256-segment reference bound (multi-line so it is not treated
+	// as generated/minified and is actually parsed).
+	chain := "a"
+	for i := 0; i < 300; i++ {
+		chain += "\n  .b"
+	}
+	writeFile(t, root, "chain.js", "function f() {\n  return "+chain+";\n}\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("a deep member chain must not reject the document: %v", err)
+	}
+	if err := doc.Validate(); err != nil {
+		t.Fatalf("document must validate: %v", err)
+	}
+	if doc.FilesSeen != 1 || doc.FilesParsed != 1 {
+		t.Fatalf("the file must be seen and parsed (seen=%d parsed=%d)", doc.FilesSeen, doc.FilesParsed)
+	}
+	for _, v := range doc.Values {
+		if len(v.Ref.Segments) > 256 {
+			t.Fatalf("reference segment cap breached: %d segments", len(v.Ref.Segments))
+		}
+	}
+}
+
+// TestJsFactsForDynamicRequireInAnyPosition guards review finding 3: require(expr) with a non-string-literal
+// argument, in ANY call position, is a dependency loaded invisibly and must be a GapDynamicImport.
+func TestJsFactsForDynamicRequireInAnyPosition(t *testing.T) {
+	cases := map[string]string{
+		"nested-in-call": "function f(m){ return wrap(require(m)); }\n",
+		"module.exports": "function f(m){ module.exports = require(m); }\n",
+		"member-of-req":  "function f(m){ return require(m).thing; }\n",
+		"dynamic-import": "async function f(m){ return await import(m); }\n",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			writeFile(t, root, "d.js", src)
+			doc, err := JsFactsFor(context.Background(), root)
+			if err != nil {
+				t.Fatalf("JsFactsFor: %v", err)
+			}
+			if !hasJsGap(doc, jsprogram.GapDynamicImport) {
+				t.Errorf("%s: expected GapDynamicImport; gaps=%+v", name, doc.CoverageGaps)
+			}
+		})
+	}
+	// require('literal') is a known dependency and must NOT be gapped as dynamic.
+	root := t.TempDir()
+	writeFile(t, root, "s.js", "const x = wrap(require('express'));\n")
+	doc, _ := JsFactsFor(context.Background(), root)
+	if hasJsGap(doc, jsprogram.GapDynamicImport) {
+		t.Errorf("require('express') is static and must not be a dynamic-import gap; gaps=%+v", doc.CoverageGaps)
+	}
+}
+
+// TestJsFactsForComputedMemberGap guards review finding 1: a computed member with a dynamic key records a
+// GapDynamicAttribute (the specific property is unresolved) while a literal-key access does not.
+func TestJsFactsForComputedMemberGap(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "c.js", "function f(o, k){ return o[k]; }\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	if !hasJsGap(doc, jsprogram.GapDynamicAttribute) {
+		t.Errorf("dynamic computed key o[k] must record GapDynamicAttribute; gaps=%+v", doc.CoverageGaps)
+	}
+
+	root2 := t.TempDir()
+	writeFile(t, root2, "s.js", "function f(o){ return o['name'] + o[0]; }\n")
+	doc2, err := JsFactsFor(context.Background(), root2)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	if hasJsGap(doc2, jsprogram.GapDynamicAttribute) {
+		t.Errorf("literal-key access must NOT gap; gaps=%+v", doc2.CoverageGaps)
+	}
+}
+
+// TestJsFactsForUnknownCalleeGap guards review finding 4: a call whose callee is not statically expressible
+// (a computed-property call) records GapUnresolvedCall, so absence is never read as proof.
+func TestJsFactsForUnknownCalleeGap(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "u.js", "function f(o, k){ return o[k](); }\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	if !hasJsGap(doc, jsprogram.GapUnresolvedCall) {
+		t.Errorf("a computed-property call must record GapUnresolvedCall; gaps=%+v", doc.CoverageGaps)
+	}
+}
+
+// TestJsFactsForByteIdenticalDeterminism confirms two extractions serialize to identical JSON bytes.
+func TestJsFactsForByteIdenticalDeterminism(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "a.js", "const e = require('express');\nfunction h(req){ const q = `x${req.query.id}`; db.query(q); }\n")
+	writeFile(t, root, "b.ts", "export class S { run(x: string) { return x; } }\n")
+	first, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	a, _ := json.Marshal(first)
+	b, _ := json.Marshal(second)
+	if string(a) != string(b) {
+		t.Fatalf("facts are not byte-identical across runs:\n%s\n%s", a, b)
+	}
+}
+
+// TestJsFactsForDestructuringTargetsFlow guards review finding 5: object/array destructuring assignment
+// targets carry the RHS flow (container-granular), so `const { a: b } = source` and `const [x, ...rest] =
+// source` do not silently lose the assignment (a false negative for taint).
+func TestJsFactsForDestructuringTargetsFlow(t *testing.T) {
+	cases := map[string][]string{
+		"const { a: b } = source":     {"b"},
+		"const { a } = source":        {"a"},
+		"const { a = 1 } = source":    {"a"},
+		"const [x, ...rest] = source": {"x", "rest"},
+		"const { p: { q } } = source": {"q"},
+	}
+	for src, want := range cases {
+		root := t.TempDir()
+		writeFile(t, root, "d.js", "function f(source){ "+src+"; }\n")
+		doc, err := JsFactsFor(context.Background(), root)
+		if err != nil {
+			t.Fatalf("%s: %v", src, err)
+		}
+		for _, w := range want {
+			if !hasJsBindingTarget(doc, w) {
+				t.Errorf("%s: destructured target %q must be bound to the RHS; assignments=%+v", src, w, doc.Assignments)
+			}
+		}
+	}
+}
+
+// TestJsFactsForThisMemberWrite guards review finding 6: `this.x = value` is not dropped; it binds the
+// container `this` (sound, intra-procedural, container-granular) rather than being silently lost.
+func TestJsFactsForThisMemberWrite(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "t.js", "class C { m(input) { this.x = input; return this.x; } }\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	if !hasJsBindingTarget(doc, "this") {
+		t.Errorf("this.x = input must bind the container `this`; assignments=%+v", doc.Assignments)
+	}
+}
+
+// TestJsFactsForOverlongChainIsIncomplete guards review finding 1: a member chain deeper than the reference
+// bound must make the document honestly incomplete (a gap), not silently Complete().
+func TestJsFactsForOverlongChainIsIncomplete(t *testing.T) {
+	chain := "a"
+	for i := 0; i < 300; i++ {
+		chain += "\n  .b"
+	}
+	root := t.TempDir()
+	writeFile(t, root, "ch.js", "function f() {\n  const y = "+chain+";\n  return y;\n}\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	if err := doc.Validate(); err != nil {
+		t.Fatalf("document must validate: %v", err)
+	}
+	if doc.Complete() {
+		t.Errorf("an over-long member chain must make the document incomplete")
+	}
+}
+
+// TestJsFactsForValidateNeverRejectsValidSource is the by-construction invariant: for ANY parseable JS/TS
+// input, JsFactsFor either returns a document Validate ACCEPTS (possibly Complete()==false) or an error only
+// for a genuine parse/IO failure. It feeds large and edge-case valid files and asserts Validate accepts.
+func TestJsFactsForValidateNeverRejectsValidSource(t *testing.T) {
+	deepNest := func(n int) string {
+		var b strings.Builder
+		for i := 0; i < n; i++ {
+			b.WriteString("function f" + itoaTest(i) + "() {\n")
+		}
+		b.WriteString("return 1;\n")
+		for i := 0; i < n; i++ {
+			b.WriteString("}\n")
+		}
+		return b.String()
+	}
+	deepChain := func(n int) string {
+		s := "a"
+		for i := 0; i < n; i++ {
+			s += "\n.b"
+		}
+		return "function g(){ return " + s + "; }\n"
+	}
+	bigDestructure := func(n int) string {
+		var names []string
+		for i := 0; i < n; i++ {
+			names = append(names, "k"+itoaTest(i))
+		}
+		return "function h(source){ const { " + strings.Join(names, ", ") + " } = source; return source; }\n"
+	}
+
+	cases := map[string]string{
+		"escaped-ident":      "function \\u0066oo(){ return 1; }\n",
+		"unicode-ident":      "function café(){ const naïve = 1; return naïve; }\n",
+		"deep-nesting":       deepNest(300),
+		"deep-member-chain":  deepChain(400),
+		"big-destructure":    bigDestructure(200),
+		"this-writes":        "class C { a(x){ this.a = x; } b(y){ this.b = y; return this.a; } }\n",
+		"computed-members":   "function f(o, k){ o[k] = o[k+1]; return o['x'][k]; }\n",
+		"duplicate-decls":    "function d(){} function d(){} class E { g(){} g(){} }\n",
+		"ts-generics":        "export function id<T>(x: T): T { return x; }\nclass Box<T> { constructor(private v: T) {} get(): T { return this.v; } }\n",
+		"overlong-ident":     "const " + strings.Repeat("a", 4097) + " = 1;\n",
+		"overlong-specifier": "import x from '" + strings.Repeat("a", 4097) + "';\n",
+		"escaped-binding":    "function f(){ const \\u0061 = source(); sink(\\u0061); }\n",
+		"destructure-deflt":  "function f(){ const { x = source() } = {}; sink(x); }\n",
+		"moderate-longname":  "function f(){ const " + strings.Repeat("z", 300) + " = 1;\n  return " + strings.Repeat("z", 300) + "; }\n",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			ext := ".js"
+			if strings.Contains(name, "ts") {
+				ext = ".ts"
+			}
+			root := t.TempDir()
+			writeFile(t, root, "f"+ext, src)
+			doc, err := JsFactsFor(context.Background(), root)
+			if err != nil {
+				t.Fatalf("valid source must not error: %v", err)
+			}
+			if err := doc.Validate(); err != nil {
+				t.Fatalf("INVARIANT VIOLATED: Validate rejected a valid-source document: %v", err)
+			}
+		})
+	}
+}
+
+func itoaTest(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{byte('0' + i%10)}, b...)
+		i /= 10
+	}
+	return string(b)
+}
+
+// TestJsFactsForEscapedBindingConnects guards review counterexample 3: an escaped-identifier binding is not
+// dropped; its write and read sanitize to the same segment, so the flow connects and the doc validates.
+func TestJsFactsForEscapedBindingConnects(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "e.js", "function f(){ const \\u0061 = source(); sink(\\u0061); }\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	if err := doc.Validate(); err != nil {
+		t.Fatalf("document must validate: %v", err)
+	}
+	if len(doc.Assignments) == 0 {
+		t.Fatalf("escaped binding must not be dropped (no assignment recorded)")
+	}
+	// The write's binding name and the read's reference name must be identical (consistent sanitization),
+	// so PR2's name-based def-use connects them.
+	bindName := ""
+	for _, a := range doc.Assignments {
+		for _, tref := range a.Targets {
+			bindName = joinJsRef(tref)
+		}
+	}
+	readName := false
+	for _, v := range doc.Values {
+		if v.Kind == jsprogram.ValueReference && len(v.Ref.Segments) == 1 && v.Ref.Segments[0] == bindName {
+			readName = true
+		}
+	}
+	if bindName == "" || !readName {
+		t.Errorf("escaped write name %q must match a read reference (values: %+v)", bindName, doc.Values)
+	}
+}
+
+// TestJsFactsForDestructuringDefaultFlow guards review counterexample 4: a destructuring default initializer
+// flows into the bound name (so `const { x = source() } = {}` taints x), rather than being lost.
+func TestJsFactsForDestructuringDefaultFlow(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "d.js", "function f(){ const { x = source() } = {}; sink(x); }\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	xBind := ""
+	for _, v := range doc.Values {
+		if v.Kind == jsprogram.ValueBinding && v.Name == "x" {
+			xBind = v.ID
+		}
+	}
+	if xBind == "" {
+		t.Fatalf("x binding not found; values=%+v", doc.Values)
+	}
+	incoming := 0
+	for _, fl := range doc.Flows {
+		if fl.ToID == xBind {
+			incoming++
+		}
+	}
+	if incoming == 0 {
+		t.Errorf("the default initializer must flow into x; flows=%+v", doc.Flows)
+	}
+}
+
+// TestJsFactsForBudgetLeavesNoDanglingId guards review counterexample 5: when the fact budget is crossed
+// mid-structure, no emitted fact references a value id that was not appended. Lowering the budget and
+// feeding a normal file, the resulting document must still be accepted by Validate (and be incomplete).
+func TestJsFactsForBudgetLeavesNoDanglingId(t *testing.T) {
+	restore := jsFactBudget
+	jsFactBudget = 12 // tiny, so the budget is crossed partway through the first function body
+	defer func() { jsFactBudget = restore }()
+
+	root := t.TempDir()
+	writeFile(t, root, "b.js", ""+
+		"function handler(req, res) {\n"+
+		"  const a = req.query.id;\n"+
+		"  const b = a + '-' + req.body.name;\n"+
+		"  const c = { x: a, y: b };\n"+
+		"  db.query(b);\n"+
+		"  res.send(c);\n"+
+		"  return c;\n"+
+		"}\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	if err := doc.Validate(); err != nil {
+		t.Fatalf("INVARIANT VIOLATED: a budget-truncated document must still validate (no dangling id): %v", err)
+	}
+	if doc.Complete() {
+		t.Errorf("a budget-truncated document must be incomplete")
+	}
+}
+
+// TestJsFactsForOverlongImportAliasNotRejected guards the round-5 fix: an over-long import alias goes through
+// the bounded segment sanitizer, so the Import fact does not exceed the validator's bound and the whole
+// document is not rejected.
+func TestJsFactsForOverlongImportAliasNotRejected(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "i.js", "import "+strings.Repeat("a", 4097)+" from 'm';\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	if verr := doc.Validate(); verr != nil {
+		t.Fatalf("an over-long import alias must not make Validate reject the document: %v", verr)
+	}
+}
+
+// TestJsFactsForComplexClassHeritageGapped guards the round-5 fix: a computed superclass (`extends
+// mixin(...)`) carries calls/flows this walk does not analyze, so it is recorded as a coverage gap rather
+// than silently dropped.
+func TestJsFactsForComplexClassHeritageGapped(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "c.js", "function mixin(x){ return class {}; }\nclass C extends mixin(taint()) {}\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	found := false
+	for _, g := range doc.CoverageGaps {
+		if g.Kind == jsprogram.GapUnresolvedValue && g.Detail == "class_heritage" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("a computed class heritage must be recorded as a class_heritage gap; gaps=%+v", doc.CoverageGaps)
+	}
+	if doc.Complete() {
+		t.Errorf("a document with an unanalyzed heritage must not be Complete")
+	}
+}
+
+// TestJsFactsForEscapedIdentifierDecodes guards the round-5 fix: an escaped identifier binding (a) decodes to
+// its plain identifier (a), so its write segment matches a plain-spelled read and the flow connects instead
+// of being silently lost. The escaped binding target must be the decoded name "a", never the raw "u0061".
+func TestJsFactsForEscapedIdentifierDecodes(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "e.js", "const \\u0061 = source();\nsink(a);\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	if verr := doc.Validate(); verr != nil {
+		t.Fatalf("Validate: %v", verr)
+	}
+	targetA := false
+	for _, a := range doc.Assignments {
+		for _, tgt := range a.Targets {
+			if len(tgt.Segments) == 1 && tgt.Segments[0] == "a" {
+				targetA = true
+			}
+			if len(tgt.Segments) == 1 && tgt.Segments[0] == "u0061" {
+				t.Errorf("escaped binding must decode to \"a\", not the raw \"u0061\"")
+			}
+		}
+	}
+	if !targetA {
+		t.Errorf("escaped binding \\u0061 must bind the decoded name \"a\"; assignments=%+v", doc.Assignments)
+	}
+}
+
+// TestJsFactsForComputedMethodNameWalked guards the round-6 fix: a computed method name expression
+// ([sink(source())]) executes at class definition, so its calls must be recorded (not silently dropped).
+func TestJsFactsForComputedMethodNameWalked(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "m.js", "function source(){ return 1; }\nfunction sink(x){}\nclass C {\n  [sink(source())]() {}\n}\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	if verr := doc.Validate(); verr != nil {
+		t.Fatalf("Validate: %v", verr)
+	}
+	// The computed-name expression's calls (sink, source) must appear among the recorded calls.
+	sawSink, sawSource := false, false
+	for _, c := range doc.Calls {
+		if len(c.Callee.Segments) == 1 {
+			switch c.Callee.Segments[0] {
+			case "sink":
+				sawSink = true
+			case "source":
+				sawSource = true
+			}
+		}
+	}
+	if !sawSink || !sawSource {
+		t.Errorf("computed method name calls must be recorded (sink=%v source=%v); calls=%+v", sawSink, sawSource, doc.Calls)
+	}
+}
+
+// TestJsFactsForDecoratorExpressionsWalked guards the round-7 fix: a class or method @decorator executes at
+// definition and must have its calls recorded and any nested dynamic construct gapped, never silently dropped.
+func TestJsFactsForDecoratorExpressionsWalked(t *testing.T) {
+	root := t.TempDir()
+	// A class decorator with a call, and a method decorator with a nested dynamic import.
+	writeFile(t, root, "d.ts", ""+
+		"function dec(x: any) { return x; }\n"+
+		"function source() { return 1; }\n"+
+		"@dec(source())\n"+
+		"class C {\n"+
+		"  @dec(source())\n"+
+		"  m() {}\n"+
+		"}\n")
+	doc, err := JsFactsFor(context.Background(), root)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	if verr := doc.Validate(); verr != nil {
+		t.Fatalf("Validate: %v", verr)
+	}
+	sawSource := 0
+	for _, c := range doc.Calls {
+		if len(c.Callee.Segments) == 1 && c.Callee.Segments[0] == "source" {
+			sawSource++
+		}
+	}
+	if sawSource < 2 {
+		t.Errorf("both decorator source() calls (class + method) must be recorded, saw %d; calls=%+v", sawSource, doc.Calls)
+	}
+
+	// A decorator carrying a dynamic import must produce a GapDynamicImport, not a silent drop.
+	root2 := t.TempDir()
+	writeFile(t, root2, "e.ts", "function dec(x: any){ return x; }\n@dec(import(name))\nclass D {}\n")
+	doc2, err := JsFactsFor(context.Background(), root2)
+	if err != nil {
+		t.Fatalf("JsFactsFor: %v", err)
+	}
+	if !hasJsGap(doc2, jsprogram.GapDynamicImport) {
+		t.Errorf("a dynamic import inside a decorator must be gapped; gaps=%+v", doc2.CoverageGaps)
+	}
+}
+
+// TestJsFactsForBroadenedDynamicExecGaps guards the round-8 fix: dynamic code construction/execution is
+// gapped for Function() without new, a receiver-qualified eval (globalThis.eval), and vm.runInContext.
+func TestJsFactsForBroadenedDynamicExecGaps(t *testing.T) {
+	cases := map[string]string{
+		"Function-no-new":  "function f(s){ Function(s)(); }\n",
+		"globalThis.eval":  "function f(s){ globalThis.eval(s); }\n",
+		"vm.runInContext":  "const vm = require('vm');\nfunction f(s, c){ vm.runInContext(s, c); }\n",
+	}
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			writeFile(t, root, "d.js", src)
+			doc, err := JsFactsFor(context.Background(), root)
+			if err != nil {
+				t.Fatalf("JsFactsFor: %v", err)
+			}
+			if !hasJsGap(doc, jsprogram.GapDynamicExecution) {
+				t.Errorf("%s must be gapped as dynamic execution; gaps=%+v", name, doc.CoverageGaps)
+			}
+		})
+	}
+}
+
+// TestJsFactsForChainedCallsNotRejected guards a fact-id-collision bug: a chained call (f()(), curry(a)(b))
+// has an outer and inner call that share a start position, so a start-only fact id collided and made the
+// whole facts document invalid. Both calls must be recorded and the document must validate.
+func TestJsFactsForChainedCallsNotRejected(t *testing.T) {
+	for _, src := range []string{"curry(a)(b);\n", "getHandler()(req);\n", "require('x')(cfg);\n", "a.b()();\n"} {
+		root := t.TempDir()
+		writeFile(t, root, "d.js", src)
+		doc, err := JsFactsFor(context.Background(), root)
+		if err != nil {
+			t.Errorf("chained call %q must not be rejected: %v", src, err)
+			continue
+		}
+		if verr := doc.Validate(); verr != nil {
+			t.Errorf("chained call %q must validate: %v", src, verr)
+		}
+		if len(doc.Calls) < 2 {
+			t.Errorf("chained call %q must record both calls, got %d", src, len(doc.Calls))
+		}
+	}
+}
+
+// TestJsFactsForIndirectEvalGapped guards the round-9 fix: eval.call / Function.apply (indirect invocation of
+// dynamic code) is gapped. Deeper indirections are a documented recall limitation.
+func TestJsFactsForIndirectEvalGapped(t *testing.T) {
+	for _, src := range []string{"function f(s){ eval.call(null, s); }\n", "function f(s){ Function.apply(null, [s]); }\n"} {
+		root := t.TempDir()
+		writeFile(t, root, "d.js", src)
+		doc, err := JsFactsFor(context.Background(), root)
+		if err != nil {
+			t.Fatalf("JsFactsFor: %v", err)
+		}
+		if !hasJsGap(doc, jsprogram.GapDynamicExecution) {
+			t.Errorf("indirect eval %q must be gapped; gaps=%+v", src, doc.CoverageGaps)
+		}
+	}
+}

--- a/internal/infrastructure/tools/astwalk/parse_cgo.go
+++ b/internal/infrastructure/tools/astwalk/parse_cgo.go
@@ -34,6 +34,8 @@ import (
 	"github.com/smacker/go-tree-sitter/rust"
 	"github.com/smacker/go-tree-sitter/scala"
 	"github.com/smacker/go-tree-sitter/swift"
+	tsx "github.com/smacker/go-tree-sitter/typescript/tsx"
+	typescript "github.com/smacker/go-tree-sitter/typescript/typescript"
 )
 
 func set(types ...string) map[string]bool {
@@ -70,6 +72,24 @@ var specs = map[string]spec{
 	},
 	"JavaScript": {
 		lang:         javascript.GetLanguage(),
+		funcType:     set("function_declaration", "function_expression", "arrow_function", "method_definition", "generator_function_declaration", "generator_function"),
+		cycDecision:  set("if_statement", "for_statement", "for_in_statement", "while_statement", "do_statement", "switch_case", "catch_clause", "ternary_expression"),
+		cogIncrement: set("if_statement", "for_statement", "for_in_statement", "while_statement", "do_statement", "switch_statement", "catch_clause", "ternary_expression"),
+		cogElse:      set("else_clause"),
+		boolOpBinry:  set("binary_expression"),
+	},
+	// TypeScript and TSX share the JavaScript node vocabulary (a superset), so the metric node sets mirror
+	// "JavaScript". Registering them wires the vendored grammars for the JS/TS semantic-facts extractor.
+	"TypeScript": {
+		lang:         typescript.GetLanguage(),
+		funcType:     set("function_declaration", "function_expression", "arrow_function", "method_definition", "generator_function_declaration", "generator_function"),
+		cycDecision:  set("if_statement", "for_statement", "for_in_statement", "while_statement", "do_statement", "switch_case", "catch_clause", "ternary_expression"),
+		cogIncrement: set("if_statement", "for_statement", "for_in_statement", "while_statement", "do_statement", "switch_statement", "catch_clause", "ternary_expression"),
+		cogElse:      set("else_clause"),
+		boolOpBinry:  set("binary_expression"),
+	},
+	"TSX": {
+		lang:         tsx.GetLanguage(),
 		funcType:     set("function_declaration", "function_expression", "arrow_function", "method_definition", "generator_function_declaration", "generator_function"),
 		cycDecision:  set("if_statement", "for_statement", "for_in_statement", "while_statement", "do_statement", "switch_case", "catch_clause", "ternary_expression"),
 		cogIncrement: set("if_statement", "for_statement", "for_in_statement", "while_statement", "do_statement", "switch_statement", "catch_clause", "ternary_expression"),

--- a/internal/infrastructure/tools/astwalk/parse_nocgo.go
+++ b/internal/infrastructure/tools/astwalk/parse_nocgo.go
@@ -5,6 +5,7 @@ package astwalk
 import (
 	"context"
 
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsprogram"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/pythonprogram"
 )
 
@@ -29,4 +30,8 @@ func QualityFor(ctx context.Context, root string) (Quality, error) {
 
 func PythonFactsFor(ctx context.Context, root string) (pythonprogram.Document, error) {
 	return pythonprogram.Document{}, ErrUnavailable
+}
+
+func JsFactsFor(ctx context.Context, root string) (jsprogram.Document, error) {
+	return jsprogram.Document{}, ErrUnavailable
 }

--- a/internal/usecase/ports/jsanalysis.go
+++ b/internal/usecase/ports/jsanalysis.go
@@ -1,0 +1,14 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/jsprogram"
+)
+
+// JsFactsProvider extracts versioned, source-only JavaScript/TypeScript semantic facts from a prepared
+// workspace. Implementations must never execute or import target JS. available=false means the sandboxed
+// parser sidecar is absent or was built without its tree-sitter backend; callers must retain the weaker tier.
+type JsFactsProvider interface {
+	JsFacts(ctx context.Context, root string) (document jsprogram.Document, available bool, err error)
+}


### PR DESCRIPTION
## What

Add the fact-extraction half of an owned JavaScript/TypeScript source-only value-flow analysis (EPIC #860 D5.2), mirroring the existing Python engine. This is PR1 of two: it produces semantic facts only, no taint findings yet, so it cannot report a false positive. The taint catalog and pipeline wiring follow in PR2.

## How

- A new `jsprogram` domain package holds the semantic-facts model (values, references, flows, calls, assignments, returns, imports, symbols, coverage gaps) with a validating `Document`, twin of `pythonprogram` with JS rules (`$` in identifiers, path-based module names, JS import/parameter kinds, `js:` symbol ids).
- A CGO tree-sitter extractor `JsFactsFor` walks JavaScript/TypeScript/TSX (the TS/TSX grammars are now registered) into that model, wired through the `synapse-ast` sidecar (`js-facts`) and a `JsFactsProvider` port, exactly like the Python facts path.

## Soundness

The extractor cannot emit a finding, so the bar is: never reject a valid file's facts (a rejection silently drops the whole file), never silently drop a flow-carrying construct, and no field sensitivity.

- Validate-safe by construction: every emitted name, segment, and specifier passes through one bounded sanitizer (unicode identifier escapes decoded so an escaped and plain spelling connect); fact ids key on the full node extent so a chained call `f()()` cannot collide into a duplicate id; budgets stop emission cleanly. For any parseable input, `JsFactsFor` returns a `Validate`-accepted document (possibly incomplete) or an error only on a genuine parse/IO failure.
- Container-granular subscript/member and object/array literals, never field-sensitive (the no-false-positive lesson from the Python engine).
- Any construct that could carry a flow invisibly (eval and its indirect/vm forms, dynamic import/require, computed member, a computed class heritage, a with-statement) is recorded as a `CoverageGap`, so a not-detected conclusion stays honest. Documented residual: vanishingly rare deeper eval-indirection (`Reflect.apply(eval, ...)`, `window["eval"]`) is a recall limitation, never a false positive.

## Tests

Per-construct extraction fixtures (bindings, member/subscript, functions incl. destructuring/rest/default params, calls/new, imports/require, template literals, classes, TS/TSX), a determinism test (byte-identical re-extraction), the dynamic-gap set, and an invariant test that feeds escaped/unicode identifiers, deep nesting, huge destructures, `this` writes, duplicate declarations, decorators, computed method names, and chained calls and asserts `Validate` always accepts.

## Review

Reviewed by Codex across nine rounds. It drove the systematic Validate-safety (two choke points), the child-recursion closure of the class/method/function handlers (computed names, decorators, defaults, heritage all walked or gapped), and it surfaced a real whole-document-rejection bug: a chained call collided on a start-only fact id (now keyed on start and end). The residual items are verified non-issues or the documented ultra-obscure recall limitations above.

Advances EPIC #860 D5.2.
