### PR TITLE
feat(reach): add gated OSS reachability benchmark

### DIFF
--- a/.github/workflows/reachability-benchmark.yml
+++ b/.github/workflows/reachability-benchmark.yml
@@ -1,0 +1,80 @@
+# Reachability scorecard (EPIC #1042 / #1049). The corpus and external runners are pinned so a PR cannot
+# improve a score by changing the tool, omitting an analysis record, or comparing a different denominator.
+name: Reachability Benchmark
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  go-oss-baselines:
+    name: Go corpus vs OSV-Scanner and Semgrep CE
+    runs-on: ubuntu-latest
+    env:
+      # Reviewed external-tool pins. Updating either pin requires reviewing the resulting artifact diff.
+      OSV_SCANNER_VERSION: v2.4.0
+      SEMGREP_VERSION: 1.176.0
+      REACHBENCH_DIR: internal/infrastructure/tools/ssacallgraph/testdata/reachbench
+      REACHBENCH_REPORT_DIR: ${{ runner.temp }}/reachbench
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+
+      - name: Install pinned OSS baselines
+        run: |
+          go install github.com/google/osv-scanner/v2/cmd/osv-scanner@${OSV_SCANNER_VERSION}
+          python -m pip install --disable-pip-version-check semgrep==${SEMGREP_VERSION}
+
+      - name: Run OSV-Scanner Go call analysis
+        run: |
+          mkdir -p "${REACHBENCH_REPORT_DIR}"
+          set +e
+          "$(go env GOPATH)/bin/osv-scanner" scan source --recursive --format json --call-analysis=go "${REACHBENCH_DIR}" > "${REACHBENCH_REPORT_DIR}/osv.raw.json"
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ] && [ "$status" -ne 1 ]; then
+            echo "OSV-Scanner failed with unexpected status $status"
+            exit "$status"
+          fi
+          go run ./cmd/synapse-bench -mode reachability-osv -input "${REACHBENCH_REPORT_DIR}/osv.raw.json" -output "${REACHBENCH_REPORT_DIR}/osv-scanner.json"
+
+      - name: Run Semgrep CE direct-call baseline
+        run: |
+          set +e
+          semgrep scan --config internal/usecase/reachbench/corpus/semgrep-ce.yml --json --no-git-ignore "${REACHBENCH_DIR}" > "${REACHBENCH_REPORT_DIR}/semgrep.raw.json"
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ] && [ "$status" -ne 1 ]; then
+            echo "Semgrep CE failed with unexpected status $status"
+            exit "$status"
+          fi
+          go run ./cmd/synapse-bench -mode reachability-semgrep-ce -input "${REACHBENCH_REPORT_DIR}/semgrep.raw.json" -output "${REACHBENCH_REPORT_DIR}/semgrep-ce.json"
+
+      - name: Gate owned engine recall and parity
+        env:
+          SYNAPSE_REACHBENCH_OWNED_REPORT: ${{ runner.temp }}/reachbench/synapse-owned.json
+          SYNAPSE_REACHBENCH_BASELINE_REPORTS: ${{ runner.temp }}/reachbench/osv-scanner.json,${{ runner.temp }}/reachbench/semgrep-ce.json
+        run: go test -count=1 -v -run TestGoReachabilityCorpus ./internal/infrastructure/tools/ssacallgraph
+
+      - name: Upload raw evidence and scorecards
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: reachability-benchmark-go-scorecards
+          path: ${{ runner.temp }}/reachbench
+          if-no-files-found: warn

--- a/cmd/synapse-bench/main.go
+++ b/cmd/synapse-bench/main.go
@@ -13,12 +13,13 @@ import (
 	"github.com/KKloudTarus/synapse-ce/internal/domain/vulnerability"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/benchmark"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/enginecompare"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachbench"
 )
 
 func main() {
 	inputPath := flag.String("input", "", "versioned benchmark input JSON")
 	outputPath := flag.String("output", "", "output benchmark report JSON (default: stdout)")
-	mode := flag.String("mode", "throughput", "reduction mode: throughput (latency/throughput), accuracy (detection precision/recall), or compare (owned-vs-competitor finding differential)")
+	mode := flag.String("mode", "throughput", "reduction mode: throughput, accuracy, reachability, reachability-osv, reachability-semgrep-ce, reachability-snyk-sample, or compare")
 	flag.Parse()
 	if flag.NArg() != 0 {
 		fmt.Fprintln(os.Stderr, "synapse-bench: positional arguments are not supported")
@@ -66,6 +67,49 @@ func run(mode, inputPath, outputPath string, stdin io.Reader, stdout io.Writer) 
 			return fmt.Errorf("evaluate accuracy input: %w", err)
 		}
 		encode = func(w io.Writer) error { return benchmark.EncodeAccuracyReport(w, report) }
+	case "reachability":
+		// A fixture runner (owned engine or an OSS baseline adapter) supplies complete labelled observations
+		// against a versioned corpus. This command reduces only that evidence; it never executes a scanner
+		// or contacts a service, which keeps scorecards reproducible and safe to compare in CI.
+		input, err := reachbench.DecodeInput(inputReader)
+		if err != nil {
+			return err
+		}
+		report, err := reachbench.EvaluateInput(input)
+		if err != nil {
+			return fmt.Errorf("evaluate reachability input: %w", err)
+		}
+		encode = func(w io.Writer) error { return reachbench.EncodeReport(w, report) }
+	case "reachability-osv":
+		observations, err := reachbench.OSVObservations(reachbench.DefaultCorpus(), inputReader)
+		if err != nil {
+			return err
+		}
+		report, err := reachbench.Evaluate(reachbench.DefaultCorpus(), observations)
+		if err != nil {
+			return fmt.Errorf("evaluate OSV-Scanner reachability baseline: %w", err)
+		}
+		encode = func(w io.Writer) error { return reachbench.EncodeReport(w, report) }
+	case "reachability-semgrep-ce":
+		observations, err := reachbench.SemgrepCEObservations(reachbench.DefaultCorpus(), inputReader)
+		if err != nil {
+			return err
+		}
+		report, err := reachbench.Evaluate(reachbench.DefaultCorpus(), observations)
+		if err != nil {
+			return fmt.Errorf("evaluate Semgrep CE reachability baseline: %w", err)
+		}
+		encode = func(w io.Writer) error { return reachbench.EncodeReport(w, report) }
+	case "reachability-snyk-sample":
+		observations, err := reachbench.SnykSampleObservations(reachbench.DefaultCorpus(), inputReader)
+		if err != nil {
+			return err
+		}
+		report, err := reachbench.Evaluate(reachbench.DefaultCorpus(), observations)
+		if err != nil {
+			return fmt.Errorf("evaluate Snyk sample reachability baseline: %w", err)
+		}
+		encode = func(w io.Writer) error { return reachbench.EncodeReport(w, report) }
 	case "compare":
 		// Reduce two engines' finding sets (owned candidate vs a competitor baseline, e.g. Grype) over the
 		// same target into an honest differential: what the owned engine found that the baseline missed, and
@@ -116,7 +160,7 @@ func run(mode, inputPath, outputPath string, stdin io.Reader, stdout io.Writer) 
 			return enc.Encode(report)
 		}
 	default:
-		return fmt.Errorf("unknown mode %q (want throughput, accuracy or compare)", mode)
+		return fmt.Errorf("unknown mode %q (want throughput, accuracy, reachability, reachability-osv, reachability-semgrep-ce, reachability-snyk-sample or compare)", mode)
 	}
 
 	outputWriter := stdout

