### PR TITLE
feat(taint): add value-level exec-sink precision to Go taint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -381,6 +381,25 @@ and this project aims to adhere to [Semantic Versioning](https://semver.org/spec
 
 ### Changed
 
+- **Go taint gains value-level exec-sink precision (fewer command-injection false positives).** The Go
+  taint engine was function-granular: any function that both read untrusted input and called
+  `os/exec.Command`/`CommandContext` was reported as CWE-78 command injection, regardless of whether the
+  program name was attacker-controlled. The sandboxed `synapse-callgraph` builder now inspects, from the
+  same SSA build, the program name (argv[0]) at every exec call site in each first-party function. When it
+  proves that argument is a compile-time constant naming a known-fixed-safe program (an allowlist of tools
+  that never execute a command or code from their arguments, e.g. `echo`, `ls`, `ping`, `curl`) AND the
+  resulting `*exec.Cmd` is confined (its program is never re-pointed via a field write such as `cmd.Path =`
+  and it does not escape before execution), the finding de-escalates from CWE-78 to CWE-88 argument
+  injection (`taint-argument-injection`): the program is fixed and attacker-uncontrolled, so the residual
+  risk is a tainted argument, not a tainted command. The classification is fail-closed: it de-escalates only
+  for the vetted safe set, so any shell, interpreter (including versioned names such as `python3.11`),
+  command-runner (`env`, `xargs`, `pkexec`, `flock`, `find`, …), unknown program, variable argv[0], mutated
+  or escaping `*exec.Cmd`, mixed call set, unresolved function-value exec call, or an older builder that
+  omits the facts keeps CWE-78. It is a precision filter, never a suppressor: the finding still fires at the
+  same location with the same witness, only its class narrows. Verdicts are keyed per sink symbol and ride
+  an additive, back/forward-compatible field on the existing call-graph wire protocol (unchanged for
+  reachability), so no configuration changes. Implements EPIC #860 D5.4.
+
 - **Dashboard theme fidelity.** The Code Quality measures table now labels bug, vulnerability, code-smell
   and hotspot columns with icons instead of emoji; the project-activity trend chart, the code-viewer
   syntax highlighter, the modern badge addon, and the dependency-graph minimap now draw from semantic

--- a/cmd/synapse-callgraph/main.go
+++ b/cmd/synapse-callgraph/main.go
@@ -19,12 +19,12 @@ func main() {
 		fmt.Fprintln(os.Stderr, "usage: synapse-callgraph build-callgraph <go-module-dir>")
 		os.Exit(2)
 	}
-	g, err := ssacallgraph.BuildGraph(context.Background(), os.Args[2])
+	g, facts, err := ssacallgraph.BuildGraphAndExecFacts(context.Background(), os.Args[2])
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "synapse-callgraph:", err)
 		os.Exit(1)
 	}
