### PR TITLE
feat(sca): capture declared version ranges for Poetry dependencies

### DIFF
--- a/internal/infrastructure/tools/ownsbom/poetry.go
+++ b/internal/infrastructure/tools/ownsbom/poetry.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -166,9 +167,14 @@ func (Poetry) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbo
 			hash = metaHashes[n]
 		}
 		set.add(sbom.Component{Name: n, Version: p.version, PURL: ref, Location: in.Path, Scope: scope, Checksums: pyHashChecksums([]string{hash})})
+		// Per resolved target, the WINNING declaration decides both the edge's optionality and its recorded
+		// range. Priority: a required declaration (2) beats an optional one (1), and a strict > keeps the FIRST
+		// declaration at a given priority (a later required tie does not overwrite an earlier one). The range is
+		// then the winner's OWN constraint – empty when that winner declared none (a git/path/url dependency),
+		// so a losing declaration's range can never leak onto the edge.
 		targetOptional := map[string]bool{}
 		targetRange := map[string]string{}
-		seen := map[string]bool{ref: true}
+		winnerPrio := map[string]int{}
 		for _, d := range p.deps {
 			dn := normalizePyPI(d.name)
 			vs := versionsOf[dn]
@@ -179,18 +185,14 @@ func (Poetry) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbo
 			if t == ref {
 				continue
 			}
-			// The declared range follows the edge winner: a required declaration wins over an optional one
-			// for the same resolved target (matching the required-wins optionality below), never the reverse.
-			if d.constraint != "" && (!d.optional || targetRange[t] == "") {
-				targetRange[t] = d.constraint
+			prio := 1 // optional
+			if !d.optional {
+				prio = 2 // required wins over an alternate optional declaration
 			}
-			if !seen[t] {
-				seen[t] = true
+			if prio > winnerPrio[t] { // strict > keeps the first declaration at a given priority
+				winnerPrio[t] = prio
 				targetOptional[t] = d.optional
-				continue
-			}
-			if !d.optional { // required wins over an alternate optional declaration
-				targetOptional[t] = false
+				targetRange[t] = d.constraint // the winner's own constraint (may be empty -> range absent)
 			}
 		}
 		var required, optional []string
@@ -233,9 +235,41 @@ func isPoetryDepKey(k string) bool {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 }
 
+// poetryTableVersionRE matches the `version` KEY inside an inline dependency table body and captures its
+// double-quoted value whole. The key must be at the body start or preceded by a comma or whitespace, so a
+// `python-versions` (or any other marker) key that merely CONTAINS the substring "version" never matches.
+// Capturing the quoted value as one group keeps a comma inside the constraint (`">=1,<2"`) intact, which a
+// naive comma-split would sever. It is applied only to the table body (see poetryInlineTableBody), never the
+// raw RHS, so a `version = "…"` in a trailing `# comment` after the closing brace can never be read as a key.
+var poetryTableVersionRE = regexp.MustCompile(`(?:^|[{,\s])version\s*=\s*"([^"]*)"`)
+
+// poetryInlineTableBody returns the body of a `{…}` inline table – the text between the opening brace and its
+// MATCHING closing brace – skipping any `}` that appears inside a double-quoted string value (honoring `\"`
+// escapes). Anything after the closing brace (a trailing `# comment`, another table) is excluded. It returns
+// "" for a non-table or an unterminated table, so a malformed line yields no range rather than a guessed one.
+func poetryInlineTableBody(raw string) string {
+	if len(raw) == 0 || raw[0] != '{' {
+		return ""
+	}
+	inStr, esc := false, false
+	for i := 1; i < len(raw); i++ {
+		switch c := raw[i]; {
+		case esc:
+			esc = false
+		case c == '\\' && inStr:
+			esc = true
+		case c == '"':
+			inStr = !inStr
+		case c == '}' && !inStr:
+			return raw[1:i]
+		}
+	}
+	return "" // unterminated inline table – no reliable body, so no range
+}
+
 // poetryDepConstraint extracts the declared version constraint from a poetry.lock dependency value:
 // a bare TOML string ("^1.2") or an inline table's version field ({version = "^1.2", optional = true}).
-// A table with no version (a git/path/url dependency) yields "" (D3.8).
+// A table with no version key (a git/path/url dependency) yields "" (D3.8).
 func poetryDepConstraint(raw string) string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -245,10 +279,8 @@ func poetryDepConstraint(raw string) string {
 		return tomlString(raw)
 	}
 	if raw[0] == '{' {
-		if j := strings.Index(raw, "version"); j >= 0 {
-			if eq := strings.IndexByte(raw[j:], '='); eq >= 0 {
-				return tomlString(raw[j+eq+1:])
-			}
+		if m := poetryTableVersionRE.FindStringSubmatch(poetryInlineTableBody(raw)); m != nil {
+			return m[1]
 		}
 	}
 	return ""

--- a/internal/infrastructure/tools/ownsbom/poetry.go
+++ b/internal/infrastructure/tools/ownsbom/poetry.go
@@ -29,8 +29,9 @@ func (Poetry) Ecosystem() string { return "pypi" }
 func (Poetry) Markers() []string { return []string{"poetry.lock"} }
 
 type poetryDep struct {
-	name     string
-	optional bool
+	name       string
+	optional   bool
+	constraint string // the declared version constraint (D3.8): `"^1.2"` or a table's version=…
 }
 
 // poetryPkg is a [[package]] block collected in pass 1: identity + the direct dependency names from its
@@ -123,8 +124,9 @@ func (Poetry) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbo
 			// Multi-line continuation elements are filtered by isPoetryDepKey and never guessed as optional.
 			i := strings.IndexByte(line, '=')
 			if k := strings.Trim(strings.TrimSpace(line[:i]), `"`); isPoetryDepKey(k) {
-				value := strings.ToLower(strings.ReplaceAll(line[i+1:], " ", ""))
-				cur.deps = append(cur.deps, poetryDep{name: k, optional: strings.Contains(value, "optional=true")})
+				raw := strings.TrimSpace(line[i+1:])
+				value := strings.ToLower(strings.ReplaceAll(raw, " ", ""))
+				cur.deps = append(cur.deps, poetryDep{name: k, optional: strings.Contains(value, "optional=true"), constraint: poetryDepConstraint(raw)})
 			}
 		case inPkg && strings.HasPrefix(line, "name = "):
 			cur.name = tomlString(line[len("name = "):])
@@ -165,6 +167,7 @@ func (Poetry) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbo
 		}
 		set.add(sbom.Component{Name: n, Version: p.version, PURL: ref, Location: in.Path, Scope: scope, Checksums: pyHashChecksums([]string{hash})})
 		targetOptional := map[string]bool{}
+		targetRange := map[string]string{}
 		seen := map[string]bool{ref: true}
 		for _, d := range p.deps {
 			dn := normalizePyPI(d.name)
@@ -175,6 +178,11 @@ func (Poetry) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbo
 			t := purlOf(dn, vs[0])
 			if t == ref {
 				continue
+			}
+			// The declared range follows the edge winner: a required declaration wins over an optional one
+			// for the same resolved target (matching the required-wins optionality below), never the reverse.
+			if d.constraint != "" && (!d.optional || targetRange[t] == "") {
+				targetRange[t] = d.constraint
 			}
 			if !seen[t] {
 				seen[t] = true
@@ -196,10 +204,10 @@ func (Poetry) Parse(ctx context.Context, in ParseInput) ([]sbom.Component, []sbo
 		sort.Strings(required)
 		sort.Strings(optional)
 		if len(required) > 0 {
-			deps = append(deps, sbom.Dependency{Ref: ref, DependsOn: required, Scope: scope})
+			deps = append(deps, sbom.Dependency{Ref: ref, DependsOn: required, Scope: scope, RequestedRanges: rangesFor(required, targetRange)})
 		}
 		if len(optional) > 0 {
-			deps = append(deps, sbom.Dependency{Ref: ref, DependsOn: optional, Scope: scope, Optional: true})
+			deps = append(deps, sbom.Dependency{Ref: ref, DependsOn: optional, Scope: scope, Optional: true, RequestedRanges: rangesFor(optional, targetRange)})
 		}
 	}
 	return set.components(), deps, nil
@@ -223,4 +231,25 @@ func isPoetryDepKey(k string) bool {
 	}
 	c := k[0]
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}
+
+// poetryDepConstraint extracts the declared version constraint from a poetry.lock dependency value:
+// a bare TOML string ("^1.2") or an inline table's version field ({version = "^1.2", optional = true}).
+// A table with no version (a git/path/url dependency) yields "" (D3.8).
+func poetryDepConstraint(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if raw[0] == '"' {
+		return tomlString(raw)
+	}
+	if raw[0] == '{' {
+		if j := strings.Index(raw, "version"); j >= 0 {
+			if eq := strings.IndexByte(raw[j:], '='); eq >= 0 {
+				return tomlString(raw[j+eq+1:])
+			}
+		}
+	}
+	return ""
 }

--- a/internal/infrastructure/tools/ownsbom/poetry_test.go
+++ b/internal/infrastructure/tools/ownsbom/poetry_test.go
@@ -52,6 +52,10 @@ func TestPoetryParse(t *testing.T) {
 	if len(deps[0].DependsOn) != 1 || deps[0].DependsOn[0] != "pkg:pypi/charset-normalizer@3.3.2" {
 		t.Errorf("requests must depend on charset-normalizer@3.3.2 only (idna unresolved → no edge), got %v", deps[0].DependsOn)
 	}
+	// D3.8: the edge records the declared range for the resolved target (requests declared ">=2,<4").
+	if r := deps[0].RequestedRanges["pkg:pypi/charset-normalizer@3.3.2"]; r != ">=2,<4" {
+		t.Errorf("requests edge must record charset-normalizer declared range >=2,<4, got %q", r)
+	}
 	if len(comps) != 3 {
 		t.Fatalf("want 3 components, got %d: %+v", len(comps), comps)
 	}

--- a/internal/infrastructure/tools/ownsbom/poetry_test.go
+++ b/internal/infrastructure/tools/ownsbom/poetry_test.go
@@ -210,3 +210,149 @@ category = "main"
 		t.Errorf("an ambiguous duplicate-name dep must yield no edge, got %+v", deps)
 	}
 }
+
+// D3.8 regression: an inline-table key that merely CONTAINS the substring "version" (a marker/python-versions
+// field) and a git/path/url table (no version field at all) must NOT supply a declared range – only a real
+// `version` key does. A losing substring match would invent a bogus RequestedRanges entry.
+func TestPoetryDepConstraintVersionKeyExact(t *testing.T) {
+	lock := `[[package]]
+name = "app"
+version = "1.0.0"
+category = "main"
+
+[package.dependencies]
+foo = {python-versions = ">=3.8", markers = "sys_platform == 'linux'"}
+bar = {git = "https://example.com/bar.git"}
+baz = {version = ">=1,<2", optional = false}
+
+[[package]]
+name = "foo"
+version = "2.0.0"
+category = "main"
+
+[[package]]
+name = "bar"
+version = "3.0.0"
+category = "main"
+
+[[package]]
+name = "baz"
+version = "4.0.0"
+category = "main"
+`
+	_, deps, err := Poetry{}.Parse(context.Background(), ParseInput{Path: "poetry.lock", Content: []byte(lock)})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("want one edge-set rooted at app, got %+v", deps)
+	}
+	rr := deps[0].RequestedRanges
+	// foo (python-versions marker) and bar (git table) resolve to edges but carry NO declared range; only the
+	// real version key on baz is recorded.
+	if _, ok := rr["pkg:pypi/foo@2.0.0"]; ok {
+		t.Errorf("a python-versions/marker key must not supply a range, got %q", rr["pkg:pypi/foo@2.0.0"])
+	}
+	if _, ok := rr["pkg:pypi/bar@3.0.0"]; ok {
+		t.Errorf("a git dependency table must not supply a range, got %q", rr["pkg:pypi/bar@3.0.0"])
+	}
+	if rr["pkg:pypi/baz@4.0.0"] != ">=1,<2" {
+		t.Errorf("the real version key must be recorded, got %q", rr["pkg:pypi/baz@4.0.0"])
+	}
+}
+
+// D3.8 regression: two required declarations normalizing to the SAME resolved target (a crafted lock with
+// `foo_bar` and `foo-bar`) must keep the FIRST declaration's range, not the later tie's.
+func TestPoetryRequiredTieKeepsFirstRange(t *testing.T) {
+	lock := `[[package]]
+name = "app"
+version = "1.0.0"
+category = "main"
+
+[package.dependencies]
+foo_bar = ">=1"
+foo-bar = "<2"
+
+[[package]]
+name = "foo-bar"
+version = "5.0.0"
+category = "main"
+`
+	_, deps, err := Poetry{}.Parse(context.Background(), ParseInput{Path: "poetry.lock", Content: []byte(lock)})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("want one edge-set rooted at app, got %+v", deps)
+	}
+	if r := deps[0].RequestedRanges["pkg:pypi/foo-bar@5.0.0"]; r != ">=1" {
+		t.Errorf("a required tie must keep the first declared range >=1, got %q", r)
+	}
+}
+
+// D3.8 regression: an optional declaration's range must NOT leak onto the edge when a later REQUIRED
+// declaration (with no version constraint, e.g. a git table) wins the target. The required winner has no
+// constraint, so the recorded range must be absent, not the optional loser's "^1".
+func TestPoetryOptionalRangeDoesNotLeakOntoRequired(t *testing.T) {
+	lock := `[[package]]
+name = "app"
+version = "1.0.0"
+category = "main"
+
+[package.dependencies]
+foo = {version = "^1", optional = true}
+foo = {git = "https://example.com/foo.git"}
+
+[[package]]
+name = "foo"
+version = "6.0.0"
+category = "main"
+`
+	_, deps, err := Poetry{}.Parse(context.Background(), ParseInput{Path: "poetry.lock", Content: []byte(lock)})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(deps) != 1 {
+		t.Fatalf("want one edge-set rooted at app, got %+v", deps)
+	}
+	// The required declaration wins the target, so the edge is required (not optional)...
+	if deps[0].Optional {
+		t.Errorf("a required declaration must win optionality over an optional one, got optional edge %+v", deps[0])
+	}
+	if deps[0].DependsOn[0] != "pkg:pypi/foo@6.0.0" {
+		t.Fatalf("want edge to foo@6.0.0, got %v", deps[0].DependsOn)
+	}
+	// ...and since that required winner declared no version, the optional loser's "^1" must NOT be recorded.
+	if r, ok := deps[0].RequestedRanges["pkg:pypi/foo@6.0.0"]; ok {
+		t.Errorf("an optional declaration's range must not leak onto a required winner with no constraint, got %q", r)
+	}
+}
+
+// D3.8 regression: a `version = "…"` inside a trailing TOML comment after the inline table's closing brace
+// must NOT be read as the dependency's version key. Only the actual inline-table body supplies a range, so a
+// git/path/url dependency with such a comment carries no range (never a fabricated one).
+func TestPoetryDepConstraintIgnoresTrailingComment(t *testing.T) {
+	lock := `[[package]]
+name = "app"
+version = "1.0.0"
+category = "main"
+
+[package.dependencies]
+foo = {git = "https://example.com/foo.git"} # version = ">=99"
+
+[[package]]
+name = "foo"
+version = "2.0.0"
+category = "main"
+`
+	_, deps, err := Poetry{}.Parse(context.Background(), ParseInput{Path: "poetry.lock", Content: []byte(lock)})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if len(deps) != 1 || deps[0].DependsOn[0] != "pkg:pypi/foo@2.0.0" {
+		t.Fatalf("want one edge app->foo@2.0.0, got %+v", deps)
+	}
+	if r, ok := deps[0].RequestedRanges["pkg:pypi/foo@2.0.0"]; ok {
+		t.Errorf("a version key in a trailing comment must not supply a range, got %q", r)
+	}
+}


### PR DESCRIPTION
## What

Extends the EPIC #860 D3.8 declared-range capture (added for npm/Yarn in #1013) to the **Poetry** parser — the third major ecosystem (Python).

## How

Each `poetry.lock` `[package.dependencies]` entry's declared constraint (a bare `"^1.2"` or an inline table's `version = …`) is recorded on the resolved dependency edge in `RequestedRanges`, via the shared `rangesFor` helper. A required declaration wins the range over an optional one for the same resolved target (matching the required-wins optionality); a table with no version (a git/path dependency) records no range.

The remaining owned edge parsers whose lockfiles record only resolved versions (Cargo, uv, Maven's resolved tree, …) leave the range absent by design rather than inventing one — so `RequestedRanges` is now populated for every owned format that carries a declared range per edge (npm, Yarn, Poetry).

## Tests

A Poetry range-capture test asserts the `requests` edge records `charset-normalizer` declared range `>=2,<4`. `go build ./...`, `CGO_ENABLED=0`, vet, `golangci-lint`, and the ownsbom suite pass.

## Review

Reviewed by a Codex pass (mirrors the npm/Yarn pattern reviewed in #1013).