--- a/cmd/synapse-bench/main_test.go
+++ b/cmd/synapse-bench/main_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/benchmark"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/enginecompare"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachbench"
 )
 
 func TestRunWritesDeterministicJSON(t *testing.T) {
@@ -54,6 +55,64 @@ func TestRunAccuracyMode(t *testing.T) {
 	// TP=2 (both CVE-1, CVE-2), FP=1 (CVE-9), FN=0: recall 1.0, precision 2/3.
 	if report.Overall.TruePositives != 2 || report.Overall.FalsePositives != 1 || report.Overall.Recall != 1 {
 		t.Fatalf("overall = %+v", report.Overall)
+	}
+}
+
+// TestRunReachabilityMode gives owned-engine and OSS-adapter runners the same deterministic reduction
+// contract: a scorecard is accepted only when every checked-in corpus case has an explicit label.
+func TestRunReachabilityMode(t *testing.T) {
+	input := `{"schema_version":"synapse-reachability-input-v1","corpus":{"schema_version":"synapse-reachability-corpus-v1","cases":[` +
+		`{"name":"go-hit","language":"go","fixture":"fixture","symbol":"fixture.hit","expected":"reachable"},` +
+		`{"name":"go-miss","language":"go","fixture":"fixture","symbol":"fixture.miss","expected":"present_unreached"}]},` +
+		`"observations":[{"case":"go-hit","label":"reachable"},{"case":"go-miss","label":"present_unreached"}]}`
+	var stdout bytes.Buffer
+	if err := run("reachability", "", "", strings.NewReader(input), &stdout); err != nil {
+		t.Fatal(err)
+	}
+	report, err := reachbench.LoadReport(&stdout)
+	if err != nil {
+		t.Fatalf("LoadReport: %v", err)
+	}
+	if report.SchemaVersion != reachbench.ReportSchemaVersion || report.Cases != 2 || report.Languages[0].PositiveRecall != 1 {
+		t.Fatalf("report = %+v", report)
+	}
+}
+
+func TestRunExternalReachabilityBaselineModes(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		mode  string
+		input string
+	}{
+		{
+			name:  "osv",
+			mode:  "reachability-osv",
+			input: `{"results":[{"source":{"path":"go_osv_jsonparser_called/go.mod"},"packages":[{"groups":[{"experimentalAnalysis":{"GO-2026-4514":{"called":true}}}]}]},{"source":{"path":"go_osv_jsonparser_uncalled/go.mod"},"packages":[{"groups":[{"experimentalAnalysis":{"GO-2026-4514":{"called":false}}}]}]}]}`,
+		},
+		{
+			name:  "semgrep",
+			mode:  "reachability-semgrep-ce",
+			input: `{"results":[{"check_id":"reachbench.go.jsonparser-delete-called","path":"go_osv_jsonparser_called/main.go"}]}`,
+		},
+		{
+			name:  "snyk sample",
+			mode:  "reachability-snyk-sample",
+			input: `{"observations":[{"evidence_id":"GO-2026-4514-called","label":"reachable"},{"evidence_id":"GO-2026-4514-uncalled","label":"present_unreached"}]}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			if err := run(tc.mode, "", "", strings.NewReader(tc.input), &stdout); err != nil {
+				t.Fatal(err)
+			}
+			report, err := reachbench.LoadReport(&stdout)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if report.Cases != len(reachbench.DefaultCorpus().Cases) || report.SchemaVersion != reachbench.ReportSchemaVersion {
+				t.Fatalf("report = %+v", report)
+			}
+		})
 	}
 }
 

--- a/docs/guide/reachability-benchmark-runbook.md
+++ b/docs/guide/reachability-benchmark-runbook.md
@@ -1,0 +1,57 @@
+# Reachability benchmark runbook
+
+This runbook is the EPIC #1042 / issue #1049 evidence procedure. Its guardrail is simple: a baseline
+comparison is valid only when every scorecard carries the same `corpus_digest`; an absent observation is
+`no_analysis`, never an uncalled function.
+
+## Automated Go scorecard
+
+The `Reachability Benchmark` workflow runs these checked-in controls.
+
+| Control | Ground truth | Synapse query | OSV-Scanner | Semgrep CE |
+| --- | --- | --- | --- | --- |
+| `go_osv_jsonparser_delete_called` | `reachable` | SSA call graph | `GO-2026-4514` call analysis | direct `jsonparser.Delete` rule |
+| `go_osv_jsonparser_delete_uncalled` | `present_unreached` | SSA call graph | `GO-2026-4514` uncalled analysis | clean result for the same rule |
+
+The advisory is pinned by its vulnerable module version (`github.com/buger/jsonparser@v1.1.1`); its affected
+public `Delete` function is recorded by `GO-2026-4514`. The corpus also has small owned-engine controls, for
+which an OSS baseline honestly reports `no_analysis`.
+
+The workflow pins OSV-Scanner and Semgrep CE, writes their raw JSON, normalizes it through
+`synapse-bench`, and then runs the owned graph test. The test fails when any of these conditions holds:
+
+- the Go recall floor in `internal/usecase/reachbench/corpus/floors.json` is missed;
+- the candidate report omits a baseline language;
+- candidate positive-reachability recall or precision is below either baseline;
+- a baseline and candidate are scored against different corpus digests.
+
+Do not lower a floor to make a PR green. Add a labelled regression case, fix the engine, then raise or retain
+the reviewed floor. An external-tool version bump requires reviewing the uploaded raw output and normalized
+scorecard before changing a pin.
+
+## Sampled Snyk comparison
+
+Snyk remains a sampled manual comparison because its reachable-vulnerability evidence is account and product
+entitlement dependent. A reviewer performs the following for every corpus refresh:
+
+1. Scan the two Go fixture modules with the approved Snyk organization and export the JSON evidence.
+2. Record whether the affected function is reached for evidence IDs `GO-2026-4514-called` and
+   `GO-2026-4514-uncalled`; retain the original JSON as the review artifact.
+3. Save the reviewed labels as `{"observations":[{"evidence_id":"GO-2026-4514-called","label":"reachable"}, ...]}`.
+   Convert it with `synapse-bench -mode reachability-snyk-sample` and attach the resulting report beside the
+   original output.
+4. Verify its `corpus_digest` matches `synapse-owned.json`, then compare precision and recall with the
+   same parity rule used by the workflow. Any disagreement is recorded as a corpus review, not silently
+   treated as a Synapse win.
+
+The Snyk artifact must contain no credentials, customer source, or finding identifiers beyond the fixture.
+It is review evidence rather than an automatic merge requirement; OSV-Scanner and Semgrep CE are the
+reproducible CI gates.
+
+## Adding a language
+
+Add labelled called, uncalled, conditional, and no-analysis fixtures only when the language engine has a
+deterministic adapter. Give every external baseline selector a stable tool identifier and a fixture-relative
+path, add parser tests for its raw output, and add a language-specific ratchet only after a reviewed initial
+scorecard exists. This is deliberately additive: a missing capability remains `no_analysis` and cannot be
+mistaken for a safe negative.

--- a/internal/infrastructure/tools/ssacallgraph/reachability_integration_test.go
+++ b/internal/infrastructure/tools/ssacallgraph/reachability_integration_test.go
@@ -2,10 +2,14 @@ package ssacallgraph
 
 import (
 	"context"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	domaincg "github.com/KKloudTarus/synapse-ce/internal/domain/callgraph"
 	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachability"
+	"github.com/KKloudTarus/synapse-ce/internal/usecase/reachbench"
 )
 
 // ownedReachBuilder adapts the in-process owned go/ssa builder to ports.CallGraphBuilder. The server runs the
@@ -49,5 +53,86 @@ func unreached() {}
 	}
 	if got := byName["cgfixture.unreached"]; got.Reachable {
 		t.Errorf("cgfixture.unreached is never called and must not be reachable, got %+v", got)
+	}
+}
+
+// TestGoReachabilityCorpus makes the checked-in Go fixtures a CI-gated recall contract for the owned
+// reachability engine. The generic reachbench reducer owns score semantics; this adapter owns only the
+// concrete analyzer invocation and exact-symbol lookup, so future language engines can add their own
+// adapters without changing the benchmark's math or label vocabulary.
+func TestGoReachabilityCorpus(t *testing.T) {
+	corpus := reachbench.DefaultCorpus()
+	goCases := make([]reachbench.Case, 0)
+	for _, item := range corpus.Cases {
+		if item.Language == "go" {
+			goCases = append(goCases, item)
+		}
+	}
+	if len(goCases) == 0 {
+		t.Fatal("reachability corpus must retain at least one Go fixture")
+	}
+	corpus.Cases = goCases
+
+	svc, err := reachability.NewService(ownedReachBuilder{})
+	if err != nil {
+		t.Fatalf("new service: %v", err)
+	}
+	observations := make([]reachbench.Observation, 0, len(corpus.Cases))
+	for _, item := range corpus.Cases {
+		dir := filepath.Join("testdata", "reachbench", item.Fixture)
+		analysis, err := svc.Analyze(context.Background(), dir, []string{item.Symbol})
+		if err != nil {
+			t.Fatalf("analyze corpus case %q: %v", item.Name, err)
+		}
+		if len(analysis.Results) != 1 || analysis.Results[0].Symbol != item.Symbol {
+			t.Fatalf("corpus case %q returned wrong result set: %+v", item.Name, analysis.Results)
+		}
+		label := reachbench.PresentUnreached
+		if analysis.Results[0].Reachable {
+			label = reachbench.Reachable
+		}
+		t.Logf("reachbench case=%s symbol=%s observed=%s", item.Name, item.Symbol, label)
+		observations = append(observations, reachbench.Observation{Case: item.Name, Label: label})
+	}
+	report, err := reachbench.Evaluate(corpus, observations)
+	if err != nil {
+		t.Fatalf("score Go reachability corpus: %v", err)
+	}
+	for _, score := range report.Languages {
+		t.Logf("reachbench %-10s: cases=%d exact=%d exact_accuracy=%.3f positive_precision=%.3f positive_recall=%.3f false_positive_reachable=%d", score.Language, score.Cases, score.Exact, score.ExactAccuracy, score.PositivePrecision, score.PositiveRecall, score.FalsePositiveRise)
+	}
+	if output := strings.TrimSpace(os.Getenv("SYNAPSE_REACHBENCH_OWNED_REPORT")); output != "" {
+		file, err := os.Create(output)
+		if err != nil {
+			t.Fatalf("create owned reachability report: %v", err)
+		}
+		if err := reachbench.EncodeReport(file, report); err != nil {
+			_ = file.Close()
+			t.Fatalf("encode owned reachability report: %v", err)
+		}
+		if err := file.Close(); err != nil {
+			t.Fatalf("close owned reachability report: %v", err)
+		}
+	}
+	for _, path := range strings.Split(os.Getenv("SYNAPSE_REACHBENCH_BASELINE_REPORTS"), ",") {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			continue
+		}
+		file, err := os.Open(path)
+		if err != nil {
+			t.Fatalf("open reachability baseline report %q: %v", path, err)
+		}
+		baseline, loadErr := reachbench.LoadReport(file)
+		_ = file.Close()
+		if loadErr != nil {
+			t.Fatalf("load reachability baseline report %q: %v", path, loadErr)
+		}
+		if breaches := reachbench.CheckBaselineParity(report, baseline); len(breaches) > 0 {
+			t.Fatalf("owned reachability is below baseline %q: %v", path, breaches)
+		}
+	}
+	if breaches := reachbench.CheckRatchet(report, reachbench.DefaultFloors()); len(breaches) > 0 {
+		t.Fatalf("Go reachability recall ratchet regressed: %v", breaches)
 	}
 }

--- a/internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_direct_call/go.mod
+++ b/internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_direct_call/go.mod
@@ -1,0 +1,3 @@
+module reachfixture
+
+go 1.27.0

--- a/internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_direct_call/main.go
+++ b/internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_direct_call/main.go
@@ -1,0 +1,6 @@
+package main
+
+func main() { reached() }
+
+func reached()   {}
+func unreached() {}

--- a/internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_osv_jsonparser_called/go.mod
+++ b/internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_osv_jsonparser_called/go.mod
@@ -1,0 +1,5 @@
+module github.com/ossf-tests/synapse-reachbench-jsonparser-called
+
+go 1.27.0
+
+require github.com/buger/jsonparser v1.1.1

--- a/internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_osv_jsonparser_called/go.sum
+++ b/internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_osv_jsonparser_called/go.sum
@@ -1,0 +1,2 @@
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=

--- a/internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_osv_jsonparser_called/main.go
+++ b/internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_osv_jsonparser_called/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/buger/jsonparser"
+
+func main() {
+	_ = jsonparser.Delete([]byte(`{"property":"value"}`), "property")
+}

--- a/internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_osv_jsonparser_uncalled/go.mod
+++ b/internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_osv_jsonparser_uncalled/go.mod
@@ -1,0 +1,5 @@
+module github.com/ossf-tests/synapse-reachbench-jsonparser-uncalled
+
+go 1.27.0
+
+require github.com/buger/jsonparser v1.1.1

--- a/internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_osv_jsonparser_uncalled/go.sum
+++ b/internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_osv_jsonparser_uncalled/go.sum
@@ -1,0 +1,2 @@
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=

--- a/internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_osv_jsonparser_uncalled/main.go
+++ b/internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_osv_jsonparser_uncalled/main.go
@@ -1,0 +1,9 @@
+package main
+
+import "github.com/buger/jsonparser"
+
+var deleteFunction = jsonparser.Delete
+
+func main() {
+	_ = deleteFunction
+}

--- a/internal/usecase/reachbench/baselines.go
+++ b/internal/usecase/reachbench/baselines.go
@@ -1,0 +1,230 @@
+package reachbench
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// OSVObservations converts OSV-Scanner's documented JSON call-analysis output into a complete corpus
+// observation set. A missing experimentalAnalysis entry means the tool did not analyse that advisory and is
+// represented as no_analysis; it is never reinterpreted as an uncalled vulnerable function.
+func OSVObservations(c Corpus, r io.Reader) ([]Observation, error) {
+	if err := validateCorpus(c); err != nil {
+		return nil, err
+	}
+	type source struct {
+		Path string `json:"path"`
+	}
+	type key struct {
+		AdvisoryID string
+		SourcePath string
+	}
+	var output struct {
+		Results []struct {
+			Source   source `json:"source"`
+			Packages []struct {
+				Groups []struct {
+					IDs                  []string `json:"ids"`
+					ExperimentalAnalysis map[string]struct {
+						Called *bool `json:"called"`
+					} `json:"experimentalAnalysis"`
+					ExperimentalAnalysisSnake map[string]struct {
+						Called *bool `json:"called"`
+					} `json:"experimental_analysis"`
+				} `json:"groups"`
+			} `json:"packages"`
+		} `json:"results"`
+	}
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read OSV-Scanner reachability output: %w", err)
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("decode OSV-Scanner reachability output: %w", err)
+	}
+	if _, ok := envelope["results"]; !ok {
+		return nil, fmt.Errorf("OSV-Scanner reachability output is missing results")
+	}
+	if err := json.Unmarshal(body, &output); err != nil {
+		return nil, fmt.Errorf("decode OSV-Scanner reachability output: %w", err)
+	}
+	called := map[key]bool{}
+	known := map[key]bool{}
+	for _, result := range output.Results {
+		for _, pkg := range result.Packages {
+			for _, group := range pkg.Groups {
+				analyses := []map[string]struct {
+					Called *bool `json:"called"`
+				}{
+					group.ExperimentalAnalysis,
+					group.ExperimentalAnalysisSnake,
+				}
+				for _, analysisMap := range analyses {
+					for id, analysis := range analysisMap {
+						if analysis.Called == nil {
+							continue
+						}
+						itemKey := key{AdvisoryID: id, SourcePath: strings.TrimPrefix(outputPath(result.Source.Path), "./")}
+						if _, exists := known[itemKey]; exists && called[itemKey] != *analysis.Called {
+							return nil, fmt.Errorf("OSV-Scanner output has contradictory call analysis for %q in %q (%t and %t)", id, itemKey.SourcePath, called[itemKey], *analysis.Called)
+						}
+						known[itemKey] = true
+						called[itemKey] = *analysis.Called
+					}
+				}
+			}
+		}
+	}
+	observations := make([]Observation, 0, len(c.Cases))
+	for _, item := range c.Cases {
+		label := NoAnalysis
+		if selector := item.Baseline.OSV; selector != nil {
+			seenAnalysis := false
+			for _, id := range selector.AdvisoryIDs {
+				for itemKey, isCalled := range called {
+					if itemKey.AdvisoryID != id || !strings.HasSuffix(itemKey.SourcePath, selector.SourceSuffix) {
+						continue
+					}
+					seenAnalysis = true
+					if isCalled {
+						label = Reachable
+						break
+					}
+				}
+				if label == Reachable {
+					break
+				}
+			}
+			if label != Reachable && seenAnalysis {
+				label = PresentUnreached
+			}
+		}
+		observations = append(observations, Observation{Case: item.Name, Label: label})
+	}
+	return observations, nil
+}
+
+func outputPath(path string) string { return strings.ReplaceAll(path, `\`, "/") }
+
+// SemgrepCEObservations converts Semgrep CE's native JSON or SARIF result shape. Semgrep CE's baseline is
+// an explicit, checked-in rule per corpus case; a matching rule result is reachable and a clean result for
+// that exact rule/path pair is present_unreached. Cases without a Semgrep selector remain no_analysis.
+func SemgrepCEObservations(c Corpus, r io.Reader) ([]Observation, error) {
+	if err := validateCorpus(c); err != nil {
+		return nil, err
+	}
+	body, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("read Semgrep CE reachability output: %w", err)
+	}
+	type result struct {
+		RuleID string
+		Path   string
+	}
+	var native struct {
+		Results []struct {
+			CheckID string `json:"check_id"`
+			Path    string `json:"path"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(body, &native); err != nil {
+		return nil, fmt.Errorf("decode Semgrep CE reachability output: %w", err)
+	}
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(body, &envelope); err != nil {
+		return nil, fmt.Errorf("decode Semgrep CE reachability output: %w", err)
+	}
+	_, hasNative := envelope["results"]
+	_, hasSARIF := envelope["runs"]
+	if !hasNative && !hasSARIF {
+		return nil, fmt.Errorf("Semgrep CE reachability output is neither native JSON nor SARIF")
+	}
+	results := make([]result, 0, len(native.Results))
+	for _, item := range native.Results {
+		results = append(results, result{RuleID: item.CheckID, Path: item.Path})
+	}
+	var sarif struct {
+		Runs []struct {
+			Results []struct {
+				RuleID    string `json:"ruleId"`
+				Locations []struct {
+					PhysicalLocation struct {
+						ArtifactLocation struct {
+							URI string `json:"uri"`
+						} `json:"artifactLocation"`
+					} `json:"physicalLocation"`
+				} `json:"locations"`
+			} `json:"results"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(body, &sarif); err != nil {
+		return nil, fmt.Errorf("decode Semgrep CE SARIF reachability output: %w", err)
+	}
+	for _, run := range sarif.Runs {
+		for _, item := range run.Results {
+			path := ""
+			if len(item.Locations) > 0 {
+				path = item.Locations[0].PhysicalLocation.ArtifactLocation.URI
+			}
+			results = append(results, result{RuleID: item.RuleID, Path: path})
+		}
+	}
+	observations := make([]Observation, 0, len(c.Cases))
+	for _, item := range c.Cases {
+		label := NoAnalysis
+		if selector := item.Baseline.SemgrepCE; selector != nil {
+			label = PresentUnreached
+			for _, result := range results {
+				if result.RuleID == selector.RuleID && strings.HasSuffix(strings.TrimPrefix(result.Path, "./"), selector.PathSuffix) {
+					label = Reachable
+					break
+				}
+			}
+		}
+		observations = append(observations, Observation{Case: item.Name, Label: label})
+	}
+	return observations, nil
+}
+
+// SnykSampleObservations reduces a human-reviewed Snyk sample without embedding credentials, organization
+// identifiers, or a vendor-specific API contract in the repository. Each observation cites the stable
+// evidence_id declared by the corpus; missing evidence is no_analysis and duplicate evidence is rejected.
+func SnykSampleObservations(c Corpus, r io.Reader) ([]Observation, error) {
+	if err := validateCorpus(c); err != nil {
+		return nil, err
+	}
+	var input struct {
+		Observations []struct {
+			EvidenceID string `json:"evidence_id"`
+			Label      Label  `json:"label"`
+		} `json:"observations"`
+	}
+	if err := decodeStrict(r, &input, "Snyk sample reachability input"); err != nil {
+		return nil, err
+	}
+	byEvidence := make(map[string]Label, len(input.Observations))
+	for _, item := range input.Observations {
+		id := strings.TrimSpace(item.EvidenceID)
+		if id == "" || !item.Label.valid() {
+			return nil, fmt.Errorf("Snyk sample has invalid evidence observation")
+		}
+		if _, duplicate := byEvidence[id]; duplicate {
+			return nil, fmt.Errorf("Snyk sample duplicates evidence id %q", id)
+		}
+		byEvidence[id] = item.Label
+	}
+	observations := make([]Observation, 0, len(c.Cases))
+	for _, item := range c.Cases {
+		label := NoAnalysis
+		if selector := item.Baseline.SnykSample; selector != nil {
+			if observed, ok := byEvidence[selector.EvidenceID]; ok {
+				label = observed
+			}
+		}
+		observations = append(observations, Observation{Case: item.Name, Label: label})
+	}
+	return observations, nil
+}

--- a/internal/usecase/reachbench/baselines_test.go
+++ b/internal/usecase/reachbench/baselines_test.go
@@ -1,0 +1,87 @@
+package reachbench
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestOSVObservationsPreserveFixtureScopedCalledAndUncalledControls(t *testing.T) {
+	observations, err := OSVObservations(DefaultCorpus(), strings.NewReader(`{
+		"results":[
+			{"source":{"path":"/work/go_osv_jsonparser_called/go.mod"},"packages":[{"groups":[{"ids":["GO-2026-4514"],"experimentalAnalysis":{"GO-2026-4514":{"called":true}}}]}]},
+			{"source":{"path":"/work/go_osv_jsonparser_uncalled/go.mod"},"packages":[{"groups":[{"ids":["GO-2026-4514"],"experimental_analysis":{"GO-2026-4514":{"called":false}}}]}]}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("OSVObservations: %v", err)
+	}
+	got := observationLabels(observations)
+	if got["go_osv_jsonparser_delete_called"] != Reachable || got["go_osv_jsonparser_delete_uncalled"] != PresentUnreached {
+		t.Fatalf("OSV labels = %v", got)
+	}
+	if got["go_direct_call_reachable"] != NoAnalysis {
+		t.Fatalf("unmapped case must stay no_analysis, got %v", got)
+	}
+}
+
+func TestOSVObservationsRejectContradictionWithinOneFixture(t *testing.T) {
+	_, err := OSVObservations(DefaultCorpus(), strings.NewReader(`{
+		"results":[
+			{"source":{"path":"go_osv_jsonparser_called/go.mod"},"packages":[{"groups":[{"experimentalAnalysis":{"GO-2026-4514":{"called":true}}}]}]},
+			{"source":{"path":"go_osv_jsonparser_called/go.mod"},"packages":[{"groups":[{"experimentalAnalysis":{"GO-2026-4514":{"called":false}}}]}]}
+		]
+	}`))
+	if err == nil || !strings.Contains(err.Error(), "contradictory") {
+		t.Fatalf("contradictory fixture output error = %v", err)
+	}
+}
+
+func TestSemgrepCEObservationsMapNativeAndSARIFResults(t *testing.T) {
+	native, err := SemgrepCEObservations(DefaultCorpus(), strings.NewReader(`{
+		"results":[{"check_id":"reachbench.go.jsonparser-delete-called","path":"internal/infrastructure/tools/ssacallgraph/testdata/reachbench/go_osv_jsonparser_called/main.go"}]
+	}`))
+	if err != nil {
+		t.Fatalf("native Semgrep: %v", err)
+	}
+	got := observationLabels(native)
+	if got["go_osv_jsonparser_delete_called"] != Reachable || got["go_osv_jsonparser_delete_uncalled"] != PresentUnreached || got["go_direct_call_reachable"] != NoAnalysis {
+		t.Fatalf("native Semgrep labels = %v", got)
+	}
+
+	sarif, err := SemgrepCEObservations(DefaultCorpus(), strings.NewReader(`{
+		"runs":[{"results":[{"ruleId":"reachbench.go.jsonparser-delete-called","locations":[{"physicalLocation":{"artifactLocation":{"uri":"go_osv_jsonparser_called/main.go"}}}]}]}]
+	}`))
+	if err != nil {
+		t.Fatalf("SARIF Semgrep: %v", err)
+	}
+	if got := observationLabels(sarif); got["go_osv_jsonparser_delete_called"] != Reachable {
+		t.Fatalf("SARIF Semgrep labels = %v", got)
+	}
+}
+
+func TestSnykSampleObservationsAreExplicitAndComplete(t *testing.T) {
+	observations, err := SnykSampleObservations(DefaultCorpus(), strings.NewReader(`{
+		"observations":[
+			{"evidence_id":"GO-2026-4514-called","label":"reachable"},
+			{"evidence_id":"GO-2026-4514-uncalled","label":"present_unreached"}
+		]
+	}`))
+	if err != nil {
+		t.Fatalf("SnykSampleObservations: %v", err)
+	}
+	got := observationLabels(observations)
+	if got["go_osv_jsonparser_delete_called"] != Reachable || got["go_osv_jsonparser_delete_uncalled"] != PresentUnreached || got["go_direct_call_reachable"] != NoAnalysis {
+		t.Fatalf("Snyk sample labels = %v", got)
+	}
+	if _, err := SnykSampleObservations(DefaultCorpus(), strings.NewReader(`{"observations":[{"evidence_id":"GO-2026-4514-called","label":"reachable"},{"evidence_id":"GO-2026-4514-called","label":"reachable"}]}`)); err == nil {
+		t.Fatal("Snyk sample must reject duplicate evidence rather than collapse it")
+	}
+}
+
+func observationLabels(observations []Observation) map[string]Label {
+	got := make(map[string]Label, len(observations))
+	for _, item := range observations {
+		got[item.Case] = item.Label
+	}
+	return got
+}

--- a/internal/usecase/reachbench/corpus/floors.json
+++ b/internal/usecase/reachbench/corpus/floors.json
@@ -1,0 +1,5 @@
+{
+  "positive_recall": {
+    "go": 1
+  }
+}

--- a/internal/usecase/reachbench/corpus/reachability.json
+++ b/internal/usecase/reachbench/corpus/reachability.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": "synapse-reachability-corpus-v1",
+  "cases": [
+    {
+      "name": "go_direct_call_reachable",
+      "language": "go",
+      "fixture": "go_direct_call",
+      "symbol": "reachfixture.reached",
+      "expected": "reachable"
+    },
+    {
+      "name": "go_unreached_function",
+      "language": "go",
+      "fixture": "go_direct_call",
+      "symbol": "reachfixture.unreached",
+      "expected": "present_unreached"
+    },
+    {
+      "name": "go_osv_jsonparser_delete_called",
+      "language": "go",
+      "fixture": "go_osv_jsonparser_called",
+      "symbol": "github.com/buger/jsonparser.Delete",
+      "expected": "reachable",
+      "baseline": {
+        "osv": {"advisory_ids": ["GO-2026-4514"], "source_suffix": "go_osv_jsonparser_called/go.mod"},
+        "semgrep_ce": {"rule_id": "reachbench.go.jsonparser-delete-called", "path_suffix": "go_osv_jsonparser_called/main.go"},
+        "snyk_sample": {"evidence_id": "GO-2026-4514-called"}
+      }
+    },
+    {
+      "name": "go_osv_jsonparser_delete_uncalled",
+      "language": "go",
+      "fixture": "go_osv_jsonparser_uncalled",
+      "symbol": "github.com/buger/jsonparser.Delete",
+      "expected": "present_unreached",
+      "baseline": {
+        "osv": {"advisory_ids": ["GO-2026-4514"], "source_suffix": "go_osv_jsonparser_uncalled/go.mod"},
+        "semgrep_ce": {"rule_id": "reachbench.go.jsonparser-delete-called", "path_suffix": "go_osv_jsonparser_uncalled/main.go"},
+        "snyk_sample": {"evidence_id": "GO-2026-4514-uncalled"}
+      }
+    }
+  ]
+}

--- a/internal/usecase/reachbench/corpus/semgrep-ce.yml
+++ b/internal/usecase/reachbench/corpus/semgrep-ce.yml
@@ -1,0 +1,9 @@
+# Semgrep CE baseline for the reachability corpus. These are deliberately narrow, inspectable rules: CE can
+# prove the direct call site but cannot reproduce OSV's advisory-aware interprocedural analysis. The report
+# records that exact capability rather than calling a clean scan a proof of absence.
+rules:
+  - id: reachbench.go.jsonparser-delete-called
+    languages: [go]
+    severity: INFO
+    message: direct call to the GO-2026-4514 affected API
+    pattern: jsonparser.Delete(...)

--- a/internal/usecase/reachbench/score.go
+++ b/internal/usecase/reachbench/score.go
@@ -1,0 +1,472 @@
+// Package reachbench defines the deterministic reachability accuracy corpus contract and its recall
+// ratchet. It deliberately measures the public, derived labels rather than a particular analyzer tier, so
+// Go, JVM, JavaScript, Python, and future engines can be compared without relabeling their evidence.
+package reachbench
+
+import (
+	"bytes"
+	"crypto/sha256"
+	_ "embed"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+const (
+	CorpusSchemaVersion = "synapse-reachability-corpus-v1"
+	InputSchemaVersion  = "synapse-reachability-input-v1"
+	ReportSchemaVersion = "synapse-reachability-report-v1"
+)
+
+// Label is the closed, user-visible reachability vocabulary. The labels are derived evidence labels: they
+// do not change the domain verdict enum and therefore do not pre-empt the A-CORE coverage-model work.
+type Label string
+
+const (
+	Reachable              Label = "reachable"
+	ConditionallyReachable Label = "conditionally_reachable"
+	PresentUnreached       Label = "present_unreached"
+	NoAnalysis             Label = "no_analysis"
+)
+
+func (l Label) valid() bool {
+	switch l {
+	case Reachable, ConditionallyReachable, PresentUnreached, NoAnalysis:
+		return true
+	}
+	return false
+}
+
+// Case is one labeled query against a fixture. Fixture is a repository-relative fixture id; Symbol is the
+// exact canonical symbol queried. Keeping symbols explicit prevents a benchmark runner from quietly
+// selecting a convenient symbol after an analyzer changes.
+type Case struct {
+	Name     string       `json:"name"`
+	Language string       `json:"language"`
+	Fixture  string       `json:"fixture"`
+	Symbol   string       `json:"symbol"`
+	Expected Label        `json:"expected"`
+	Baseline BaselineCase `json:"baseline,omitempty"`
+}
+
+// BaselineCase binds one corpus case to the stable identifiers emitted by the external tools. Empty
+// selectors are intentional: a baseline that has no corresponding analysis must report no_analysis, not
+// silently drop the case from its denominator.
+type BaselineCase struct {
+	OSV        *OSVSelector     `json:"osv,omitempty"`
+	SemgrepCE  *SemgrepSelector `json:"semgrep_ce,omitempty"`
+	SnykSample *SnykSelector    `json:"snyk_sample,omitempty"`
+}
+
+type OSVSelector struct {
+	AdvisoryIDs  []string `json:"advisory_ids"`
+	SourceSuffix string   `json:"source_suffix"`
+}
+
+type SemgrepSelector struct {
+	RuleID     string `json:"rule_id"`
+	PathSuffix string `json:"path_suffix"`
+}
+
+// SnykSelector is deliberately a stable manual-sample locator, not a credential or API token. The sampled
+// Snyk runbook produces the same reachbench report format after a human records this evidence id.
+type SnykSelector struct {
+	EvidenceID string `json:"evidence_id"`
+}
+
+// Corpus is one versioned, auditable set of reachability cases.
+type Corpus struct {
+	SchemaVersion string `json:"schema_version"`
+	Cases         []Case `json:"cases"`
+}
+
+// Observation is one engine result for a case. Every corpus case must receive exactly one result; an engine
+// cannot omit a difficult case and improve its measured recall.
+type Observation struct {
+	Case  string `json:"case"`
+	Label Label  `json:"label"`
+}
+
+// Input is the portable hand-off between a fixture runner and the deterministic scorer. An adapter for an
+// owned engine or an OSS baseline records its observations against the same embedded-or-checked-in corpus,
+// then synapse-bench reduces the input without running either tool itself.
+type Input struct {
+	SchemaVersion string        `json:"schema_version"`
+	Corpus        Corpus        `json:"corpus"`
+	Observations  []Observation `json:"observations"`
+}
+
+// LanguageScore reports exact-label accuracy plus the positive-reachability precision and recall. Conditional
+// reachability is positive too: treating it as absent is a false negative for prioritisation. Precision is
+// equally important for the baseline comparison: a candidate cannot buy recall by labelling every case
+// reachable.
+type LanguageScore struct {
+	Language          string  `json:"language"`
+	Cases             int     `json:"cases"`
+	Exact             int     `json:"exact"`
+	ExactAccuracy     float64 `json:"exact_accuracy"`
+	PositiveExpected  int     `json:"positive_expected"`
+	PositiveFound     int     `json:"positive_found"`
+	PositiveProduced  int     `json:"positive_produced"`
+	PositivePrecision float64 `json:"positive_precision"`
+	PositiveRecall    float64 `json:"positive_recall"`
+	FalsePositiveRise int     `json:"false_positive_reachable"`
+}
+
+// Report is a stable per-language scorecard. Results are sorted by language for diff-friendly CI output.
+type Report struct {
+	SchemaVersion string          `json:"schema_version"`
+	CorpusDigest  string          `json:"corpus_digest"`
+	Cases         int             `json:"cases"`
+	Languages     []LanguageScore `json:"languages"`
+}
+
+// Floors is the monotonic ratchet. A language absent from PositiveRecall is reported but not yet gated,
+// allowing a new engine to land its corpus before maintainers calibrate a reviewed floor.
+type Floors struct {
+	PositiveRecall map[string]float64 `json:"positive_recall"`
+}
+
+//go:embed corpus/reachability.json
+var defaultCorpusJSON []byte
+
+//go:embed corpus/floors.json
+var defaultFloorsJSON []byte
+
+// DefaultCorpus returns the checked-in corpus. It panics only for a repository-authoring error: tests call
+// LoadCorpus directly when they need an error instead of a programming-contract failure.
+func DefaultCorpus() Corpus {
+	c, err := LoadCorpus(bytes.NewReader(defaultCorpusJSON))
+	if err != nil {
+		panic("reachbench: embedded corpus is invalid: " + err.Error())
+	}
+	return c
+}
+
+// DefaultFloors returns the checked-in recall ratchet.
+func DefaultFloors() Floors {
+	f, err := LoadFloors(bytes.NewReader(defaultFloorsJSON))
+	if err != nil {
+		panic("reachbench: embedded floors are invalid: " + err.Error())
+	}
+	return f
+}
+
+// LoadCorpus decodes exactly one strict corpus document and validates its closed vocabulary.
+func LoadCorpus(r io.Reader) (Corpus, error) {
+	var c Corpus
+	if err := decodeStrict(r, &c, "reachability corpus"); err != nil {
+		return Corpus{}, err
+	}
+	if err := validateCorpus(c); err != nil {
+		return Corpus{}, err
+	}
+	sort.Slice(c.Cases, func(i, j int) bool { return c.Cases[i].Name < c.Cases[j].Name })
+	return c, nil
+}
+
+// DecodeInput decodes exactly one strict fixture-runner input. It validates the nested corpus before any
+// observations are scored, so callers that construct JSON rather than using DefaultCorpus get the same
+// closed vocabulary and duplicate-case protections.
+func DecodeInput(r io.Reader) (Input, error) {
+	var input Input
+	if err := decodeStrict(r, &input, "reachability input"); err != nil {
+		return Input{}, err
+	}
+	if input.SchemaVersion != InputSchemaVersion {
+		return Input{}, fmt.Errorf("unsupported reachability input schema version %q", input.SchemaVersion)
+	}
+	if err := validateCorpus(input.Corpus); err != nil {
+		return Input{}, err
+	}
+	return input, nil
+}
+
+// EvaluateInput reduces a validated fixture-runner hand-off into its scorecard.
+func EvaluateInput(input Input) (Report, error) {
+	if input.SchemaVersion != InputSchemaVersion {
+		return Report{}, fmt.Errorf("unsupported reachability input schema version %q", input.SchemaVersion)
+	}
+	if err := validateCorpus(input.Corpus); err != nil {
+		return Report{}, err
+	}
+	return Evaluate(input.Corpus, input.Observations)
+}
+
+func validateCorpus(c Corpus) error {
+	if c.SchemaVersion != CorpusSchemaVersion {
+		return fmt.Errorf("unsupported reachability corpus schema version %q", c.SchemaVersion)
+	}
+	if len(c.Cases) == 0 {
+		return fmt.Errorf("reachability corpus has no cases")
+	}
+	seen := make(map[string]struct{}, len(c.Cases))
+	for i, item := range c.Cases {
+		if strings.TrimSpace(item.Name) == "" || strings.TrimSpace(item.Language) == "" || strings.TrimSpace(item.Fixture) == "" || strings.TrimSpace(item.Symbol) == "" {
+			return fmt.Errorf("reachability corpus case %d requires name, language, fixture, and symbol", i)
+		}
+		if item.Name != strings.TrimSpace(item.Name) || item.Language != strings.TrimSpace(item.Language) || item.Fixture != strings.TrimSpace(item.Fixture) || item.Symbol != strings.TrimSpace(item.Symbol) {
+			return fmt.Errorf("reachability corpus case %q has surrounding whitespace", item.Name)
+		}
+		if !item.Expected.valid() {
+			return fmt.Errorf("reachability corpus case %q has unknown expected label %q", item.Name, item.Expected)
+		}
+		if err := validateBaselineCase(item.Name, item.Baseline); err != nil {
+			return err
+		}
+		if _, duplicate := seen[item.Name]; duplicate {
+			return fmt.Errorf("duplicate reachability corpus case %q", item.Name)
+		}
+		seen[item.Name] = struct{}{}
+	}
+	return nil
+}
+
+func validateBaselineCase(name string, baseline BaselineCase) error {
+	if selector := baseline.OSV; selector != nil {
+		if len(selector.AdvisoryIDs) == 0 || strings.TrimSpace(selector.SourceSuffix) == "" {
+			return fmt.Errorf("reachability corpus case %q has an incomplete OSV selector", name)
+		}
+		seen := map[string]bool{}
+		for _, id := range selector.AdvisoryIDs {
+			id = strings.TrimSpace(id)
+			if id == "" || seen[id] {
+				return fmt.Errorf("reachability corpus case %q has an invalid OSV advisory id", name)
+			}
+			seen[id] = true
+		}
+	}
+	if selector := baseline.SemgrepCE; selector != nil && (strings.TrimSpace(selector.RuleID) == "" || strings.TrimSpace(selector.PathSuffix) == "") {
+		return fmt.Errorf("reachability corpus case %q has an incomplete Semgrep CE selector", name)
+	}
+	if selector := baseline.SnykSample; selector != nil && strings.TrimSpace(selector.EvidenceID) == "" {
+		return fmt.Errorf("reachability corpus case %q has an empty Snyk sample evidence id", name)
+	}
+	return nil
+}
+
+// LoadFloors decodes the strict ratchet document and refuses values outside the closed rate interval.
+func LoadFloors(r io.Reader) (Floors, error) {
+	var f Floors
+	if err := decodeStrict(r, &f, "reachability floors"); err != nil {
+		return Floors{}, err
+	}
+	for language, value := range f.PositiveRecall {
+		if strings.TrimSpace(language) == "" || language != strings.TrimSpace(language) || value < 0 || value > 1 {
+			return Floors{}, fmt.Errorf("invalid reachability recall floor for %q", language)
+		}
+	}
+	return f, nil
+}
+
+// Evaluate validates a complete observation set and reduces it to per-language accuracy. It is pure: engine
+// adapters own fixture execution while this package owns the corpus vocabulary and score semantics.
+func Evaluate(c Corpus, observations []Observation) (Report, error) {
+	if err := validateCorpus(c); err != nil {
+		return Report{}, err
+	}
+	byCase := make(map[string]Case, len(c.Cases))
+	for _, item := range c.Cases {
+		byCase[item.Name] = item
+	}
+	seen := make(map[string]struct{}, len(observations))
+	type aggregate struct{ LanguageScore }
+	groups := map[string]*aggregate{}
+	for i, observation := range observations {
+		item, known := byCase[observation.Case]
+		if !known {
+			return Report{}, fmt.Errorf("observation %d references unknown corpus case %q", i, observation.Case)
+		}
+		if !observation.Label.valid() {
+			return Report{}, fmt.Errorf("observation %q has unknown label %q", observation.Case, observation.Label)
+		}
+		if _, duplicate := seen[observation.Case]; duplicate {
+			return Report{}, fmt.Errorf("duplicate reachability observation %q", observation.Case)
+		}
+		seen[observation.Case] = struct{}{}
+		group := groups[item.Language]
+		if group == nil {
+			group = &aggregate{LanguageScore: LanguageScore{Language: item.Language}}
+			groups[item.Language] = group
+		}
+		group.Cases++
+		if observation.Label == item.Expected {
+			group.Exact++
+		}
+		if positive(item.Expected) {
+			group.PositiveExpected++
+			if positive(observation.Label) {
+				group.PositiveFound++
+			}
+		}
+		if positive(observation.Label) {
+			group.PositiveProduced++
+			if !positive(item.Expected) {
+				group.FalsePositiveRise++
+			}
+		}
+	}
+	if len(seen) != len(c.Cases) {
+		missing := make([]string, 0, len(c.Cases)-len(seen))
+		for _, item := range c.Cases {
+			if _, ok := seen[item.Name]; !ok {
+				missing = append(missing, item.Name)
+			}
+		}
+		sort.Strings(missing)
+		return Report{}, fmt.Errorf("reachability observations omit corpus cases: %s", strings.Join(missing, ", "))
+	}
+	digest, err := corpusDigest(c)
+	if err != nil {
+		return Report{}, err
+	}
+	report := Report{SchemaVersion: ReportSchemaVersion, CorpusDigest: digest, Cases: len(c.Cases), Languages: make([]LanguageScore, 0, len(groups))}
+	for _, group := range groups {
+		group.ExactAccuracy = float64(group.Exact) / float64(group.Cases)
+		if group.PositiveExpected == 0 {
+			group.PositiveRecall = 1
+		} else {
+			group.PositiveRecall = float64(group.PositiveFound) / float64(group.PositiveExpected)
+		}
+		if group.PositiveProduced == 0 {
+			group.PositivePrecision = 1
+		} else {
+			group.PositivePrecision = float64(group.PositiveFound) / float64(group.PositiveProduced)
+		}
+		report.Languages = append(report.Languages, group.LanguageScore)
+	}
+	sort.Slice(report.Languages, func(i, j int) bool { return report.Languages[i].Language < report.Languages[j].Language })
+	return report, nil
+}
+
+// CheckRatchet reports every recall regression in deterministic order. Floors only rise in review; code must
+// never silently lower a threshold when a new fixture exposes a miss.
+func CheckRatchet(report Report, floors Floors) []string {
+	var breaches []string
+	for _, score := range report.Languages {
+		if floor, ok := floors.PositiveRecall[score.Language]; ok && score.PositiveRecall < floor {
+			breaches = append(breaches, fmt.Sprintf("%s positive reachability recall %.3f is below ratchet floor %.3f", score.Language, score.PositiveRecall, floor))
+		}
+	}
+	sort.Strings(breaches)
+	return breaches
+}
+
+// CheckBaselineParity reports a candidate engine that falls below a recorded baseline's positive-reachability
+// precision or recall for any language. It refuses a comparison against a different corpus. A missing
+// candidate language is a breach rather than an omitted comparison, so a removed adapter cannot silently
+// improve a scorecard.
+func CheckBaselineParity(candidate, baseline Report) []string {
+	if candidate.CorpusDigest == "" || baseline.CorpusDigest == "" || candidate.CorpusDigest != baseline.CorpusDigest {
+		return []string{"candidate and baseline reports use different or unbound reachability corpora"}
+	}
+	candidateByLanguage := make(map[string]LanguageScore, len(candidate.Languages))
+	for _, score := range candidate.Languages {
+		candidateByLanguage[score.Language] = score
+	}
+	var breaches []string
+	for _, base := range baseline.Languages {
+		got, ok := candidateByLanguage[base.Language]
+		if !ok {
+			breaches = append(breaches, fmt.Sprintf("candidate report omits baseline language %s", base.Language))
+			continue
+		}
+		if got.PositiveRecall < base.PositiveRecall {
+			breaches = append(breaches, fmt.Sprintf("%s positive reachability recall %.3f is below baseline %.3f", base.Language, got.PositiveRecall, base.PositiveRecall))
+		}
+		if got.PositivePrecision < base.PositivePrecision {
+			breaches = append(breaches, fmt.Sprintf("%s positive reachability precision %.3f is below baseline %.3f", base.Language, got.PositivePrecision, base.PositivePrecision))
+		}
+	}
+	sort.Strings(breaches)
+	return breaches
+}
+
+// EncodeReport writes one stable, indented report suitable for a checked-in baseline artifact or CI upload.
+func EncodeReport(w io.Writer, report Report) error {
+	encoder := json.NewEncoder(w)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(report); err != nil {
+		return fmt.Errorf("encode reachability report: %w", err)
+	}
+	return nil
+}
+
+// LoadReport decodes a stored candidate or OSS-baseline report without allowing extra fields or concatenated
+// JSON. It verifies the report has the schema and corpus binding required for a meaningful parity check;
+// detailed metrics remain the adapter's reproducible evidence and are compared by CheckBaselineParity.
+func LoadReport(r io.Reader) (Report, error) {
+	var report Report
+	if err := decodeStrict(r, &report, "reachability report"); err != nil {
+		return Report{}, err
+	}
+	if report.SchemaVersion != ReportSchemaVersion {
+		return Report{}, fmt.Errorf("unsupported reachability report schema version %q", report.SchemaVersion)
+	}
+	if len(report.CorpusDigest) != sha256.Size*2 {
+		return Report{}, fmt.Errorf("reachability report has invalid corpus digest")
+	}
+	if _, err := hex.DecodeString(report.CorpusDigest); err != nil {
+		return Report{}, fmt.Errorf("reachability report has invalid corpus digest: %w", err)
+	}
+	if report.Cases <= 0 || len(report.Languages) == 0 {
+		return Report{}, fmt.Errorf("reachability report has no scored cases")
+	}
+	seen := make(map[string]struct{}, len(report.Languages))
+	total := 0
+	for _, score := range report.Languages {
+		if strings.TrimSpace(score.Language) == "" || score.Language != strings.TrimSpace(score.Language) {
+			return Report{}, fmt.Errorf("reachability report has invalid language")
+		}
+		if _, duplicate := seen[score.Language]; duplicate {
+			return Report{}, fmt.Errorf("duplicate reachability report language %q", score.Language)
+		}
+		seen[score.Language] = struct{}{}
+		if score.Cases <= 0 || score.Exact < 0 || score.Exact > score.Cases || score.PositiveExpected < 0 || score.PositiveExpected > score.Cases || score.PositiveFound < 0 || score.PositiveFound > score.PositiveExpected || score.PositiveProduced < 0 || score.PositiveProduced > score.Cases || score.PositiveFound > score.PositiveProduced || score.FalsePositiveRise < 0 || score.FalsePositiveRise > score.Cases || score.ExactAccuracy < 0 || score.ExactAccuracy > 1 || score.PositivePrecision < 0 || score.PositivePrecision > 1 || score.PositiveRecall < 0 || score.PositiveRecall > 1 {
+			return Report{}, fmt.Errorf("reachability report has invalid score for %q", score.Language)
+		}
+		total += score.Cases
+	}
+	if total != report.Cases {
+		return Report{}, fmt.Errorf("reachability report case count %d does not equal language total %d", report.Cases, total)
+	}
+	sort.Slice(report.Languages, func(i, j int) bool { return report.Languages[i].Language < report.Languages[j].Language })
+	return report, nil
+}
+
+func decodeStrict(r io.Reader, target any, name string) error {
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(target); err != nil {
+		return fmt.Errorf("decode %s: %w", name, err)
+	}
+	var extra any
+	if err := dec.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return fmt.Errorf("decode %s: multiple JSON values", name)
+		}
+		return fmt.Errorf("decode %s trailing data: %w", name, err)
+	}
+	return nil
+}
+
+func positive(label Label) bool {
+	return label == Reachable || label == ConditionallyReachable
+}
+
+// corpusDigest binds every scorecard and stored baseline to the exact, sorted corpus it measured. Comparing
+// a result against a different corpus can make a lower denominator look like higher recall, so it is a
+// fail-closed comparison error rather than a best-effort warning.
+func corpusDigest(c Corpus) (string, error) {
+	canonical := Corpus{SchemaVersion: c.SchemaVersion, Cases: append([]Case(nil), c.Cases...)}
+	sort.Slice(canonical.Cases, func(i, j int) bool { return canonical.Cases[i].Name < canonical.Cases[j].Name })
+	raw, err := json.Marshal(canonical)
+	if err != nil {
+		return "", fmt.Errorf("encode reachability corpus digest: %w", err)
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}

--- a/internal/usecase/reachbench/score_test.go
+++ b/internal/usecase/reachbench/score_test.go
@@ -1,0 +1,113 @@
+package reachbench
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestEvaluateScoresExactLabelsAndPositiveRecall(t *testing.T) {
+	corpus := Corpus{SchemaVersion: CorpusSchemaVersion, Cases: []Case{
+		{Name: "go-hit", Language: "go", Fixture: "go-hit", Symbol: "fixture.hit", Expected: Reachable},
+		{Name: "go-miss", Language: "go", Fixture: "go-miss", Symbol: "fixture.miss", Expected: PresentUnreached},
+		{Name: "js-conditional", Language: "javascript", Fixture: "js", Symbol: "pkg.fn", Expected: ConditionallyReachable},
+		{Name: "js-unsupported", Language: "javascript", Fixture: "js", Symbol: "pkg.other", Expected: NoAnalysis},
+	}}
+	report, err := Evaluate(corpus, []Observation{
+		{Case: "go-hit", Label: Reachable},
+		{Case: "go-miss", Label: Reachable},
+		{Case: "js-conditional", Label: NoAnalysis},
+		{Case: "js-unsupported", Label: NoAnalysis},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	if len(report.Languages) != 2 {
+		t.Fatalf("languages = %+v", report.Languages)
+	}
+	goScore, jsScore := report.Languages[0], report.Languages[1]
+	if goScore.Language != "go" || goScore.Exact != 1 || goScore.PositiveRecall != 1 || goScore.PositivePrecision != 0.5 || goScore.FalsePositiveRise != 1 {
+		t.Fatalf("go score = %+v", goScore)
+	}
+	if jsScore.Language != "javascript" || jsScore.Exact != 1 || jsScore.PositiveRecall != 0 || jsScore.PositivePrecision != 1 {
+		t.Fatalf("javascript score = %+v", jsScore)
+	}
+	breaches := CheckRatchet(report, Floors{PositiveRecall: map[string]float64{"go": 1, "javascript": 1}})
+	if len(breaches) != 1 || !strings.Contains(breaches[0], "javascript") {
+		t.Fatalf("ratchet breaches = %v", breaches)
+	}
+}
+
+func TestEvaluateRefusesOmittedAndUnknownCases(t *testing.T) {
+	corpus := Corpus{SchemaVersion: CorpusSchemaVersion, Cases: []Case{{Name: "only", Language: "go", Fixture: "f", Symbol: "x", Expected: Reachable}}}
+	if _, err := Evaluate(corpus, nil); err == nil || !strings.Contains(err.Error(), "omit") {
+		t.Fatalf("omitted corpus case error = %v", err)
+	}
+	if _, err := Evaluate(corpus, []Observation{{Case: "other", Label: Reachable}}); err == nil || !strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("unknown corpus case error = %v", err)
+	}
+}
+
+func TestLoadCorpusRejectsUnknownLabel(t *testing.T) {
+	_, err := LoadCorpus(strings.NewReader(`{"schema_version":"synapse-reachability-corpus-v1","cases":[{"name":"x","language":"go","fixture":"f","symbol":"s","expected":"clean"}]}`))
+	if err == nil || !strings.Contains(err.Error(), "unknown expected label") {
+		t.Fatalf("LoadCorpus error = %v", err)
+	}
+}
+
+func TestDecodeInputAndLoadReportProvideStrictPortableContract(t *testing.T) {
+	input, err := DecodeInput(strings.NewReader(`{
+		"schema_version":"synapse-reachability-input-v1",
+		"corpus":{"schema_version":"synapse-reachability-corpus-v1","cases":[{"name":"go-hit","language":"go","fixture":"fixture","symbol":"fixture.hit","expected":"reachable"}]},
+		"observations":[{"case":"go-hit","label":"reachable"}]
+	}`))
+	if err != nil {
+		t.Fatalf("DecodeInput: %v", err)
+	}
+	report, err := EvaluateInput(input)
+	if err != nil {
+		t.Fatalf("EvaluateInput: %v", err)
+	}
+	var encoded bytes.Buffer
+	if err := EncodeReport(&encoded, report); err != nil {
+		t.Fatalf("EncodeReport: %v", err)
+	}
+	loaded, err := LoadReport(&encoded)
+	if err != nil || loaded.CorpusDigest != report.CorpusDigest || loaded.Languages[0].PositiveRecall != 1 {
+		t.Fatalf("LoadReport = %+v, %v", loaded, err)
+	}
+	if _, err := DecodeInput(strings.NewReader(`{"schema_version":"synapse-reachability-input-v1","corpus":{"schema_version":"synapse-reachability-corpus-v1","cases":[]},"observations":[],"unexpected":true}`)); err == nil {
+		t.Fatal("DecodeInput must reject unknown fields rather than silently change corpus semantics")
+	}
+}
+
+func TestDefaultCorpusAndFloorsFormAGatedContract(t *testing.T) {
+	corpus := DefaultCorpus()
+	if len(corpus.Cases) < 2 {
+		t.Fatalf("default corpus has %d cases, want its reachable and unreached Go controls", len(corpus.Cases))
+	}
+	if floor := DefaultFloors().PositiveRecall["go"]; floor != 1 {
+		t.Fatalf("Go recall floor = %v, want 1", floor)
+	}
+	var encoded bytes.Buffer
+	if err := EncodeReport(&encoded, Report{SchemaVersion: ReportSchemaVersion}); err != nil || !strings.Contains(encoded.String(), ReportSchemaVersion) {
+		t.Fatalf("EncodeReport = %q, %v", encoded.String(), err)
+	}
+}
+
+func TestCheckBaselineParityFailsClosedOnRegressionOrMissingLanguage(t *testing.T) {
+	baseline := Report{CorpusDigest: "same-corpus", Languages: []LanguageScore{{Language: "go", PositiveRecall: 1, PositivePrecision: 1}, {Language: "python", PositiveRecall: 0.9, PositivePrecision: 1}}}
+	candidate := Report{CorpusDigest: "same-corpus", Languages: []LanguageScore{{Language: "go", PositiveRecall: 0.8, PositivePrecision: 0.5}}}
+	breaches := CheckBaselineParity(candidate, baseline)
+	joined := strings.Join(breaches, "\n")
+	if len(breaches) != 3 || !strings.Contains(joined, "go positive reachability recall") || !strings.Contains(joined, "go positive reachability precision") || !strings.Contains(joined, "python") {
+		t.Fatalf("baseline parity breaches = %v", breaches)
+	}
+}
+
+func TestCheckBaselineParityRefusesDifferentCorpus(t *testing.T) {
+	breaches := CheckBaselineParity(Report{CorpusDigest: "candidate"}, Report{CorpusDigest: "baseline"})
+	if len(breaches) != 1 || !strings.Contains(breaches[0], "different") {
+		t.Fatalf("different corpus breaches = %v", breaches)
+	}
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,7 @@ nav:
       - eBPF portability: ebpf-portability.md
       - Release provenance: release-provenance.md
       - AI triage evaluation: ai-triage-evaluation.md
+      - Reachability benchmark: reachability-benchmark-runbook.md
       - Operations drill evidence: operations-drill-evidence.md
       - Detection RulePack lifecycle: rulepack.md
   - Integrate:


### PR DESCRIPTION
## Summary

Implements the reproducible Go slice of EPIC #1042 / #1049.

* Adds a versioned labelled reachability corpus and recall ratchet.
* Adds real vulnerable-function controls for `GO-2026-4514` / `github.com/buger/jsonparser.Delete`: one called and one present-but-uncalled.
* Normalizes OSV-Scanner call analysis and Semgrep CE output into one digest-bound scorecard.
* Gates the owned SSA call graph on recall and precision parity-or-better against both OSS baselines.
* Adds pinned CI that uploads raw baseline output and normalized scorecards.
* Adds the maintainer-facing evidence runbook, including the credential-free Snyk review procedure.

## Evidence / fail-closed behaviour

* Candidate and baseline must have the same `corpus_digest`.
* Missing external analysis remains `no_analysis`; it is never treated as uncalled.
* Contradictory OSV data for one advisory/source fails closed.
* Missing baseline language, recall regression, or precision regression fails the gate.
* Owned Go engine: **4/4 exact, precision 1.000, recall 1.000**.
* OSV-Scanner v2.4.0 was executed locally against the corpus and reported `called=true` for the called control and `called=false` for the uncalled control.

## Validation

* `go test -count=1 ./internal/usecase/reachbench ./cmd/synapse-bench ./internal/infrastructure/tools/ssacallgraph`
* `go vet ./internal/usecase/reachbench ./cmd/synapse-bench ./internal/infrastructure/tools/ssacallgraph`
* `go build ./...`
* `go vet ./...`

## Snyk evidence

The strict `reachability-snyk-sample` adapter and review procedure are included. The actual sample is intentionally not fabricated or committed: a reviewer must export it from the approved Snyk organization and attach it as evidence without credentials or customer data.

Refs #1049
