### PR TITLE
docs(vulnintel): exclude internal implementation plan from nav

### DIFF
--- a/docs/docs_publication_test.go
+++ b/docs/docs_publication_test.go
@@ -29,7 +29,11 @@ type mkdocsConfig struct {
 // navExclusions lists Markdown files under the guide directory that are intentionally absent from the
 // navigation. It is empty on purpose: every current guide is reachable. An entry added here must carry a
 // reason, so "not in nav" stays a decision rather than an oversight.
-var navExclusions = map[string]string{}
+var navExclusions = map[string]string{
+	// An internal implementation/tracking plan for the vulnerability-intelligence work, not end-user guide
+	// content; it lives under docs/guide for co-location but is intentionally kept out of the published nav.
+	"vulnerability-intelligence-implementation-plan.md": "internal implementation plan, not a user guide",
+}
 
 // TestEveryGuidePageIsPublished fails when a Markdown file under the MkDocs docs_dir is missing from the
 // navigation. Such a page builds but is unreachable except by direct URL.


### PR DESCRIPTION
## What

`TestEveryGuidePageIsPublished` fails on `main`: `docs/guide/vulnerability-intelligence-implementation-plan.md` is committed but absent from the MkDocs nav, so the drift guard flags it as an unpublished page.

That file is an internal implementation/tracking plan, not end-user guide content. It sits under `docs/guide` for co-location. Add it to `navExclusions` with a reason so "not in nav" stays a deliberate decision rather than an oversight, and the guard goes green.

## Why not add it to nav

The published guide is end-user documentation; an implementation plan does not belong in that navigation. Excluding it is the honest classification.

## Test

`go test ./docs/` passes.
