### PR TITLE
feat(taint): correlate flows with SCA findings

### DIFF
--- a/internal/domain/judgment/claim.go
+++ b/internal/domain/judgment/claim.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"sort"
 	"strings"
 	"unicode"
 
@@ -125,6 +126,9 @@ const (
 	maxClaimPathElemLen = 256
 	maxSASTLocationLen  = 512
 	maxSASTRuleLen      = 128
+	maxSASTSymbolLen    = 512
+	maxSASTSinkSymbols  = 64
+	maxSASTCorrelations = 128
 	// MaxSASTDataFlowSteps caps the structured witness admitted to the judgment ledger.
 	MaxSASTDataFlowSteps = 64
 	maxRiskDrivers       = 32
@@ -237,11 +241,23 @@ func (c ReachabilityClaim) Validate() error {
 // SASTClaim is the typed result of a SAST judgment: the weakness (CWE), where, and the
 // rule that fired. No free-text – a "hardcoded secret at L42" finding renders from these fields.
 type SASTClaim struct {
-	CWE      string        `json:"cwe"`
-	Location string        `json:"location"` // path[:line]
-	Rule     string        `json:"rule"`
-	AssetID  shared.ID     `json:"asset_id"`
-	DataFlow *SASTDataFlow `json:"data_flow,omitempty"`
+	CWE          string                   `json:"cwe"`
+	Location     string                   `json:"location"` // path[:line]
+	Rule         string                   `json:"rule"`
+	AssetID      shared.ID                `json:"asset_id"`
+	DataFlow     *SASTDataFlow            `json:"data_flow,omitempty"`
+	SinkSymbols  []string                 `json:"sink_symbols,omitempty"`
+	Correlations []SASTFindingCorrelation `json:"correlations,omitempty"`
+}
+
+// SASTFindingCorrelation is an evidence-bearing relation from a taint-flow judgment to an existing SCA
+// finding. A data-flow judgment deliberately remains about SubjectDataFlow: this relation records which
+// SubjectFinding it can raise, never changes the judgment subject or turns an unmatched flow into a finding.
+// SinkSymbol and AffectedSymbol preserve the exact symmetric symbol match used to make the link auditable.
+type SASTFindingCorrelation struct {
+	FindingID      shared.ID `json:"finding_id"`
+	SinkSymbol     string    `json:"sink_symbol"`
+	AffectedSymbol string    `json:"affected_symbol"`
 }
 
 // SASTFlowLocation is a source-only point in a repository-relative file. Columns are zero-based UTF-8
@@ -352,12 +368,83 @@ func (c SASTClaim) Validate() error {
 	if len(c.Rule) > maxSASTRuleLen || !sastRuleRE.MatchString(c.Rule) {
 		return fmt.Errorf("%w: sast claim rule must be a structured token of at most %d bytes", shared.ErrValidation, maxSASTRuleLen)
 	}
+	if len(c.SinkSymbols) > maxSASTSinkSymbols {
+		return fmt.Errorf("%w: sast claim has too many sink symbols (%d > %d)", shared.ErrValidation, len(c.SinkSymbols), maxSASTSinkSymbols)
+	}
+	sinks := make(map[string]struct{}, len(c.SinkSymbols))
+	for _, symbol := range c.SinkSymbols {
+		if err := validateSASTSymbol(symbol); err != nil {
+			return err
+		}
+		if _, duplicate := sinks[symbol]; duplicate {
+			return fmt.Errorf("%w: sast claim repeats sink symbol %q", shared.ErrValidation, symbol)
+		}
+		sinks[symbol] = struct{}{}
+	}
+	if len(c.Correlations) > maxSASTCorrelations {
+		return fmt.Errorf("%w: sast claim has too many finding correlations (%d > %d)", shared.ErrValidation, len(c.Correlations), maxSASTCorrelations)
+	}
+	correlations := make(map[string]struct{}, len(c.Correlations))
+	for _, link := range c.Correlations {
+		if link.FindingID.IsZero() {
+			return fmt.Errorf("%w: sast finding correlation requires a finding id", shared.ErrValidation)
+		}
+		if err := validateSASTSymbol(link.SinkSymbol); err != nil {
+			return err
+		}
+		if err := validateSASTSymbol(link.AffectedSymbol); err != nil {
+			return err
+		}
+		if _, present := sinks[link.SinkSymbol]; !present {
+			return fmt.Errorf("%w: sast finding correlation sink %q is not declared by the claim", shared.ErrValidation, link.SinkSymbol)
+		}
+		key := link.FindingID.String() + "\x00" + link.SinkSymbol + "\x00" + link.AffectedSymbol
+		if _, duplicate := correlations[key]; duplicate {
+			return fmt.Errorf("%w: sast claim repeats a finding correlation", shared.ErrValidation)
+		}
+		correlations[key] = struct{}{}
+	}
 	if c.DataFlow != nil {
 		if err := c.DataFlow.validate(); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func validateSASTSymbol(symbol string) error {
+	if symbol == "" || strings.TrimSpace(symbol) != symbol || len(symbol) > maxSASTSymbolLen {
+		return fmt.Errorf("%w: sast symbol must be a non-empty bounded token", shared.ErrValidation)
+	}
+	for _, r := range symbol {
+		if unicode.IsControl(r) {
+			return fmt.Errorf("%w: sast symbol contains control characters", shared.ErrValidation)
+		}
+	}
+	return nil
+}
+
+// CorrelatedFindingIDs returns the distinct SCA findings linked by this SAST claim in stable order.
+// A correlation is evidence for a later raise-only promotion decision; it does not change the SAST
+// judgment's subject or decide a severity by itself.
+func (c SASTClaim) CorrelatedFindingIDs() []shared.ID {
+	if len(c.Correlations) == 0 {
+		return nil
+	}
+	seen := make(map[shared.ID]struct{}, len(c.Correlations))
+	out := make([]shared.ID, 0, len(c.Correlations))
+	for _, link := range c.Correlations {
+		if link.FindingID.IsZero() {
+			continue
+		}
+		if _, exists := seen[link.FindingID]; exists {
+			continue
+		}
+		seen[link.FindingID] = struct{}{}
+		out = append(out, link.FindingID)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
 }
 
 // RiskNarrativeClaim explains the Go-computed priority via STRUCTURED drivers (never prose):

--- a/internal/domain/judgment/claim_test.go
+++ b/internal/domain/judgment/claim_test.go
@@ -14,6 +14,9 @@ func TestClaimRoundTrip(t *testing.T) {
 	claims := []Claim{
 		ReachabilityClaim{Reachable: Reachable, Tier: Tier2, Path: []string{"main", "vuln"}, Confidence: 95},
 		SASTClaim{CWE: "CWE-327", Location: "auth.go:42", Rule: "weak-hash-md5"},
+		SASTClaim{CWE: "CWE-89", Location: "app/db.go:42", Rule: "taint-sqli", SinkSymbols: []string{"database/sql.DB.Query"}, Correlations: []SASTFindingCorrelation{
+			{FindingID: "finding-1", SinkSymbol: "database/sql.DB.Query", AffectedSymbol: "database/sql.DB.Query"},
+		}},
 		SASTClaim{CWE: "CWE-78", Location: "app.py:4", Rule: "python-taint-command", DataFlow: &SASTDataFlow{
 			Language: "python", Source: SASTFlowLocation{File: "app.py", Line: 3, Column: 4}, Sink: SASTFlowLocation{File: "app.py", Line: 4, Column: 4},
 			Steps: []SASTFlowLocation{{File: "app.py", Line: 3, Column: 4}, {File: "app.py", Line: 4, Column: 4}},
@@ -142,6 +145,41 @@ func TestSASTClaimValidateRejectsModelProseAndOversizedFields(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := tc.claim.Validate(); !errors.Is(err, shared.ErrValidation) {
+				t.Fatalf("want ErrValidation, got %v", err)
+			}
+		})
+	}
+}
+
+func TestSASTClaimValidatesFindingCorrelations(t *testing.T) {
+	valid := SASTClaim{
+		CWE: "CWE-89", Location: "internal/db/query.go:42", Rule: "taint-sqli",
+		SinkSymbols: []string{"database/sql.DB.Query"},
+		Correlations: []SASTFindingCorrelation{{
+			FindingID: "finding-1", SinkSymbol: "database/sql.DB.Query", AffectedSymbol: "database/sql.DB.Query",
+		}},
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("valid SAST finding correlation rejected: %v", err)
+	}
+
+	wrongSink := valid
+	wrongSink.Correlations = []SASTFindingCorrelation{{
+		FindingID: "finding-1", SinkSymbol: "database/sql.DB.Exec", AffectedSymbol: "database/sql.DB.Exec",
+	}}
+	emptyFinding := valid
+	emptyFinding.Correlations = []SASTFindingCorrelation{{
+		SinkSymbol: "database/sql.DB.Query", AffectedSymbol: "database/sql.DB.Query",
+	}}
+	duplicateSink := valid
+	duplicateSink.SinkSymbols = []string{"database/sql.DB.Query", "database/sql.DB.Query"}
+	for name, claim := range map[string]SASTClaim{
+		"correlation sink not declared": wrongSink,
+		"correlation finding missing":   emptyFinding,
+		"duplicate sink symbol":         duplicateSink,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := claim.Validate(); !errors.Is(err, shared.ErrValidation) {
 				t.Fatalf("want ErrValidation, got %v", err)
 			}
 		})

--- a/internal/usecase/ports/ports.go
+++ b/internal/usecase/ports/ports.go
@@ -1643,6 +1643,15 @@ type TaintScanner interface {
 	Scan(ctx context.Context, engagementID shared.ID, targetRef string) (int, error)
 }
 
+// CorrelatedTaintScanner is the optional finding-aware extension of TaintScanner. The SCA pipeline passes
+// its version-correct advisory symbols for each existing finding; implementations attach an exact
+// dataflow-to-finding correlation to the proposed SAST claim. A scanner that does not implement this
+// extension keeps the legacy proposal-only behavior.
+type CorrelatedTaintScanner interface {
+	TaintScanner
+	ScanCorrelated(ctx context.Context, engagementID shared.ID, targetRef string, subjects []ReachabilitySubject) (TaintScanOutcome, error)
+}
+
 // DependencyGraphResolver augments a generated SBOM with transitive dependency EDGES that a static
 // lockfile/manifest parse cannot provide on its own – e.g. Go modules, whose edge graph is not in go.mod
 // but in the module cache, read via `go mod graph`. Unlike SBOMEnricher (pure file reads), an

--- a/internal/usecase/sca/service.go
+++ b/internal/usecase/sca/service.go
@@ -3524,20 +3524,34 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 		}
 	}
 
+	// Taint correlation consumes the same version-correct finding subjects as symbol reachability. It is
+	// computed once from this scan's findings so a flow can only link to an SCA finding that actually exists.
+	taintSubjects := reachabilitySubjects(result.Findings, result.Vulnerabilities)
+
 	// Deterministic taint-analysis CapSAST proposals, best-effort + opt-in: build the workspace call
 	// graph (sandboxed), assemble the taint FlowGraph over the injection catalog, and PROPOSE gated CapSAST
 	// judgments (one per injection path × class) for a distinct verifier to gate. Same best-effort contract
 	// as reachability – a no-coverage/un-buildable target returns an error here that is IGNORED (taint is an
 	// enhancement; the scan is never failed). Runs while ws.Dir still exists.
 	if opts.scansVulnerabilities() && s.taint != nil {
-		_, _ = s.taint.Scan(ctx, engagementID, ws.Dir)
+		if scanner, ok := s.taint.(ports.CorrelatedTaintScanner); ok {
+			_, _ = scanner.ScanCorrelated(ctx, engagementID, ws.Dir, taintSubjects)
+		} else {
+			_, _ = s.taint.Scan(ctx, engagementID, ws.Dir)
+		}
 	}
 
 	// Python semantic taint is source-only and value-granular. It runs independently of the legacy Go
 	// function-level scanner, but follows the same propose-only lifecycle: positive witnesses become gated
 	// CapSAST proposals, while missing/partial coverage never becomes a clean conclusion.
 	if opts.scansVulnerabilities() && s.pythonTaint != nil {
-		if scanner, ok := s.pythonTaint.(ports.TaintCoverageScanner); ok {
+		if scanner, ok := s.pythonTaint.(ports.CorrelatedTaintScanner); ok {
+			outcome, _ := scanner.ScanCorrelated(ctx, engagementID, ws.Dir, taintSubjects)
+			result.AnalysisCoverage = mergeAnalysisCoverage(result.AnalysisCoverage, outcome.Coverage)
+			if warning := semanticCoverageWarning(outcome.Coverage); warning != "" {
+				result.SourceWarnings = mergeStrings(result.SourceWarnings, []string{warning})
+			}
+		} else if scanner, ok := s.pythonTaint.(ports.TaintCoverageScanner); ok {
 			outcome, _ := scanner.ScanWithCoverage(ctx, engagementID, ws.Dir)
 			result.AnalysisCoverage = mergeAnalysisCoverage(result.AnalysisCoverage, outcome.Coverage)
 			if warning := semanticCoverageWarning(outcome.Coverage); warning != "" {
@@ -3552,7 +3566,13 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 	// Python and Go scanners on the same propose-only lifecycle: positive witnesses become gated CapSAST
 	// proposals, while missing/partial coverage never becomes a clean conclusion.
 	if opts.scansVulnerabilities() && s.jsTaint != nil {
-		if scanner, ok := s.jsTaint.(ports.TaintCoverageScanner); ok {
+		if scanner, ok := s.jsTaint.(ports.CorrelatedTaintScanner); ok {
+			outcome, _ := scanner.ScanCorrelated(ctx, engagementID, ws.Dir, taintSubjects)
+			result.AnalysisCoverage = mergeAnalysisCoverage(result.AnalysisCoverage, outcome.Coverage)
+			if warning := semanticCoverageWarning(outcome.Coverage); warning != "" {
+				result.SourceWarnings = mergeStrings(result.SourceWarnings, []string{warning})
+			}
+		} else if scanner, ok := s.jsTaint.(ports.TaintCoverageScanner); ok {
 			outcome, _ := scanner.ScanWithCoverage(ctx, engagementID, ws.Dir)
 			result.AnalysisCoverage = mergeAnalysisCoverage(result.AnalysisCoverage, outcome.Coverage)
 			if warning := semanticCoverageWarning(outcome.Coverage); warning != "" {
@@ -3565,7 +3585,13 @@ func (s *Service) runPipeline(ctx context.Context, actor string, engagementID sh
 
 	// Java semantic value-flow taint, same propose-only lifecycle as the JS/Python/Go scanners.
 	if opts.scansVulnerabilities() && s.javaTaint != nil {
-		if scanner, ok := s.javaTaint.(ports.TaintCoverageScanner); ok {
+		if scanner, ok := s.javaTaint.(ports.CorrelatedTaintScanner); ok {
+			outcome, _ := scanner.ScanCorrelated(ctx, engagementID, ws.Dir, taintSubjects)
+			result.AnalysisCoverage = mergeAnalysisCoverage(result.AnalysisCoverage, outcome.Coverage)
+			if warning := semanticCoverageWarning(outcome.Coverage); warning != "" {
+				result.SourceWarnings = mergeStrings(result.SourceWarnings, []string{warning})
+			}
+		} else if scanner, ok := s.javaTaint.(ports.TaintCoverageScanner); ok {
 			outcome, _ := scanner.ScanWithCoverage(ctx, engagementID, ws.Dir)
 			result.AnalysisCoverage = mergeAnalysisCoverage(result.AnalysisCoverage, outcome.Coverage)
 			if warning := semanticCoverageWarning(outcome.Coverage); warning != "" {

--- a/internal/usecase/sca/service_test.go
+++ b/internal/usecase/sca/service_test.go
@@ -114,6 +114,19 @@ type staticTaintCoverage struct {
 	calls   int
 }
 
+type staticCorrelatedTaint struct {
+	calls    int
+	subjects []ports.ReachabilitySubject
+}
+
+func (*staticCorrelatedTaint) Scan(context.Context, shared.ID, string) (int, error) { return 0, nil }
+
+func (s *staticCorrelatedTaint) ScanCorrelated(_ context.Context, _ shared.ID, _ string, subjects []ports.ReachabilitySubject) (ports.TaintScanOutcome, error) {
+	s.calls++
+	s.subjects = append([]ports.ReachabilitySubject(nil), subjects...)
+	return ports.TaintScanOutcome{Proposed: 1}, nil
+}
+
 func (s *staticTaintCoverage) Scan(context.Context, shared.ID, string) (int, error) {
 	return s.outcome.Proposed, s.err
 }
@@ -321,6 +334,28 @@ func TestScanSurfacesJSTaintCoverageEvenWhenBestEffortScannerFails(t *testing.T)
 	}
 	if len(result.SourceWarnings) != 1 || strings.Contains(result.SourceWarnings[0], "untrusted parser detail") {
 		t.Fatalf("safe source warning = %v", result.SourceWarnings)
+	}
+}
+
+func TestScanPassesVersionCorrectFindingSymbolsToCorrelatedTaint(t *testing.T) {
+	svc := newSvcWithSources(
+		&fakeEngRepo{eng: engagementWithScope(t, "myrepo")}, fakeClock{t: time.Unix(0, 0).UTC()},
+		&fakeAcquirer{dir: "/tmp/ws"}, &fakeAudit{}, &fakeDetector{},
+		[]ports.DetectionSource{staticVuln{{
+			Source: "static", AdvisoryID: "CVE-2026-1050", Component: "example.com/lib", Version: "1.0.0",
+			Severity: shared.SeverityHigh, AffectedSymbols: []string{"example.com/lib.Parser.Parse"},
+		}}},
+	)
+	scanner := &staticCorrelatedTaint{}
+	svc.SetTaint(scanner)
+	if _, err := svc.ScanWithOptions(context.Background(), "operator", "e1", ports.AcquireRequest{Kind: "local", Value: "myrepo"}, ScanOptions{Mode: ScanModeVulnerabilities}); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if scanner.calls != 1 || len(scanner.subjects) != 1 {
+		t.Fatalf("correlated scanner calls=%d subjects=%+v", scanner.calls, scanner.subjects)
+	}
+	if scanner.subjects[0].FindingID.IsZero() || len(scanner.subjects[0].Symbols) != 1 || scanner.subjects[0].Symbols[0] != "example.com/lib.Parser.Parse" {
+		t.Fatalf("scanner must receive the real finding id and version-correct advisory symbol: %+v", scanner.subjects[0])
 	}
 }
 

--- a/internal/usecase/taintscan/coordinator.go
+++ b/internal/usecase/taintscan/coordinator.go
@@ -25,11 +25,13 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/KKloudTarus/synapse-ce/internal/domain/callgraph"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/symbolcanon"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/taint"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
@@ -69,6 +71,7 @@ type Coordinator struct {
 }
 
 var _ ports.TaintScanner = (*Coordinator)(nil)
+var _ ports.CorrelatedTaintScanner = (*Coordinator)(nil)
 
 // NewCoordinator validates and returns the coordinator. The catalog must be non-empty (an empty catalog
 // would silently propose nothing – a misconfiguration, not a clean result).
@@ -87,6 +90,18 @@ func NewCoordinator(b builder, p proposer, catalog taint.Catalog, audit ports.Au
 // no-coverage build error proposes NOTHING (never a false "clean"). Every judgment is born
 // StateProposed/score-0 and awaits a distinct verifier.
 func (c *Coordinator) Scan(ctx context.Context, engagementID shared.ID, targetRef string) (int, error) {
+	return c.scan(ctx, engagementID, targetRef, nil)
+}
+
+// ScanCorrelated is the finding-aware form of Scan. Subjects are the SCA pipeline's version-correct
+// advisory-symbol inputs, keyed by their real SubjectFinding id. A missing or non-matching subject never
+// suppresses the ordinary SAST judgment; it merely leaves Correlations empty.
+func (c *Coordinator) ScanCorrelated(ctx context.Context, engagementID shared.ID, targetRef string, subjects []ports.ReachabilitySubject) (ports.TaintScanOutcome, error) {
+	n, err := c.scan(ctx, engagementID, targetRef, subjects)
+	return ports.TaintScanOutcome{Proposed: n}, err
+}
+
+func (c *Coordinator) scan(ctx context.Context, engagementID shared.ID, targetRef string, subjects []ports.ReachabilitySubject) (int, error) {
 	if engagementID.IsZero() {
 		return 0, fmt.Errorf("%w: engagement id is required", shared.ErrValidation)
 	}
@@ -111,13 +126,24 @@ func (c *Coordinator) Scan(ctx context.Context, engagementID shared.ID, targetRe
 		// same class at one function (e.g. DB.Query + DB.Exec, both CWE-89) produce a byte-identical claim
 		// (Location is the function, not the specific sink call), so they are the SAME finding and must be
 		// proposed once. This also matches flowSubjectID's per-class key (no duplicate subjects/seals).
-		seen := map[string]bool{}
+		byClass := map[string][]taint.Sink{}
 		for _, sink := range sinkClass[v.Sink] {
 			classKey := sink.CWE + "|" + sink.Rule
-			if seen[classKey] {
-				continue
+			byClass[classKey] = append(byClass[classKey], sink)
+		}
+		classKeys := make([]string, 0, len(byClass))
+		for classKey := range byClass {
+			classKeys = append(classKeys, classKey)
+		}
+		sort.Strings(classKeys)
+		for _, classKey := range classKeys {
+			classSinks := byClass[classKey]
+			sort.Slice(classSinks, func(i, j int) bool { return classSinks[i].Symbol < classSinks[j].Symbol })
+			sinkSymbols := make([]string, 0, len(classSinks))
+			for _, sink := range classSinks {
+				sinkSymbols = append(sinkSymbols, sink.Symbol)
 			}
-			seen[classKey] = true
+			sink := classSinks[0]
 			// Location prefers the sink-using function's "relpath:line" (def-use precision, from the SSA
 			// build's Positions side table) so the finding cites a file:line like the pattern engine, not
 			// only a symbol. It is a coarse, function-granular over-approximation — the function's
@@ -128,8 +154,11 @@ func (c *Coordinator) Scan(ctx context.Context, engagementID shared.ID, targetRe
 			if sinkPos != "" {
 				loc = sinkPos
 			}
-			claim := judgment.SASTClaim{CWE: sink.CWE, Location: loc, Rule: sink.Rule}
-			j, err := c.proposer.Propose(ctx, proposerActor, engagementID, judgment.CapSAST, judgment.SubjectDataFlow, flowSubjectID(engagementID, v, sink), claim)
+			claim := judgment.SASTClaim{
+				CWE: sink.CWE, Location: loc, Rule: sink.Rule, SinkSymbols: sinkSymbols,
+				Correlations: correlateSASTFindings(symbolcanon.Go, sinkSymbols, subjects),
+			}
+			j, err := c.proposer.Propose(ctx, proposerActor, engagementID, judgment.CapSAST, judgment.SubjectDataFlow, flowSubjectID(engagementID, v, sinkSymbols, sink), claim)
 			if err != nil {
 				return proposed, fmt.Errorf("propose taint judgment: %w", err)
 			}
@@ -147,8 +176,8 @@ func (c *Coordinator) Scan(ctx context.Context, engagementID shared.ID, targetRe
 // engagement. Keyed on source/sink importPath.Symbol + CWE + Rule (the fields that distinguish a claim) –
 // never file contents (mirrors sca.findingID's derivation). Cross-scan idempotency additionally depends on
 // the judgment store, as with reachproof.
-func flowSubjectID(engagementID shared.ID, v taint.TaintPath, sink taint.Sink) shared.ID {
-	sum := sha256.Sum256([]byte(engagementID.String() + "|taint|" + v.Source + "|" + v.Sink + "|" + sink.CWE + "|" + sink.Rule))
+func flowSubjectID(engagementID shared.ID, v taint.TaintPath, sinkSymbols []string, sink taint.Sink) shared.ID {
+	sum := sha256.Sum256([]byte(engagementID.String() + "|taint|" + v.Source + "|" + v.Sink + "|" + strings.Join(sinkSymbols, ",") + "|" + sink.CWE + "|" + sink.Rule))
 	return shared.ID(hex.EncodeToString(sum[:16]))
 }
 

--- a/internal/usecase/taintscan/coordinator_test.go
+++ b/internal/usecase/taintscan/coordinator_test.go
@@ -278,6 +278,42 @@ func TestScanSameClassSinkDedup(t *testing.T) {
 	}
 }
 
+func TestScanCorrelatedLinksReachedVulnerableSymbolToSCAFinding(t *testing.T) {
+	b := &fakeBuilder{g: &callgraph.Graph{Edges: []callgraph.Edge{
+		{Caller: "app.handler", Callees: []string{"os.Getenv", "os/exec.Command"}},
+	}}}
+	p := &fakeProposer{}
+	outcome, err := newCoord(t, b, p, &fakeAudit{}).ScanCorrelated(context.Background(), engID, "/work/target", []ports.ReachabilitySubject{
+		{FindingID: "finding-command", Symbols: []string{"os/exec.Command"}},
+		{FindingID: "finding-other", Symbols: []string{"database/sql.DB.Query"}},
+	})
+	if err != nil || outcome.Proposed != 1 || len(p.calls) != 1 {
+		t.Fatalf("want one correlated proposal, got outcome=%+v calls=%d err=%v", outcome, len(p.calls), err)
+	}
+	claim := p.calls[0].claim.(judgment.SASTClaim)
+	if len(claim.SinkSymbols) != 1 || claim.SinkSymbols[0] != "os/exec.Command" {
+		t.Fatalf("claim must retain the reached library sink, got %+v", claim.SinkSymbols)
+	}
+	if len(claim.Correlations) != 1 || claim.Correlations[0].FindingID != "finding-command" {
+		t.Fatalf("taint flow must link only the matching SCA finding, got %+v", claim.Correlations)
+	}
+}
+
+func TestScanCorrelatedLeavesUnmatchedFlowUnlinked(t *testing.T) {
+	b := &fakeBuilder{g: &callgraph.Graph{Edges: []callgraph.Edge{
+		{Caller: "app.handler", Callees: []string{"os.Getenv", "os/exec.Command"}},
+	}}}
+	p := &fakeProposer{}
+	if _, err := newCoord(t, b, p, &fakeAudit{}).ScanCorrelated(context.Background(), engID, "/work/target", []ports.ReachabilitySubject{
+		{FindingID: "finding-local", Symbols: []string{"app.Command"}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := p.calls[0].claim.(judgment.SASTClaim).Correlations; len(got) != 0 {
+		t.Fatalf("non-advisory sink must not fabricate a finding link: %+v", got)
+	}
+}
+
 // A no-coverage build error proposes NOTHING and never a false "clean" (fail-closed).
 func TestScanNoCoverageProposesNothing(t *testing.T) {
 	b := &fakeBuilder{err: errors.New("module cache offline")}

--- a/internal/usecase/taintscan/correlation.go
+++ b/internal/usecase/taintscan/correlation.go
@@ -1,0 +1,79 @@
+package taintscan
+
+import (
+	"sort"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/symbolcanon"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+// correlateSASTFindings joins a reached taint sink to an SCA finding only when the sink symbol and an
+// advisory affected symbol canonically match as a whole symbol. It is deliberately stricter than the
+// raise-only tail matching used by some reachability engines: a dataflow link is promotion input, so a
+// same-named local/helper function must never be attributed to an advisory.
+//
+// ReachabilitySubject already carries the per-finding, version-correct affected-symbol set produced by the
+// SCA pipeline. The result is sorted and duplicate-free so the Claim survives rescans without churn.
+func correlateSASTFindings(language symbolcanon.Language, sinkSymbols []string, subjects []ports.ReachabilitySubject) []judgment.SASTFindingCorrelation {
+	if len(sinkSymbols) == 0 || len(subjects) == 0 {
+		return nil
+	}
+
+	type candidate struct {
+		link      judgment.SASTFindingCorrelation
+		canonical string
+	}
+	links := make([]candidate, 0)
+	for _, sink := range sinkSymbols {
+		canonicalSink := symbolcanon.Canonicalize(language, sink)
+		// A bare leaf such as "Parse" cannot safely identify a library function. Require the immediate
+		// owner/module too, and refuse a binary name that was not demangled at extraction time.
+		if symbolcanon.LooksMangled(sink) || len(canonicalSink.Segments) < 2 {
+			continue
+		}
+		for _, subject := range subjects {
+			if subject.FindingID.IsZero() {
+				continue
+			}
+			for _, affected := range subject.Symbols {
+				canonicalAffected := symbolcanon.Canonicalize(language, affected)
+				if symbolcanon.LooksMangled(affected) || len(canonicalAffected.Segments) < 2 || !symbolcanon.Equal(canonicalSink, canonicalAffected) {
+					continue
+				}
+				links = append(links, candidate{
+					link:      judgment.SASTFindingCorrelation{FindingID: subject.FindingID, SinkSymbol: sink, AffectedSymbol: affected},
+					canonical: canonicalAffected.String(),
+				})
+			}
+		}
+	}
+	if len(links) == 0 {
+		return nil
+	}
+	sort.Slice(links, func(i, j int) bool {
+		left, right := links[i], links[j]
+		if left.link.FindingID != right.link.FindingID {
+			return left.link.FindingID < right.link.FindingID
+		}
+		if left.link.SinkSymbol != right.link.SinkSymbol {
+			return left.link.SinkSymbol < right.link.SinkSymbol
+		}
+		if left.canonical != right.canonical {
+			return left.canonical < right.canonical
+		}
+		return left.link.AffectedSymbol < right.link.AffectedSymbol
+	})
+
+	seen := make(map[string]struct{}, len(links))
+	out := make([]judgment.SASTFindingCorrelation, 0, len(links))
+	for _, item := range links {
+		key := item.link.FindingID.String() + "\x00" + item.link.SinkSymbol + "\x00" + item.canonical
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, item.link)
+	}
+	return out
+}

--- a/internal/usecase/taintscan/correlation_test.go
+++ b/internal/usecase/taintscan/correlation_test.go
@@ -1,0 +1,41 @@
+package taintscan
+
+import (
+	"testing"
+
+	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/symbolcanon"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
+)
+
+func TestCorrelateSASTFindingsMatchesOnlyWholeCanonicalSymbols(t *testing.T) {
+	subjects := []ports.ReachabilitySubject{
+		{FindingID: "z-unrelated", Symbols: []string{"example.com/other.Parser.Parse"}},
+		{FindingID: "b-match", Symbols: []string{"example.com/lib.(*Parser).Parse[string]"}},
+		{FindingID: "a-match", Symbols: []string{"example.com/lib.Parser.Parse"}},
+		{FindingID: "bare-leaf", Symbols: []string{"Parse"}},
+	}
+	links := correlateSASTFindings(symbolcanon.Go, []string{"example.com/lib.Parser.Parse"}, subjects)
+	if len(links) != 2 {
+		t.Fatalf("want two exact advisory matches, got %+v", links)
+	}
+	if links[0].FindingID != "a-match" || links[1].FindingID != "b-match" {
+		t.Fatalf("links must be sorted by finding id, got %+v", links)
+	}
+	if links[0].SinkSymbol != "example.com/lib.Parser.Parse" || links[0].AffectedSymbol != "example.com/lib.Parser.Parse" {
+		t.Fatalf("link must preserve the exact matched symbols, got %+v", links[0])
+	}
+	if got := (judgment.SASTClaim{Correlations: links}).CorrelatedFindingIDs(); len(got) != 2 || got[0] != shared.ID("a-match") || got[1] != shared.ID("b-match") {
+		t.Fatalf("correlated ids = %v, want [a-match b-match]", got)
+	}
+}
+
+func TestCorrelateSASTFindingsNeverFabricatesLinkForSameNamedLocal(t *testing.T) {
+	links := correlateSASTFindings(symbolcanon.Go, []string{"app.Parse"}, []ports.ReachabilitySubject{{
+		FindingID: "finding-1", Symbols: []string{"example.com/lib.Parser.Parse", "Parse"},
+	}})
+	if len(links) != 0 {
+		t.Fatalf("a same-named local or bare leaf must not link to an advisory: %+v", links)
+	}
+}

--- a/internal/usecase/taintscan/java_coordinator.go
+++ b/internal/usecase/taintscan/java_coordinator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/javaprogram"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/symbolcanon"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/taint"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
@@ -38,6 +39,7 @@ type JavaCoordinator struct {
 
 var _ ports.TaintScanner = (*JavaCoordinator)(nil)
 var _ ports.TaintCoverageScanner = (*JavaCoordinator)(nil)
+var _ ports.CorrelatedTaintScanner = (*JavaCoordinator)(nil)
 
 func NewJavaCoordinator(provider ports.JavaFactsProvider, p proposer, catalog taint.JavaCatalog, audit ports.AuditLogger, clock ports.Clock) (*JavaCoordinator, error) {
 	if provider == nil || p == nil || audit == nil || clock == nil {
@@ -59,6 +61,16 @@ func (c *JavaCoordinator) Scan(ctx context.Context, engagementID shared.ID, targ
 // ScanWithCoverage is the coverage-aware form of Scan. Failures retain a closed, non-sensitive reason so a
 // caller can tell zero findings from zero analysis without exposing parser or target data.
 func (c *JavaCoordinator) ScanWithCoverage(ctx context.Context, engagementID shared.ID, targetRef string) (ports.TaintScanOutcome, error) {
+	return c.scanWithCoverage(ctx, engagementID, targetRef, nil)
+}
+
+// ScanCorrelated is the finding-aware form of ScanWithCoverage. It records only whole-symbol matches to
+// existing SCA findings, leaving unmatched taint paths as their original gated SAST proposals.
+func (c *JavaCoordinator) ScanCorrelated(ctx context.Context, engagementID shared.ID, targetRef string, subjects []ports.ReachabilitySubject) (ports.TaintScanOutcome, error) {
+	return c.scanWithCoverage(ctx, engagementID, targetRef, subjects)
+}
+
+func (c *JavaCoordinator) scanWithCoverage(ctx context.Context, engagementID shared.ID, targetRef string, subjects []ports.ReachabilitySubject) (ports.TaintScanOutcome, error) {
 	outcome := ports.TaintScanOutcome{Coverage: ports.AnalysisCoverage{
 		Analyzer: "java-semantic-taint-v1", Language: "java", Status: ports.AnalysisCoverageUnavailable,
 	}}
@@ -139,7 +151,8 @@ func (c *JavaCoordinator) ScanWithCoverage(ctx context.Context, engagementID sha
 		location := boundedJavaLocation(javaPositionLineString(finding.SinkPos), finding.Callee)
 		claim := judgment.SASTClaim{
 			CWE: finding.CWE, Location: location, Rule: finding.Rule,
-			DataFlow: javaClaimDataFlow(finding, graph, analysisComplete),
+			DataFlow: javaClaimDataFlow(finding, graph, analysisComplete), SinkSymbols: []string{finding.Callee},
+			Correlations: correlateSASTFindings(symbolcanon.Generic, []string{finding.Callee}, subjects),
 		}
 		judged, err := c.proposer.Propose(
 			ctx, javaProposerActor, engagementID, judgment.CapSAST, judgment.SubjectDataFlow,

--- a/internal/usecase/taintscan/js_coordinator.go
+++ b/internal/usecase/taintscan/js_coordinator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/jsprogram"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/symbolcanon"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/taint"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
@@ -38,6 +39,7 @@ type JsCoordinator struct {
 
 var _ ports.TaintScanner = (*JsCoordinator)(nil)
 var _ ports.TaintCoverageScanner = (*JsCoordinator)(nil)
+var _ ports.CorrelatedTaintScanner = (*JsCoordinator)(nil)
 
 func NewJsCoordinator(provider ports.JsFactsProvider, p proposer, catalog taint.JsCatalog, audit ports.AuditLogger, clock ports.Clock) (*JsCoordinator, error) {
 	if provider == nil || p == nil || audit == nil || clock == nil {
@@ -59,6 +61,16 @@ func (c *JsCoordinator) Scan(ctx context.Context, engagementID shared.ID, target
 // ScanWithCoverage is the coverage-aware form of Scan. Failures retain a closed, non-sensitive reason so a
 // caller can tell zero findings from zero analysis without exposing parser or target data.
 func (c *JsCoordinator) ScanWithCoverage(ctx context.Context, engagementID shared.ID, targetRef string) (ports.TaintScanOutcome, error) {
+	return c.scanWithCoverage(ctx, engagementID, targetRef, nil)
+}
+
+// ScanCorrelated is the finding-aware form of ScanWithCoverage. It only records exact symbol links;
+// absence of a link never changes the positive/raise-only taint result.
+func (c *JsCoordinator) ScanCorrelated(ctx context.Context, engagementID shared.ID, targetRef string, subjects []ports.ReachabilitySubject) (ports.TaintScanOutcome, error) {
+	return c.scanWithCoverage(ctx, engagementID, targetRef, subjects)
+}
+
+func (c *JsCoordinator) scanWithCoverage(ctx context.Context, engagementID shared.ID, targetRef string, subjects []ports.ReachabilitySubject) (ports.TaintScanOutcome, error) {
 	outcome := ports.TaintScanOutcome{Coverage: ports.AnalysisCoverage{
 		Analyzer: "js-semantic-taint-v1", Language: "javascript", Status: ports.AnalysisCoverageUnavailable,
 	}}
@@ -139,7 +151,8 @@ func (c *JsCoordinator) ScanWithCoverage(ctx context.Context, engagementID share
 		location := boundedJsLocation(jsPositionLineString(finding.SinkPos), finding.Callee)
 		claim := judgment.SASTClaim{
 			CWE: finding.CWE, Location: location, Rule: finding.Rule,
-			DataFlow: jsClaimDataFlow(finding, graph, analysisComplete),
+			DataFlow: jsClaimDataFlow(finding, graph, analysisComplete), SinkSymbols: []string{finding.Callee},
+			Correlations: correlateSASTFindings(symbolcanon.Generic, []string{finding.Callee}, subjects),
 		}
 		judged, err := c.proposer.Propose(
 			ctx, jsProposerActor, engagementID, judgment.CapSAST, judgment.SubjectDataFlow,

--- a/internal/usecase/taintscan/python_coordinator.go
+++ b/internal/usecase/taintscan/python_coordinator.go
@@ -13,6 +13,7 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/judgment"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/pythonprogram"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/shared"
+	"github.com/KKloudTarus/synapse-ce/internal/domain/symbolcanon"
 	"github.com/KKloudTarus/synapse-ce/internal/domain/taint"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/ports"
 )
@@ -42,6 +43,7 @@ type PythonCoordinator struct {
 
 var _ ports.TaintScanner = (*PythonCoordinator)(nil)
 var _ ports.TaintCoverageScanner = (*PythonCoordinator)(nil)
+var _ ports.CorrelatedTaintScanner = (*PythonCoordinator)(nil)
 
 func NewPythonCoordinator(provider ports.PythonFactsProvider, p proposer, catalog taint.PythonCatalog, audit ports.AuditLogger, clock ports.Clock) (*PythonCoordinator, error) {
 	if provider == nil || p == nil || audit == nil || clock == nil {
@@ -64,6 +66,16 @@ func (c *PythonCoordinator) Scan(ctx context.Context, engagementID shared.ID, ta
 // ScanWithCoverage is the coverage-aware form of Scan. Failures retain a closed, non-sensitive reason
 // so callers can distinguish zero findings from zero analysis without exposing parser or target data.
 func (c *PythonCoordinator) ScanWithCoverage(ctx context.Context, engagementID shared.ID, targetRef string) (ports.TaintScanOutcome, error) {
+	return c.scanWithCoverage(ctx, engagementID, targetRef, nil)
+}
+
+// ScanCorrelated is the finding-aware form of ScanWithCoverage. Correlation is additive evidence only:
+// unmatched flows remain ordinary gated CapSAST proposals and never imply a clean SCA finding.
+func (c *PythonCoordinator) ScanCorrelated(ctx context.Context, engagementID shared.ID, targetRef string, subjects []ports.ReachabilitySubject) (ports.TaintScanOutcome, error) {
+	return c.scanWithCoverage(ctx, engagementID, targetRef, subjects)
+}
+
+func (c *PythonCoordinator) scanWithCoverage(ctx context.Context, engagementID shared.ID, targetRef string, subjects []ports.ReachabilitySubject) (ports.TaintScanOutcome, error) {
 	outcome := ports.TaintScanOutcome{Coverage: ports.AnalysisCoverage{
 		Analyzer: "python-semantic-taint-v1", Language: "python", Status: ports.AnalysisCoverageUnavailable,
 	}}
@@ -149,7 +161,8 @@ func (c *PythonCoordinator) ScanWithCoverage(ctx context.Context, engagementID s
 		location := boundedPythonLocation(positionLineString(finding.SinkPos), finding.Callee)
 		claim := judgment.SASTClaim{
 			CWE: finding.CWE, Location: location, Rule: finding.Rule,
-			DataFlow: pythonClaimDataFlow(finding, graph, analysisComplete),
+			DataFlow: pythonClaimDataFlow(finding, graph, analysisComplete), SinkSymbols: []string{finding.Callee},
+			Correlations: correlateSASTFindings(symbolcanon.Generic, []string{finding.Callee}, subjects),
 		}
 		judged, err := c.proposer.Propose(
 			ctx, pythonProposerActor, engagementID, judgment.CapSAST, judgment.SubjectDataFlow,


### PR DESCRIPTION
## Summary

Implements deterministic taint-flow to SCA-finding correlation.

- Adds bounded, auditable `SASTFindingCorrelation` evidence to `SASTClaim`.
- Wires version-correct SCA symbols into Go, Python, JavaScript, and Java taint scanners.
- Links only whole canonical symbol matches; no fabricated link for bare/mangled/local same-named functions.
- Keeps behavior raise-only: no promotion, suppression, or severity change here.

Closes #1050

## Validation

- `go test ./internal/...`
- `go vet ./internal/domain/judgment ./internal/usecase/taintscan ./internal/usecase/sca`
- `git diff --check`