-	if err := taintcallgraph.EncodeGraph(os.Stdout, g); err != nil {
+	if err := taintcallgraph.EncodeGraphWithFacts(os.Stdout, g, facts); err != nil {
 		fmt.Fprintln(os.Stderr, "synapse-callgraph: encode:", err)
 		os.Exit(1)
 	}

--- a/internal/domain/taint/catalog.go
+++ b/internal/domain/taint/catalog.go
@@ -13,6 +13,12 @@ type Sink struct {
 	Symbol string // "importPath.Symbol", e.g. "database/sql.DB.Query"
 	CWE    string // e.g. "CWE-89"
 	Rule   string // e.g. "taint-sqli"
+	// Exec, when non-nil, marks this as an exec-style command sink and carries the value-level
+	// de-escalation policy (D5.4): the argument index of the program name (argv[0]) plus the class the
+	// finding drops to when the SSA pass proves that argument is a compile-time-constant, non-interpreter
+	// string at every call site. It is the ONLY value-level refinement the coarse call-graph model needs,
+	// and it never suppresses — see ExecPolicy + AssembleWithFacts.
+	Exec *ExecPolicy
 }
 
 // Catalog is the curated, per-language set of taint roles in the shared "importPath.Symbol" convention
@@ -56,7 +62,22 @@ type Catalog struct {
 // kept to PURPOSE-BUILT neutralizers (escapers / containment checks) and deliberately omits incidental
 // general utilities (e.g. strconv.Atoi) that, walling every flow through their caller, would suppress
 // unrelated real injections.
+//
+// Assemble carries no value-level facts (an empty ExecFacts), so it keeps the coarse over-approximation
+// verbatim. AssembleWithFacts is the value-level-aware entry point (D5.4).
 func Assemble(g callgraph.Graph, cat Catalog) (FlowGraph, map[string][]Sink) {
+	return AssembleWithFacts(g, cat, ExecFacts{})
+}
+
+// AssembleWithFacts is Assemble plus the value-level exec-sink precision filter (D5.4): when facts prove a
+// sink-using function's os/exec program names are all compile-time-constant + non-interpreter, that
+// function's command-injection sink is DE-ESCALATED from its CWE-78 class to the sink's ExecPolicy target
+// (CWE-88 argument injection). This never removes a finding and never touches path detection — the same
+// source→sink flow still reports, only its injection CLASS narrows — and it defaults to KEEPING CWE-78
+// whenever facts are absent or inconclusive (fail-closed). It thus adds precision without adding a false
+// negative: a function whose exec program name is variable, an interpreter (sh/bash/env/…), or unproven
+// retains the CWE-78 over-approximation exactly as before.
+func AssembleWithFacts(g callgraph.Graph, cat Catalog, facts ExecFacts) (FlowGraph, map[string][]Sink) {
 	srcSet := toSet(cat.Sources)
 	sanSet := toSet(cat.Sanitizers)
 	sinkSet := make(map[string]Sink, len(cat.Sinks))
@@ -95,7 +116,11 @@ func Assemble(g callgraph.Graph, cat Catalog) (FlowGraph, map[string][]Sink) {
 				if sinkClassSet[e.Caller] == nil {
 					sinkClassSet[e.Caller] = map[string]Sink{}
 				}
-				sinkClassSet[e.Caller][s.Symbol] = s
+				// Value-level de-escalation: an exec sink at a function whose program names are all
+				// provably constant + non-interpreter drops from CWE-78 to CWE-88. The map key stays the
+				// sink SYMBOL (unchanged by de-escalation), so a function reaching the same exec sink by two
+				// edges dedups to one entry, and the coordinator's (CWE,Rule) dedup then folds it correctly.
+				sinkClassSet[e.Caller][s.Symbol] = deEscalateExecSink(s, facts.Funcs[e.Caller])
 			}
 		}
 	}
@@ -166,9 +191,13 @@ func DefaultCatalog() Catalog {
 			{Symbol: "database/sql.Tx.QueryContext", CWE: "CWE-89", Rule: "taint-sqli"},
 			{Symbol: "database/sql.Tx.Exec", CWE: "CWE-89", Rule: "taint-sqli"},
 			{Symbol: "database/sql.Tx.ExecContext", CWE: "CWE-89", Rule: "taint-sqli"},
-			// CWE-78 – OS command injection.
-			{Symbol: "os/exec.Command", CWE: "CWE-78", Rule: "taint-command-injection"},
-			{Symbol: "os/exec.CommandContext", CWE: "CWE-78", Rule: "taint-command-injection"},
+			// CWE-78 – OS command injection. Go's exec.Command execs an argv array directly (no shell), so
+			// the program (argv[0]) being attacker-controlled is the command-injection risk. When the SSA
+			// pass (D5.4) proves argv[0] is a compile-time-constant, non-interpreter string at every call
+			// site, the program is fixed and the worst case is argument injection (CWE-88), so the finding
+			// de-escalates. argv[0] is arg 0 of Command; arg 1 of CommandContext (arg 0 is the context).
+			{Symbol: "os/exec.Command", CWE: "CWE-78", Rule: "taint-command-injection", Exec: &ExecPolicy{ProgramNameArg: 0, DeEscalatedCWE: "CWE-88", DeEscalatedRule: "taint-argument-injection"}},
+			{Symbol: "os/exec.CommandContext", CWE: "CWE-78", Rule: "taint-command-injection", Exec: &ExecPolicy{ProgramNameArg: 1, DeEscalatedCWE: "CWE-88", DeEscalatedRule: "taint-argument-injection"}},
 			// CWE-22 – path traversal: an attacker-controlled path opened on the host filesystem. Only
 			// symbols whose sole meaningful argument is a PATH are listed, so a class-blind function-level
 			// match cannot fire on a tainted content/mode argument (os.WriteFile's data, for example, is

--- a/internal/domain/taint/execfacts.go
+++ b/internal/domain/taint/execfacts.go
@@ -1,0 +1,128 @@
+package taint
+
+import "strings"
+
+// ExecPolicy is the value-level de-escalation policy for an exec-style command sink (D5.4). It is pure,
+// auditable security data (no behavior): a reviewer reads it to see exactly when a CWE-78 command-injection
+// finding is allowed to narrow to a lower class, and to what.
+//
+// ProgramNameArg is the call-argument index of the program name (argv[0]) — os/exec.Command's arg 0,
+// CommandContext's arg 1 (arg 0 is the context). It is consumed by the SSA pass (which inspects that exact
+// argument at every call site); the domain never dereferences a call. DeEscalatedCWE/DeEscalatedRule is the
+// class the finding drops TO when the program name is proven a compile-time constant naming a known-fixed
+// safe program at every site (see IsFixedSafeProgram) AND the resulting *exec.Cmd is confined: the program
+// is then fixed and attacker-uncontrolled, so the residual risk is argument injection, not command injection.
+type ExecPolicy struct {
+	ProgramNameArg  int
+	DeEscalatedCWE  string
+	DeEscalatedRule string
+}
+
+// ExecFacts carries the value-level exec-sink verdicts the SSA pass computes in the sandboxed call-graph
+// builder — the argv[0]-is-constant precision the function-granular call graph cannot express. Funcs maps a
+// first-party function "importPath.Symbol" (the same identity the call graph uses for a sink-using node) to
+// its verdict. An ABSENT entry means "no proof" and keeps the coarse CWE-78 over-approximation (fail-closed),
+// so a builder that omits the table (older binary, or a target it could not analyze) degrades safely.
+type ExecFacts struct {
+	Funcs map[string]ExecFuncFacts
+}
+
+// ExecFuncFacts is one function's value-level exec verdict, keyed PER SINK SYMBOL: SafeSinks holds the exec
+// sink symbols (e.g. "os/exec.Command") for which the SSA pass proved EVERY call site in the function passes
+// a compile-time-constant, non-interpreter program name AND the resulting *exec.Cmd is confined (its program
+// is never re-pointed via a field write and it never escapes before execution). De-escalation applies ONLY
+// to a sink symbol in this set — a sink the pass never inspected (a future/other exec sink the builder's
+// default catalog does not cover) is absent and keeps CWE-78, so a builder/catalog drift fails closed
+// rather than de-escalating a sink whose safety was never checked.
+type ExecFuncFacts struct {
+	SafeSinks map[string]bool
+}
+
+// ExecSinkArgs projects the catalog's exec sinks to a "symbol → program-name arg index" map, the single
+// source of truth the SSA pass reads to know which call argument to inspect. A catalog with no exec sinks
+// yields an empty map (the pass then computes no verdicts, and every command-injection finding keeps CWE-78).
+func ExecSinkArgs(cat Catalog) map[string]int {
+	out := make(map[string]int, len(cat.Sinks))
+	for _, s := range cat.Sinks {
+		if s.Exec != nil && s.Symbol != "" {
+			out[s.Symbol] = s.Exec.ProgramNameArg
+		}
+	}
+	return out
+}
+
+// deEscalateExecSink returns the sink to record for a sink-using function: the original sink unchanged,
+// unless it is an exec-style sink (Exec != nil) that the SSA pass listed in the function's SafeSinks set
+// (argv[0] a constant, known-fixed-safe program at every call site AND the *exec.Cmd result confined), in
+// which case its CWE/Rule narrow to the ExecPolicy target and Exec is cleared (already de-escalated). The
+// check is PER SINK SYMBOL, so a sink the pass never inspected is never de-escalated. The Symbol is never
+// changed, so the caller's symbol-keyed dedup is unaffected.
+func deEscalateExecSink(s Sink, f ExecFuncFacts) Sink {
+	if s.Exec == nil || !f.SafeSinks[s.Symbol] {
+		return s
+	}
+	s.CWE = s.Exec.DeEscalatedCWE
+	s.Rule = s.Exec.DeEscalatedRule
+	s.Exec = nil
+	return s
+}
+
+// IsFixedSafeProgram reports whether a constant program name (argv[0]) is on the curated ALLOWLIST of
+// programs that provably do NOT execute or interpret a command or code taken from their arguments — so that
+// with a fixed argv[0] the worst case is argument injection (CWE-88), never command injection (CWE-78).
+//
+// It de-escalates ONLY a BARE program name matched EXACTLY (case-sensitive, no suffix stripping) against the
+// vetted set. Any name containing a path separator ("/bin/echo", "./echo", "..\\x") keeps CWE-78: a
+// directory component can point at attacker-writable or otherwise untrusted code (e.g. "/tmp/echo"), so the
+// basename does NOT prove the program is fixed. Any name with whitespace, a different case ("ECHO"), or a
+// suffix ("echo.exe") is a DIFFERENT file on a case-sensitive filesystem and also keeps CWE-78. It assumes
+// the runtime PATH used to resolve a bare name is not attacker-controlled; a target that rewrites its own
+// PATH to an attacker directory is a separate untrusted-search-path weakness, not the taint flow analyzed
+// here.
+//
+// This is FAIL-CLOSED by design (the #1 bar: never understate a real command injection). The set of programs
+// that DO run a command from their arguments — shells (sh -c), interpreters (python -c, deno eval), and
+// command-runners (env, xargs, pkexec, flock, chroot, find -exec, …) — is open-ended and version-suffixed
+// on real hosts ("python3.11", "php8.2"), so a denylist of them can never be complete and would fail OPEN.
+// Instead only an explicitly-vetted safe program de-escalates; ANY other constant program name (an unknown
+// tool, a versioned interpreter, a command-runner, a path) keeps CWE-78. A program missing from this
+// allowlist costs only a residual false positive (the pre-D5.4 over-approximation, gated by a verifier);
+// de-escalating an unrecognized program would risk understating a real command injection, which this must
+// never do. Every entry takes data/paths/URLs as arguments and never spawns an argument as a command.
+func IsFixedSafeProgram(name string) bool {
+	if name == "" || strings.ContainsAny(name, `/\`) || strings.ContainsAny(name, " \t\r\n\v\f") {
+		return false // a path, or a name with whitespace, is not a bare vetted program
+	}
+	return fixedSafePrograms[name]
+}
+
+// fixedSafePrograms is the curated allowlist of programs that never execute a command/code from their
+// arguments, so a constant argv[0] naming one makes the exec call at worst argument injection (CWE-88). It
+// deliberately EXCLUDES anything that can run a program named in a later argument (shells, interpreters,
+// sudo/pkexec/env/xargs/find/flock/chroot/ssh/awk/sed/…) and grows only under security review. Grouped by
+// kind. A program's OTHER risks (path traversal for cp/cat, SSRF for curl) are separate CWEs, not CWE-78.
+var fixedSafePrograms = map[string]bool{
+	// Trivial / control.
+	"echo": true, "printf": true, "true": true, "false": true, "sleep": true, "yes": true, "seq": true,
+	// Text processing that does not exec. Deliberately ABSENT: sed/awk (interpreters), and "sort" (GNU sort's
+	// --compress-program=PROG executes PROG, an argument-to-command-exec vector).
+	"cat": true, "tac": true, "head": true, "tail": true, "nl": true, "wc": true, "cut": true, "tr": true,
+	"rev": true, "fold": true, "fmt": true, "tee": true, "uniq": true, "comm": true,
+	"paste": true, "cmp": true, "column": true, "expand": true, "unexpand": true,
+	// Search (grep has no exec option; ripgrep's --pre runs a command, so "rg" is absent).
+	"grep": true, "egrep": true, "fgrep": true,
+	// Encoding / hashing.
+	"base64": true, "base32": true, "md5sum": true, "sha1sum": true, "sha256sum": true, "sha512sum": true,
+	"cksum": true, "b2sum": true,
+	// Filesystem inspection / manipulation (path traversal is CWE-22/CWE-88, not command exec).
+	"ls": true, "stat": true, "file": true, "basename": true, "dirname": true, "readlink": true,
+	"realpath": true, "pwd": true, "cp": true, "mv": true, "mkdir": true, "rmdir": true, "touch": true,
+	"ln": true, "df": true, "du": true,
+	// System / identity info.
+	"date": true, "hostname": true, "uname": true, "whoami": true, "id": true, "groups": true,
+	"uptime": true, "arch": true, "nproc": true, "printenv": true, "logname": true,
+	// Network probes (SSRF/URL risk is CWE-918, not command exec). Deliberately ABSENT: curl/wget (wget
+	// --use-askpass=CMD runs CMD; rich option surfaces), "traceroute" (-M/--module can select an external
+	// module), and "ip"/"nmap" (ip netns exec, nmap --script) — all can execute a command/code from an arg.
+	"ping": true, "ping6": true, "tracepath": true, "dig": true, "nslookup": true, "host": true,
+}

--- a/internal/domain/taint/execfacts_test.go
+++ b/internal/domain/taint/execfacts_test.go
@@ -1,0 +1,188 @@
+package taint
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/callgraph"
+)
+
+func TestIsFixedSafeProgram(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		// Allowlisted BARE names → safe to de-escalate (exact, case-sensitive, no suffix strip).
+		{"echo", true},
+		{"ping", true},
+		{"ping6", true},
+		{"ls", true},
+		{"cat", true},
+		{"grep", true},
+		{"sha256sum", true},
+		// A path form is NOT de-escalated: a directory component can point at untrusted code (/tmp/echo),
+		// so the basename does not prove the program is fixed.
+		{"/bin/echo", false},
+		{"/tmp/echo", false},
+		{"./echo", false},
+		{`..\echo`, false},
+		// Case / suffix / whitespace variants are DIFFERENT files → keep CWE-78 (no normalization).
+		{"ECHO", false},
+		{"echo.exe", false},
+		{"echo ", false},
+		{" echo", false},
+		// NOT allowlisted → keep CWE-78 (fail-closed). Shells + interpreters + command-runners.
+		{"sh", false},
+		{"/bin/sh", false},
+		{"bash", false},
+		{"python", false},
+		{"python3", false},
+		{"python3.11", false}, // versioned interpreter: the common real binary name — must NOT de-escalate
+		{"php8.2", false},
+		{"ruby2.7", false},
+		{"node18", false},
+		{"deno", false},
+		{"bun", false},
+		{"pkexec", false},
+		{"flock", false},
+		{"chroot", false},
+		{"env", false},
+		{"xargs", false},
+		{"sudo", false},
+		{"find", false},       // find -exec runs commands
+		{"awk", false},        // awk system()/interpreter
+		{"sed", false},        // sed e command execs
+		{"git", false},        // argument-to-RCE (git -c core.sshCommand); keep CWE-78
+		{"sort", false},       // GNU sort --compress-program=PROG runs PROG
+		{"wget", false},       // wget --use-askpass=CMD runs CMD
+		{"curl", false},       // excluded out of caution (rich option surface; SSRF is CWE-918)
+		{"traceroute", false}, // traceroute -M/--module can select an external module
+		{"", false},
+		{"someunknowntool", false}, // unknown → keep CWE-78
+	}
+	for _, c := range cases {
+		if got := IsFixedSafeProgram(c.name); got != c.want {
+			t.Errorf("IsFixedSafeProgram(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func TestExecSinkArgs(t *testing.T) {
+	args := ExecSinkArgs(DefaultCatalog())
+	if got, ok := args["os/exec.Command"]; !ok || got != 0 {
+		t.Errorf("os/exec.Command program-name arg must be 0, got %d ok=%v", got, ok)
+	}
+	if got, ok := args["os/exec.CommandContext"]; !ok || got != 1 {
+		t.Errorf("os/exec.CommandContext program-name arg must be 1 (arg 0 is the context), got %d ok=%v", got, ok)
+	}
+	// A non-exec sink must not appear (only Exec-tagged sinks are exec sinks).
+	if _, ok := args["database/sql.DB.Query"]; ok {
+		t.Error("a SQLi sink must not be listed as an exec sink")
+	}
+}
+
+// AssembleWithFacts de-escalates a command-injection sink to CWE-88 only when the SSA pass listed that exact
+// sink symbol in the function's SafeSinks; without it the coarse CWE-78 over-approximation stands.
+func TestAssembleWithFactsDeEscalatesExecSink(t *testing.T) {
+	g := callgraph.Graph{Edges: []callgraph.Edge{
+		{Caller: "app.safe", Callees: []string{"os.Getenv", "os/exec.Command"}},
+	}}
+	facts := ExecFacts{Funcs: map[string]ExecFuncFacts{
+		"app.safe": {SafeSinks: map[string]bool{"os/exec.Command": true}},
+	}}
+
+	_, sinkClass := AssembleWithFacts(g, DefaultCatalog(), facts)
+	classes := sinkClass["app.safe"]
+	if len(classes) != 1 || classes[0].CWE != "CWE-88" || classes[0].Rule != "taint-argument-injection" {
+		t.Fatalf("a safe exec sink must de-escalate to CWE-88 argument injection: %+v", classes)
+	}
+	if classes[0].Symbol != "os/exec.Command" {
+		t.Errorf("de-escalation must not change the sink symbol, got %q", classes[0].Symbol)
+	}
+	if classes[0].Exec != nil {
+		t.Errorf("a de-escalated sink must clear its Exec policy (already de-escalated): %+v", classes[0].Exec)
+	}
+}
+
+func TestAssembleWithFactsKeepsCWE78WithoutFact(t *testing.T) {
+	g := callgraph.Graph{Edges: []callgraph.Edge{
+		{Caller: "app.unsafe", Callees: []string{"os.Getenv", "os/exec.Command"}},
+	}}
+	// No fact for app.unsafe (variable argv[0] emits none) → keep CWE-78.
+	_, sinkClass := AssembleWithFacts(g, DefaultCatalog(), ExecFacts{})
+	classes := sinkClass["app.unsafe"]
+	if len(classes) != 1 || classes[0].CWE != "CWE-78" || classes[0].Rule != "taint-command-injection" {
+		t.Fatalf("no fact must keep CWE-78 command injection: %+v", classes)
+	}
+}
+
+// A per-symbol fact for a DIFFERENT sink must not de-escalate an exec sink it does not name (fail-closed
+// against builder/catalog drift).
+func TestAssembleWithFactsIsPerSinkSymbol(t *testing.T) {
+	g := callgraph.Graph{Edges: []callgraph.Edge{
+		{Caller: "app.h", Callees: []string{"os.Getenv", "os/exec.Command"}},
+	}}
+	// The function is marked safe for CommandContext, but it calls Command — Command must NOT de-escalate.
+	facts := ExecFacts{Funcs: map[string]ExecFuncFacts{
+		"app.h": {SafeSinks: map[string]bool{"os/exec.CommandContext": true}},
+	}}
+	_, sinkClass := AssembleWithFacts(g, DefaultCatalog(), facts)
+	if c := sinkClass["app.h"]; len(c) != 1 || c[0].CWE != "CWE-78" {
+		t.Fatalf("a fact naming a different sink must not de-escalate os/exec.Command: %+v", c)
+	}
+}
+
+// CommandContext (program name at arg 1) de-escalates the same way as Command when its symbol is listed.
+func TestAssembleWithFactsDeEscalatesCommandContext(t *testing.T) {
+	g := callgraph.Graph{Edges: []callgraph.Edge{
+		{Caller: "app.ctx", Callees: []string{"os.Getenv", "os/exec.CommandContext"}},
+	}}
+	facts := ExecFacts{Funcs: map[string]ExecFuncFacts{
+		"app.ctx": {SafeSinks: map[string]bool{"os/exec.CommandContext": true}},
+	}}
+	_, sinkClass := AssembleWithFacts(g, DefaultCatalog(), facts)
+	if c := sinkClass["app.ctx"]; len(c) != 1 || c[0].CWE != "CWE-88" {
+		t.Fatalf("CommandContext must de-escalate to CWE-88, got %+v", c)
+	}
+}
+
+// De-escalation is scoped to exec sinks: a safe verdict on a function must not touch its non-exec (e.g.
+// SQLi) sinks — those have no ExecPolicy.
+func TestAssembleWithFactsLeavesNonExecSinksAlone(t *testing.T) {
+	g := callgraph.Graph{Edges: []callgraph.Edge{
+		{Caller: "app.both", Callees: []string{"os.Getenv", "os/exec.Command", "database/sql.DB.Query"}},
+	}}
+	facts := ExecFacts{Funcs: map[string]ExecFuncFacts{
+		"app.both": {SafeSinks: map[string]bool{"os/exec.Command": true}},
+	}}
+	_, sinkClass := AssembleWithFacts(g, DefaultCatalog(), facts)
+	var sawSQLi, sawArgInj bool
+	for _, s := range sinkClass["app.both"] {
+		if s.CWE == "CWE-89" && s.Rule == "taint-sqli" {
+			sawSQLi = true
+		}
+		if s.CWE == "CWE-88" && s.Symbol == "os/exec.Command" {
+			sawArgInj = true
+		}
+		if s.CWE == "CWE-78" {
+			t.Errorf("the exec sink must have de-escalated, not stayed CWE-78: %+v", s)
+		}
+	}
+	if !sawSQLi {
+		t.Error("the SQLi sink must be untouched by exec de-escalation")
+	}
+	if !sawArgInj {
+		t.Error("the exec sink must de-escalate to CWE-88")
+	}
+}
+
+// Assemble (no facts) is exactly AssembleWithFacts with an empty table: the command-injection sink stays
+// CWE-78, proving back-compatibility for every existing caller.
+func TestAssembleIsAssembleWithEmptyFacts(t *testing.T) {
+	g := callgraph.Graph{Edges: []callgraph.Edge{
+		{Caller: "app.h", Callees: []string{"os.Getenv", "os/exec.Command"}},
+	}}
+	_, viaAssemble := Assemble(g, DefaultCatalog())
+	if c := viaAssemble["app.h"]; len(c) != 1 || c[0].CWE != "CWE-78" {
+		t.Fatalf("Assemble must keep CWE-78 (empty facts), got %+v", c)
+	}
+}

--- a/internal/infrastructure/tools/ssacallgraph/builder.go
+++ b/internal/infrastructure/tools/ssacallgraph/builder.go
@@ -14,6 +14,7 @@ package ssacallgraph
 import (
 	"context"
 	"fmt"
+	"go/constant"
 	"go/token"
 	"go/types"
 	"path/filepath"
@@ -26,15 +27,30 @@ import (
 	"golang.org/x/tools/go/ssa/ssautil"
 
 	domaincg "github.com/KKloudTarus/synapse-ce/internal/domain/callgraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/taint"
 )
 
 // BuildGraph loads the Go packages under dir (the module's./...), builds SSA + a CHA call graph, and
 // reduces it to the deterministic domain callgraph.Graph: edges are caller→callee by "importPath.Symbol";
 // entrypoints are the FIRST-PARTY (loaded-module) exported functions + any main. CHA (class-hierarchy
-// analysis) is a SOUND over-approximation – the right precision tier for the taint over-approximation MVP
-// ; precise VTA/def-use is a later refinement. Output is deterministic (sorted, deduped). Honors
-// ctx. Load/type errors fail closed (a partial graph would silently drop edges → false-negative taint).
+// analysis) is a SOUND over-approximation – the right precision tier for the taint over-approximation MVP.
+// Output is deterministic (sorted, deduped). Honors ctx. Load/type errors fail closed (a partial graph would
+// silently drop edges → false-negative taint). This is the reachability contract (ports.CallGraphBuilder);
+// it discards the value-level exec facts BuildGraphAndExecFacts also computes.
 func BuildGraph(ctx context.Context, dir string) (*domaincg.Graph, error) {
+	g, _, err := BuildGraphAndExecFacts(ctx, dir)
+	return g, err
+}
+
+// BuildGraphAndExecFacts is BuildGraph plus the value-level exec-sink facts D5.4 needs: from the SAME single
+// SSA build it also returns, per first-party function, whether every os/exec.Command/CommandContext call
+// site in it passes a compile-time-constant, non-interpreter program name (argv[0]). The call graph is
+// byte-identical to BuildGraph's (reachability depends on it, so the facts are strictly ADDITIVE), and the
+// facts only ever DE-ESCALATE a CWE-78 finding to CWE-88 downstream — a function with a variable, interpreter,
+// or unproven program name simply carries no fact and keeps CWE-78 (fail-closed). Facts are bounded to
+// first-party functions (like the position table): a sink-using function in a dependency carries no fact and
+// keeps CWE-78.
+func BuildGraphAndExecFacts(ctx context.Context, dir string) (*domaincg.Graph, taint.ExecFacts, error) {
 	cfg := &packages.Config{
 		Mode:    packages.LoadAllSyntax,
 		Dir:     dir,
@@ -43,13 +59,13 @@ func BuildGraph(ctx context.Context, dir string) (*domaincg.Graph, error) {
 	}
 	pkgs, err := packages.Load(cfg, "./...")
 	if err != nil {
-		return nil, fmt.Errorf("load packages: %w", err)
+		return nil, taint.ExecFacts{}, fmt.Errorf("load packages: %w", err)
 	}
 	if n := packages.PrintErrors(pkgs); n > 0 {
-		return nil, fmt.Errorf("%d package load/type error(s) – refusing a partial call graph", n)
+		return nil, taint.ExecFacts{}, fmt.Errorf("%d package load/type error(s) – refusing a partial call graph", n)
 	}
 	if len(pkgs) == 0 {
-		return &domaincg.Graph{}, nil
+		return &domaincg.Graph{}, taint.ExecFacts{}, nil
 	}
 
 	// First-party package paths (the loaded module's own packages) – entrypoints are drawn from these, so a
@@ -66,6 +82,17 @@ func BuildGraph(ctx context.Context, dir string) (*domaincg.Graph, error) {
 	cg := cha.CallGraph(prog)
 	cg.DeleteSyntheticNodes() // collapse wrapper/thunk nodes so edges connect real functions
 
+	// execArgs is the catalog's single source of truth for which callee is an exec sink and which of its
+	// arguments is the program name (argv[0]) the value-level check inspects.
+	execArgs := taint.ExecSinkArgs(taint.DefaultCatalog())
+	// execSeen/execSafe accumulate the verdict PER (function symbol, exec sink symbol) ACROSS the (possibly
+	// several) SSA nodes that map to one "importPath.Symbol" id — generic instances share an origin id via
+	// nodeID, so a (function, sink) is safe only when EVERY node for it is (AND, the fail-closed direction).
+	// Keying by sink symbol means a sink the pass never inspected is never marked safe (builder/catalog
+	// drift fails closed).
+	execSeen := map[string]map[string]bool{} // function symbol → sink symbol → seen
+	execSafe := map[string]map[string]bool{} // function symbol → sink symbol → all sites safe so far
+
 	adj := map[string]map[string]bool{}
 	entry := map[string]bool{}
 	positions := map[string]string{} // first-party symbol → "relpath:line" (def-use precision for taint findings)
@@ -80,6 +107,21 @@ func BuildGraph(ctx context.Context, dir string) (*domaincg.Graph, error) {
 		if p := firstPartyPos(prog.Fset, fn, dir, firstParty); p != "" {
 			positions[caller] = p
 		}
+		if isFirstPartyFunc(fn, firstParty) {
+			for sink, siteSafe := range execConstantSafe(fn, execArgs) {
+				if execSeen[caller] == nil {
+					execSeen[caller] = map[string]bool{}
+					execSafe[caller] = map[string]bool{}
+				}
+				if !execSeen[caller][sink] {
+					execSeen[caller][sink] = true
+					execSafe[caller][sink] = true // optimistic; AND-ed down below
+				}
+				if !siteSafe {
+					execSafe[caller][sink] = false
+				}
+			}
+		}
 		for _, e := range node.Out {
 			callee := nodeID(e.Callee.Func)
 			if callee == "" || callee == caller {
@@ -91,7 +133,195 @@ func BuildGraph(ctx context.Context, dir string) (*domaincg.Graph, error) {
 			adj[caller][callee] = true
 		}
 	}
-	return &domaincg.Graph{Entrypoints: sortedKeys(entry), Edges: edgesOf(adj), Positions: positions}, nil
+
+	var execFuncs map[string]taint.ExecFuncFacts
+	for caller, sinks := range execSeen {
+		var safe map[string]bool
+		for sink := range sinks {
+			if execSafe[caller][sink] {
+				if safe == nil {
+					safe = map[string]bool{}
+				}
+				safe[sink] = true
+			}
+		}
+		if len(safe) > 0 {
+			if execFuncs == nil {
+				execFuncs = map[string]taint.ExecFuncFacts{}
+			}
+			execFuncs[caller] = taint.ExecFuncFacts{SafeSinks: safe}
+		}
+	}
+	g := &domaincg.Graph{Entrypoints: sortedKeys(entry), Edges: edgesOf(adj), Positions: positions}
+	return g, taint.ExecFacts{Funcs: execFuncs}, nil
+}
+
+// isFirstPartyFunc reports whether fn is defined in a loaded-module (first-party) package, resolving a
+// generic instance to its origin so the check matches nodeID's id. It bounds the value-level exec analysis
+// to the module's own code (where taint sink-using functions live), mirroring firstPartyPos.
+func isFirstPartyFunc(fn *ssa.Function, firstParty map[string]bool) bool {
+	if fn == nil {
+		return false
+	}
+	if o := fn.Origin(); o != nil {
+		fn = o
+	}
+	return fn.Pkg != nil && fn.Pkg.Pkg != nil && firstParty[fn.Pkg.Pkg.Path()]
+}
+
+// execConstantSafe inspects fn's body for calls to the catalog's exec sinks (execArgs: callee id → the
+// program-name argument index) and returns, per exec sink symbol seen in fn, whether EVERY call site to it is
+// provably safe to de-escalate. A site is safe only when it is a plain *ssa.Call (not go/defer) whose
+// program-name argument is a compile-time constant naming a known-fixed-safe program (argIsFixedSafeProgram)
+// AND whose *exec.Cmd result is confined (execResultConfined): the program cannot be re-pointed via a field
+// write and does not escape before execution.
+//
+// It is fail-closed against the SAME over-approximation the CHA call graph uses. CHA attributes an exec-sink
+// edge not only to a static call but also to a call THROUGH A FUNCTION VALUE whose signature matches the
+// sink (chautil resolves func-value calls by signature). Such a call has StaticCallee()==nil, so it is
+// invisible to the per-site check; if it returns *exec.Cmd it could be an exec.Command alias with an
+// attacker-controlled program. So any unresolved (StaticCallee==nil) call returning *exec.Cmd poisons EVERY
+// exec-sink verdict for fn (result "safe" only when there is no such call), matching the edge set the finding
+// actually fires on. A returned map with a false value keeps CWE-78; an absent sink means no de-escalation.
+func execConstantSafe(fn *ssa.Function, execArgs map[string]int) map[string]bool {
+	safe := map[string]bool{}
+	unresolvedExecCmd := false
+	for _, b := range fn.Blocks {
+		for _, instr := range b.Instrs {
+			ci, ok := instr.(ssa.CallInstruction)
+			if !ok {
+				continue
+			}
+			common := ci.Common()
+			callee := common.StaticCallee()
+			if callee == nil {
+				// A dynamic/indirect call CHA may resolve to an exec sink by signature. If it can yield a
+				// *exec.Cmd we cannot prove the program is fixed — fail closed for the whole function.
+				if signatureReturnsExecCmd(common.Signature()) {
+					unresolvedExecCmd = true
+				}
+				continue
+			}
+			argIdx, isExec := execArgs[nodeID(callee)]
+			if !isExec {
+				continue
+			}
+			call, isPlainCall := instr.(*ssa.Call) // go/defer have no usable result to confine
+			siteSafe := isPlainCall &&
+				argIsFixedSafeProgram(common.Args, argIdx) &&
+				execResultConfined(call)
+			if prev, seen := safe[nodeID(callee)]; !seen {
+				safe[nodeID(callee)] = siteSafe
+			} else {
+				safe[nodeID(callee)] = prev && siteSafe
+			}
+		}
+	}
+	if unresolvedExecCmd {
+		for sink := range safe {
+			safe[sink] = false
+		}
+	}
+	return safe
+}
+
+// argIsFixedSafeProgram reports whether the call argument at idx is a compile-time-constant string naming a
+// known-fixed-safe program (allowlist) — a fixed program that makes the exec call at worst argument
+// injection. It is deliberately strict: it treats ONLY a literal *ssa.Const string as constant (a value
+// derived from a parameter, a call, a Phi, or string concatenation is NOT provably constant), and an
+// out-of-range index, a non-string constant, an empty string, or a program not on the allowlist is not safe.
+// Every "not proven" answer keeps CWE-78.
+func argIsFixedSafeProgram(args []ssa.Value, idx int) bool {
+	if idx < 0 || idx >= len(args) {
+		return false
+	}
+	c, ok := args[idx].(*ssa.Const)
+	if !ok || c.Value == nil || c.Value.Kind() != constant.String {
+		return false
+	}
+	name := constant.StringVal(c.Value)
+	if name == "" {
+		return false // an empty program name is not a normal fixed program; keep the CWE-78 over-approximation
+	}
+	return taint.IsFixedSafeProgram(name)
+}
+
+// execResultConfined reports whether the *exec.Cmd produced by call cannot have its executed program
+// changed before it runs: every use of the result is either a method call ON the Cmd (Run/Output/Start/…,
+// none of which re-point .Path/.Args from stdlib) or a harmless debug ref. ANY other use — taking a field
+// address (&cmd.Path, the classic cmd.Path = attacker), storing the Cmd, boxing it into an interface,
+// returning it, or passing it to another function that could mutate it — is treated as NOT confined
+// (fail-closed), so a fixed constant argv[0] whose Cmd is later re-pointed keeps CWE-78. A result with no
+// uses is confined (it is never executed, so nothing can be injected through it).
+func execResultConfined(call *ssa.Call) bool {
+	refs := call.Referrers()
+	if refs == nil {
+		return true
+	}
+	for _, r := range *refs {
+		switch instr := r.(type) {
+		case *ssa.Call:
+			if !cmdIsReceiver(instr.Common(), call) {
+				return false
+			}
+		case *ssa.Go:
+			if !cmdIsReceiver(instr.Common(), call) {
+				return false
+			}
+		case *ssa.Defer:
+			if !cmdIsReceiver(instr.Common(), call) {
+				return false
+			}
+		case *ssa.DebugRef:
+			// debug metadata only; cannot affect execution
+		default:
+			return false // FieldAddr / Store / MakeInterface / Return / Phi / … → conservative: not confined
+		}
+	}
+	return true
+}
+
+// cmdIsReceiver reports whether cmd is used in cc purely as the RECEIVER of a concrete method (Args[0] of a
+// static method call), as opposed to being passed as an ordinary argument (which could escape and be
+// mutated) or used in a dynamic call. Method calls on *exec.Cmd (Run/Output/…) are the only confined use.
+func cmdIsReceiver(cc *ssa.CallCommon, cmd *ssa.Call) bool {
+	callee := cc.StaticCallee()
+	if callee == nil || callee.Signature == nil || callee.Signature.Recv() == nil {
+		return false // dynamic call, or a non-method function taking cmd as a plain arg → escape
+	}
+	return len(cc.Args) > 0 && cc.Args[0] == ssa.Value(cmd) // cmd must be the receiver (first arg)
+}
+
+// signatureReturnsExecCmd reports whether sig returns an *os/exec.Cmd, so an unresolved call with this
+// signature could be an exec.Command/CommandContext alias whose program name we cannot inspect.
+func signatureReturnsExecCmd(sig *types.Signature) bool {
+	if sig == nil {
+		return false
+	}
+	res := sig.Results()
+	for i := 0; i < res.Len(); i++ {
+		if isExecCmdPtr(res.At(i).Type()) {
+			return true
+		}
+	}
+	return false
+}
+
+// isExecCmdPtr reports whether t is *os/exec.Cmd. It unwraps type aliases at each level (Go 1.23+
+// materializes aliases as types.Alias by default), so a "type CmdAlias = exec.Cmd" or "type P = *exec.Cmd"
+// return type is still recognized and cannot be used to smuggle an unresolved exec constructor past the
+// fail-closed check.
+func isExecCmdPtr(t types.Type) bool {
+	p, ok := types.Unalias(t).(*types.Pointer)
+	if !ok {
+		return false
+	}
+	named, ok := types.Unalias(p.Elem()).(*types.Named)
+	if !ok {
+		return false
+	}
+	obj := named.Obj()
+	return obj != nil && obj.Pkg() != nil && obj.Pkg().Path() == "os/exec" && obj.Name() == "Cmd"
 }
 
 // firstPartyPos returns fn's definition position as "relpath:line" (relative to the scan root dir) for a

--- a/internal/infrastructure/tools/ssacallgraph/builder_test.go
+++ b/internal/infrastructure/tools/ssacallgraph/builder_test.go
@@ -2,10 +2,14 @@ package ssacallgraph
 
 import (
 	"context"
+	"go/constant"
+	"go/types"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"golang.org/x/tools/go/ssa"
 
 	domaincg "github.com/KKloudTarus/synapse-ce/internal/domain/callgraph"
 )
@@ -185,5 +189,200 @@ func TestBuildGraphLoadErrorFailsClosed(t *testing.T) {
 	})
 	if _, err := BuildGraph(context.Background(), dir); err == nil {
 		t.Error("a module with a type error must fail closed, not yield a partial graph")
+	}
+}
+
+// TestBuildGraphExecFactsSafeVsUnsafe is the value-level proof for D5.4 over the acceptance twins and the
+// adversarial cases the review surfaced. A first-party function's exec sink is reported safe-to-de-escalate
+// ONLY when argv[0] is a constant known-fixed-safe program at every site AND the *exec.Cmd is confined AND
+// there is no unresolved *exec.Cmd-returning call; everything else keeps CWE-78. The reachability call graph
+// is unchanged by this additive pass.
+func TestBuildGraphExecFactsSafeVsUnsafe(t *testing.T) {
+	dir := writeModule(t, map[string]string{
+		"go.mod": "module bench\n\ngo 1.21\n",
+		"main.go": `package main
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+type Commander func(string, ...string) *exec.Cmd
+
+// AliasCmd is a type ALIAS of exec.Cmd (Go 1.23+ materializes it as types.Alias); AliasRunner returns a
+// pointer to it, exercising the alias-unwrapping path in isExecCmdPtr.
+type AliasCmd = exec.Cmd
+type AliasRunner func(string, ...string) *AliasCmd
+
+func main() {
+	in := os.Getenv("X")
+	SafeEcho(in)
+	SafePing(in)
+	CtxSafe(context.Background(), in)
+	UnsafeVar(in)
+	ShellInterp(in)
+	VersionedPython(in)
+	Mixed(in)
+	PathMutated(in)
+	Escapes(in)
+	IndirectFuncValue(exec.Command, in)
+	AbsPath(in)
+	AliasIndirect(aliasCommand, in)
+	NoExec(in)
+}
+
+func aliasCommand(name string, arg ...string) *AliasCmd { return exec.Command(name, arg...) }
+
+// constant, allowlisted argv[0], result flows straight into Run → safe (de-escalates to CWE-88).
+func SafeEcho(in string) { _ = exec.Command("echo", in).Run() }
+
+// constant argv[0] with fixed flags then a tainted arg → still safe (fixed program).
+func SafePing(host string) { _ = exec.Command("ping", "-c", "1", host).Run() }
+
+// CommandContext: the program name is arg 1 (arg 0 is the context) → safe.
+func CtxSafe(ctx context.Context, in string) { _ = exec.CommandContext(ctx, "echo", in).Run() }
+
+// variable argv[0] (attacker picks the program) → NOT safe (keeps CWE-78).
+func UnsafeVar(in string) {
+	parts := strings.Fields(in)
+	_ = exec.Command(parts[0], parts[1:]...).Run()
+}
+
+// constant argv[0] but a shell (not on the allowlist; command rides in -c) → NOT safe.
+func ShellInterp(cmd string) { _ = exec.Command("sh", "-c", cmd).Run() }
+
+// constant argv[0] naming a versioned interpreter (not on the allowlist) → NOT safe.
+func VersionedPython(code string) { _ = exec.Command("python3.11", "-c", code).Run() }
+
+// two exec sites, one safe one variable → NOT safe (every site must be safe).
+func Mixed(in string) {
+	_ = exec.Command("echo", in).Run()
+	_ = exec.Command(in).Run()
+}
+
+// constant, allowlisted argv[0] BUT the program is re-pointed via a field write → NOT safe (real command
+// injection through cmd.Path).
+func PathMutated(in string) {
+	cmd := exec.Command("echo", "ok")
+	cmd.Path = in
+	_ = cmd.Run()
+}
+
+// the *exec.Cmd escapes to another function that could mutate it → NOT safe (conservative).
+func Escapes(in string) {
+	cmd := exec.Command("echo", in)
+	configure(cmd)
+	_ = cmd.Run()
+}
+
+func configure(c *exec.Cmd) { _ = c }
+
+// a direct constant exec call PLUS an indirect func-value exec call with a variable program. CHA attributes
+// an os/exec.Command edge to the func-value call by signature, but StaticCallee is nil there, so the pass
+// must fail closed for the whole function → NOT safe.
+func IndirectFuncValue(pick Commander, prog string) {
+	_ = exec.Command("echo", "ok").Run()
+	_ = pick(prog).Run()
+}
+
+// constant but a PATH form (basename echo is allowlisted, but the directory could point at untrusted code)
+// → NOT safe.
+func AbsPath(in string) { _ = exec.Command("/tmp/echo", in).Run() }
+
+// a direct constant exec call PLUS an indirect func-value call returning *AliasCmd (an alias of exec.Cmd).
+// The alias-unwrapping fail-closed check must poison the verdict → NOT safe.
+func AliasIndirect(run AliasRunner, prog string) {
+	_ = exec.Command("echo", "ok").Run()
+	_ = run(prog).Run()
+}
+
+// no exec call → no fact at all.
+func NoExec(in string) { _ = os.Getenv(in) }
+`,
+	})
+	_, facts, err := BuildGraphAndExecFacts(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	safeFor := func(sym, sink string) bool { return facts.Funcs[sym].SafeSinks[sink] }
+
+	// Safe cases de-escalate.
+	if !safeFor("bench.SafeEcho", "os/exec.Command") {
+		t.Errorf("SafeEcho must be safe-to-de-escalate; facts=%+v", facts.Funcs["bench.SafeEcho"])
+	}
+	if !safeFor("bench.SafePing", "os/exec.Command") {
+		t.Errorf("SafePing must be safe-to-de-escalate")
+	}
+	if !safeFor("bench.CtxSafe", "os/exec.CommandContext") {
+		t.Errorf("CtxSafe must be safe-to-de-escalate for CommandContext")
+	}
+
+	// Every unsafe case must keep CWE-78 (no safe fact for its exec sink).
+	unsafe := []struct{ fn, sink string }{
+		{"bench.UnsafeVar", "os/exec.Command"},         // variable argv[0]
+		{"bench.ShellInterp", "os/exec.Command"},       // shell interpreter
+		{"bench.VersionedPython", "os/exec.Command"},   // versioned interpreter not on the allowlist
+		{"bench.Mixed", "os/exec.Command"},             // one unsafe site among two
+		{"bench.PathMutated", "os/exec.Command"},       // cmd.Path re-pointed
+		{"bench.Escapes", "os/exec.Command"},           // *exec.Cmd escapes to another function
+		{"bench.IndirectFuncValue", "os/exec.Command"}, // unresolved func-value exec call
+		{"bench.AbsPath", "os/exec.Command"},           // path form (basename not enough)
+		{"bench.AliasIndirect", "os/exec.Command"},     // func-value returning an alias of *exec.Cmd
+	}
+	for _, u := range unsafe {
+		if safeFor(u.fn, u.sink) {
+			t.Errorf("%s must NOT be safe-to-de-escalate (keeps CWE-78); facts=%+v", u.fn, facts.Funcs[u.fn])
+		}
+	}
+
+	// A function with no exec call carries no fact.
+	if _, ok := facts.Funcs["bench.NoExec"]; ok {
+		t.Errorf("a function with no exec sink must carry no exec fact")
+	}
+
+	// The reachability contract's graph is unchanged by the additive facts pass, and CHA does attribute the
+	// os/exec.Command edge to the func-value caller (the reason the pass must fail closed there).
+	g, err := BuildGraph(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("BuildGraph: %v", err)
+	}
+	if !hasEdge(g, "bench.SafeEcho", "os/exec.Command") {
+		t.Errorf("the call graph must be unchanged by the facts pass (SafeEcho → os/exec.Command edge missing)")
+	}
+	if !hasEdge(g, "bench.IndirectFuncValue", "os/exec.Command") {
+		t.Errorf("CHA must attribute the func-value exec edge to IndirectFuncValue (the fail-closed trigger)")
+	}
+}
+
+// TestArgIsFixedSafeProgramFailClosedBranches unit-tests the SSA argument gate's fail-closed branches that
+// the integration fixture does not isolate: out-of-range index, non-const arg, non-string const, empty
+// const, and a non-allowlisted program.
+func TestArgIsFixedSafeProgramFailClosedBranches(t *testing.T) {
+	strConst := func(s string) ssa.Value { return ssa.NewConst(constant.MakeString(s), types.Typ[types.String]) }
+	intConst := ssa.NewConst(constant.MakeInt64(7), types.Typ[types.Int]) // non-string const
+	variable := new(ssa.Parameter)                                        // stands in for a variable argv[0]
+
+	if argIsFixedSafeProgram([]ssa.Value{strConst("echo")}, 1) {
+		t.Error("out-of-range index must be unsafe")
+	}
+	if argIsFixedSafeProgram([]ssa.Value{strConst("echo")}, -1) {
+		t.Error("negative index must be unsafe")
+	}
+	if argIsFixedSafeProgram([]ssa.Value{variable}, 0) {
+		t.Error("a non-const (variable) argv[0] must be unsafe")
+	}
+	if argIsFixedSafeProgram([]ssa.Value{intConst}, 0) {
+		t.Error("a non-string const must be unsafe")
+	}
+	if argIsFixedSafeProgram([]ssa.Value{strConst("")}, 0) {
+		t.Error("an empty-string const must be unsafe")
+	}
+	if argIsFixedSafeProgram([]ssa.Value{strConst("sh")}, 0) {
+		t.Error("a shell const must be unsafe")
+	}
+	if !argIsFixedSafeProgram([]ssa.Value{strConst("echo")}, 0) {
+		t.Error("an allowlisted const must be safe")
 	}
 }

--- a/internal/infrastructure/tools/taintcallgraph/builder.go
+++ b/internal/infrastructure/tools/taintcallgraph/builder.go
@@ -10,6 +10,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/callgraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/taint"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
 
@@ -40,17 +41,26 @@ var _ ports.CallGraphBuilder = (*Builder)(nil)
 
 // Build runs `synapse-callgraph build-callgraph <targetRef>` and parses its wire output into the domain
 // call graph. A load/type error in the target fails closed (the binary exits non-zero) – never a partial
-// graph, which would drop taint paths.
+// graph, which would drop taint paths. This satisfies ports.CallGraphBuilder (the reachability contract);
+// it discards the value-level exec facts BuildWithExecFacts also returns.
 func (b *Builder) Build(ctx context.Context, targetRef string) (*callgraph.Graph, error) {
+	g, _, err := b.BuildWithExecFacts(ctx, targetRef)
+	return g, err
+}
+
+// BuildWithExecFacts is Build plus the value-level exec-sink facts (D5.4) the taint coordinator uses to
+// de-escalate constant-argv command-injection findings. Same exec + same fail-closed behavior; the facts
+// are parsed from the additive wire field (empty when the binary omits it, which keeps every CWE-78).
+func (b *Builder) BuildWithExecFacts(ctx context.Context, targetRef string) (*callgraph.Graph, taint.ExecFacts, error) {
 	out, err := b.run(ctx, targetRef)
 	if err != nil {
-		return nil, err
+		return nil, taint.ExecFacts{}, err
 	}
-	g, err := parseCallgraph(out)
+	g, facts, err := parseCallgraph(out)
 	if err != nil {
-		return nil, fmt.Errorf("parse synapse-callgraph: %w", err)
+		return nil, taint.ExecFacts{}, fmt.Errorf("parse synapse-callgraph: %w", err)
 	}
-	return g, nil
+	return g, facts, nil
 }
 
 // run executes the binary (sandboxed when a runner is set, else direct os/exec) and returns its raw wire

--- a/internal/infrastructure/tools/taintcallgraph/wire.go
+++ b/internal/infrastructure/tools/taintcallgraph/wire.go
@@ -14,8 +14,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/callgraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/taint"
 )
 
 // protocolVersion guards the synapse-callgraph JSON contract: the adapter refuses a stream whose version it
@@ -32,6 +34,12 @@ type wireGraph struct {
 	// findings). Additive and back/forward compatible: an older binary omits it, an older adapter ignores
 	// it — so the protocol version stays v1.0.0 (no hard cutover for a purely additive field).
 	Positions map[string]string `json:"positions,omitempty"`
+	// ExecFacts is the OPTIONAL value-level exec-sink verdict table (D5.4): a first-party function symbol →
+	// the exec sink symbols in it the SSA pass proved safe to de-escalate (constant known-fixed-safe program
+	// name at every call site AND a confined *exec.Cmd result). Additive + back/forward compatible like
+	// Positions, so the protocol version stays v1.0.0. It only DE-ESCALATES a CWE-78 finding to CWE-88; an
+	// absent function or an absent sink keeps CWE-78 (fail-closed). Only proven-safe entries are emitted.
+	ExecFacts map[string]wireExecFunc `json:"exec_facts,omitempty"`
 }
 
 type wireEdge struct {
@@ -39,31 +47,79 @@ type wireEdge struct {
 	Callees []string `json:"callees"`
 }
 
-// EncodeGraph writes g as the versioned wire envelope (used by cmd/synapse-callgraph). Deterministic input
-// (the builder sorts) ⇒ deterministic bytes.
+// wireExecFunc is the JSON form of taint.ExecFuncFacts: the sorted set of exec sink symbols proven safe to
+// de-escalate for the function. A struct (not a bare list) so future value-level facts can be added
+// additively without a protocol cutover.
+type wireExecFunc struct {
+	SafeSinks []string `json:"safe_sinks,omitempty"`
+}
+
+// EncodeGraph writes g (no value-level facts) as the versioned wire envelope. Kept for callers that only
+// have a graph; the command uses EncodeGraphWithFacts.
 func EncodeGraph(w io.Writer, g *callgraph.Graph) error {
+	return EncodeGraphWithFacts(w, g, taint.ExecFacts{})
+}
+
+// EncodeGraphWithFacts writes g plus the value-level exec-sink facts as the versioned wire envelope (used by
+// cmd/synapse-callgraph). Deterministic input (the builder sorts) ⇒ deterministic bytes. Only constant-safe
+// verdicts are serialized, so an empty facts table emits no exec_facts key (byte-identical to EncodeGraph).
+func EncodeGraphWithFacts(w io.Writer, g *callgraph.Graph, facts taint.ExecFacts) error {
 	wg := wireGraph{ProtocolVersion: protocolVersion, Entrypoints: g.Entrypoints, Positions: g.Positions}
 	for _, e := range g.Edges {
 		wg.Edges = append(wg.Edges, wireEdge{Caller: e.Caller, Callees: e.Callees})
 	}
+	for sym, f := range facts.Funcs {
+		sinks := make([]string, 0, len(f.SafeSinks))
+		for sink, ok := range f.SafeSinks {
+			if ok && sink != "" {
+				sinks = append(sinks, sink)
+			}
+		}
+		if len(sinks) == 0 {
+			continue // only proven-safe verdicts ride the wire; absence means keep CWE-78
+		}
+		sort.Strings(sinks) // deterministic bytes
+		if wg.ExecFacts == nil {
+			wg.ExecFacts = map[string]wireExecFunc{}
+		}
+		wg.ExecFacts[sym] = wireExecFunc{SafeSinks: sinks}
+	}
 	return json.NewEncoder(w).Encode(wg)
 }
 
-// parseCallgraph decodes the synapse-callgraph wire envelope into the domain callgraph.Graph. It fails
-// closed on a JSON error or an unrecognized protocol version (a drifted format must not be silently
-// mis-parsed into a partial graph – that would drop taint paths). This is the testable core (like
-// parseGovulncheck): the exec wrapper just feeds it the captured stdout.
-func parseCallgraph(data []byte) (*callgraph.Graph, error) {
+// parseCallgraph decodes the synapse-callgraph wire envelope into the domain callgraph.Graph plus the
+// value-level exec-sink facts. It fails closed on a JSON error or an unrecognized protocol version (a
+// drifted format must not be silently mis-parsed into a partial graph – that would drop taint paths). Only
+// constant-safe verdicts are carried into the facts (absence = keep CWE-78), so an older binary that omits
+// the field yields empty facts and the coordinator keeps every CWE-78 finding. This is the testable core
+// (like parseGovulncheck): the exec wrapper just feeds it the captured stdout.
+func parseCallgraph(data []byte) (*callgraph.Graph, taint.ExecFacts, error) {
 	var wg wireGraph
 	if err := json.Unmarshal(data, &wg); err != nil {
-		return nil, fmt.Errorf("decode synapse-callgraph output: %w", err)
+		return nil, taint.ExecFacts{}, fmt.Errorf("decode synapse-callgraph output: %w", err)
 	}
 	if wg.ProtocolVersion != "" && wg.ProtocolVersion != protocolVersion {
-		return nil, fmt.Errorf("unsupported synapse-callgraph protocol %q (want %s)", wg.ProtocolVersion, protocolVersion)
+		return nil, taint.ExecFacts{}, fmt.Errorf("unsupported synapse-callgraph protocol %q (want %s)", wg.ProtocolVersion, protocolVersion)
 	}
 	g := &callgraph.Graph{Entrypoints: wg.Entrypoints, Positions: wg.Positions}
 	for _, e := range wg.Edges {
 		g.Edges = append(g.Edges, callgraph.Edge{Caller: e.Caller, Callees: e.Callees})
 	}
-	return g, nil
+	var facts taint.ExecFacts
+	for sym, f := range wg.ExecFacts {
+		safe := make(map[string]bool, len(f.SafeSinks))
+		for _, sink := range f.SafeSinks {
+			if sink != "" {
+				safe[sink] = true
+			}
+		}
+		if len(safe) == 0 {
+			continue
+		}
+		if facts.Funcs == nil {
+			facts.Funcs = map[string]taint.ExecFuncFacts{}
+		}
+		facts.Funcs[sym] = taint.ExecFuncFacts{SafeSinks: safe}
+	}
+	return g, facts, nil
 }

--- a/internal/infrastructure/tools/taintcallgraph/wire_test.go
+++ b/internal/infrastructure/tools/taintcallgraph/wire_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/callgraph"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/taint"
 )
 
 func TestEncodeParseRoundTrip(t *testing.T) {
@@ -20,7 +21,7 @@ func TestEncodeParseRoundTrip(t *testing.T) {
 	if err := EncodeGraph(&buf, g); err != nil {
 		t.Fatalf("encode: %v", err)
 	}
-	got, err := parseCallgraph(buf.Bytes())
+	got, _, err := parseCallgraph(buf.Bytes())
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -41,7 +42,7 @@ func TestEncodeParseCarriesPositions(t *testing.T) {
 	if err := EncodeGraph(&buf, g); err != nil {
 		t.Fatalf("encode: %v", err)
 	}
-	got, err := parseCallgraph(buf.Bytes())
+	got, _, err := parseCallgraph(buf.Bytes())
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -58,7 +59,7 @@ func TestEncodeParseEmptyGraph(t *testing.T) {
 	if err := EncodeGraph(&buf, &callgraph.Graph{}); err != nil {
 		t.Fatalf("encode: %v", err)
 	}
-	got, err := parseCallgraph(buf.Bytes())
+	got, _, err := parseCallgraph(buf.Bytes())
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
@@ -70,15 +71,59 @@ func TestEncodeParseEmptyGraph(t *testing.T) {
 	}
 }
 
+func TestEncodeParseCarriesExecFacts(t *testing.T) {
+	// The value-level exec-sink verdict table (D5.4) must survive the exec-boundary round-trip so the
+	// coordinator can de-escalate a constant-argv command-injection finding to CWE-88.
+	g := &callgraph.Graph{
+		Entrypoints: []string{"m.main"},
+		Edges:       []callgraph.Edge{{Caller: "m.main", Callees: []string{"os/exec.Command"}}},
+	}
+	facts := taint.ExecFacts{Funcs: map[string]taint.ExecFuncFacts{
+		"m.main":     {SafeSinks: map[string]bool{"os/exec.Command": true}},
+		"m.variable": {SafeSinks: map[string]bool{}}, // no safe sink → must NOT ride the wire (keep CWE-78)
+	}}
+	var buf bytes.Buffer
+	if err := EncodeGraphWithFacts(&buf, g, facts); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	_, gotFacts, err := parseCallgraph(buf.Bytes())
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	want := map[string]taint.ExecFuncFacts{"m.main": {SafeSinks: map[string]bool{"os/exec.Command": true}}}
+	if !reflect.DeepEqual(gotFacts.Funcs, want) {
+		t.Errorf("only proven-safe verdicts must round-trip:\n got %+v\nwant %+v", gotFacts.Funcs, want)
+	}
+}
+
+// EncodeGraph (no facts) must emit byte-identical output to an empty facts table and no exec_facts key, so
+// a graph-only caller is unaffected by the additive field.
+func TestEncodeGraphOmitsExecFactsKey(t *testing.T) {
+	g := &callgraph.Graph{Edges: []callgraph.Edge{{Caller: "m.main", Callees: []string{"m.run"}}}}
+	var a, b bytes.Buffer
+	if err := EncodeGraph(&a, g); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if err := EncodeGraphWithFacts(&b, g, taint.ExecFacts{}); err != nil {
+		t.Fatalf("encode with empty facts: %v", err)
+	}
+	if a.String() != b.String() {
+		t.Errorf("EncodeGraph must equal EncodeGraphWithFacts(empty):\n %q\n %q", a.String(), b.String())
+	}
+	if bytes.Contains(a.Bytes(), []byte("exec_facts")) {
+		t.Errorf("no exec_facts key must be emitted for an empty facts table: %s", a.String())
+	}
+}
+
 func TestParseRejectsBadProtocol(t *testing.T) {
 	// A drifted format must fail closed, not be silently mis-parsed into a partial (taint-false-negative) graph.
-	if _, err := parseCallgraph([]byte(`{"protocol_version":"v9.9.9","edges":[]}`)); err == nil {
+	if _, _, err := parseCallgraph([]byte(`{"protocol_version":"v9.9.9","edges":[]}`)); err == nil {
 		t.Error("an unrecognized protocol version must fail closed")
 	}
 }
 
 func TestParseRejectsBadJSON(t *testing.T) {
-	if _, err := parseCallgraph([]byte("{not json")); err == nil {
+	if _, _, err := parseCallgraph([]byte("{not json")); err == nil {
 		t.Error("malformed JSON must fail closed")
 	}
 }

--- a/internal/usecase/taintscan/coordinator.go
+++ b/internal/usecase/taintscan/coordinator.go
@@ -44,10 +44,11 @@ const proposerActor = "system:taint-scan"
 // seal an unbounded string (generous – a real taint path is far smaller).
 const maxWitnessElems = 64
 
-// builder builds a target's call graph (ports.CallGraphBuilder satisfies it). A build error is NO COVERAGE
-// – the coordinator proposes nothing rather than a false "clean".
+// builder builds a target's call graph plus the value-level exec-sink facts (taintcallgraph.Builder
+// satisfies it). A build error is NO COVERAGE – the coordinator proposes nothing rather than a false
+// "clean". The facts carry the D5.4 de-escalation signal; an empty facts table keeps every CWE-78 finding.
 type builder interface {
-	Build(ctx context.Context, targetRef string) (*callgraph.Graph, error)
+	BuildWithExecFacts(ctx context.Context, targetRef string) (*callgraph.Graph, taint.ExecFacts, error)
 }
 
 // proposer is the NARROW propose-only slice of the judgment lifecycle the coordinator needs
@@ -89,7 +90,7 @@ func (c *Coordinator) Scan(ctx context.Context, engagementID shared.ID, targetRe
 	if engagementID.IsZero() {
 		return 0, fmt.Errorf("%w: engagement id is required", shared.ErrValidation)
 	}
-	g, err := c.builder.Build(ctx, targetRef)
+	g, execFacts, err := c.builder.BuildWithExecFacts(ctx, targetRef)
 	if err != nil {
 		// No coverage: propose nothing. The wrapped error may carry tool stderr – it is returned to the
 		// best-effort caller (which ignores it) and never reaches the audit log or an LLM transcript.
@@ -99,7 +100,10 @@ func (c *Coordinator) Scan(ctx context.Context, engagementID shared.ID, targetRe
 		return 0, fmt.Errorf("%w: taint call-graph build returned no graph", shared.ErrValidation)
 	}
 
-	fg, sinkClass := taint.Assemble(*g, c.catalog)
+	// AssembleWithFacts applies the value-level exec-sink precision filter (D5.4): a constant-argv
+	// command-injection finding de-escalates CWE-78 → CWE-88; anything unproven keeps CWE-78. It never
+	// removes a path, so recall is unchanged.
+	fg, sinkClass := taint.AssembleWithFacts(*g, c.catalog, execFacts)
 	proposed := 0
 	for _, v := range fg.Vulnerabilities() {
 		// Join the sink-class index against the REPORTED path: every injection CLASS the reached

--- a/internal/usecase/taintscan/coordinator_test.go
+++ b/internal/usecase/taintscan/coordinator_test.go
@@ -18,11 +18,14 @@ import (
 const engID = shared.ID("eng-1")
 
 type fakeBuilder struct {
-	g   *callgraph.Graph
-	err error
+	g     *callgraph.Graph
+	facts taint.ExecFacts // value-level exec-sink verdicts (D5.4); zero value = no de-escalation (keep CWE-78)
+	err   error
 }
 
-func (f *fakeBuilder) Build(context.Context, string) (*callgraph.Graph, error) { return f.g, f.err }
+func (f *fakeBuilder) BuildWithExecFacts(context.Context, string) (*callgraph.Graph, taint.ExecFacts, error) {
+	return f.g, f.facts, f.err
+}
 
 type proposeCall struct {
 	proposer    string
@@ -118,6 +121,56 @@ func TestScanProposesSameFunctionInjection(t *testing.T) {
 	}
 	if a.entries[0].Metadata["cwe"] != "CWE-78" {
 		t.Errorf("witness must carry the injection class: %+v", a.entries[0].Metadata)
+	}
+}
+
+// D5.4: a same-function command-injection finding DE-ESCALATES from CWE-78 to CWE-88 when the SSA pass
+// proves the exec program name (argv[0]) is a compile-time-constant, non-interpreter string at every call
+// site (e.g. exec.Command("echo", userInput)). The finding is NOT removed — it still fires, at the same
+// location and with the same witness path — only its injection class narrows.
+func TestScanDeEscalatesConstantArgvToArgumentInjection(t *testing.T) {
+	b := &fakeBuilder{
+		g: &callgraph.Graph{Edges: []callgraph.Edge{
+			{Caller: "app.handler", Callees: []string{"os.Getenv", "os/exec.Command"}},
+		}},
+		facts: taint.ExecFacts{Funcs: map[string]taint.ExecFuncFacts{
+			"app.handler": {SafeSinks: map[string]bool{"os/exec.Command": true}},
+		}},
+	}
+	p := &fakeProposer{}
+	a := &fakeAudit{}
+	n, err := newCoord(t, b, p, a).Scan(context.Background(), engID, "/work/target")
+	if err != nil || n != 1 || len(p.calls) != 1 {
+		t.Fatalf("want 1 proposal, got n=%d calls=%d err=%v", n, len(p.calls), err)
+	}
+	sc := p.calls[0].claim.(judgment.SASTClaim)
+	if sc.CWE != "CWE-88" || sc.Rule != "taint-argument-injection" {
+		t.Errorf("constant argv[0] must de-escalate to CWE-88 argument injection, got %+v", sc)
+	}
+	if a.entries[0].Metadata["cwe"] != "CWE-88" {
+		t.Errorf("the witness must carry the de-escalated class, got %+v", a.entries[0].Metadata)
+	}
+}
+
+// D5.4 fail-closed: an exec fact for a DIFFERENT function must not de-escalate one it does not cover. The
+// unsafe twin (exec.Command(parts[0], parts[1:]...), a variable argv[0]) emits no constant-safe fact, so it
+// keeps CWE-78.
+func TestScanKeepsCommandInjectionWithoutConstantSafeFact(t *testing.T) {
+	b := &fakeBuilder{
+		g: &callgraph.Graph{Edges: []callgraph.Edge{
+			{Caller: "app.unsafe", Callees: []string{"os.Getenv", "os/exec.Command"}},
+		}},
+		facts: taint.ExecFacts{Funcs: map[string]taint.ExecFuncFacts{
+			"app.other": {SafeSinks: map[string]bool{"os/exec.Command": true}}, // unrelated function; app.unsafe is uncovered
+		}},
+	}
+	p := &fakeProposer{}
+	if _, err := newCoord(t, b, p, &fakeAudit{}).Scan(context.Background(), engID, "/work/target"); err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	sc := p.calls[0].claim.(judgment.SASTClaim)
+	if sc.CWE != "CWE-78" || sc.Rule != "taint-command-injection" {
+		t.Errorf("a function with no constant-safe fact must keep CWE-78, got %+v", sc)
 	}
 }
 


### PR DESCRIPTION
## What

Raises Go taint analysis from function-granular to value-level for `os/exec` sinks (EPIC #860 D5.4).

The engine was function-granular: any function that both read untrusted input and called `os/exec.Command`/`CommandContext` was reported as CWE-78 command injection, regardless of whether the program name (argv[0]) was attacker-controlled. That over-reports the safe shape `exec.Command("echo", userInput)`, which is at worst argument injection.

The sandboxed `synapse-callgraph` builder now inspects, from the same SSA build, the program-name argument at every exec call site in each first-party function. When the program is **provably fixed**, the finding de-escalates from CWE-78 to CWE-88 argument injection (`taint-argument-injection`).

## Fail-closed by design (the #1 bar: never understate a real command injection)

De-escalation fires only when ALL of:

- argv[0] is a compile-time-constant **bare** name (exact, case-sensitive, no path separator, no whitespace, no suffix strip) on an **allowlist** of programs that never run a command/code from their arguments (`echo`, `ls`, `ping`, `grep`, `sha256sum`, …); and
- the resulting `*exec.Cmd` is **confined**: no field write that re-points the program (`cmd.Path = …`), no escape to another function, no store/return/interface-boxing; and
- the function has no unresolved function-value call returning `*exec.Cmd` (CHA attributes an exec edge to such calls by signature; type aliases unwrapped via `types.Unalias`).

Anything else keeps CWE-78: a variable argv[0], any shell/interpreter (including versioned names like `python3.11`), any command-runner (`env`, `xargs`, `pkexec`, `flock`, `find`, …), any argument-to-exec tool (`sort --compress-program`, `wget --use-askpass`, `traceroute -M`, `curl`), a path form, a mutated or escaping `Cmd`, a mixed call set, or an older builder that omits the facts. Verdicts are keyed **per sink symbol** so a sink the pass never inspected is never de-escalated.

The finding is never removed, only reclassified. The engine remains propose-only; a distinct verifier gates every finding.

## Compatibility

Facts ride an additive, back/forward-compatible field (`exec_facts`) on the existing call-graph wire protocol (version stays v1.0.0, like the `positions` table). The call graph itself is byte-identical, so Tier-2 reachability (which shares it) is unaffected. No new config, route, or CLI surface.

## Complexity

O(total first-party SSA instructions), one pass shared with the call-graph build. No new external call.

## Review

Reviewed across five independent passes (three Codex rounds + `qa-verifier` + `security-auditor` + `algorithm-verifier`). Findings from the first passes (denylist fail-open, `cmd.Path=` mutation, func-value/alias bypass, `DefaultCatalog` drift) were all fixed and re-verified; the final Codex pass reports no confirmed soundness holes.

## Tests

- Domain: allowlist boundaries, per-symbol de-escalation, back-compat of `Assemble`.
- Real go/ssa fixtures over the acceptance twins and every adversarial case: `exec.Command("echo"/"ping", …)` → CWE-88; variable argv[0], `sh -c`, `python3.11`, mixed sites, `cmd.Path=` mutation, escape-to-function, func-value indirect (ordinary + type-alias signatures), absolute/path form → all keep CWE-78.
- Wire round-trip of the additive per-symbol facts; fail-closed unit tests for the SSA argument gate.

`make build vet test`, `golangci-lint`, and `CGO_ENABLED=0 go build ./cmd/...` all pass. (Pre-existing environmental `internal/infrastructure/sandbox` bubblewrap tests fail identically on `main` in this environment and are unrelated.)

Refs #860
